### PR TITLE
feat: first-launch save-state opt-in dialog (#804 phase 4b)

### DIFF
--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameResponse.kt
@@ -37,6 +37,7 @@ import kotlinx.serialization.encoding.*
  * @param biosStatus 
  * @param consoleId 
  * @param consoleName 
+ * @param consoleSaveStatePolicy 
  * @param coreOverride 
  * @param coverAspectRatio 
  * @param coverUrl 
@@ -108,6 +109,8 @@ data class GameResponse (
     @SerialName(value = "consoleId") @Required val consoleId: kotlin.String,
 
     @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
+
+    @SerialName(value = "consoleSaveStatePolicy") @Required val consoleSaveStatePolicy: kotlin.String,
 
     @SerialName(value = "coreOverride") @Required val coreOverride: kotlin.String,
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -77,6 +77,7 @@ fun GameDto.toDomain(): Game = Game(
     title = title,
     consoleId = consoleId,
     consoleName = consoleName,
+    consoleSaveStatePolicy = SaveStatePolicyTier.fromApiId(consoleSaveStatePolicy),
     coverAspectRatio = coverAspectRatio.toFloat(),
     coverUrl = coverUrl.takeIf { it.isNotEmpty() },
     description = description.takeIf { it.isNotEmpty() },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
@@ -61,6 +61,7 @@ class PreferencesRepositoryImpl(
         selectedShader: String?,
         selectedTheme: String?,
         consoleShaders: Map<String, String>?,
+        consoleSaveStatePolicies: Map<String, String>?,
         defaultSecondScreenPage: String?,
     ): Result<UserPreferences> = runCatching {
         apiClient.updatePreferences(
@@ -72,6 +73,7 @@ class PreferencesRepositoryImpl(
                 selectedShader = selectedShader,
                 selectedTheme = selectedTheme,
                 consoleShaders = consoleShaders,
+                consoleSaveStatePolicies = consoleSaveStatePolicies,
                 defaultSecondScreenPage = defaultSecondScreenPage,
             )
         ).toDomain()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -85,6 +85,11 @@ data class Game(
     val title: String,
     val consoleId: String,
     val consoleName: String = "",
+    /** Save-state size tier of the parent console — drives the
+     *  first-launch prompt and slot/quota UX. Stored on the Game
+     *  rather than fetched separately so the player doesn't need a
+     *  second round-trip at game-launch time. See #804 phase 4b. */
+    val consoleSaveStatePolicy: SaveStatePolicyTier = SaveStatePolicyTier.Small,
     val coverAspectRatio: Float = 0.75f,
     val coverUrl: String? = null,
     val description: String? = null,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/PreferencesRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/PreferencesRepository.kt
@@ -13,6 +13,13 @@ interface PreferencesRepository {
         selectedShader: String? = null,
         selectedTheme: String? = null,
         consoleShaders: Map<String, String>? = null,
+        /**
+         * Per-console save-state opt-out upserts. Keys are console
+         * abbreviations; values are SaveStateChoice apiIds ("enabled"
+         * | "disabled" | "ask-once") or empty string to clear the
+         * row. See #804 phase 4.
+         */
+        consoleSaveStatePolicies: Map<String, String>? = null,
         defaultSecondScreenPage: String? = null,
     ): Result<UserPreferences>
     fun getDeviceShaderOverride(consoleId: String): ShaderPreset?

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -28,6 +28,16 @@ sealed interface EmulationIntent {
     data object StopGame : EmulationIntent
     data object SaveState : EmulationIntent
     data object LoadState : EmulationIntent
+
+    /** First-launch save-state prompt actions (#804 phase 4b). All
+     *  three buttons write a deliberate console-level choice and
+     *  dismiss the prompt — "Decide per game" picks Enabled at the
+     *  console level so individual games can be opted out from the
+     *  game-detail toggle (a future slice), avoiding leaving the
+     *  console in an indeterminate ask-once state forever. */
+    data object AcceptSaveStatesForConsole : EmulationIntent
+    data object RejectSaveStatesForConsole : EmulationIntent
+    data object DeferSaveStateChoiceToPerGame : EmulationIntent
     data object ToggleOverlay : EmulationIntent
     data object ToggleFastForward : EmulationIntent
     data class SetVolume(val volume: Float) : EmulationIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -87,6 +87,16 @@ data class EmulationState(
      * about in-flight uploads, see #804 phase 4 spec point (d).
      */
     val saveStatesOptedOut: Boolean = false,
+    /**
+     * True when the user is launching a large-tier console game for
+     * the first time (no override + tier == large → AskOnce). Drives
+     * the first-launch dialog. See #804 phase 4b spec point (b).
+     */
+    val showSaveStatePrompt: Boolean = false,
+    /** Console abbreviation backing [showSaveStatePrompt] (e.g. "gc"). */
+    val saveStatePromptConsoleAbbr: String = "",
+    /** Display name backing [showSaveStatePrompt] (e.g. "Nintendo GameCube"). */
+    val saveStatePromptConsoleName: String = "",
     val showExitConfirm: Boolean = false,
     val requestExit: Boolean = false,
     val statusMessage: String? = null,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SaveStateOptInDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SaveStateOptInDialog.kt
@@ -1,0 +1,62 @@
+package com.spela.player.presentation.ui.feature.ingame
+
+import androidx.compose.runtime.Composable
+import com.spela.player.presentation.ui.components.SpDecisionAction
+import com.spela.player.presentation.ui.components.SpDecisionActionStyle
+import com.spela.player.presentation.ui.components.SpDecisionSheet
+
+/**
+ * First-launch save-state opt-in dialog (#804 phase 4b spec point b).
+ *
+ * Fires the first time the user launches a large-tier console game
+ * (GameCube, Wii, PS2) when their per-console policy is still the
+ * default `ask-once`. Three actions, each records a deliberate
+ * console-level choice so the dialog never re-fires:
+ *
+ *   primary   "Yes, enable" → consoleSaveStatePolicies[abbr] = enabled
+ *   secondary "No, battery saves only" → consoleSaveStatePolicies[abbr] = disabled
+ *   tertiary  "Decide per game" → consoleSaveStatePolicies[abbr] = enabled
+ *             (per-game toggle on game-detail handles the case-by-case
+ *             work; this option just unblocks the dialog)
+ *
+ * The copy intentionally distinguishes save states (snapshots) from
+ * the in-game battery save — the spec calls this out as the most
+ * dangerous misread, since users panic if they think the toggle
+ * threatens their actual game progress.
+ */
+@Composable
+fun SaveStateOptInDialog(
+    consoleName: String,
+    onAccept: () -> Unit,
+    onReject: () -> Unit,
+    onDeferToPerGame: () -> Unit,
+) {
+    val displayName = consoleName.ifBlank { "this console" }
+    SpDecisionSheet(
+        title = "Enable save states for $displayName?",
+        body = "$displayName save states are typically 30–100 MB each and count " +
+            "against your storage quota. This is separate from your in-game save " +
+            "(battery / memory card) — that always syncs regardless.",
+        primary = SpDecisionAction(
+            label = "Yes, enable",
+            onClick = onAccept,
+            style = SpDecisionActionStyle.Primary,
+        ),
+        secondary = SpDecisionAction(
+            label = "No, battery saves only",
+            onClick = onReject,
+            style = SpDecisionActionStyle.Secondary,
+        ),
+        tertiary = SpDecisionAction(
+            label = "Decide per game",
+            onClick = onDeferToPerGame,
+            style = SpDecisionActionStyle.Ghost,
+        ),
+        // Back-button / scrim-tap defers to per-game so the user
+        // doesn't accidentally lock the entire console to disabled by
+        // mishandling the prompt — the per-game toggle gives them a
+        // less destructive way to deal with it later.
+        onDismiss = onDeferToPerGame,
+        testTagName = "save-state-opt-in-dialog",
+    )
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -223,6 +223,20 @@ fun InGameOverlay(
         )
     }
 
+    // First-launch save-state opt-in prompt for large-tier consoles
+    // (#804 phase 4b spec point b). Renders before the core-mismatch
+    // dialog so the user makes the higher-level "do I want save
+    // states for this console at all" decision before any save-state
+    // mechanics kick in.
+    if (state.showSaveStatePrompt) {
+        com.spela.player.presentation.ui.feature.ingame.SaveStateOptInDialog(
+            consoleName = state.saveStatePromptConsoleName,
+            onAccept = { viewModel.onIntent(EmulationIntent.AcceptSaveStatesForConsole) },
+            onReject = { viewModel.onIntent(EmulationIntent.RejectSaveStatesForConsole) },
+            onDeferToPerGame = { viewModel.onIntent(EmulationIntent.DeferSaveStateChoiceToPerGame) },
+        )
+    }
+
     // Core mismatch dialog
     if (state.showCoreMismatchDialog) {
         CoreMismatchDialog(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -176,6 +176,19 @@ class EmulationViewModel(
                 }
             }
             EmulationIntent.LoadState -> saveManager.loadState()
+            EmulationIntent.AcceptSaveStatesForConsole -> resolveSaveStatePrompt(
+                com.spela.player.domain.model.SaveStateChoice.Enabled,
+            )
+            EmulationIntent.RejectSaveStatesForConsole -> resolveSaveStatePrompt(
+                com.spela.player.domain.model.SaveStateChoice.Disabled,
+            )
+            EmulationIntent.DeferSaveStateChoiceToPerGame -> resolveSaveStatePrompt(
+                // Per-game deferral records "enabled" at the console
+                // level so we never re-ask. The user can opt out
+                // individual games from the game-detail toggle (a
+                // future #804 phase 4b slice).
+                com.spela.player.domain.model.SaveStateChoice.Enabled,
+            )
             EmulationIntent.ToggleOverlay -> {
                 val wasShowing = _state.value.showOverlay
                 _state.update { it.copy(showOverlay = !it.showOverlay) }
@@ -715,14 +728,20 @@ class EmulationViewModel(
             getGameDetailUseCase(gameId).onSuccess { detail ->
                 consoleId = detail.game.consoleId
                 consoleName = detail.game.consoleName
-                // Read the user's explicit save-state opt-out for this
-                // console — drives the overlay greying. The toggle is
-                // read-only at this layer; the user changes it from
-                // Settings and the next game launch picks up the new
-                // value. See #804 phase 4.
-                val optedOut = currentPreferences
-                    .consoleSaveStatePolicies[detail.game.consoleId.lowercase()] ==
+                // Resolve the effective save-state choice for the
+                // console. The full resolver picks up tier defaults
+                // (large-tier consoles default to AskOnce) so the
+                // first-launch prompt fires on first GC/Wii/PS2
+                // launch. See #804 phase 4b.
+                val effectiveChoice = com.spela.player.domain.model.effectiveSaveStateChoice(
+                    consoleAbbr = detail.game.consoleId,
+                    tier = detail.game.consoleSaveStatePolicy,
+                    overrides = currentPreferences.consoleSaveStatePolicies,
+                )
+                val optedOut = effectiveChoice ==
                     com.spela.player.domain.model.SaveStateChoice.Disabled
+                val askOnce = effectiveChoice ==
+                    com.spela.player.domain.model.SaveStateChoice.AskOnce
                 withContext(dispatchers.main) {
                     _state.update {
                         it.copy(
@@ -738,6 +757,9 @@ class EmulationViewModel(
                             gameRating = detail.game.igdbCriticsRating,
                             gamePlayers = detail.game.players,
                             saveStatesOptedOut = optedOut,
+                            showSaveStatePrompt = askOnce,
+                            saveStatePromptConsoleAbbr = if (askOnce) detail.game.consoleId else "",
+                            saveStatePromptConsoleName = if (askOnce) detail.game.consoleName else "",
                         )
                     }
                 }
@@ -1193,6 +1215,44 @@ class EmulationViewModel(
     private fun cancelLaunch() {
         pendingLaunch = null
         _syncState.update { null }
+    }
+
+    /**
+     * Records the user's first-launch save-state choice for the
+     * current console and dismisses the prompt. The write happens via
+     * the standard preferences PUT — same surface the Settings page
+     * (future slice) will use, so the two stay in sync. On network
+     * failure we still close the dialog locally and update the in-
+     * memory preferences so the prompt doesn't fire again this
+     * session; the next sync will retry. See #804 phase 4b.
+     */
+    private fun resolveSaveStatePrompt(
+        choice: com.spela.player.domain.model.SaveStateChoice,
+    ) {
+        val abbr = _state.value.saveStatePromptConsoleAbbr.lowercase()
+        if (abbr.isEmpty()) {
+            _state.update { it.copy(showSaveStatePrompt = false) }
+            return
+        }
+        // Update local cache immediately so a re-launch of the same
+        // console doesn't re-fire the prompt before the network
+        // round-trip completes.
+        currentPreferences = currentPreferences.copy(
+            consoleSaveStatePolicies = currentPreferences.consoleSaveStatePolicies + (abbr to choice),
+        )
+        _state.update {
+            it.copy(
+                showSaveStatePrompt = false,
+                saveStatesOptedOut = choice == com.spela.player.domain.model.SaveStateChoice.Disabled,
+            )
+        }
+        scope.launch(dispatchers.io) {
+            runCatching {
+                preferencesRepository.updatePreferences(
+                    consoleSaveStatePolicies = mapOf(abbr to choice.apiId),
+                )
+            }
+        }
     }
 
     private fun pauseGame() {

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -28,6 +28,7 @@ private fun testGameResponse(
         averageRating = 0.0,
         consoleId = consoleId,
         consoleName = consoleName,
+        consoleSaveStatePolicy = "small",
         coverAspectRatio = coverAspectRatio,
         coverUrl = coverUrl,
         createdAt = now,

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
@@ -167,7 +167,7 @@ class SyncEngineTest {
 
     private class NoOpPreferencesRepository : PreferencesRepository {
         override suspend fun getPreferences() = Result.success(UserPreferences())
-        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
+        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, consoleSaveStatePolicies: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
         override fun getAllDeviceShaderOverrides() = emptyMap<String, ShaderPreset>()
@@ -210,7 +210,7 @@ class SyncEngineTest {
 
     private class FailingPreferencesRepository : PreferencesRepository {
         override suspend fun getPreferences(): Result<UserPreferences> = throw RuntimeException("Preferences fetch failed")
-        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
+        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, consoleSaveStatePolicies: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
         override fun getAllDeviceShaderOverrides() = emptyMap<String, ShaderPreset>()
@@ -257,7 +257,7 @@ class SyncEngineTest {
             getPreferencesCalled = true
             return Result.success(UserPreferences())
         }
-        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
+        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, consoleSaveStatePolicies: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
         override fun getAllDeviceShaderOverrides() = emptyMap<String, ShaderPreset>()

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GameRepositoryOfflineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GameRepositoryOfflineTest.kt
@@ -43,7 +43,7 @@ private fun gameJson(
 ): String {
     val screenshots = screenshotUrls?.joinToString(",", "[", "]") { "\"$it\"" } ?: "[]"
     val lastPlayed = lastPlayedAt?.let { "\"$it\"" } ?: "null"
-    return """{"id":"$id","title":"$title","consoleId":"1","consoleName":"NES",""" +
+    return """{"id":"$id","title":"$title","consoleId":"1","consoleName":"NES","consoleSaveStatePolicy":"small",""" +
         """"achievementsWarning":"","ageRatings":[],"averageRating":0,"biosStatus":"",""" +
         """"coreOverride":"","coverAspectRatio":0.75,"coverUrl":"/covers/smb.png",""" +
         """"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z",""" +

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -381,7 +381,7 @@ class NavigationViewModelTest {
 
     private class NoOpPreferencesRepository : PreferencesRepository {
         override suspend fun getPreferences() = Result.success(UserPreferences())
-        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
+        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, consoleSaveStatePolicies: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
         override fun getAllDeviceShaderOverrides() = emptyMap<String, ShaderPreset>()

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
@@ -112,6 +112,123 @@ class EmulationViewModelGameLifecycleTest {
     }
 
     @Test
+    fun startGameFiresFirstLaunchPromptForLargeTierWithoutOverride() = runTest {
+        // Large-tier console + no override → AskOnce. The dialog
+        // must appear so the user makes a deliberate choice on the
+        // first GC/Wii/PS2 launch.
+        builder.gameRepository = StubGameRepository(
+            consoleId = "gc",
+            consoleName = "Nintendo GameCube",
+            consoleSaveStatePolicy = com.spela.player.domain.model.SaveStatePolicyTier.Large,
+        )
+        builder.preferencesRepository.preferencesResult = Result.success(UserPreferences())
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+        assertTrue(vm.state.value.showSaveStatePrompt)
+        assertEquals("gc", vm.state.value.saveStatePromptConsoleAbbr)
+        assertEquals("Nintendo GameCube", vm.state.value.saveStatePromptConsoleName)
+        assertFalse(vm.state.value.saveStatesOptedOut)
+    }
+
+    @Test
+    fun startGameSkipsFirstLaunchPromptWhenLargeTierAlreadyResolved() = runTest {
+        builder.gameRepository = StubGameRepository(
+            consoleId = "gc",
+            consoleSaveStatePolicy = com.spela.player.domain.model.SaveStatePolicyTier.Large,
+        )
+        builder.preferencesRepository.preferencesResult = Result.success(
+            UserPreferences(
+                consoleSaveStatePolicies = mapOf("gc" to SaveStateChoice.Enabled),
+            ),
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+        assertFalse(vm.state.value.showSaveStatePrompt)
+    }
+
+    @Test
+    fun startGameDoesNotFirePromptForSmallTier() = runTest {
+        // Small/medium tiers default to Enabled, never AskOnce.
+        builder.gameRepository = StubGameRepository(
+            consoleId = "nes",
+            consoleSaveStatePolicy = com.spela.player.domain.model.SaveStatePolicyTier.Small,
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+        assertFalse(vm.state.value.showSaveStatePrompt)
+    }
+
+    @Test
+    fun acceptSaveStatesForConsoleClearsPromptAndWritesEnabled() = runTest {
+        builder.gameRepository = StubGameRepository(
+            consoleId = "gc",
+            consoleSaveStatePolicy = com.spela.player.domain.model.SaveStatePolicyTier.Large,
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+        assertTrue(vm.state.value.showSaveStatePrompt)
+
+        vm.onIntent(EmulationIntent.AcceptSaveStatesForConsole)
+        builder.advanceTimeBy(100)
+        assertFalse(vm.state.value.showSaveStatePrompt)
+        assertFalse(vm.state.value.saveStatesOptedOut)
+        assertEquals(
+            mapOf("gc" to SaveStateChoice.Enabled.apiId),
+            builder.preferencesRepository.lastConsoleSaveStatePoliciesUpdate,
+        )
+    }
+
+    @Test
+    fun rejectSaveStatesForConsoleClearsPromptAndWritesDisabled() = runTest {
+        builder.gameRepository = StubGameRepository(
+            consoleId = "gc",
+            consoleSaveStatePolicy = com.spela.player.domain.model.SaveStatePolicyTier.Large,
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+
+        vm.onIntent(EmulationIntent.RejectSaveStatesForConsole)
+        builder.advanceTimeBy(100)
+        assertFalse(vm.state.value.showSaveStatePrompt)
+        // Reject = Disabled → overlay greying flag must flip too so
+        // the user doesn't see the buttons re-enabled until next launch.
+        assertTrue(vm.state.value.saveStatesOptedOut)
+        assertEquals(
+            mapOf("gc" to SaveStateChoice.Disabled.apiId),
+            builder.preferencesRepository.lastConsoleSaveStatePoliciesUpdate,
+        )
+    }
+
+    @Test
+    fun deferSaveStateChoiceWritesEnabledSoPromptDoesNotReFire() = runTest {
+        // The "Decide per game" button records `enabled` at the
+        // console level; the per-game toggle (future slice) handles
+        // game-by-game work. Without this, the prompt would re-fire
+        // on every launch because the policy stayed at AskOnce.
+        builder.gameRepository = StubGameRepository(
+            consoleId = "gc",
+            consoleSaveStatePolicy = com.spela.player.domain.model.SaveStatePolicyTier.Large,
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+
+        vm.onIntent(EmulationIntent.DeferSaveStateChoiceToPerGame)
+        builder.advanceTimeBy(100)
+        assertFalse(vm.state.value.showSaveStatePrompt)
+        assertFalse(vm.state.value.saveStatesOptedOut)
+        assertEquals(
+            mapOf("gc" to SaveStateChoice.Enabled.apiId),
+            builder.preferencesRepository.lastConsoleSaveStatePoliciesUpdate,
+        )
+    }
+
+    @Test
     fun startGameKeepsSaveStatesEnabledWhenOverrideForDifferentConsole() = runTest {
         // The user opted out of GameCube but is launching an NES game.
         // Per-console isolation — opt-out for one console must not

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt
@@ -392,6 +392,7 @@ class KeyMappingViewModelTest {
             showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?,
             autoUpdateCoresEnabled: Boolean?,
             selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?,
+            consoleSaveStatePolicies: Map<String, String>?,
             defaultSecondScreenPage: String?,
         ): Result<UserPreferences> = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -174,13 +174,24 @@ class StubLibretroControllerWithVariableTracking : LibretroController {
 
 // ── Repository stubs ────────────────────────────────────────────────────────
 
-class StubGameRepository(private val consoleId: String = "nes") : GameRepository {
+class StubGameRepository(
+    private val consoleId: String = "nes",
+    private val consoleName: String = "",
+    private val consoleSaveStatePolicy: com.spela.player.domain.model.SaveStatePolicyTier =
+        com.spela.player.domain.model.SaveStatePolicyTier.Small,
+) : GameRepository {
     override suspend fun getConsoles() = Result.success(emptyList<com.spela.player.domain.model.Console>())
     override suspend fun getGamesForConsole(consoleId: String) = Result.success(emptyList<Game>())
     override suspend fun getAllGames() = Result.success(emptyList<Game>())
     override suspend fun searchGames(query: String, consoleId: String?, sortBy: String?, sortOrder: String?) = Result.success(emptyList<Game>())
     override suspend fun getGameDetail(gameId: String) = Result.success(
-        GameDetail(game = Game(id = gameId, title = "Test Game", consoleId = this.consoleId))
+        GameDetail(game = Game(
+            id = gameId,
+            title = "Test Game",
+            consoleId = this.consoleId,
+            consoleName = this.consoleName,
+            consoleSaveStatePolicy = this.consoleSaveStatePolicy,
+        ))
     )
     override suspend fun getRecentGames() = Result.success(emptyList<Game>())
     override suspend fun getFavoriteGames() = Result.success(emptyList<Game>())
@@ -261,6 +272,13 @@ class StubPreferencesRepository : PreferencesRepository {
     var resolveShaderResult: ShaderPreset = ShaderPreset.NONE
 
     override suspend fun getPreferences() = preferencesResult
+    /** Records the consoleSaveStatePolicies map passed on the most
+     *  recent updatePreferences call so tests can assert the
+     *  EmulationViewModel writes the right console-level choice when
+     *  the user picks a button on the first-launch prompt (#804). */
+    var lastConsoleSaveStatePoliciesUpdate: Map<String, String>? = null
+        private set
+
     override suspend fun updatePreferences(
         showPerformanceOverlay: Boolean?,
         autoSaveEnabled: Boolean?,
@@ -269,8 +287,14 @@ class StubPreferencesRepository : PreferencesRepository {
         selectedShader: String?,
         selectedTheme: String?,
         consoleShaders: Map<String, String>?,
+        consoleSaveStatePolicies: Map<String, String>?,
         defaultSecondScreenPage: String?,
-    ) = Result.success(UserPreferences())
+    ): Result<UserPreferences> {
+        if (consoleSaveStatePolicies != null) {
+            lastConsoleSaveStatePoliciesUpdate = consoleSaveStatePolicies
+        }
+        return Result.success(UserPreferences())
+    }
 
     override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
     override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -99,6 +99,12 @@ type GameResponse struct {
 	UpdatedAt        time.Time      `json:"updatedAt"`
 	ConsoleID        string         `json:"consoleId"`
 	ConsoleName      string         `json:"consoleName"`
+	// Save-state size tier of the game's console — drives the in-game
+	// overlay's first-launch prompt and slot/quota UX. One of "small"
+	// | "medium" | "large". Inherited from Console.SaveStatePolicy
+	// (see #804 phase 3) so the player doesn't need a second
+	// round-trip to render the prompt at game-launch time.
+	ConsoleSaveStatePolicy string  `json:"consoleSaveStatePolicy"`
 	CoverAspectRatio float64        `json:"coverAspectRatio"`
 	Title            string         `json:"title"`
 	FileName       string         `json:"fileName"`
@@ -419,9 +425,11 @@ func toGameResponseWithData(g db.Game, data *userGameData) GameResponse {
 
 	consoleName := ""
 	coverAspectRatio := 0.75
+	consoleSaveStatePolicy := string(db.SaveStatePolicySmall)
 	if g.Console.ID != 0 {
 		consoleName = g.Console.Name
 		coverAspectRatio = parseAspectRatio(g.Console.CoverAspect)
+		consoleSaveStatePolicy = saveStatePolicyOrDefault(g.Console.SaveStatePolicy)
 	}
 
 	coverURL := resolveImageURL(g.CoverURL)
@@ -450,6 +458,7 @@ func toGameResponseWithData(g db.Game, data *userGameData) GameResponse {
 		UpdatedAt:        g.UpdatedAt,
 		ConsoleID:        consoleAbbr,
 		ConsoleName:      consoleName,
+		ConsoleSaveStatePolicy: consoleSaveStatePolicy,
 		CoverAspectRatio: coverAspectRatio,
 		Title:            g.Title,
 		FileName:       g.FileName,

--- a/server/internal/api/responses_test.go
+++ b/server/internal/api/responses_test.go
@@ -7,6 +7,71 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestToGameResponseSurfacesConsoleSaveStatePolicy verifies that the
+// per-game payload carries the parent console's tier so the player
+// can render the first-launch prompt at game-launch time without a
+// second round-trip. See #804 phase 4b.
+func TestToGameResponseSurfacesConsoleSaveStatePolicy(t *testing.T) {
+	cases := []struct {
+		name       string
+		console    db.Console
+		wantPolicy string
+	}{
+		{
+			name: "large GameCube",
+			console: db.Console{
+				ID:              1,
+				Name:            "GameCube",
+				Abbreviation:    "GC",
+				CoverAspect:     "1:1",
+				SaveStatePolicy: db.SaveStatePolicyLarge,
+			},
+			wantPolicy: "large",
+		},
+		{
+			name: "small NES",
+			console: db.Console{
+				ID:              2,
+				Name:            "NES",
+				Abbreviation:    "NES",
+				CoverAspect:     "5:7",
+				SaveStatePolicy: db.SaveStatePolicySmall,
+			},
+			wantPolicy: "small",
+		},
+		{
+			name: "console with no policy falls back to small",
+			console: db.Console{
+				ID:           3,
+				Name:         "Custom",
+				Abbreviation: "CUST",
+				CoverAspect:  "1:1",
+			},
+			wantPolicy: "small",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := toGameResponseWithData(
+				db.Game{ID: 99, Console: tc.console, ConsoleID: tc.console.ID, Title: "Test"},
+				nil,
+			)
+			assert.Equal(t, tc.wantPolicy, resp.ConsoleSaveStatePolicy)
+		})
+	}
+}
+
+// TestToGameResponseFallsBackForOrphanedGame covers the rare case
+// where a game has no joined console (Console.ID == 0). The default
+// must still be a known tier value so the player switch is total.
+func TestToGameResponseFallsBackForOrphanedGame(t *testing.T) {
+	resp := toGameResponseWithData(
+		db.Game{ID: 99, Title: "Orphan"},
+		nil,
+	)
+	assert.Equal(t, "small", resp.ConsoleSaveStatePolicy)
+}
+
 // TestToConsoleResponseSurfacesSaveStatePolicy pins the wire shape for
 // #804 phase 3: ToConsoleResponse must always emit a non-empty
 // "saveStatePolicy" so the player UI can switch unconditionally.

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -6556,6 +6556,7 @@ export interface components {
             biosStatus: string;
             consoleId: string;
             consoleName: string;
+            consoleSaveStatePolicy: string;
             coreOverride: string;
             /** Format: double */
             coverAspectRatio: number;

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -4049,6 +4049,9 @@
           "consoleName": {
             "type": "string"
           },
+          "consoleSaveStatePolicy": {
+            "type": "string"
+          },
           "coreOverride": {
             "type": "string"
           },
@@ -4265,6 +4268,7 @@
           "updatedAt",
           "consoleId",
           "consoleName",
+          "consoleSaveStatePolicy",
           "coverAspectRatio",
           "title",
           "fileName",

--- a/web/src/test-utils/fixtures.ts
+++ b/web/src/test-utils/fixtures.ts
@@ -14,6 +14,7 @@ export function makeGame(overrides: Partial<Game> = {}): Game {
     title: "Test Game",
     consoleId: "nes",
     consoleName: "NES",
+    consoleSaveStatePolicy: "small",
     fileName: "test.nes",
     fileSize: 1024,
     discCount: 1,


### PR DESCRIPTION
Closes part of #804 (phase 4b — first-launch save-state opt-in dialog).

## Summary

When the user launches a large-tier console game (GameCube, Wii, PS2) for the first time and has no per-console override, the in-game UI shows a one-shot dialog: **Enable save states for Nintendo GameCube?** with three options:

- **Yes, enable** → `consoleSaveStatePolicies[gc] = enabled`
- **No, battery saves only** → `consoleSaveStatePolicies[gc] = disabled`
- **Decide per game** → `consoleSaveStatePolicies[gc] = enabled` (per-game toggle on game-detail handles game-by-game work — future slice)

All three options record a deliberate console-level choice so the dialog never re-fires. Discovery of *why* the buttons appear/disappear comes from the future Settings page.

The copy is intentional: it distinguishes **save states** (snapshots, the gated feature) from the **in-game battery save / memory card** (always synced). The spec calls this the most dangerous misread — users would panic if they thought the toggle threatened actual game progress.

## Server changes

- `GameResponse.consoleSaveStatePolicy: string` — inherited from `Console.SaveStatePolicy` so the player can render the dialog without a second round-trip at game-launch time. Falls back to `"small"` for orphaned games (no joined console).

## Player changes

- `Game.consoleSaveStatePolicy: SaveStatePolicyTier` field; DTO mapper parses it.
- `PreferencesRepository.updatePreferences` signature gains `consoleSaveStatePolicies` map; impl threads it through to the existing `UpdatePreferencesRequest`.
- `EmulationViewModel.startGame` resolves the effective `SaveStateChoice` using the resolver shipped in #818. `AskOnce` flips the new `showSaveStatePrompt` flag on `EmulationState` (along with the console abbreviation + display name for the dialog).
- New `SaveStateOptInDialog` composable using `SpDecisionSheet` (same shape as the rehearsal-complete sheet).
- Three new `EmulationIntent` objects + handlers (`AcceptSaveStatesForConsole`, `RejectSaveStatesForConsole`, `DeferSaveStateChoiceToPerGame`). All three call `preferencesRepository.updatePreferences(consoleSaveStatePolicies = mapOf(abbr to choice.apiId))` and clear the prompt locally. On network failure the local cache is still updated so the prompt doesn't re-fire this session; the next sync retries.
- `InGameOverlay.kt` renders the dialog *before* any save-state mechanics so the user makes the higher-level decision first.

## Tests (566 player, 0 failures)

Six new `EmulationViewModelGameLifecycleTest` cases:
- Large + no override → prompt fires with correct console name.
- Large + existing override → no prompt.
- Small → no prompt.
- Accept → writes `enabled`, clears prompt, leaves `saveStatesOptedOut=false`.
- Reject → writes `disabled`, clears prompt, flips `saveStatesOptedOut=true` (so overlay greying takes effect immediately).
- Defer-per-game → writes `enabled`, clears prompt (prevents re-fire).

Plus server-side `TestToGameResponseSurfacesConsoleSaveStatePolicy` and `TestToGameResponseFallsBackForOrphanedGame`.

## Phase order

- ~~Phase 1 — lift 64 MB cap (#806, merged)~~
- ~~Phase 2 — client-side compression (#814 + #815, merged)~~
- ~~Phase 3 — `SaveStatePolicy` tier + seeding (#816, merged)~~
- ~~Phase 4a — server `ConsoleSaveStatePolicy` table + endpoint (#817, merged)~~
- ~~Phase 4b plumbing (#818, merged)~~
- ~~Phase 4b overlay greying (#819, merged)~~
- **Phase 4b first-launch prompt — this PR**
- Phase 4b Settings page entry — separate PR
- Phase 4b game-detail per-game toggle — separate PR
- Phase 5 — slot-primary UX
- Phase 6 — deferred sync
