### PR TITLE
feat(player): pending-upload queue infrastructure (#804 phase 6)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/local/ExpectedSchema.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/local/ExpectedSchema.kt
@@ -30,5 +30,10 @@ object ExpectedSchema {
         ),
         "DeviceSettingEntity" to setOf("key", "value"),
         "CheatEntity" to setOf("id", "game_id", "cheat_index", "description", "code", "enabled", "cached_at"),
+        "PendingSaveUploadEntity" to setOf(
+            "id", "session_id", "kind", "slot", "name", "core_name", "compression",
+            "file_path", "file_size", "screenshot_path", "created_at",
+            "retry_count", "last_error",
+        ),
     )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PendingSaveUploadRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PendingSaveUploadRepositoryImpl.kt
@@ -1,0 +1,85 @@
+package com.spela.player.data.repository
+
+import com.spela.player.PendingSaveUploadEntity
+import com.spela.player.data.local.SpelaDatabase
+import com.spela.player.domain.model.PendingSaveUpload
+import com.spela.player.domain.model.PendingUploadKind
+import com.spela.player.domain.repository.PendingSaveUploadRepository
+
+/**
+ * SQLDelight-backed implementation of the pending-upload queue.
+ * Plain CRUD — no policy, no upload logic. The drain worker (a
+ * separate slice of #804 phase 6) is what actually pushes rows to
+ * the server.
+ */
+class PendingSaveUploadRepositoryImpl(
+    database: SpelaDatabase,
+) : PendingSaveUploadRepository {
+
+    private val queries = database.spelaDatabaseQueries
+
+    override suspend fun enqueue(
+        sessionId: String,
+        kind: PendingUploadKind,
+        slot: Int?,
+        name: String,
+        coreName: String,
+        compression: String,
+        filePath: String,
+        fileSize: Long,
+        screenshotPath: String?,
+        createdAt: Long,
+    ): Long {
+        queries.enqueuePendingSaveUpload(
+            session_id = sessionId,
+            kind = kind.apiId,
+            slot = slot?.toLong(),
+            name = name,
+            core_name = coreName,
+            compression = compression,
+            file_path = filePath,
+            file_size = fileSize,
+            screenshot_path = screenshotPath,
+            created_at = createdAt,
+        )
+        return queries.lastInsertedPendingSaveUploadId().executeAsOne()
+    }
+
+    override suspend fun getAll(): List<PendingSaveUpload> =
+        queries.getAllPendingSaveUploads().executeAsList().map { it.toDomain() }
+
+    override suspend fun getForSession(sessionId: String): List<PendingSaveUpload> =
+        queries.getPendingSaveUploadsForSession(sessionId)
+            .executeAsList()
+            .map { it.toDomain() }
+
+    override suspend fun getById(id: Long): PendingSaveUpload? =
+        queries.getPendingSaveUploadById(id).executeAsOneOrNull()?.toDomain()
+
+    override suspend fun count(): Long =
+        queries.countPendingSaveUploads().executeAsOne()
+
+    override suspend fun delete(id: Long) {
+        queries.deletePendingSaveUpload(id)
+    }
+
+    override suspend fun markRetry(id: Long, lastError: String?) {
+        queries.incrementPendingSaveUploadRetry(last_error = lastError, id = id)
+    }
+}
+
+private fun PendingSaveUploadEntity.toDomain(): PendingSaveUpload = PendingSaveUpload(
+    id = id,
+    sessionId = session_id,
+    kind = PendingUploadKind.fromApiId(kind),
+    slot = slot?.toInt(),
+    name = name,
+    coreName = core_name,
+    compression = compression,
+    filePath = file_path,
+    fileSize = file_size,
+    screenshotPath = screenshot_path,
+    createdAt = created_at,
+    retryCount = retry_count.toInt(),
+    lastError = last_error,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -67,6 +67,7 @@ val commonModule = module {
     single<ChallengeRepository> { ChallengeRepositoryImpl(get()) }
     single<GameStatsRepository> { GameStatsRepositoryImpl(get()) }
     single<CheatRepository> { CheatRepositoryImpl(get(), get()) }
+    single<PendingSaveUploadRepository> { PendingSaveUploadRepositoryImpl(get()) }
     single<SessionRepository> { SessionRepositoryImpl(get(), get()) }
     single<ExploreRepository> { ExploreRepositoryImpl(get()) }
     single<SearchRepository> { SearchRepositoryImpl(get(), get()) }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/PendingSaveUpload.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/PendingSaveUpload.kt
@@ -1,0 +1,44 @@
+package com.spela.player.domain.model
+
+/**
+ * One save staged on disk that has not yet been uploaded to the
+ * server. Phase 6 of #804 — the user no longer waits for a network
+ * round-trip on every Save tap; the queue runs opportunistically
+ * (game exit, app pause, network reconnect).
+ *
+ * Survives an app kill: rows live in SQLDelight so a save+force-quit
+ * sequence is replayed on next launch rather than dropped.
+ */
+data class PendingSaveUpload(
+    val id: Long,
+    val sessionId: String,
+    val kind: PendingUploadKind,
+    /** Slot number when [kind] is [PendingUploadKind.Slot]; null otherwise. */
+    val slot: Int?,
+    /** Display name for [PendingUploadKind.Manual] saves; ignored for auto/slot. */
+    val name: String,
+    val coreName: String,
+    /** Codec applied to the bytes at [filePath] — `""` raw or `"gzip"`. */
+    val compression: String,
+    val filePath: String,
+    val fileSize: Long,
+    /** Absolute path to a PNG screenshot file, or null when none was captured. */
+    val screenshotPath: String?,
+    /** Epoch milliseconds when the save was staged. Used for FIFO ordering. */
+    val createdAt: Long,
+    val retryCount: Int,
+    /** Most recent upload error message, when retry_count > 0. */
+    val lastError: String?,
+)
+
+/** Categorises a pending upload so the worker calls the right server endpoint. */
+enum class PendingUploadKind(val apiId: String) {
+    Manual("manual"),
+    Auto("auto"),
+    Slot("slot");
+
+    companion object {
+        fun fromApiId(apiId: String?): PendingUploadKind =
+            entries.find { it.apiId == apiId } ?: Manual
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/PendingSaveUploadRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/PendingSaveUploadRepository.kt
@@ -1,0 +1,66 @@
+package com.spela.player.domain.repository
+
+import com.spela.player.domain.model.PendingSaveUpload
+import com.spela.player.domain.model.PendingUploadKind
+
+/**
+ * Persistent FIFO queue of save uploads that have been staged to
+ * disk but not yet sent to the server. The implementation is
+ * SQLDelight-backed so the queue survives an app kill — a save
+ * followed by a force-quit replays on the next launch rather than
+ * being silently dropped. See #804 phase 6.
+ *
+ * The repository is the data layer only — it does not know how to
+ * upload. The drain worker (a separate slice) reads from here, calls
+ * the appropriate session endpoint, and either deletes the row on
+ * success or increments [PendingSaveUpload.retryCount] on failure.
+ */
+interface PendingSaveUploadRepository {
+    /**
+     * Enqueue a save for later upload. Returns the row's auto-
+     * incremented id so callers can correlate UI feedback (e.g.
+     * "save 17 syncing…") with the persistent row.
+     *
+     * The caller is responsible for the file lifecycle at
+     * [filePath] — rows in the queue point to files the SaveManager
+     * has already staged via the existing #798 staging fast-path.
+     */
+    suspend fun enqueue(
+        sessionId: String,
+        kind: PendingUploadKind,
+        slot: Int?,
+        name: String,
+        coreName: String,
+        compression: String,
+        filePath: String,
+        fileSize: Long,
+        screenshotPath: String?,
+        createdAt: Long,
+    ): Long
+
+    /** All pending uploads in FIFO order (created_at ASC, id ASC). */
+    suspend fun getAll(): List<PendingSaveUpload>
+
+    /** Pending uploads scoped to a single session. */
+    suspend fun getForSession(sessionId: String): List<PendingSaveUpload>
+
+    /** Single row by id; null when the row has already drained. */
+    suspend fun getById(id: Long): PendingSaveUpload?
+
+    /** Total number of rows currently queued. */
+    suspend fun count(): Long
+
+    /**
+     * Remove a row after a successful upload. The caller is responsible
+     * for deleting the on-disk file at [PendingSaveUpload.filePath]
+     * (this method does not touch the filesystem).
+     */
+    suspend fun delete(id: Long)
+
+    /**
+     * Bump [PendingSaveUpload.retryCount] and record [lastError] on a
+     * failed upload attempt. The row stays in the queue so the drain
+     * worker can retry on the next opportunity.
+     */
+    suspend fun markRetry(id: Long, lastError: String?)
+}

--- a/player/shared/src/commonMain/sqldelight/com/spela/player/SpelaDatabase.sq
+++ b/player/shared/src/commonMain/sqldelight/com/spela/player/SpelaDatabase.sq
@@ -311,3 +311,66 @@ UPDATE CheatEntity SET enabled = ? WHERE game_id = ?;
 
 deleteGameCheats:
 DELETE FROM CheatEntity WHERE game_id = ?;
+
+-- Pending save-state uploads (#804 phase 6 deferred sync).
+-- Each row tracks a save that has been staged to disk but not yet
+-- uploaded to the server. Uploads happen opportunistically (game
+-- exit, app pause, network reconnect) instead of blocking the user
+-- on every Save tap. Surviving an app kill matters: if the user
+-- saves and force-quits before the upload completes, we replay on
+-- next launch.
+--
+--   kind: "manual" | "auto" | "slot"
+--   slot: NULL when kind != "slot"
+--   compression: "" or "gzip"
+--   screenshot_path: NULL when no screenshot was captured
+CREATE TABLE PendingSaveUploadEntity (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    slot INTEGER,
+    name TEXT NOT NULL DEFAULT '',
+    core_name TEXT NOT NULL DEFAULT '',
+    compression TEXT NOT NULL DEFAULT '',
+    file_path TEXT NOT NULL,
+    file_size INTEGER NOT NULL,
+    screenshot_path TEXT,
+    created_at INTEGER NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT
+);
+
+CREATE INDEX pending_save_upload_session_idx
+    ON PendingSaveUploadEntity(session_id);
+
+enqueuePendingSaveUpload:
+INSERT INTO PendingSaveUploadEntity(
+    session_id, kind, slot, name, core_name, compression,
+    file_path, file_size, screenshot_path, created_at,
+    retry_count, last_error
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL);
+
+lastInsertedPendingSaveUploadId:
+SELECT last_insert_rowid();
+
+getAllPendingSaveUploads:
+SELECT * FROM PendingSaveUploadEntity ORDER BY created_at ASC, id ASC;
+
+getPendingSaveUploadsForSession:
+SELECT * FROM PendingSaveUploadEntity WHERE session_id = ?
+ORDER BY created_at ASC, id ASC;
+
+getPendingSaveUploadById:
+SELECT * FROM PendingSaveUploadEntity WHERE id = ?;
+
+countPendingSaveUploads:
+SELECT COUNT(*) FROM PendingSaveUploadEntity;
+
+deletePendingSaveUpload:
+DELETE FROM PendingSaveUploadEntity WHERE id = ?;
+
+incrementPendingSaveUploadRetry:
+UPDATE PendingSaveUploadEntity
+SET retry_count = retry_count + 1, last_error = ?
+WHERE id = ?;

--- a/player/shared/src/commonMain/sqldelight/com/spela/player/migrations/2.sqm
+++ b/player/shared/src/commonMain/sqldelight/com/spela/player/migrations/2.sqm
@@ -1,0 +1,20 @@
+-- Migration from schema version 2 to 3: add PendingSaveUploadEntity
+-- table for the deferred-upload queue (#804 phase 6).
+CREATE TABLE PendingSaveUploadEntity (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    slot INTEGER,
+    name TEXT NOT NULL DEFAULT '',
+    core_name TEXT NOT NULL DEFAULT '',
+    compression TEXT NOT NULL DEFAULT '',
+    file_path TEXT NOT NULL,
+    file_size INTEGER NOT NULL,
+    screenshot_path TEXT,
+    created_at INTEGER NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT
+);
+
+CREATE INDEX pending_save_upload_session_idx
+    ON PendingSaveUploadEntity(session_id);

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/PendingSaveUploadRepositoryImplTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/PendingSaveUploadRepositoryImplTest.kt
@@ -1,0 +1,158 @@
+package com.spela.player.data.repository
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.spela.player.data.local.SpelaDatabase
+import com.spela.player.domain.model.PendingUploadKind
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit-tests the SQLDelight-backed pending-upload queue (#804 phase 6).
+ * Pins the contract the future drain worker hangs off:
+ *
+ *   - FIFO ordering across enqueue / getAll
+ *   - per-session scoping
+ *   - retry counter + last_error increment
+ *   - delete on success
+ *   - persistence across "process restart" (reopening the same DB)
+ *
+ * The queue is deliberately data-only; the upload side lives in a
+ * later slice, so these tests don't talk to the network.
+ */
+class PendingSaveUploadRepositoryImplTest {
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var database: SpelaDatabase
+    private lateinit var repo: PendingSaveUploadRepositoryImpl
+
+    @BeforeTest
+    fun setup() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        SpelaDatabase.Schema.create(driver)
+        database = SpelaDatabase(driver)
+        repo = PendingSaveUploadRepositoryImpl(database)
+    }
+
+    @Test
+    fun enqueueAssignsAutoIncrementedIdAndPersistsAllFields() = runTest {
+        val id = repo.enqueue(
+            sessionId = "session-1",
+            kind = PendingUploadKind.Manual,
+            slot = null,
+            name = "Boss attempt 17",
+            coreName = "dolphin",
+            compression = "gzip",
+            filePath = "/tmp/.tmp-save-1",
+            fileSize = 75_000_000L,
+            screenshotPath = "/tmp/screenshot-1.png",
+            createdAt = 1_000L,
+        )
+        assertTrue(id > 0L)
+
+        val row = repo.getById(id)
+        assertNotNull(row)
+        assertEquals("session-1", row.sessionId)
+        assertEquals(PendingUploadKind.Manual, row.kind)
+        assertNull(row.slot)
+        assertEquals("Boss attempt 17", row.name)
+        assertEquals("dolphin", row.coreName)
+        assertEquals("gzip", row.compression)
+        assertEquals("/tmp/.tmp-save-1", row.filePath)
+        assertEquals(75_000_000L, row.fileSize)
+        assertEquals("/tmp/screenshot-1.png", row.screenshotPath)
+        assertEquals(1_000L, row.createdAt)
+        assertEquals(0, row.retryCount)
+        assertNull(row.lastError)
+    }
+
+    @Test
+    fun getAllReturnsRowsInFifoOrder() = runTest {
+        // FIFO matters because the drain worker uploads in order — a
+        // user who saves twice in a row expects their second save to
+        // overwrite the first one server-side, which only happens if
+        // the queue serialises properly.
+        val first = repo.enqueueDefault(sessionId = "s", createdAt = 1_000L)
+        val second = repo.enqueueDefault(sessionId = "s", createdAt = 2_000L)
+        val third = repo.enqueueDefault(sessionId = "s", createdAt = 3_000L)
+
+        val all = repo.getAll().map { it.id }
+        assertEquals(listOf(first, second, third), all)
+    }
+
+    @Test
+    fun getForSessionScopesByConsole() = runTest {
+        val a1 = repo.enqueueDefault(sessionId = "a", createdAt = 1L)
+        val b1 = repo.enqueueDefault(sessionId = "b", createdAt = 2L)
+        val a2 = repo.enqueueDefault(sessionId = "a", createdAt = 3L)
+
+        val a = repo.getForSession("a").map { it.id }
+        assertEquals(listOf(a1, a2), a)
+        val b = repo.getForSession("b").map { it.id }
+        assertEquals(listOf(b1), b)
+    }
+
+    @Test
+    fun deleteRemovesRowAndDecrementsCount() = runTest {
+        val id = repo.enqueueDefault(sessionId = "s", createdAt = 1L)
+        assertEquals(1L, repo.count())
+
+        repo.delete(id)
+
+        assertEquals(0L, repo.count())
+        assertNull(repo.getById(id))
+    }
+
+    @Test
+    fun markRetryIncrementsCounterAndStoresLastError() = runTest {
+        val id = repo.enqueueDefault(sessionId = "s", createdAt = 1L)
+        assertEquals(0, repo.getById(id)!!.retryCount)
+
+        repo.markRetry(id, "HTTP 503")
+        repo.markRetry(id, "timeout")
+
+        val row = repo.getById(id)!!
+        assertEquals(2, row.retryCount)
+        assertEquals("timeout", row.lastError, "last_error stores the latest")
+    }
+
+    @Test
+    fun queueSurvivesAcrossDatabaseReopen() = runTest {
+        // Simulates an app kill: we enqueue, drop the DB handle,
+        // re-create it from the same on-disk file (here: the same
+        // in-memory connection), and verify the row still exists.
+        // SQLDelight migrations + the queue table being durable is
+        // what fixes the silent-drop case the spec calls out.
+        val id = repo.enqueueDefault(sessionId = "s", createdAt = 1L)
+
+        // Rebuild repo against the same database — equivalent to a
+        // fresh app start with the same persistent DB file in
+        // production. JDBC IN_MEMORY survives only as long as the
+        // driver is open, so we keep the driver but reopen the
+        // SpelaDatabase wrapper.
+        val rebuilt = PendingSaveUploadRepositoryImpl(SpelaDatabase(driver))
+        val row = rebuilt.getById(id)
+        assertNotNull(row)
+        assertEquals(id, row.id)
+    }
+
+    private suspend fun PendingSaveUploadRepositoryImpl.enqueueDefault(
+        sessionId: String,
+        createdAt: Long,
+    ): Long = enqueue(
+        sessionId = sessionId,
+        kind = PendingUploadKind.Manual,
+        slot = null,
+        name = "x",
+        coreName = "core",
+        compression = "",
+        filePath = "/tmp/$sessionId-$createdAt",
+        fileSize = 1024L,
+        screenshotPath = null,
+        createdAt = createdAt,
+    )
+}


### PR DESCRIPTION
First slice of phase 6 (deferred / opportunistic sync). Adds the persistent FIFO queue the future drain worker reads from.

## What this PR ships

A SQLDelight-backed pending-upload queue. **No behaviour change yet** — nothing enqueues to it. This is intentionally infrastructure-only so each subsequent slice is small and reviewable.

## What lands in follow-ups

| Slice | What |
|---|---|
| 2 (next PR) | \`SaveManager\` enqueues instead of uploading inline. UI shows "Saved locally · syncing". |
| 3 | Drain worker triggered by game exit / app pause / network reconnect. UI flips to "Synced ✓" when queue empties. |
| 4 | Polish — visible queue count in the in-game overlay, retry/error UX. |

Surviving an app kill matters: rows live in SQLDelight so a save+force-quit sequence is replayed on next launch rather than silently dropped — the exact failure mode the umbrella issue calls out.

## Schema

```sql
CREATE TABLE PendingSaveUploadEntity (
    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
    session_id TEXT NOT NULL,
    kind TEXT NOT NULL,                 -- "manual" | "auto" | "slot"
    slot INTEGER,                       -- NULL when kind != "slot"
    name TEXT NOT NULL DEFAULT '',
    core_name TEXT NOT NULL DEFAULT '',
    compression TEXT NOT NULL DEFAULT '',
    file_path TEXT NOT NULL,            -- staged save bytes (#798 fast-path)
    file_size INTEGER NOT NULL,
    screenshot_path TEXT,
    created_at INTEGER NOT NULL,
    retry_count INTEGER NOT NULL DEFAULT 0,
    last_error TEXT
);
CREATE INDEX pending_save_upload_session_idx ON PendingSaveUploadEntity(session_id);
```

Migration \`2.sqm\` + \`ExpectedSchema\` entry so existing databases upgrade cleanly on next launch.

## API

```kotlin
interface PendingSaveUploadRepository {
    suspend fun enqueue(...): Long
    suspend fun getAll(): List<PendingSaveUpload>
    suspend fun getForSession(sessionId: String): List<PendingSaveUpload>
    suspend fun getById(id: Long): PendingSaveUpload?
    suspend fun count(): Long
    suspend fun delete(id: Long)
    suspend fun markRetry(id: Long, lastError: String?)
}
```

Plain CRUD. No upload logic — that's slice 3.

## Tests (6 new, 577 desktop total)

- enqueue assigns auto-incremented id and persists every field round-trip
- getAll returns rows in FIFO order (matters because the worker uploads in order — two consecutive saves expect the second to overwrite the first server-side)
- getForSession scopes by session_id
- delete removes the row + decrements count
- markRetry increments retry_count and stores the latest last_error
- queue survives a database "reopen" — simulates app restart, verifies durability

Player desktop suite green. Android compile clean. detekt clean.

## Phase order

- ~~Phase 1 — lift 64 MB cap (#806)~~
- ~~Phase 2 — client-side compression (#814 + #815)~~
- ~~Phase 3 — \`SaveStatePolicy\` tier + seeding (#816)~~
- ~~Phase 4a — server endpoint (#817)~~
- ~~Phase 4b plumbing (#818) + overlay greying (#819) + first-launch prompt (#820) + Settings entry (#821)~~
- ~~Phase 5 — slot-primary UX (#822)~~
- **Phase 6 slice 1 (queue infrastructure) — this PR**
- Phase 6 slice 2 — \`SaveManager\` enqueues instead of uploads inline
- Phase 6 slice 3 — drain worker
- Phase 6 slice 4 — UX polish (queue count badge, retry messaging)