### PR TITLE
feat(player): slot-primary save/load UX for medium/large consoles (#804 phase 5)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -95,6 +95,9 @@ sealed interface EmulationIntent {
     data class SaveToSlot(val slot: Int) : EmulationIntent
     /** Load state from the given slot (selects it first, then loads). */
     data class LoadFromSlot(val slot: Int) : EmulationIntent
+    /** Dismiss the slot-primary slot picker modal without saving or
+     *  loading. The user is bailing out of the choice. See #804 phase 5. */
+    data object DismissSlotPicker : EmulationIntent
 
     // Rewind
     data object RewindStep : EmulationIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -4,7 +4,15 @@ import com.spela.player.domain.model.AchievementEvent
 import com.spela.player.domain.model.AchievementProgress
 import com.spela.player.domain.model.BiosMissingFile
 import com.spela.player.domain.model.GameAchievement
+import com.spela.player.domain.model.SaveStatePolicyTier
 import com.spela.player.domain.model.ShaderPreset
+
+/**
+ * Mode of the in-game slot-picker modal that the slot-primary UX
+ * (medium / large console tiers) opens when the user taps Save or
+ * Load on the in-game overlay. See #804 phase 5.
+ */
+enum class SlotPickerMode { Save, Load }
 
 /** Input mode tabs available on the secondary screen controls page. */
 enum class ControlTab(val id: String) {
@@ -87,6 +95,22 @@ data class EmulationState(
      * about in-flight uploads, see #804 phase 4 spec point (d).
      */
     val saveStatesOptedOut: Boolean = false,
+    /**
+     * Save-state size tier of the current game's console (small /
+     * medium / large). Drives slot-primary UX on medium/large tiers
+     * (#804 phase 5): tapping Save opens a slot picker rather than
+     * performing a free-form named save. Small-tier UX is unchanged.
+     * Defaults to small so unknown / unset cases keep the historical
+     * behaviour.
+     */
+    val consoleSaveStatePolicyTier: SaveStatePolicyTier = SaveStatePolicyTier.Small,
+    /**
+     * Non-null when the in-game slot picker modal is open. The user
+     * dismisses it via back / scrim tap, or commits by picking a
+     * slot which triggers SaveToSlot or LoadFromSlot. See #804
+     * phase 5.
+     */
+    val slotPickerMode: SlotPickerMode? = null,
     /**
      * True when the user is launching a large-tier console game for
      * the first time (no override + tier == large → AskOnce). Drives

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameSlotPickerDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameSlotPickerDialog.kt
@@ -1,0 +1,189 @@
+package com.spela.player.presentation.ui.feature.ingame
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.state.SaveSlotInfo
+import com.spela.player.presentation.state.SlotPickerMode
+import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpSecondaryButton
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Slot-primary save/load picker that appears in-game on medium and
+ * large console tiers (#804 phase 5). Replaces the historical
+ * "free-form named manual save" affordance for these tiers because
+ * for ~30+ MB save states the named-saves-unlimited UX silently
+ * blows past the user's storage quota.
+ *
+ * Slot count tracks the tier:
+ *   medium → 10 slots (PSX, N64, NDS-style states)
+ *   large  → 5 slots (GameCube, Wii, PS2, 3DS-style states)
+ *
+ * The picker dismisses on scrim tap / back, on a slot-row tap (the
+ * action commits then closes), or by an explicit Cancel.
+ */
+@Composable
+fun InGameSlotPickerDialog(
+    mode: SlotPickerMode,
+    slotCount: Int,
+    saveSlots: Map<Int, SaveSlotInfo>,
+    onSaveToSlot: (Int) -> Unit,
+    onLoadFromSlot: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val title = when (mode) {
+        SlotPickerMode.Save -> "Save to slot"
+        SlotPickerMode.Load -> "Load from slot"
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SpColor.Scrim)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onDismiss,
+            )
+            .testTag("in-game-slot-picker"),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .clip(RoundedCornerShape(SpSpacing.RadiusXLarge))
+                .background(SpColor.SurfaceElevated)
+                .padding(SpSpacing.XLarge)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = {}, // Prevent click-through to scrim.
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = title,
+                style = SpTypography.HeadlineSmall,
+                color = SpColor.OnBackground,
+            )
+
+            // Slots laid out in rows of 5 so 10-slot (medium) shows
+            // two rows and 5-slot (large) shows one. Compact enough
+            // to fit on the in-game overlay without a scroller.
+            val slots = (1..slotCount).toList()
+            slots.chunked(5).forEach { row ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = SpSpacing.Medium),
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    row.forEach { slot ->
+                        SlotPickerCell(
+                            slot = slot,
+                            slotInfo = saveSlots[slot],
+                            mode = mode,
+                            onClick = {
+                                when (mode) {
+                                    SlotPickerMode.Save -> onSaveToSlot(slot)
+                                    SlotPickerMode.Load -> onLoadFromSlot(slot)
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+
+            // Hint clarifies what tapping a filled slot does in Save
+            // mode — the user might assume Save is destructive only
+            // on selection, not on the slot row itself.
+            Text(
+                text = when (mode) {
+                    SlotPickerMode.Save -> "Tap a slot to save here. Filled slots are overwritten."
+                    SlotPickerMode.Load -> "Tap a filled slot to load."
+                },
+                style = SpTypography.LabelSmall,
+                color = SpColor.OnBackgroundTertiary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(top = SpSpacing.Medium)
+                    .fillMaxWidth(),
+            )
+
+            SpSecondaryButton(
+                text = "Cancel",
+                onClick = onDismiss,
+                modifier = Modifier
+                    .padding(top = SpSpacing.Medium)
+                    .testTag("in-game-slot-picker-cancel"),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SlotPickerCell(
+    slot: Int,
+    slotInfo: SaveSlotInfo?,
+    mode: SlotPickerMode,
+    onClick: () -> Unit,
+) {
+    val filled = slotInfo?.isFilled == true
+    // Load-from-empty is a no-op so we render those cells as inert
+    // — clicking does nothing rather than firing onLoadFromSlot to
+    // produce an error toast.
+    val enabled = mode == SlotPickerMode.Save || filled
+    val background = when {
+        !enabled -> SpColor.Surface
+        filled -> SpColor.Primary
+        else -> SpColor.SurfaceElevated
+    }
+    val labelColor = when {
+        !enabled -> SpColor.OnBackgroundTertiary
+        filled -> SpColor.OnPrimary
+        else -> SpColor.OnBackground
+    }
+    Box(
+        modifier = Modifier
+            .size(64.dp)
+            .clip(RoundedCornerShape(SpSpacing.RadiusMedium))
+            .background(background)
+            .let { if (enabled) it.clickable(onClick = onClick) else it }
+            .testTag("slot-picker-cell-$slot"),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = slot.toString(),
+                style = SpTypography.TitleMedium,
+                color = labelColor,
+            )
+            if (slotInfo?.timestamp != null) {
+                Text(
+                    text = slotInfo.timestamp,
+                    style = SpTypography.LabelSmall,
+                    color = labelColor,
+                )
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameSlotPickerDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameSlotPickerDialog.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.state.SaveSlotInfo
 import com.spela.player.presentation.state.SlotPickerMode
-import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -237,6 +237,26 @@ fun InGameOverlay(
         )
     }
 
+    // Slot-primary save/load picker for medium / large console tiers
+    // (#804 phase 5). Tapping Save or Load on the in-game overlay
+    // sets state.slotPickerMode; this renders the modal in front of
+    // everything else so the user picks a slot rather than performing
+    // a free-form named save.
+    state.slotPickerMode?.let { mode ->
+        val slotCount = when (state.consoleSaveStatePolicyTier) {
+            com.spela.player.domain.model.SaveStatePolicyTier.Large -> 5
+            else -> 10
+        }
+        com.spela.player.presentation.ui.feature.ingame.InGameSlotPickerDialog(
+            mode = mode,
+            slotCount = slotCount,
+            saveSlots = state.saveSlots,
+            onSaveToSlot = { slot -> viewModel.onIntent(EmulationIntent.SaveToSlot(slot)) },
+            onLoadFromSlot = { slot -> viewModel.onIntent(EmulationIntent.LoadFromSlot(slot)) },
+            onDismiss = { viewModel.onIntent(EmulationIntent.DismissSlotPicker) },
+        )
+    }
+
     // Core mismatch dialog
     if (state.showCoreMismatchDialog) {
         CoreMismatchDialog(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -171,11 +171,23 @@ class EmulationViewModel(
             EmulationIntent.ResumeGame -> resumeGame()
             EmulationIntent.StopGame -> stopGame()
             EmulationIntent.SaveState -> {
-                if (checkCoreMismatchBeforeSave("manual")) {
+                // Slot-primary UX: medium / large tiers open a slot
+                // picker rather than performing a free-form named
+                // save (#804 phase 5). Small tier keeps the
+                // historical "Save" → manual save behaviour.
+                if (_state.value.consoleSaveStatePolicyTier != com.spela.player.domain.model.SaveStatePolicyTier.Small) {
+                    _state.update { it.copy(slotPickerMode = com.spela.player.presentation.state.SlotPickerMode.Save) }
+                } else if (checkCoreMismatchBeforeSave("manual")) {
                     saveManager.saveState()
                 }
             }
-            EmulationIntent.LoadState -> saveManager.loadState()
+            EmulationIntent.LoadState -> {
+                if (_state.value.consoleSaveStatePolicyTier != com.spela.player.domain.model.SaveStatePolicyTier.Small) {
+                    _state.update { it.copy(slotPickerMode = com.spela.player.presentation.state.SlotPickerMode.Load) }
+                } else {
+                    saveManager.loadState()
+                }
+            }
             EmulationIntent.AcceptSaveStatesForConsole -> resolveSaveStatePrompt(
                 com.spela.player.domain.model.SaveStateChoice.Enabled,
             )
@@ -272,14 +284,21 @@ class EmulationViewModel(
             EmulationIntent.QuickLoad -> quickLoadFromSlot()
             is EmulationIntent.SelectSlot -> _state.update { it.copy(activeSlot = intent.slot) }
             is EmulationIntent.SaveToSlot -> {
-                _state.update { it.copy(activeSlot = intent.slot) }
+                // Picking a slot from the slot-primary modal closes it
+                // before the save kicks off, so the user sees the
+                // overlay's regular "Saving…" feedback rather than a
+                // stuck modal. See #804 phase 5.
+                _state.update { it.copy(activeSlot = intent.slot, slotPickerMode = null) }
                 if (checkCoreMismatchBeforeSave("slot", intent.slot)) {
                     saveManager.saveToSlot(intent.slot)
                 }
             }
             is EmulationIntent.LoadFromSlot -> {
-                _state.update { it.copy(activeSlot = intent.slot) }
+                _state.update { it.copy(activeSlot = intent.slot, slotPickerMode = null) }
                 saveManager.loadFromSlot(intent.slot)
+            }
+            EmulationIntent.DismissSlotPicker -> {
+                _state.update { it.copy(slotPickerMode = null) }
             }
 
             // Rewind
@@ -760,6 +779,7 @@ class EmulationViewModel(
                             showSaveStatePrompt = askOnce,
                             saveStatePromptConsoleAbbr = if (askOnce) detail.game.consoleId else "",
                             saveStatePromptConsoleName = if (askOnce) detail.game.consoleName else "",
+                            consoleSaveStatePolicyTier = detail.game.consoleSaveStatePolicy,
                         )
                     }
                 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
@@ -3,8 +3,10 @@ package com.spela.player.presentation.viewmodel
 import com.spela.player.presentation.viewmodel.emulation.EmulationViewModelTestBuilder
 import com.spela.player.presentation.viewmodel.emulation.StubGameRepository
 import com.spela.player.domain.model.SaveStateChoice
+import com.spela.player.domain.model.SaveStatePolicyTier
 import com.spela.player.domain.model.ShaderPreset
 import com.spela.player.domain.model.UserPreferences
+import com.spela.player.presentation.state.SlotPickerMode
 import com.spela.player.presentation.intent.EmulationIntent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -243,6 +245,110 @@ class EmulationViewModelGameLifecycleTest {
         builder.advanceTimeBy(100)
         assertFalse(vm.state.value.saveStatesOptedOut)
     }
+
+    // ── Slot-primary UX (#804 phase 5) ──────────────────────────────────
+
+    @Test
+    fun saveIntentOnLargeTierOpensSlotPickerInsteadOfSaving() = runTest {
+        builder.gameRepository = StubGameRepository(
+            consoleId = "gc",
+            consoleSaveStatePolicy = SaveStatePolicyTier.Large,
+        )
+        // Pre-resolve the AskOnce prompt so it doesn't sit on top
+        // and confuse the test.
+        builder.preferencesRepository.preferencesResult = Result.success(
+            UserPreferences(consoleSaveStatePolicies = mapOf("gc" to SaveStateChoice.Enabled)),
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+        assertEquals(SaveStatePolicyTier.Large, vm.state.value.consoleSaveStatePolicyTier)
+        assertNull(vm.state.value.slotPickerMode)
+
+        vm.onIntent(EmulationIntent.SaveState)
+        builder.advanceTimeBy(100)
+        assertEquals(SlotPickerMode.Save, vm.state.value.slotPickerMode)
+    }
+
+    @Test
+    fun loadIntentOnMediumTierOpensSlotPicker() = runTest {
+        builder.gameRepository = StubGameRepository(
+            consoleId = "psx",
+            consoleSaveStatePolicy = SaveStatePolicyTier.Medium,
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+
+        vm.onIntent(EmulationIntent.LoadState)
+        builder.advanceTimeBy(100)
+        assertEquals(SlotPickerMode.Load, vm.state.value.slotPickerMode)
+    }
+
+    @Test
+    fun saveIntentOnSmallTierKeepsHistoricalNamedSaveBehaviour() = runTest {
+        // Phase 5 must not regress the small-tier UX. Tapping Save on
+        // an NES game still calls SaveManager.saveState() rather than
+        // opening a picker — the picker is the right answer for ~30 MB
+        // states, the wrong answer for ~30 KB ones.
+        builder.gameRepository = StubGameRepository(
+            consoleId = "nes",
+            consoleSaveStatePolicy = SaveStatePolicyTier.Small,
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+
+        vm.onIntent(EmulationIntent.SaveState)
+        builder.advanceTimeBy(100)
+        assertNull(vm.state.value.slotPickerMode)
+    }
+
+    @Test
+    fun pickingSlotFromSavePickerCommitsAndDismisses() = runTest {
+        builder.gameRepository = StubGameRepository(
+            consoleId = "gc",
+            consoleSaveStatePolicy = SaveStatePolicyTier.Large,
+        )
+        builder.preferencesRepository.preferencesResult = Result.success(
+            UserPreferences(consoleSaveStatePolicies = mapOf("gc" to SaveStateChoice.Enabled)),
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+        vm.onIntent(EmulationIntent.SaveState)
+        builder.advanceTimeBy(100)
+        assertEquals(SlotPickerMode.Save, vm.state.value.slotPickerMode)
+
+        vm.onIntent(EmulationIntent.SaveToSlot(3))
+        builder.advanceTimeBy(100)
+        // Picker closes immediately so the user sees the regular
+        // "Saving…" feedback rather than a stuck modal.
+        assertNull(vm.state.value.slotPickerMode)
+        assertEquals(3, vm.state.value.activeSlot)
+    }
+
+    @Test
+    fun dismissSlotPickerClosesWithoutSaving() = runTest {
+        builder.gameRepository = StubGameRepository(
+            consoleId = "gc",
+            consoleSaveStatePolicy = SaveStatePolicyTier.Large,
+        )
+        builder.preferencesRepository.preferencesResult = Result.success(
+            UserPreferences(consoleSaveStatePolicies = mapOf("gc" to SaveStateChoice.Enabled)),
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+        vm.onIntent(EmulationIntent.SaveState)
+        builder.advanceTimeBy(100)
+
+        vm.onIntent(EmulationIntent.DismissSlotPicker)
+        builder.advanceTimeBy(100)
+        assertNull(vm.state.value.slotPickerMode)
+    }
+
+    // ────────────────────────────────────────────────────────────────────
 
     @Test
     fun startGameResolvesShader() = runTest {


### PR DESCRIPTION
Closes part of #804 (phase 5 — slot-primary UX for medium/large console tiers).

## Summary

When the user taps **Save** or **Load** on the in-game overlay, medium and large console tiers open a slot-picker modal rather than performing a free-form named save. Small tier UX is unchanged.

| Tier | Examples | Slots | Save tap | Load tap |
|---|---|---|---|---|
| small | NES, SNES, GBA, NEOGEO, … | n/a | named save (unchanged) | most-recent (unchanged) |
| medium | PSX, N64, NDS, Saturn, DC, PSP, 3DS | 10 | open picker | open picker |
| large | GameCube, Wii, PS2 | 5 | open picker | open picker |

Slot count tracks the tier — fewer slots for larger states, because each slot eats a bigger chunk of the user's quota (the storage-tier reasoning that motivated the whole #804 rethink).

## What it looks like

```
                ┌──────────────────────────────────┐
                │       Save to slot               │
                │                                  │
                │  [1]  [2]  [3]  [4]  [5]         │
                │                                  │
                │ Tap a slot to save here.         │
                │ Filled slots are overwritten.    │
                │                                  │
                │             [Cancel]             │
                └──────────────────────────────────┘
```

Filled slots are highlighted (Primary color) and show their timestamp. In Load mode, empty slots are inert — tapping them does nothing rather than firing a "no save here" error toast.

## Implementation

- `EmulationState.consoleSaveStatePolicyTier` populated from `detail.game.consoleSaveStatePolicy` at game-launch time. Added in this PR rather than #820 because that slice only needed the resolver's `AskOnce` decision and didn't expose the tier itself.
- `EmulationState.slotPickerMode: SlotPickerMode? = null` — null means the picker is closed.
- `EmulationIntent.SaveState` / `LoadState` route through the tier: `Small` → behaves exactly as before (calls `SaveManager.saveState` / `loadState`); medium / large → sets `slotPickerMode`. The branch is at the intent layer rather than inside `SaveManager` because the decision is purely UX, not save-mechanics.
- `EmulationIntent.SaveToSlot` / `LoadFromSlot` already exist (used by the secondary screen). The handlers now dismiss the picker on commit so the user sees the regular `"Saving…"` inline feedback rather than a stuck modal.
- New `EmulationIntent.DismissSlotPicker` for back / scrim / Cancel.
- New `InGameSlotPickerDialog` composable — scrim + centered card with slot cells laid out in rows of 5. Wired into `InGameOverlay.kt` before the core-mismatch dialog so the slot pick happens first if both surfaces would compete.

## Tests (571 desktop, 0 failures)

Five new `EmulationViewModelGameLifecycleTest` cases:
1. **Save on Large → opens picker** (no save kicked off).
2. **Load on Medium → opens picker** (no load kicked off).
3. **Save on Small → keeps historical named-save behaviour** (no picker).
4. **`SaveToSlot` dismisses on commit** (picker closes immediately).
5. **`DismissSlotPicker` closes without saving**.

Android compile clean.

## Out of scope

- The spec's "named save as secondary affordance for medium tier" sub-bullet — the slot-primary flow is the high-value piece and ships standalone. A small "Save with custom name…" link in the picker can land later if users ask.
- A "manage slots" surface for renaming / deleting individual slots from the picker — already exists on the secondary-screen save-slots page; reusing that for the in-game overlay is a separate UX call.

## Phase order

- ~~Phase 1 — lift 64 MB cap (#806)~~
- ~~Phase 2 — client-side compression (#814 + #815)~~
- ~~Phase 3 — `SaveStatePolicy` tier + seeding (#816)~~
- ~~Phase 4a — server `ConsoleSaveStatePolicy` table + endpoint (#817)~~
- ~~Phase 4b plumbing (#818) + overlay greying (#819) + first-launch prompt (#820) + Settings entry (#821)~~
- **Phase 5 — slot-primary UX — this PR**
- Phase 4b game-detail per-game toggle — separate PR (escape hatch for users who want fine control)
- Phase 6 — deferred / opportunistic sync