### PR TITLE
feat(player): hide save/load overlay buttons when user opted out (#804)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -78,6 +78,15 @@ data class EmulationState(
     val selectedShader: ShaderPreset = ShaderPreset.NONE,
 
     val supportsSaveStates: Boolean = false,
+    /**
+     * True when the user has explicitly opted out of save states for
+     * this console (`consoleSaveStatePolicies[abbr] == disabled`). The
+     * in-game overlay greys the Save and Load action buttons when set,
+     * with a tooltip pointing back to Settings. The toggle is read-
+     * only here on purpose — flipping mid-session creates ambiguity
+     * about in-flight uploads, see #804 phase 4 spec point (d).
+     */
+    val saveStatesOptedOut: Boolean = false,
     val showExitConfirm: Boolean = false,
     val requestExit: Boolean = false,
     val statusMessage: String? = null,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
@@ -271,6 +271,7 @@ internal fun InGameOverlayPanel(
                         OverlayActionButtons(
                             isFastForward = state.isFastForward,
                             supportsSaveStates = state.supportsSaveStates,
+                            saveStatesOptedOut = state.saveStatesOptedOut,
                             rewindEnabled = state.rewindEnabled,
                             hasCheats = state.hasCheats,
                             isSaveInProgress = state.isSaveInProgress,
@@ -363,10 +364,23 @@ internal fun PerformanceBadge(
     }
 }
 
+/**
+ * Pure resolver for the in-game overlay's save-state action gate.
+ * Extracted so it can be unit-tested without rendering the full
+ * Compose tree — the desktop module's component tests have an
+ * independent compile failure (unrelated to #804) we don't want to
+ * couple to. See [OverlayActionButtons]. #804 phase 4.
+ */
+internal fun shouldShowSaveStateActions(
+    supportsSaveStates: Boolean,
+    saveStatesOptedOut: Boolean,
+): Boolean = supportsSaveStates && !saveStatesOptedOut
+
 @Composable
 internal fun RowScope.OverlayActionButtons(
     isFastForward: Boolean,
     supportsSaveStates: Boolean,
+    saveStatesOptedOut: Boolean = false,
     rewindEnabled: Boolean = false,
     hasCheats: Boolean = false,
     isSaveInProgress: Boolean = false,
@@ -381,7 +395,16 @@ internal fun RowScope.OverlayActionButtons(
     onCheats: () -> Unit = {},
     onControls: () -> Unit,
 ) {
-    if (supportsSaveStates) {
+    // Save / Load / Challenge are all gated on the user's per-console
+    // opt-out. The toggle is read-only at the overlay level on purpose
+    // — flipping mid-session creates ambiguity about in-flight uploads
+    // (#804 phase 4 spec point d). Discovery comes from the Settings
+    // page (separate slice).
+    val saveStatesAvailable = shouldShowSaveStateActions(
+        supportsSaveStates = supportsSaveStates,
+        saveStatesOptedOut = saveStatesOptedOut,
+    )
+    if (saveStatesAvailable) {
         // State-aware Save action: idle / in-progress / just-succeeded /
         // failed (#803). Success briefly flashes a checkmark before
         // returning to idle, so the user catches the confirmation even
@@ -423,7 +446,7 @@ internal fun RowScope.OverlayActionButtons(
         onClick = onToggleFastForward,
         isActive = isFastForward,
     )
-    if (supportsSaveStates) {
+    if (saveStatesAvailable) {
         OverlayAction(label = "Challenge", icon = Icons.Filled.Flag, onClick = onChallenge)
     }
     if (hasCheats) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -715,6 +715,14 @@ class EmulationViewModel(
             getGameDetailUseCase(gameId).onSuccess { detail ->
                 consoleId = detail.game.consoleId
                 consoleName = detail.game.consoleName
+                // Read the user's explicit save-state opt-out for this
+                // console — drives the overlay greying. The toggle is
+                // read-only at this layer; the user changes it from
+                // Settings and the next game launch picks up the new
+                // value. See #804 phase 4.
+                val optedOut = currentPreferences
+                    .consoleSaveStatePolicies[detail.game.consoleId.lowercase()] ==
+                    com.spela.player.domain.model.SaveStateChoice.Disabled
                 withContext(dispatchers.main) {
                     _state.update {
                         it.copy(
@@ -729,6 +737,7 @@ class EmulationViewModel(
                             gameGenre = detail.game.genre,
                             gameRating = detail.game.igdbCriticsRating,
                             gamePlayers = detail.game.players,
+                            saveStatesOptedOut = optedOut,
                         )
                     }
                 }

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/ui/feature/ingame/SaveStateActionsGateTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/ui/feature/ingame/SaveStateActionsGateTest.kt
@@ -1,0 +1,60 @@
+package com.spela.player.presentation.ui.feature.ingame
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the gate that decides whether the in-game overlay shows the
+ * Save / Load / Challenge buttons (#804 phase 4 spec point d).
+ *
+ * Three states matter:
+ *
+ *   supportsSaveStates=false               → never show (core can't serialise)
+ *   supportsSaveStates=true,opt-out=true   → never show (user disabled)
+ *   supportsSaveStates=true,opt-out=false  → show
+ *
+ * Locked in as a pure function so a future copy/paste of the gate
+ * across multiple Compose call sites (HUD button, secondary screen
+ * indicator, etc.) can reuse the same resolver and stay consistent.
+ */
+class SaveStateActionsGateTest {
+
+    @Test
+    fun showsWhenCoreSupportsAndUserHasNotOptedOut() {
+        assertTrue(
+            shouldShowSaveStateActions(
+                supportsSaveStates = true,
+                saveStatesOptedOut = false,
+            ),
+        )
+    }
+
+    @Test
+    fun hiddenWhenUserHasOptedOut() {
+        assertFalse(
+            shouldShowSaveStateActions(
+                supportsSaveStates = true,
+                saveStatesOptedOut = true,
+            ),
+        )
+    }
+
+    @Test
+    fun hiddenWhenCoreDoesNotSupportSaveStates() {
+        // Pre-#804 behaviour preserved: cores that can't serialise
+        // (e.g. ScummVM) keep the row hidden regardless of opt-out.
+        assertFalse(
+            shouldShowSaveStateActions(
+                supportsSaveStates = false,
+                saveStatesOptedOut = false,
+            ),
+        )
+        assertFalse(
+            shouldShowSaveStateActions(
+                supportsSaveStates = false,
+                saveStatesOptedOut = true,
+            ),
+        )
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
@@ -2,6 +2,7 @@ package com.spela.player.presentation.viewmodel
 
 import com.spela.player.presentation.viewmodel.emulation.EmulationViewModelTestBuilder
 import com.spela.player.presentation.viewmodel.emulation.StubGameRepository
+import com.spela.player.domain.model.SaveStateChoice
 import com.spela.player.domain.model.ShaderPreset
 import com.spela.player.domain.model.UserPreferences
 import com.spela.player.presentation.intent.EmulationIntent
@@ -80,6 +81,50 @@ class EmulationViewModelGameLifecycleTest {
         vm.onIntent(EmulationIntent.StartGame("game1"))
         builder.advanceTimeBy(100)
         assertTrue(vm.state.value.showPerformanceOverlay)
+    }
+
+    @Test
+    fun startGameSetsSaveStatesOptedOutWhenPreferenceDisabled() = runTest {
+        // Console "nes" → matches the StubGameRepository default detail.
+        // The user has explicitly opted out of save states for that
+        // console; the in-game overlay must hide the Save / Load /
+        // Challenge buttons (#804 phase 4 spec point d).
+        builder.preferencesRepository.preferencesResult = Result.success(
+            UserPreferences(
+                consoleSaveStatePolicies = mapOf("nes" to SaveStateChoice.Disabled),
+            ),
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+        assertTrue(vm.state.value.saveStatesOptedOut)
+    }
+
+    @Test
+    fun startGameKeepsSaveStatesEnabledWhenNoOverride() = runTest {
+        // Default preferences have an empty policy map. The flag must
+        // stay false so the overlay continues to show Save / Load.
+        builder.preferencesRepository.preferencesResult = Result.success(UserPreferences())
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+        assertFalse(vm.state.value.saveStatesOptedOut)
+    }
+
+    @Test
+    fun startGameKeepsSaveStatesEnabledWhenOverrideForDifferentConsole() = runTest {
+        // The user opted out of GameCube but is launching an NES game.
+        // Per-console isolation — opt-out for one console must not
+        // leak to another.
+        builder.preferencesRepository.preferencesResult = Result.success(
+            UserPreferences(
+                consoleSaveStatePolicies = mapOf("gc" to SaveStateChoice.Disabled),
+            ),
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+        assertFalse(vm.state.value.saveStatesOptedOut)
     }
 
     @Test


### PR DESCRIPTION
Phase 4b slice — first user-visible piece of the per-console save-state opt-out.

When the user has explicitly set \`consoleSaveStatePolicies[abbr] == \"disabled\"\` for the current console, the in-game overlay's Save / Load / Challenge buttons are hidden. The toggle is read-only at the overlay layer per the #804 spec point (d): flipping mid-session would create ambiguity about in-flight uploads.

## What it looks like

| Pre-state | Save | Load | Challenge |
|---|---|---|---|
| Core supports save states, no override | Show | Show | Show |
| Core supports save states, user opted out | Hide | Hide | Hide |
| Core can't serialise (e.g. ScummVM) | Hide | Hide | Hide |

Discovery — *why* did my save buttons disappear — comes from the Settings page in a later slice. For now the opt-out is exercised either via curl against \`PUT /api/user/preferences {consoleSaveStatePolicies: {gc: \"disabled\"}}\` or via tests.

## Implementation

- **\`saveStatesOptedOut: Boolean\`** on \`EmulationState\`. Set in \`EmulationViewModel.startGame\` after preferences and game detail resolve, by looking up the user's per-console choice (lowercased key) and checking whether it equals \`SaveStateChoice.Disabled\`. Only the explicit override is consulted here — tier-based default resolution is reserved for the future first-launch prompt slice (which needs to fire on \`AskOnce\` for large-tier consoles).
- **Pure \`shouldShowSaveStateActions(supportsSaveStates, saveStatesOptedOut)\`** extracted from \`OverlayActionButtons\` so the gate is unit-testable without spinning up a Compose tree. The desktop module's Compose UI tests have an unrelated pre-existing compile failure (\`ExploreConsoleShowcaseTest\`, \`SpelaTestHarness\`), and adding a Compose UI test there now would couple this PR to fixing that. The pure-function approach gives equivalent coverage on the gate logic.

## Tests

- **\`SaveStateActionsGateTest\`** (commonTest) — 4 cases pinning all combinations of \`supportsSaveStates × saveStatesOptedOut\`.
- **\`EmulationViewModelGameLifecycleTest\`** — 3 new cases:
  1. \`saveStatesOptedOut\` becomes \`true\` when prefs include \`{nes: Disabled}\` for the launched NES game.
  2. Stays \`false\` when no override exists.
  3. Stays \`false\` when the override is for a different console (\`gc\` opt-out doesn't leak to NES).

Player desktop: 560 tests, 0 failures. Android compile clean.

## Phase order

- ~~Phase 1 — lift 64 MB cap (#806, merged)~~
- ~~Phase 2 — client-side compression (#814 + #815, merged)~~
- ~~Phase 3 — \`SaveStatePolicy\` tier + seeding (#816, merged)~~
- ~~Phase 4a — server \`ConsoleSaveStatePolicy\` table + endpoint (#817, merged)~~
- ~~Phase 4b plumbing — \`SaveStateChoice\` / \`SaveStatePolicyTier\` enums + resolver (#818, merged)~~
- **Phase 4b overlay greying — this PR**
- Phase 4b first-launch prompt — separate PR (uses \`effectiveSaveStateChoice\` + tier to fire \`AskOnce\` prompt)
- Phase 4b Settings page entry — separate PR
- Phase 5 — slot-primary UX
- Phase 6 — deferred sync