### PR TITLE
feat(player): SaveManager enqueues for deferred upload (#804 phase 6)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -183,6 +183,7 @@ val commonModule = module {
             scope = get(),
             sessionRepository = get(),
             fileStorage = get(),
+            pendingUploadRepository = get(),
         )
     }
     single {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -138,6 +138,14 @@ data class EmulationState(
      *  Auto-cleared by SaveManager ~1.5 s after the upload settles. */
     val saveStateJustSucceeded: Boolean = false,
     /**
+     * True when one or more save uploads are sitting in the persistent
+     * pending-upload queue (#804 phase 6). The Save button shows
+     * "Saved locally · syncing" while this is set so the user knows
+     * their save is captured even though the upload hasn't completed
+     * yet. SaveManager flips this off when the queue empties.
+     */
+    val hasPendingUploads: Boolean = false,
+    /**
      * Non-blocking warning shown when the session's pinned core
      * version (see `GameSession.pinnedCoreSha256`) is no longer
      * available on the server (pruned from history retention) and

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
@@ -277,6 +277,7 @@ internal fun InGameOverlayPanel(
                             isSaveInProgress = state.isSaveInProgress,
                             saveStateError = state.saveStateError,
                             saveStateJustSucceeded = state.saveStateJustSucceeded,
+                            hasPendingUploads = state.hasPendingUploads,
                             onSave = { viewModel.onIntent(EmulationIntent.SaveState) },
                             onLoad = { viewModel.onIntent(EmulationIntent.LoadState) },
                             onScreenshot = { viewModel.onIntent(EmulationIntent.TakeScreenshot) },
@@ -386,6 +387,7 @@ internal fun RowScope.OverlayActionButtons(
     isSaveInProgress: Boolean = false,
     saveStateError: String? = null,
     saveStateJustSucceeded: Boolean = false,
+    hasPendingUploads: Boolean = false,
     onSave: () -> Unit,
     onLoad: () -> Unit,
     onScreenshot: () -> Unit,
@@ -416,10 +418,19 @@ internal fun RowScope.OverlayActionButtons(
                 saveLabel = "Saving…"
                 saveIcon = Icons.Filled.Sync
             }
+            hasPendingUploads -> {
+                // The bytes are on disk + queued; the upload runs in
+                // the background. Phase 6 of #804 — the user isn't
+                // blocked on the network round-trip. The label flips
+                // to "Synced" via saveStateJustSucceeded once the
+                // queue empties.
+                saveLabel = "Saved locally · syncing"
+                saveIcon = Icons.Filled.Sync
+            }
             saveStateJustSucceeded -> {
                 // "Synced" rather than just "Saved" — communicates that
                 // the bytes reached the server, not just local. SaveManager
-                // only flips this flag after the upload's onSuccess fires,
+                // only flips this flag after the upload drain settles,
                 // so the label is accurate. (#803)
                 saveLabel = "Synced"
                 saveIcon = Icons.Filled.CloudDone

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -89,6 +89,16 @@ class SaveManager(
     private val scope: CoroutineScope,
     private val sessionRepository: SessionRepository,
     private val fileStorage: FileStorage,
+    /**
+     * Persistent FIFO queue used by the deferred-sync path (#804
+     * phase 6). Manual save taps stage to disk, enqueue here, and
+     * return immediately — the user isn't blocked on the network
+     * round-trip. The drain runs opportunistically right after each
+     * enqueue (slice 2); future slices add explicit triggers (game
+     * exit, app pause, network reconnect).
+     */
+    private val pendingUploadRepository:
+        com.spela.player.domain.repository.PendingSaveUploadRepository,
 ) {
     /** The libretro core name used for the current emulation session. */
     var currentCoreName: String = ""
@@ -464,6 +474,16 @@ class SaveManager(
         const val GZIP_MIN_BYTES: Long = 32 * 1024L
     }
 
+    /**
+     * In-memory screenshot bytes keyed by pending-upload row id. We
+     * could persist screenshots to disk for full app-kill durability,
+     * but for slice 2 the screenshot is a polish detail — losing it
+     * after an app kill leaves the save bytes intact, just without a
+     * thumbnail on the saves list. Slice 4 will stage screenshots
+     * properly. See #804 phase 6.
+     */
+    private val pendingScreenshots = mutableMapOf<Long, ByteArray>()
+
     fun saveState() {
         if (_state.value.isChallengeMode) return
         if (_state.value.isHardcoreMode) {
@@ -474,11 +494,12 @@ class SaveManager(
             emitRehearsalBlocked(RehearsalSaveKind.Manual)
             return
         }
-        // Inline button feedback: tap → "Saving…" immediately, even
-        // if the user dismisses the overlay before the toast renders.
-        // Clears any stale error from a prior failed attempt so the
-        // button doesn't read "Save failed" while a fresh save is
-        // in flight (#803).
+        // Inline button feedback: tap → "Saving…" immediately so the
+        // user knows the tap registered. The save flips to
+        // "Saved locally · syncing" the moment the bytes are on disk
+        // and queued (~milliseconds), and to idle once the upload
+        // drain finishes. Clears any stale error from a prior failed
+        // attempt. See #803 + #804 phase 6.
         _state.update {
             it.copy(
                 isSaveInProgress = true,
@@ -487,12 +508,6 @@ class SaveManager(
             )
         }
         scope.launch(dispatchers.io) {
-            // Wrap staging in try/catch so a thrown exception still
-            // clears isSaveInProgress — otherwise the button is stuck
-            // on "Saving…" for the rest of the session. The inner
-            // runCatching in stageSaveToTempFile only covers the
-            // file write, not the controller / FileStorage calls
-            // around it.
             val staged = try {
                 stageSaveToTempFile() ?: run {
                     _state.update { it.copy(isSaveInProgress = false) }
@@ -507,64 +522,145 @@ class SaveManager(
                 }
                 return@launch
             }
-            try {
-                val sessionId = currentSessionId
-                if (sessionId != null) {
-                    val screenshot = screenshotCapture?.captureScreenshot()
-                    sessionRepository.uploadSessionSaveFromFile(
-                        sessionId, "Manual Save", staged.path, staged.size, screenshot, currentCoreName, staged.compression,
-                    ).fold(
-                        onSuccess = {
-                            withContext(dispatchers.main) {
-                                _state.update {
-                                    it.copy(
-                                        statusMessage = "State saved",
-                                        isSaveInProgress = false,
-                                        saveStateJustSucceeded = true,
-                                        secondaryToast = SecondaryToastData(
-                                            message = "Saved to Slot ${it.activeSlot}",
-                                            type = SecondaryToastType.SAVE,
-                                        ),
-                                    )
-                                }
-                            }
-                            refreshSaveSlots()
-                            // Hold the "Saved" checkmark briefly so the
-                            // user catches it even if the toast is
-                            // dismissed first, then drop the flag so
-                            // the button returns to idle. (#803)
-                            scope.launch(dispatchers.io) {
-                                kotlinx.coroutines.delay(SAVE_SUCCESS_FLASH_MS)
-                                withContext(dispatchers.main) {
-                                    _state.update { it.copy(saveStateJustSucceeded = false) }
-                                }
-                            }
-                        },
-                        onFailure = { error ->
-                            withContext(dispatchers.main) {
-                                // saveStateError is the canonical surface for
-                                // manual-save failures (sticky inline label on
-                                // the Save button). Don't *also* fire the
-                                // top-of-screen error toast — duplicate UX.
-                                _state.update {
-                                    it.copy(
-                                        isSaveInProgress = false,
-                                        saveStateError = "Failed to save: ${error.message}",
-                                    )
-                                }
-                            }
-                        },
-                    )
-                } else {
-                    // No session — save state was serialized by the controller
-                    withContext(dispatchers.main) {
-                        _state.update { it.copy(statusMessage = "State saved", isSaveInProgress = false) }
-                    }
-                }
-            } finally {
+            val sessionId = currentSessionId
+            if (sessionId == null) {
+                // No session — save state was serialized by the
+                // controller but we have nothing to upload. Treat as
+                // immediately complete; the staged temp file is
+                // unused.
                 staged.cleanup()
+                withContext(dispatchers.main) {
+                    _state.update { it.copy(statusMessage = "State saved", isSaveInProgress = false) }
+                }
+                return@launch
+            }
+            // Capture the screenshot before enqueueing so the in-memory
+            // bytes are correlated with the queue row by id. The
+            // staging-temp-file path is owned by the queue from this
+            // point forward; the drain worker deletes it on success.
+            val screenshot = screenshotCapture?.captureScreenshot()
+            val rowId = pendingUploadRepository.enqueue(
+                sessionId = sessionId,
+                kind = com.spela.player.domain.model.PendingUploadKind.Manual,
+                slot = null,
+                name = "Manual Save",
+                coreName = currentCoreName,
+                compression = staged.compression,
+                filePath = staged.path,
+                fileSize = staged.size,
+                screenshotPath = null,
+                createdAt = kotlin.time.Clock.System.now().toEpochMilliseconds(),
+            )
+            if (screenshot != null) {
+                pendingScreenshots[rowId] = screenshot
+            }
+            withContext(dispatchers.main) {
+                _state.update {
+                    it.copy(
+                        isSaveInProgress = false,
+                        hasPendingUploads = true,
+                        secondaryToast = SecondaryToastData(
+                            message = "Saved locally — syncing",
+                            type = SecondaryToastType.SAVE,
+                        ),
+                    )
+                }
+            }
+            // Fire-and-forget drain. Slice 3 will hook this same call
+            // to game-exit / app-pause / network-reconnect triggers
+            // for the cases where the immediate-after-enqueue drain
+            // didn't manage to run (e.g. lost connectivity at save
+            // time).
+            launchDrainPendingUploads()
+        }
+    }
+
+    /**
+     * Walks the pending-upload queue oldest-first, uploading each row
+     * via the appropriate session endpoint. Stops on first failure to
+     * avoid an infinite retry storm; retry-counter + last_error are
+     * persisted on the row so the next drain can pick up where this
+     * one left off. Clears [EmulationState.hasPendingUploads] when the
+     * queue empties. See #804 phase 6.
+     */
+    private fun launchDrainPendingUploads() {
+        scope.launch(dispatchers.io) {
+            while (true) {
+                val pending = pendingUploadRepository.getAll()
+                if (pending.isEmpty()) {
+                    withContext(dispatchers.main) {
+                        _state.update {
+                            it.copy(
+                                hasPendingUploads = false,
+                                saveStateJustSucceeded = true,
+                            )
+                        }
+                    }
+                    refreshSaveSlots()
+                    scope.launch(dispatchers.io) {
+                        kotlinx.coroutines.delay(SAVE_SUCCESS_FLASH_MS)
+                        withContext(dispatchers.main) {
+                            _state.update { it.copy(saveStateJustSucceeded = false) }
+                        }
+                    }
+                    return@launch
+                }
+                val row = pending.first()
+                val screenshot = pendingScreenshots[row.id]
+                val result = uploadPendingRow(row, screenshot)
+                if (result.isSuccess) {
+                    pendingUploadRepository.delete(row.id)
+                    pendingScreenshots.remove(row.id)
+                    runCatching { fileStorage.deleteFile(row.filePath) }
+                } else {
+                    val msg = result.exceptionOrNull()?.message ?: "upload failed"
+                    pendingUploadRepository.markRetry(row.id, msg)
+                    println("[SaveManager] drain: row ${row.id} failed: $msg — leaving in queue")
+                    return@launch
+                }
             }
         }
+    }
+
+    /**
+     * Routes a queued row to the correct session endpoint based on
+     * its [com.spela.player.domain.model.PendingUploadKind]. Kept
+     * here rather than on the repository so the SQL layer stays
+     * upload-agnostic.
+     */
+    private suspend fun uploadPendingRow(
+        row: com.spela.player.domain.model.PendingSaveUpload,
+        screenshot: ByteArray?,
+    ): Result<Unit> = when (row.kind) {
+        com.spela.player.domain.model.PendingUploadKind.Manual ->
+            sessionRepository.uploadSessionSaveFromFile(
+                sessionId = row.sessionId,
+                name = row.name,
+                savePath = row.filePath,
+                saveSize = row.fileSize,
+                screenshot = screenshot,
+                coreName = row.coreName,
+                compression = row.compression,
+            ).map { Unit }
+        com.spela.player.domain.model.PendingUploadKind.Auto ->
+            sessionRepository.uploadSessionAutoSaveFromFile(
+                sessionId = row.sessionId,
+                savePath = row.filePath,
+                saveSize = row.fileSize,
+                screenshot = screenshot,
+                coreName = row.coreName,
+                compression = row.compression,
+            )
+        com.spela.player.domain.model.PendingUploadKind.Slot ->
+            sessionRepository.uploadSlotSaveFromFile(
+                sessionId = row.sessionId,
+                slot = row.slot ?: 1,
+                savePath = row.filePath,
+                saveSize = row.fileSize,
+                screenshot = screenshot,
+                coreName = row.coreName,
+                compression = row.compression,
+            ).map { Unit }
     }
 
     /**
@@ -664,7 +760,12 @@ class SaveManager(
             cleanupGz()
             return StagedSave(rawPath, rawSize, "", cleanupRaw)
         }
-        return StagedSave(gzPath, gzSize, "gzip", cleanupBoth)
+        // Gzip succeeded — drop the raw bytes immediately. The
+        // returned StagedSave references one file (the .gz), so the
+        // deferred-upload queue can hand off a single path/cleanup
+        // pair without leaking the raw sibling. See #804 phase 6.
+        cleanupRaw()
+        return StagedSave(gzPath, gzSize, "gzip", cleanupGz)
     }
 
     /**

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerCompressionTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerCompressionTest.kt
@@ -103,6 +103,7 @@ class SaveManagerCompressionTest {
             scope = scope,
             sessionRepository = sessionRepo,
             fileStorage = storage,
+            pendingUploadRepository = com.spela.player.presentation.viewmodel.emulation.StubPendingSaveUploadRepository(),
         )
         manager.currentSessionId = "s1"
         manager.currentCoreName = "nestopia"

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerDeferredSyncTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerDeferredSyncTest.kt
@@ -1,0 +1,165 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.data.remote.ConnectivityMonitor
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.interceptor.TokenManager
+import com.spela.player.presentation.state.EmulationState
+import com.spela.player.presentation.viewmodel.emulation.StubLibretroController
+import com.spela.player.presentation.viewmodel.emulation.StubMockEngineFactory
+import com.spela.player.presentation.viewmodel.emulation.StubPendingSaveUploadRepository
+import com.spela.player.presentation.viewmodel.emulation.StubSaveDataRepository
+import com.spela.player.presentation.viewmodel.emulation.StubSessionRepository
+import com.spela.player.util.DispatcherProvider
+import com.spela.player.util.FileStorage
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Positive coverage for the deferred-sync flow added in #804 phase 6
+ * slice 2. Companion to [SaveManagerRehearsalTest], which covers the
+ * failure path (row stays queued, no error UI). These tests verify
+ * the happy path: enqueue → drain → queue empty → hasPendingUploads
+ * flips back to false.
+ *
+ * The user-visible contract is "Save is fast and tells me whether
+ * the bytes have left the device" — that's what we pin here.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SaveManagerDeferredSyncTest {
+
+    private fun testDispatchers(dispatcher: CoroutineDispatcher): DispatcherProvider =
+        object : DispatcherProvider {
+            override val main: CoroutineDispatcher = dispatcher
+            override val io: CoroutineDispatcher = dispatcher
+            override val default: CoroutineDispatcher = dispatcher
+        }
+
+    private fun makeFixture(
+        scope: CoroutineScope,
+        dispatcher: CoroutineDispatcher,
+    ): Fixture {
+        val dispatchers = testDispatchers(dispatcher)
+        val apiClient = SpelaApiClient(StubMockEngineFactory, TokenManager())
+        val connectivity = ConnectivityMonitor(apiClient, dispatchers, scope)
+        val sessionRepo = StubSessionRepository()
+        val libretro = StubLibretroController()
+        val state = MutableStateFlow(EmulationState())
+        val pending = StubPendingSaveUploadRepository()
+        val manager = SaveManager(
+            saveDataRepository = StubSaveDataRepository(),
+            connectivityMonitor = connectivity,
+            libretroController = libretro,
+            screenshotCapture = null,
+            _state = state,
+            dispatchers = dispatchers,
+            scope = scope,
+            sessionRepository = sessionRepo,
+            fileStorage = TestFileStorage(),
+            pendingUploadRepository = pending,
+        )
+        manager.currentSessionId = "s1"
+        manager.currentCoreName = "nestopia"
+        return Fixture(manager, sessionRepo, state, pending)
+    }
+
+    private data class Fixture(
+        val manager: SaveManager,
+        val sessionRepo: StubSessionRepository,
+        val state: MutableStateFlow<EmulationState>,
+        val pending: StubPendingSaveUploadRepository,
+    )
+
+    @Test
+    fun saveStateEnqueuesRowAndFlipsHasPendingUploads() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+
+        fx.manager.saveState()
+        advanceUntilIdle()
+
+        // Successful drain: queue ends empty (sessionRepo defaults
+        // to Result.success on the manual upload path), and the
+        // hasPendingUploads flag has cycled back to false. We don't
+        // assert saveStateJustSucceeded here because its 1.5 s
+        // auto-clear timer also fires under advanceUntilIdle, putting
+        // it back at false; that transient flash is covered by the
+        // existing #803 tests in SaveManagerRehearsalTest.
+        assertEquals(0L, fx.pending.count())
+        assertFalse(fx.state.value.isSaveInProgress)
+        assertFalse(fx.state.value.hasPendingUploads)
+    }
+
+    @Test
+    fun saveStateRoutesUploadThroughManualEndpoint() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+
+        fx.manager.saveState()
+        advanceUntilIdle()
+
+        // The drain hits uploadSessionSaveFromFile (not auto / slot)
+        // for a manual save. The session repo stub increments its
+        // counter on every call regardless of fold result.
+        assertEquals(1, fx.sessionRepo.uploadSessionSaveCallCount)
+    }
+
+    @Test
+    fun saveStateOnUploadFailureLeavesRowInQueueWithLastError() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+        fx.sessionRepo.uploadSessionSaveResult =
+            Result.failure(RuntimeException("test: 503 unavailable"))
+
+        fx.manager.saveState()
+        advanceUntilIdle()
+
+        // Row remains in the queue with retry counter bumped + error
+        // recorded; user sees "Saved locally · syncing" indefinitely
+        // until a future drain succeeds.
+        assertEquals(1L, fx.pending.count())
+        val row = fx.pending.getAll().single()
+        assertEquals(1, row.retryCount, "markRetry incremented the counter once")
+        assertTrue(row.lastError?.contains("503 unavailable") == true,
+            "lastError captures the upload failure for diagnostics")
+        assertTrue(fx.state.value.hasPendingUploads)
+    }
+
+    /** Minimal FileStorage that no-ops everything — the staging path
+     *  in tests goes through `serialize() + writeFile`, both of which
+     *  are no-ops on the stub controller, so the staged "file" is
+     *  fictional. The deferred-upload drain happens on the same
+     *  fiction. */
+    private class TestFileStorage : FileStorage {
+        override fun getGamesDir(): String = "/tmp/games"
+        override fun getCoresDir(): String = "/tmp/cores"
+        override fun getSavesDir(): String = "/tmp/saves"
+        override fun getBiosDir(): String = "/tmp/bios"
+        override suspend fun createDirectory(path: String) {}
+        override suspend fun writeFile(path: String, data: ByteArray) {}
+        override suspend fun readFile(path: String): ByteArray = byteArrayOf()
+        override suspend fun fileExists(path: String): Boolean = false
+        override suspend fun deleteFile(path: String) {}
+        override suspend fun deleteDirectory(path: String) {}
+        override suspend fun getDirectorySize(path: String): Long = 0
+        override suspend fun writeFileStreaming(path: String, writer: suspend (append: suspend (ByteArray, Int, Int) -> Unit) -> Unit) {}
+        override suspend fun getFileSize(path: String): Long = 0
+        override suspend fun listFiles(path: String): List<String> = emptyList()
+        override suspend fun isDirectory(path: String): Boolean = false
+        override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
+        override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+        override suspend fun sha256File(path: String): String? = null
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
@@ -76,6 +76,7 @@ class SaveManagerRehearsalTest {
             scope = scope,
             sessionRepository = sessionRepo,
             fileStorage = TestFileStorage(),
+            pendingUploadRepository = com.spela.player.presentation.viewmodel.emulation.StubPendingSaveUploadRepository(),
         )
         manager.currentSessionId = "s1"
         manager.currentCoreName = "nestopia"
@@ -102,6 +103,7 @@ class SaveManagerRehearsalTest {
             scope = scope,
             sessionRepository = sessionRepo,
             fileStorage = TestFileStorage(),
+            pendingUploadRepository = com.spela.player.presentation.viewmodel.emulation.StubPendingSaveUploadRepository(),
         )
         manager.currentSessionId = "s1"
         manager.currentCoreName = "nestopia"
@@ -310,9 +312,16 @@ class SaveManagerRehearsalTest {
             "saveStateJustSucceeded should auto-clear after the flash window")
     }
 
-    /** Failure path: error sticks until cleared, in-progress drops. */
+    /** Deferred-sync contract (#804 phase 6): a failed upload no
+     *  longer surfaces saveStateError directly — the row stays in
+     *  the persistent queue and is retried opportunistically. The
+     *  user sees "Saved locally · syncing" until a future drain
+     *  succeeds. Slice 4 of phase 6 will add an explicit indicator
+     *  after N failed retries; for slice 2 the contract is "no
+     *  immediate error UI, save is captured."
+     */
     @Test
-    fun saveStateRecordsErrorOnFailure() = runTest {
+    fun saveStateOnUploadFailureKeepsRowQueuedWithoutSurfacingError() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher + Job())
         val fx = makeManagerFixture(scope, dispatcher)
@@ -325,11 +334,11 @@ class SaveManagerRehearsalTest {
         advanceUntilIdle()
 
         assertEquals(false, fx.state.value.isSaveInProgress,
-            "isSaveInProgress should be false after the upload finishes (success or failure)")
-        assertTrue(
-            fx.state.value.saveStateError?.contains("test: 413 too large") == true,
-            "saveStateError should carry the failure message; got '${fx.state.value.saveStateError}'",
-        )
+            "isSaveInProgress should be false after the enqueue completes")
+        assertTrue(fx.state.value.hasPendingUploads,
+            "hasPendingUploads must stay true while the row sits in the queue with a retry counter")
+        assertEquals(null, fx.state.value.saveStateError,
+            "deferred-sync failures stay in the queue rather than surfacing as saveStateError")
     }
 
     /** Regression: if staging the save state throws (rather than

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -612,6 +612,79 @@ private class StubFileStorage : com.spela.player.util.FileStorage {
     override suspend fun sha256File(path: String): String? = null
 }
 
+/**
+ * In-memory pending-upload queue for SaveManager tests (#804 phase 6).
+ * Mirrors the SQLDelight repo's contract — auto-incremented ids, FIFO
+ * ordering — without standing up a real database.
+ */
+class StubPendingSaveUploadRepository :
+    com.spela.player.domain.repository.PendingSaveUploadRepository {
+
+    private val rows = mutableListOf<com.spela.player.domain.model.PendingSaveUpload>()
+    private var nextId = 1L
+
+    override suspend fun enqueue(
+        sessionId: String,
+        kind: com.spela.player.domain.model.PendingUploadKind,
+        slot: Int?,
+        name: String,
+        coreName: String,
+        compression: String,
+        filePath: String,
+        fileSize: Long,
+        screenshotPath: String?,
+        createdAt: Long,
+    ): Long {
+        val id = nextId++
+        rows.add(
+            com.spela.player.domain.model.PendingSaveUpload(
+                id = id,
+                sessionId = sessionId,
+                kind = kind,
+                slot = slot,
+                name = name,
+                coreName = coreName,
+                compression = compression,
+                filePath = filePath,
+                fileSize = fileSize,
+                screenshotPath = screenshotPath,
+                createdAt = createdAt,
+                retryCount = 0,
+                lastError = null,
+            ),
+        )
+        return id
+    }
+
+    override suspend fun getAll(): List<com.spela.player.domain.model.PendingSaveUpload> =
+        rows.sortedWith(compareBy({ it.createdAt }, { it.id }))
+
+    override suspend fun getForSession(
+        sessionId: String,
+    ): List<com.spela.player.domain.model.PendingSaveUpload> =
+        rows.filter { it.sessionId == sessionId }
+            .sortedWith(compareBy({ it.createdAt }, { it.id }))
+
+    override suspend fun getById(
+        id: Long,
+    ): com.spela.player.domain.model.PendingSaveUpload? =
+        rows.find { it.id == id }
+
+    override suspend fun count(): Long = rows.size.toLong()
+
+    override suspend fun delete(id: Long) {
+        rows.removeAll { it.id == id }
+    }
+
+    override suspend fun markRetry(id: Long, lastError: String?) {
+        val idx = rows.indexOfFirst { it.id == id }
+        if (idx >= 0) {
+            val r = rows[idx]
+            rows[idx] = r.copy(retryCount = r.retryCount + 1, lastError = lastError)
+        }
+    }
+}
+
 // ── ViewModel Builder ───────────────────────────────────────────────────────
 
 /**
@@ -692,6 +765,7 @@ class EmulationViewModelTestBuilder {
             scope = vmScope,
             sessionRepository = sessionRepository,
             fileStorage = StubFileStorage(),
+            pendingUploadRepository = StubPendingSaveUploadRepository(),
         )
         saveManager = saveManagerLocal
         val challengeManager = ChallengeManager(


### PR DESCRIPTION
Slice 2 of phase 6 (deferred / opportunistic sync). Builds on #823 (the persistent queue) — when the user taps **Save**, the bytes stage to disk, enqueue into the queue, and the button releases immediately. The drain runs in the background; the user sees **"Saved locally · syncing"** until it settles, then the existing **"Synced ✓"** flash. They are no longer blocked on a network round-trip on every Save tap.

## What changes

**Manual save (\`saveState\`)** — moves to the deferred path:
1. Stage to disk (existing #798 fast-path).
2. Capture screenshot (in memory; slice 4 will persist to disk for app-kill durability).
3. Enqueue a \`Manual\` row in the persistent queue.
4. Flip \`hasPendingUploads = true\`, clear \`isSaveInProgress\`.
5. Fire-and-forget drain: walk the queue oldest-first, upload each row, delete on success / \`markRetry\` on failure.
6. When the queue empties, flip \`hasPendingUploads = false\` and trigger the existing #803 "Synced" checkmark flash.

**Auto-save and slot save** — still use the inline path. Auto-save runs at game stop where deferred makes no sense; slot save is spec-deferred to a follow-up alongside the slot-primary UX.

## What this PR does NOT include

| Slice | What |
|---|---|
| 3 | Explicit drain triggers — game exit, app pause, network reconnect (currently only the immediate-after-enqueue drain runs). |
| 4 | Persist screenshots to disk so app-kill doesn't lose the thumbnail. Surface a UX indicator after N failed retries. |

For now, if the immediate drain fails (network down, server 5xx), the row sits in the queue with \`retry_count\` bumped and \`last_error\` recorded. The user sees "Saved locally · syncing" until they re-tap Save (which spawns another drain) or until slice 3 ships the explicit triggers. The save bytes are not lost — they're durable in SQLDelight per #823.

## State machine

| Pre-state | Action | Next state | Save button label |
|---|---|---|---|
| idle | tap Save | stage + enqueue | "Saving…" (briefly) |
| enqueued, queue non-empty | drain running | unchanged | "Saved locally · syncing" |
| enqueued, drain success | row deleted, queue empty | hasPendingUploads=false | "Synced" (1.5 s) → "Save" |
| enqueued, drain failure | retry_count++ | unchanged | "Saved locally · syncing" (forever, slice 4 polish) |

## Test contract shifts

Two existing tests adjusted to match the new contract:

- \`SaveManagerRehearsalTest.saveStateRecordsErrorOnFailure\` → \`saveStateOnUploadFailureKeepsRowQueuedWithoutSurfacingError\`. Failures no longer surface as \`state.saveStateError\`; they sit in the queue with \`markRetry\`. The user sees "Saved locally · syncing" indefinitely until a future drain succeeds. Slice 4 will add an indicator after N failed retries.
- \`SaveManagerCompressionTest.manualSaveAboveThresholdIsGzippedAndTagged\` continues to pass because \`maybeGzipStaged\` now deletes the raw temp file as soon as the gz succeeds — the StagedSave references one path only, the queue can hand off a single (path, cleanup) pair without leaking the raw sibling.

New tests in \`SaveManagerDeferredSyncTest\`:
- \`saveStateEnqueuesRowAndFlipsHasPendingUploads\` — happy path: queue empties, \`hasPendingUploads=false\`.
- \`saveStateRoutesUploadThroughManualEndpoint\` — the drain calls \`uploadSessionSaveFromFile\`, not auto/slot.
- \`saveStateOnUploadFailureLeavesRowInQueueWithLastError\` — row stays with \`retryCount=1\` and the failure message in \`lastError\`.

580 player desktop tests, 0 failures. Android compile + detekt clean.

## Phase order

- ~~Phase 1-5 — see #806/#814/#815/#816/#817/#818/#819/#820/#821/#822~~
- ~~Phase 6 slice 1 — queue infrastructure (#823)~~
- **Phase 6 slice 2 — SaveManager enqueues — this PR**
- Phase 6 slice 3 — explicit drain triggers (game exit, app pause, network reconnect)
- Phase 6 slice 4 — UX polish (screenshot persistence, retry/error indicator)