### PR TITLE
feat(player): explicit drain triggers for pending uploads (#804 phase 6)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -184,7 +184,14 @@ val commonModule = module {
             sessionRepository = get(),
             fileStorage = get(),
             pendingUploadRepository = get(),
-        )
+        ).also {
+            // Kick off the network-reconnect collector once the
+            // SaveManager singleton is wired. Tests don't get this
+            // (they construct SaveManager directly) so their
+            // `runTest` scopes still complete cleanly. See #804
+            // phase 6 slice 3.
+            it.startReconnectListener()
+        }
     }
     single {
         ChallengeManager(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -1294,6 +1294,12 @@ class EmulationViewModel(
             presenceService.paused = true
             _state.update { it.copy(isLifecyclePaused = true, isPaused = true) }
         }
+        // App-pause drain (#804 phase 6 slice 3 spec point b). The
+        // user is putting the device down (clamshell close, home
+        // button, screen lock) — a good moment to push any pending
+        // saves to the server while we still have network. Idempotent
+        // when the queue is empty.
+        saveManager.drainPendingUploads()
     }
 
     private fun lifecycleResume() {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -453,6 +454,11 @@ class SaveManager(
         } finally {
             staged.cleanup()
         }
+        // Game-exit drain (#804 phase 6 slice 3 spec point a). The
+        // auto-save itself runs inline above, but any manual saves
+        // queued during gameplay are still on disk waiting for an
+        // opportunity. This is that opportunity.
+        drainPendingUploads()
     }
 
     /**
@@ -483,6 +489,46 @@ class SaveManager(
      * properly. See #804 phase 6.
      */
     private val pendingScreenshots = mutableMapOf<Long, ByteArray>()
+
+    /**
+     * Serialises drain calls so concurrent triggers (e.g. game-exit
+     * + network-reconnect arriving in the same second) don't kick
+     * off two drain loops that both pick up the same row and
+     * upload it twice. tryLock semantics — the second call is a
+     * no-op rather than a wait, because the in-flight drain already
+     * sees any rows the second trigger would have picked up. See
+     * #804 phase 6 slice 3.
+     */
+    private val drainMutex = Mutex()
+
+    /**
+     * Public entry point for the drain triggers (game exit, app
+     * pause, network reconnect, post-enqueue immediate drain).
+     * Idempotent: when the queue is empty the drain coroutine flips
+     * [EmulationState.hasPendingUploads] to false and exits. When a
+     * drain is already in flight, the call is a no-op (the in-flight
+     * drain will pick up any newly-enqueued rows on its next
+     * iteration). See #804 phase 6 slice 3.
+     */
+    fun drainPendingUploads() {
+        launchDrainPendingUploads()
+    }
+
+    /**
+     * Subscribes to [ConnectivityMonitor.onReconnect] and triggers a
+     * drain on every reconnect. Called once by the DI module after
+     * construction; tests don't call this so the long-lived collector
+     * doesn't keep their `runTest` scopes from completing. See #804
+     * phase 6 slice 3 spec point (c).
+     */
+    fun startReconnectListener() {
+        scope.launch(dispatchers.io) {
+            connectivityMonitor.onReconnect.collect {
+                println("[SaveManager] onReconnect — draining pending uploads")
+                drainPendingUploads()
+            }
+        }
+    }
 
     fun saveState() {
         if (_state.value.isChallengeMode) return
@@ -585,39 +631,50 @@ class SaveManager(
      */
     private fun launchDrainPendingUploads() {
         scope.launch(dispatchers.io) {
-            while (true) {
-                val pending = pendingUploadRepository.getAll()
-                if (pending.isEmpty()) {
-                    withContext(dispatchers.main) {
-                        _state.update {
-                            it.copy(
-                                hasPendingUploads = false,
-                                saveStateJustSucceeded = true,
-                            )
-                        }
-                    }
-                    refreshSaveSlots()
-                    scope.launch(dispatchers.io) {
-                        kotlinx.coroutines.delay(SAVE_SUCCESS_FLASH_MS)
+            // tryLock so a redundant trigger (e.g. reconnect arrives
+            // while the post-enqueue drain is still running) is a
+            // cheap no-op instead of a parallel drain that would
+            // race on the same rows.
+            if (!drainMutex.tryLock()) {
+                return@launch
+            }
+            try {
+                while (true) {
+                    val pending = pendingUploadRepository.getAll()
+                    if (pending.isEmpty()) {
                         withContext(dispatchers.main) {
-                            _state.update { it.copy(saveStateJustSucceeded = false) }
+                            _state.update {
+                                it.copy(
+                                    hasPendingUploads = false,
+                                    saveStateJustSucceeded = true,
+                                )
+                            }
                         }
+                        refreshSaveSlots()
+                        scope.launch(dispatchers.io) {
+                            kotlinx.coroutines.delay(SAVE_SUCCESS_FLASH_MS)
+                            withContext(dispatchers.main) {
+                                _state.update { it.copy(saveStateJustSucceeded = false) }
+                            }
+                        }
+                        return@launch
                     }
-                    return@launch
+                    val row = pending.first()
+                    val screenshot = pendingScreenshots[row.id]
+                    val result = uploadPendingRow(row, screenshot)
+                    if (result.isSuccess) {
+                        pendingUploadRepository.delete(row.id)
+                        pendingScreenshots.remove(row.id)
+                        runCatching { fileStorage.deleteFile(row.filePath) }
+                    } else {
+                        val msg = result.exceptionOrNull()?.message ?: "upload failed"
+                        pendingUploadRepository.markRetry(row.id, msg)
+                        println("[SaveManager] drain: row ${row.id} failed: $msg — leaving in queue")
+                        return@launch
+                    }
                 }
-                val row = pending.first()
-                val screenshot = pendingScreenshots[row.id]
-                val result = uploadPendingRow(row, screenshot)
-                if (result.isSuccess) {
-                    pendingUploadRepository.delete(row.id)
-                    pendingScreenshots.remove(row.id)
-                    runCatching { fileStorage.deleteFile(row.filePath) }
-                } else {
-                    val msg = result.exceptionOrNull()?.message ?: "upload failed"
-                    pendingUploadRepository.markRetry(row.id, msg)
-                    println("[SaveManager] drain: row ${row.id} failed: $msg — leaving in queue")
-                    return@launch
-                }
+            } finally {
+                drainMutex.unlock()
             }
         }
     }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerDeferredSyncTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerDeferredSyncTest.kt
@@ -137,6 +137,55 @@ class SaveManagerDeferredSyncTest {
         assertTrue(fx.state.value.hasPendingUploads)
     }
 
+    @Test
+    fun drainPendingUploadsIsNoOpWhenQueueEmpty() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+
+        // Idempotent: explicit drain call on an empty queue must
+        // not crash, must not invoke the upload endpoint, and must
+        // leave hasPendingUploads at false. See #804 phase 6 slice 3.
+        fx.manager.drainPendingUploads()
+        advanceUntilIdle()
+
+        assertEquals(0L, fx.pending.count())
+        assertEquals(0, fx.sessionRepo.uploadSessionSaveCallCount)
+        assertFalse(fx.state.value.hasPendingUploads)
+    }
+
+    @Test
+    fun drainPendingUploadsRetriesAFailedRowOnNextCall() = runTest {
+        // Simulates the network-reconnect / app-pause / game-exit
+        // path: a previous drain failed (server 503) and left the
+        // row in the queue with retryCount=1. The next drain
+        // (e.g. fired by ConnectivityMonitor.onReconnect once the
+        // network is back) succeeds and drains the row. See #804
+        // phase 6 slice 3.
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+
+        // First save fails so the row stays queued.
+        fx.sessionRepo.uploadSessionSaveResult =
+            Result.failure(RuntimeException("test: 503 unavailable"))
+        fx.manager.saveState()
+        advanceUntilIdle()
+        assertEquals(1L, fx.pending.count())
+
+        // "Network came back" — flip the stub to succeed and call
+        // drain explicitly. This is what slice 3's reconnect /
+        // lifecyclePause / autoSaveOnStop hooks do.
+        fx.sessionRepo.uploadSessionSaveResult =
+            Result.success(com.spela.player.domain.model.SaveState(id = "1", name = "Manual Save"))
+        fx.manager.drainPendingUploads()
+        advanceUntilIdle()
+
+        assertEquals(0L, fx.pending.count(),
+            "the second drain must clear the failed-then-recovered row")
+        assertFalse(fx.state.value.hasPendingUploads)
+    }
+
     /** Minimal FileStorage that no-ops everything — the staging path
      *  in tests goes through `serialize() + writeFile`, both of which
      *  are no-ops on the stub controller, so the staged "file" is


### PR DESCRIPTION
Slice 3 of phase 6 (deferred / opportunistic sync). Builds on the queue infra (#823) and the SaveManager-enqueues path (#824) by wiring the three triggers from the umbrella spec.

## What this PR does

| Trigger | Where | Why |
|---|---|---|
| **Game exit** | \`SaveManager.autoSaveOnStop\` | Auto-save runs inline at stop; pending manual saves queued during gameplay get flushed before the player tears down. |
| **Android app pause** | \`EmulationViewModel.lifecyclePause\` | Clamshell close, home button, screen lock — last chance to push bytes while we still have network. |
| **Network reconnect** | \`SaveManager.startReconnectListener\` collects \`ConnectivityMonitor.onReconnect\` | Failed drains (503, offline) automatically retry the moment the network comes back. |

All three call \`drainPendingUploads()\`, which is idempotent — a no-op when the queue is empty.

## Concurrency

New \`drainMutex\` (kotlinx.coroutines.sync.Mutex) wrapped around the drain loop with \`tryLock\` semantics. Concurrent triggers — e.g. reconnect fires mid-game-exit, or an immediate-after-enqueue drain is still running when the user backgrounds the app — are cheap no-ops rather than parallel drains that would race on the same row and upload it twice.

## Why \`startReconnectListener\` is opt-in (not init-block)

The first version had \`init { scope.launch { connectivityMonitor.onReconnect.collect { ... } } }\` — clean in production but it hung two existing tests (\`SaveManagerCompressionTest.manualSaveBelowThresholdSkipsGzip\` and \`manualSaveAboveThresholdIsGzippedAndTagged\`) for 60 seconds each on \`runTest\`'s "uncompleted coroutines" timeout. The collector is an infinite Flow.collect that keeps the test scope alive forever.

Fix: expose \`startReconnectListener()\` as an explicit method. The DI module calls it once after construction; tests that construct \`SaveManager\` directly skip it. Production behaviour unchanged.

## Tests (582 desktop, 0 failures)

Two new cases in \`SaveManagerDeferredSyncTest\`:

- **\`drainPendingUploadsIsNoOpWhenQueueEmpty\`** — explicit drain on an empty queue must not crash, must not call the upload endpoint, must leave \`hasPendingUploads\` at false. Covers all three triggers' empty-queue case.
- **\`drainPendingUploadsRetriesAFailedRowOnNextCall\`** — simulates the realistic flow: first save fails with server 503 → row stays queued → "network came back" → next \`drainPendingUploads()\` call clears the row. This is what the new reconnect / app-pause / game-exit hooks do for users in the field.

The existing 5 SaveManager tests + the deferred-sync tests from #824 all still pass. Android compile + detekt clean.

## Phase order

- ~~Phase 6 slice 1 — queue infrastructure (#823)~~
- ~~Phase 6 slice 2 — SaveManager enqueues (#824)~~
- **Phase 6 slice 3 — explicit drain triggers — this PR**
- Phase 6 slice 4 — UX polish (screenshot persistence, retry/error indicator after N failed attempts)

After this merges, phase 6 is structurally complete: persistent queue, deferred enqueue path, three opportunistic triggers. Slice 4 is pure polish — the deferred-sync flow itself works end-to-end without it.