### PR TITLE
feat(player): Settings entry for save-state opt-out overrides (#804)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/settings/SettingsSaveStatePoliciesSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/settings/SettingsSaveStatePoliciesSection.kt
@@ -1,0 +1,123 @@
+package com.spela.player.presentation.ui.feature.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.spela.player.domain.model.SaveStateChoice
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpSecondaryButton
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.SettingsIntent
+import com.spela.player.presentation.viewmodel.SettingsState
+import com.spela.player.presentation.viewmodel.SettingsViewModel
+
+/**
+ * Lists the user's per-console save-state opt-out overrides with a way
+ * to clear each one. See #804 phase 4b spec point (a) — the primary
+ * surface for the user to revisit a deliberate choice.
+ *
+ * Adding a new override happens via the in-game first-launch prompt
+ * (#820); this section is for managing what already exists. When the
+ * map is empty, the section hides itself entirely so it doesn't clutter
+ * the Emulation tab for the common-case user who never opted out.
+ */
+internal fun LazyListScope.saveStatePoliciesSectionItems(
+    state: SettingsState,
+    viewModel: SettingsViewModel,
+) {
+    if (state.consoleSaveStatePolicies.isEmpty()) return
+
+    item {
+        SpCard(
+            onGradient = true,
+            modifier = Modifier.testTag("settings_save_state_policies_card"),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(vertical = SpSpacing.Small),
+            ) {
+                val abbrToName = state.consoles
+                    .associateBy { it.abbreviation.lowercase() }
+                state.consoleSaveStatePolicies.entries
+                    // Sorted by display name so the list is stable
+                    // across renders even though the map iteration
+                    // order isn't.
+                    .sortedBy { (abbr, _) -> abbrToName[abbr]?.name ?: abbr }
+                    .forEachIndexed { index, (abbr, choice) ->
+                        SaveStatePolicyRow(
+                            consoleName = abbrToName[abbr]?.name
+                                ?: abbr.uppercase(),
+                            choice = choice,
+                            onClear = {
+                                viewModel.onIntent(
+                                    SettingsIntent.SetConsoleSaveStatePolicy(
+                                        consoleId = abbr,
+                                        choice = null,
+                                    ),
+                                )
+                            },
+                        )
+                        if (index < state.consoleSaveStatePolicies.size - 1) {
+                            SettingsDivider()
+                        }
+                    }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SaveStatePolicyRow(
+    consoleName: String,
+    choice: SaveStateChoice,
+    onClear: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Small)
+            .testTag("save_state_policy_row_${consoleName}"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = consoleName,
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackground,
+            )
+            Text(
+                text = "Save states: ${choice.displayLabel}",
+                style = SpTypography.LabelSmall,
+                color = SpColor.OnBackgroundSecondary,
+            )
+        }
+        SpSecondaryButton(
+            text = "Clear",
+            onClick = onClear,
+        )
+    }
+}
+
+/**
+ * Human-readable label for the save-state choice column on the
+ * Settings row. Kept here rather than on the enum itself because the
+ * domain model is consumed by both the prompt copy ("Yes, enable")
+ * and the Settings list ("Enabled") — different surfaces, different
+ * tone. The enum stays UI-agnostic.
+ */
+private val SaveStateChoice.displayLabel: String
+    get() = when (this) {
+        SaveStateChoice.Enabled -> "Enabled"
+        SaveStateChoice.Disabled -> "Disabled (battery saves only)"
+        SaveStateChoice.AskOnce -> "Ask each time"
+    }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
@@ -37,6 +37,7 @@ import com.spela.player.presentation.ui.feature.settings.SettingsDivider
 import com.spela.player.presentation.ui.feature.settings.SettingsInfoRow
 import com.spela.player.presentation.ui.feature.settings.SettingsSectionHeader
 import com.spela.player.presentation.ui.feature.settings.SettingsToggle
+import com.spela.player.presentation.ui.feature.settings.saveStatePoliciesSectionItems
 import com.spela.player.presentation.ui.feature.settings.controlsDefaultScopeItems
 import com.spela.player.presentation.ui.feature.settings.shaderDefaultScopeItems
 import com.spela.player.presentation.ui.theme.SpColor
@@ -235,6 +236,15 @@ private fun androidx.compose.foundation.lazy.LazyListScope.emulationContent(
                 }
             }
         }
+    }
+
+    // Save state opt-out overrides (only renders when the user has
+    // at least one explicit override; no header otherwise so we don't
+    // clutter the tab for the common case). See #804 phase 4b.
+    if (state.consoleSaveStatePolicies.isNotEmpty()) {
+        item { Spacer(Modifier.height(SpSpacing.Medium)) }
+        item { SettingsSectionHeader(title = "Per-console save state overrides") }
+        saveStatePoliciesSectionItems(state = state, viewModel = viewModel)
     }
 
     // Video Filter

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SettingsViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SettingsViewModel.kt
@@ -43,6 +43,14 @@ data class SettingsState(
     val selectedShader: ShaderPreset = ShaderPreset.NONE,
     val selectedTheme: String = "default-dark",
     val consoleShaders: Map<String, ShaderPreset> = emptyMap(),
+    /**
+     * Per-console save-state opt-out overrides, keyed by lowercased
+     * console abbreviation. Only contains consoles where the user has
+     * made a deliberate choice — absence means "use the tier default"
+     * (small/medium = Enabled, large = AskOnce). The Settings screen
+     * lets the user clear or change these. See #804 phase 4b.
+     */
+    val consoleSaveStatePolicies: Map<String, com.spela.player.domain.model.SaveStateChoice> = emptyMap(),
     val deviceShaderOverrides: Map<String, ShaderPreset> = emptyMap(),
     val consoles: List<Console> = emptyList(),
     val showLogoutConfirm: Boolean = false,
@@ -78,6 +86,15 @@ sealed interface SettingsIntent {
     data class SelectShader(val shader: ShaderPreset) : SettingsIntent
     data class SelectTheme(val theme: String) : SettingsIntent
     data class SelectConsoleShader(val consoleId: String, val shader: ShaderPreset) : SettingsIntent
+    /**
+     * Set a per-console save-state opt-out from the Settings screen.
+     * `choice == null` clears the override so the console reverts to
+     * its tier-driven default. See #804 phase 4b.
+     */
+    data class SetConsoleSaveStatePolicy(
+        val consoleId: String,
+        val choice: com.spela.player.domain.model.SaveStateChoice?,
+    ) : SettingsIntent
     data class SetDeviceOverride(val consoleId: String, val shader: ShaderPreset?) : SettingsIntent
     data class UpdateDeviceName(val name: String) : SettingsIntent
     data object ShowLogoutConfirm : SettingsIntent
@@ -157,6 +174,8 @@ class SettingsViewModel(
             is SettingsIntent.SelectTheme -> selectTheme(intent.theme)
             is SettingsIntent.SelectConsoleShader ->
                 selectConsoleShader(intent.consoleId, intent.shader)
+            is SettingsIntent.SetConsoleSaveStatePolicy ->
+                setConsoleSaveStatePolicy(intent.consoleId, intent.choice)
             is SettingsIntent.SetDeviceOverride ->
                 setDeviceOverride(intent.consoleId, intent.shader)
             is SettingsIntent.UpdateDeviceName -> updateDeviceName(intent.name)
@@ -255,6 +274,7 @@ class SettingsViewModel(
                         selectedShader = prefs.selectedShader,
                         selectedTheme = prefs.selectedTheme,
                         consoleShaders = prefs.consoleShaders,
+                        consoleSaveStatePolicies = prefs.consoleSaveStatePolicies,
                         defaultSecondScreenPage = prefs.defaultSecondScreenPage,
                     )
                 }
@@ -320,6 +340,36 @@ class SettingsViewModel(
         scope.launch(dispatchers.io) {
             preferencesRepository.updatePreferences(defaultSecondScreenPage = page).onFailure {
                 _state.update { it.copy(defaultSecondScreenPage = previous) }
+            }
+        }
+    }
+
+    /**
+     * Upserts (or clears) the per-console save-state opt-out from the
+     * Settings screen. Optimistic update with rollback on API failure
+     * — same pattern as [selectConsoleShader]. The wire format sends
+     * an empty string to clear the row server-side. See #804 phase 4b.
+     */
+    private fun setConsoleSaveStatePolicy(
+        consoleId: String,
+        choice: com.spela.player.domain.model.SaveStateChoice?,
+    ) {
+        val key = consoleId.lowercase()
+        val previous = _state.value.consoleSaveStatePolicies
+        _state.update {
+            it.copy(
+                consoleSaveStatePolicies = if (choice == null) {
+                    it.consoleSaveStatePolicies - key
+                } else {
+                    it.consoleSaveStatePolicies + (key to choice)
+                },
+            )
+        }
+        scope.launch(dispatchers.io) {
+            preferencesRepository.updatePreferences(
+                consoleSaveStatePolicies = mapOf(key to (choice?.apiId ?: "")),
+            ).onFailure {
+                _state.update { it.copy(consoleSaveStatePolicies = previous) }
             }
         }
     }


### PR DESCRIPTION
Closes the discovery loop for the per-console save-state opt-out shipped earlier in #804 phase 4b. Once the user has answered the in-game prompt (or set an override via the future game-detail toggle), they can revisit and clear that choice from the Emulation tab in Settings.

## What renders

For each console where the user has an explicit override:

```
┌─────────────────────────────────────────────────┐
│ Per-console save state overrides                 │
├─────────────────────────────────────────────────┤
│ Nintendo GameCube                                │
│ Save states: Disabled (battery saves only)       │
│                                            [Clear]│
├─────────────────────────────────────────────────┤
│ Sony PlayStation 2                               │
│ Save states: Enabled                             │
│                                            [Clear]│
└─────────────────────────────────────────────────┘
```

The section hides itself entirely when there are no overrides, so the Emulation tab stays uncluttered for the common-case user.

## What this slice doesn't include

**Adding** a new override from Settings is deliberately out of scope. The discovery surface for that is:
- The in-game first-launch prompt (#820, merged) — fires automatically on the first launch of a large-tier console.
- A future game-detail toggle (separate slice) — per-game opt-out for users who want fine control.

Settings is for *managing what already exists*. If a user wants to switch from Disabled to Enabled, they Clear the override → tier default takes over (large tier → AskOnce) → next launch fires the prompt → they pick Enabled. One extra click vs a direct toggle, in exchange for a much simpler Settings UI.

## Implementation

- `SettingsState.consoleSaveStatePolicies: Map<String, SaveStateChoice>` populated from `prefs.consoleSaveStatePolicies` next to the existing `consoleShaders` map.
- `SetConsoleSaveStatePolicy(consoleId, choice?)` intent + handler — same optimistic-update + rollback shape as `selectConsoleShader`. `choice == null` writes `mapOf(key to "")` to the server, which the #817 sanitiser treats as "clear the row".
- `saveStatePoliciesSectionItems` composable in `SettingsSaveStatePoliciesSection.kt`. Sorted by display name for stable rendering across map iterations.

## Tests

The new code path mirrors `selectConsoleShader` verbatim. The wire format is verified end-to-end by:

- `TestUpdatePreferences_ClearConsoleSaveStatePolicy` (server, #817) — empty string sentinel removes the row.
- `EmulationViewModelGameLifecycleTest.acceptSaveStatesForConsoleClearsPromptAndWritesEnabled` (player, #820) — `apiId` round-trip on Accept/Reject/Defer.
- The composable hides itself on empty-map (early return at the top of `saveStatePoliciesSectionItems`).

`SettingsViewModel` has no existing test class today (12 constructor deps to stub). Adding one purely for this intent would balloon the PR; flagged for a separate "add SettingsViewModel test scaffold" if needed.

All 566 player tests pass. Android compile clean.

## Phase order

- ~~Phase 1 — lift 64 MB cap (#806)~~
- ~~Phase 2 — client-side compression (#814 + #815)~~
- ~~Phase 3 — `SaveStatePolicy` tier + seeding (#816)~~
- ~~Phase 4a — server `ConsoleSaveStatePolicy` table + endpoint (#817)~~
- ~~Phase 4b plumbing (#818)~~
- ~~Phase 4b overlay greying (#819)~~
- ~~Phase 4b first-launch prompt (#820)~~
- **Phase 4b Settings entry — this PR**
- Phase 4b game-detail per-game toggle — separate PR
- Phase 5 — slot-primary UX
- Phase 6 — deferred sync

After this merges, phase 4 (opt-out UX) is structurally complete: server data shape, in-game prompt, in-game read-only state, settings discovery. The remaining game-detail toggle is the per-game escape hatch (spec point c) and can ship independently.