### PR TITLE
feat(player): plumb save-state tier + opt-out into domain (#804)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -47,6 +47,7 @@ fun com.spela.client.models.ConsoleResponse.toDomain(): Console = Console(
     iconUrl = iconUrl,
     logoUrl = logoPngUrl.ifEmpty { logoUrl },
     saveStateSupport = saveStateSupport,
+    saveStatePolicy = SaveStatePolicyTier.fromApiId(saveStatePolicy),
     browserPlayable = browserPlayable,
     playable = playable,
     generation = generation.toInt(),
@@ -170,6 +171,11 @@ fun com.spela.client.models.UserPreferencesResponse.toDomain(): UserPreferences 
     selectedShader = ShaderPreset.fromApiId(selectedShader),
     selectedTheme = selectedTheme,
     consoleShaders = consoleShaders.mapValues { ShaderPreset.fromApiId(it.value) },
+    consoleSaveStatePolicies = consoleSaveStatePolicies.mapNotNull { (k, v) ->
+        // Drop any entry the server sent that doesn't parse to a known
+        // value rather than crashing the player on a future codec.
+        SaveStateChoice.fromApiId(v)?.let { k.lowercase() to it }
+    }.toMap(),
     selectedKeyMapping = selectedKeyMapping,
     consoleKeyMappings = consoleKeyMappings.mapValues {
         ConsoleKeyMappingPref(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -34,6 +34,24 @@ data class User(
 )
 
 @Serializable
+/**
+ * Save-state size tier the server seeded for a console — drives
+ * retention, slot count, and opt-out UX. Loaded from
+ * [ConsoleResponse.saveStatePolicy] which is one of "small" |
+ * "medium" | "large". Unknown values fall back to [Small] so a
+ * future server tier doesn't crash older clients. See #804 phase 3.
+ */
+enum class SaveStatePolicyTier(val apiId: String) {
+    Small("small"),
+    Medium("medium"),
+    Large("large");
+
+    companion object {
+        fun fromApiId(apiId: String?): SaveStatePolicyTier =
+            entries.find { it.apiId == apiId } ?: Small
+    }
+}
+
 data class Console(
     val id: String,
     val name: String,
@@ -46,6 +64,7 @@ data class Console(
     val iconUrl: String = "",
     val logoUrl: String = "",
     val saveStateSupport: Boolean = true,
+    val saveStatePolicy: SaveStatePolicyTier = SaveStatePolicyTier.Small,
     val browserPlayable: Boolean = false,
     val playable: Boolean = true,
     val generation: Int = 0,
@@ -187,6 +206,23 @@ data class ConsoleKeyMappingPref(
     val customMapping: Map<String, String> = emptyMap(),
 )
 
+/**
+ * User's per-console save-state opt-out choice. The map only holds
+ * consoles where the user has made a deliberate choice in
+ * [UserPreferences.consoleSaveStatePolicies]; absence means "use the
+ * tier default" — see [effectiveSaveStateChoice]. See #804 phase 4.
+ */
+enum class SaveStateChoice(val apiId: String) {
+    Enabled("enabled"),
+    Disabled("disabled"),
+    AskOnce("ask-once");
+
+    companion object {
+        fun fromApiId(apiId: String?): SaveStateChoice? =
+            entries.find { it.apiId == apiId }
+    }
+}
+
 data class UserPreferences(
     val showPerformanceOverlay: Boolean = false,
     val autoSaveEnabled: Boolean = true,
@@ -195,10 +231,40 @@ data class UserPreferences(
     val selectedShader: ShaderPreset = ShaderPreset.NONE,
     val selectedTheme: String = "default-dark",
     val consoleShaders: Map<String, ShaderPreset> = emptyMap(),
+    val consoleSaveStatePolicies: Map<String, SaveStateChoice> = emptyMap(),
     val selectedKeyMapping: String = "default",
     val consoleKeyMappings: Map<String, ConsoleKeyMappingPref> = emptyMap(),
     val defaultSecondScreenPage: String = "art",
 )
+
+/**
+ * Resolves the effective save-state choice for [consoleAbbr] given
+ * the console's tier and the user's per-console overrides.
+ *
+ * Precedence (high → low):
+ *
+ *   1. explicit override in [overrides] (key matched case-insensitively)
+ *   2. tier default — small/medium → Enabled, large → AskOnce
+ *
+ * The resolver intentionally returns [SaveStateChoice.AskOnce] for
+ * large-tier consoles with no override so the player can fire the
+ * first-launch prompt; the in-game overlay treats AskOnce the same
+ * as Enabled until that prompt resolves to a deliberate choice. See
+ * #804 phase 4.
+ */
+fun effectiveSaveStateChoice(
+    consoleAbbr: String,
+    tier: SaveStatePolicyTier,
+    overrides: Map<String, SaveStateChoice>,
+): SaveStateChoice {
+    val key = consoleAbbr.lowercase()
+    overrides[key]?.let { return it }
+    return when (tier) {
+        SaveStatePolicyTier.Small,
+        SaveStatePolicyTier.Medium -> SaveStateChoice.Enabled
+        SaveStatePolicyTier.Large -> SaveStateChoice.AskOnce
+    }
+}
 
 data class DownloadedGame(
     val gameId: String,

--- a/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/SaveStatePolicyTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/SaveStatePolicyTest.kt
@@ -1,0 +1,107 @@
+package com.spela.player.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Covers the resolver the in-game overlay calls every render to decide
+ * whether to grey out the save/load buttons. If this drifts the
+ * Disabled state can leak through as Enabled (silent footgun for the
+ * user that asked for opt-out) or vice versa (broken UX for users
+ * who didn't opt out).
+ */
+class SaveStatePolicyTest {
+
+    @Test
+    fun overrideTakesPrecedenceOverTier() {
+        val resolved = effectiveSaveStateChoice(
+            consoleAbbr = "GC",
+            tier = SaveStatePolicyTier.Large,
+            overrides = mapOf("gc" to SaveStateChoice.Enabled),
+        )
+        assertEquals(SaveStateChoice.Enabled, resolved)
+    }
+
+    @Test
+    fun overrideMatchedCaseInsensitively() {
+        // The map keys are stored lowercased on the server but the
+        // game-launch flow passes the abbreviation as-typed. The
+        // resolver must canonicalise so a case mismatch doesn't
+        // silently fall through to the tier default.
+        val resolved = effectiveSaveStateChoice(
+            consoleAbbr = "GC",
+            tier = SaveStatePolicyTier.Large,
+            overrides = mapOf("gc" to SaveStateChoice.Disabled),
+        )
+        assertEquals(SaveStateChoice.Disabled, resolved)
+
+        val resolvedUpper = effectiveSaveStateChoice(
+            consoleAbbr = "gc",
+            tier = SaveStatePolicyTier.Large,
+            overrides = mapOf("gc" to SaveStateChoice.Disabled),
+        )
+        assertEquals(SaveStateChoice.Disabled, resolvedUpper)
+    }
+
+    @Test
+    fun smallTierDefaultsToEnabled() {
+        val resolved = effectiveSaveStateChoice(
+            consoleAbbr = "NES",
+            tier = SaveStatePolicyTier.Small,
+            overrides = emptyMap(),
+        )
+        assertEquals(SaveStateChoice.Enabled, resolved)
+    }
+
+    @Test
+    fun mediumTierDefaultsToEnabled() {
+        val resolved = effectiveSaveStateChoice(
+            consoleAbbr = "PSX",
+            tier = SaveStatePolicyTier.Medium,
+            overrides = emptyMap(),
+        )
+        assertEquals(SaveStateChoice.Enabled, resolved)
+    }
+
+    @Test
+    fun largeTierDefaultsToAskOnce() {
+        val resolved = effectiveSaveStateChoice(
+            consoleAbbr = "GC",
+            tier = SaveStatePolicyTier.Large,
+            overrides = emptyMap(),
+        )
+        assertEquals(SaveStateChoice.AskOnce, resolved)
+    }
+
+    @Test
+    fun overrideForOneConsoleDoesNotLeakToOthers() {
+        val overrides = mapOf("gc" to SaveStateChoice.Disabled)
+        val gc = effectiveSaveStateChoice("GC", SaveStatePolicyTier.Large, overrides)
+        val ps2 = effectiveSaveStateChoice("PS2", SaveStatePolicyTier.Large, overrides)
+        assertEquals(SaveStateChoice.Disabled, gc)
+        assertEquals(SaveStateChoice.AskOnce, ps2, "no override → tier default")
+    }
+
+    @Test
+    fun saveStatePolicyTierFallsBackToSmallOnUnknown() {
+        // A future server tier (e.g. "huge") must not crash older
+        // clients — they should treat it as the safest existing tier
+        // (small = unbounded named saves) so the user keeps working.
+        // The opposite default would silently disable saves.
+        assertEquals(SaveStatePolicyTier.Small, SaveStatePolicyTier.fromApiId(null))
+        assertEquals(SaveStatePolicyTier.Small, SaveStatePolicyTier.fromApiId(""))
+        assertEquals(SaveStatePolicyTier.Small, SaveStatePolicyTier.fromApiId("future-tier"))
+        assertEquals(SaveStatePolicyTier.Large, SaveStatePolicyTier.fromApiId("large"))
+    }
+
+    @Test
+    fun saveStateChoiceUnknownReturnsNull() {
+        // Unlike tier, an unknown choice must not silently become
+        // Enabled — the DTO mapper drops the entry instead so the
+        // resolver falls back to tier default for that console.
+        assertEquals(null, SaveStateChoice.fromApiId(null))
+        assertEquals(null, SaveStateChoice.fromApiId(""))
+        assertEquals(null, SaveStateChoice.fromApiId("foo"))
+        assertEquals(SaveStateChoice.Disabled, SaveStateChoice.fromApiId("disabled"))
+    }
+}


### PR DESCRIPTION
Phase 4b plumbing for #804 — wires the data shipped in earlier phases into the player's domain model. Pure data flow, no UX yet.

## What this enables

The next slices (in-game overlay greying for "Disabled", first-launch prompt for "AskOnce", Settings page entry) all key off a single resolver: `effectiveSaveStateChoice(consoleAbbr, tier, overrides) → SaveStateChoice`. Shipping the resolver alone keeps each follow-up small and reviewable.

## What changed

- `SaveStatePolicyTier` enum (small / medium / large) on `Console`. Loaded from the field shipped in #816. Unknown values fall back to `Small` so a future server tier doesn't crash older clients.
- `SaveStateChoice` enum (enabled / disabled / ask-once) and `consoleSaveStatePolicies: Map<String, SaveStateChoice>` on `UserPreferences`. Loaded from the override map shipped in #817. The DTO mapper drops unknown choice values rather than silently coercing them — the resolver then falls back to tier default for that console.
- `effectiveSaveStateChoice` resolver:
  - Explicit override (case-insensitive on the abbreviation) wins.
  - Otherwise tier default: small / medium → `Enabled`, large → `AskOnce`.
  - The `AskOnce` default is intentional — the future first-launch prompt fires for any large console without an override; the in-game overlay treats `AskOnce` the same as `Enabled` until the prompt resolves to a deliberate choice.

## Tests

8 cases in `SaveStatePolicyTest` covering:
- override beats tier default
- abbreviation matched case-insensitively (the override map keys are stored lowercased server-side, the game-launch path passes uppercase)
- small / medium / large defaults
- override for one console doesn't leak to others
- unknown tier API value → `Small` (safest existing tier)
- unknown choice API value → `null` (DTO mapper drops it)

Player desktop: 554 tests, 0 failures. Android compile clean.

## Phase order

- ~~Phase 1 — lift 64 MB cap (#806, merged)~~
- ~~Phase 2 — client-side compression (#814 + #815, merged)~~
- ~~Phase 3 — `SaveStatePolicy` tier + seeding (#816, merged)~~
- ~~Phase 4a — server `ConsoleSaveStatePolicy` table + endpoint (#817, merged)~~
- **Phase 4b plumbing — this PR**
- Phase 4b overlay greying — next PR
- Phase 4b first-launch prompt — separate PR
- Phase 4b Settings page entry — separate PR
- Phase 5 — slot-primary UX
- Phase 6 — deferred sync