### PR TITLE
feat(player): screenshot persistence + stuck-uploads indicator (#804 phase 6 slice 4)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -146,6 +146,15 @@ data class EmulationState(
      */
     val hasPendingUploads: Boolean = false,
     /**
+     * Number of pending uploads whose retry count has reached the
+     * "stuck" threshold — failed enough times that they're probably
+     * not just slow. The in-game overlay surfaces a "Sync paused — N
+     * saves waiting" line when this is > 0 so the user can tell
+     * stuck-on-error apart from in-flight-and-slow without having to
+     * dig into logs. See #804 phase 6 slice 4.
+     */
+    val stuckUploadCount: Int = 0,
+    /**
      * Non-blocking warning shown when the session's pinned core
      * version (see `GameSession.pinnedCoreSha256`) is no longer
      * available on the server (pruned from history retention) and

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
@@ -293,6 +293,28 @@ internal fun InGameOverlayPanel(
                         )
                     }
 
+                    // Stuck-uploads banner (#804 phase 6 slice 4).
+                    // Surfaces only when at least one queued save has
+                    // failed STUCK_RETRY_THRESHOLD times so the user
+                    // can tell stuck-on-error apart from
+                    // in-flight-and-slow without digging into logs.
+                    if (state.stuckUploadCount > 0) {
+                        Spacer(Modifier.height(SpSpacing.Small))
+                        val msg = if (state.stuckUploadCount == 1) {
+                            "Sync paused — 1 save waiting"
+                        } else {
+                            "Sync paused — ${state.stuckUploadCount} saves waiting"
+                        }
+                        Text(
+                            text = msg,
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundSecondary,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .semantics { contentDescription = msg },
+                        )
+                    }
+
                     Spacer(Modifier.height(if (isLandscape) SpSpacing.Medium else SpSpacing.Large))
 
                     // Volume slider

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -478,17 +478,17 @@ class SaveManager(
          * state. See #804 phase 2.
          */
         const val GZIP_MIN_BYTES: Long = 32 * 1024L
+
+        /**
+         * Retry count at which a pending upload counts as "stuck"
+         * for the in-game overlay's "Sync paused — N saves waiting"
+         * indicator. Three transient failures is enough to suspect a
+         * server-side issue (quota, 5xx) rather than just packet
+         * loss. See #804 phase 6 slice 4.
+         */
+        const val STUCK_RETRY_THRESHOLD = 3
     }
 
-    /**
-     * In-memory screenshot bytes keyed by pending-upload row id. We
-     * could persist screenshots to disk for full app-kill durability,
-     * but for slice 2 the screenshot is a polish detail — losing it
-     * after an app kill leaves the save bytes intact, just without a
-     * thumbnail on the saves list. Slice 4 will stage screenshots
-     * properly. See #804 phase 6.
-     */
-    private val pendingScreenshots = mutableMapOf<Long, ByteArray>()
 
     /**
      * Serialises drain calls so concurrent triggers (e.g. game-exit
@@ -580,11 +580,19 @@ class SaveManager(
                 }
                 return@launch
             }
-            // Capture the screenshot before enqueueing so the in-memory
-            // bytes are correlated with the queue row by id. The
-            // staging-temp-file path is owned by the queue from this
-            // point forward; the drain worker deletes it on success.
+            // Capture the screenshot and stage it to disk alongside
+            // the save bytes so the queue is fully durable across
+            // app-kill — a force-quit between save and upload no
+            // longer drops the thumbnail. See #804 phase 6 slice 4.
             val screenshot = screenshotCapture?.captureScreenshot()
+            val now = kotlin.time.Clock.System.now().toEpochMilliseconds()
+            val screenshotPath = if (screenshot != null) {
+                runCatching {
+                    val path = "${fileStorage.getSavesDir()}/.tmp-shot-$sessionId-$now.png"
+                    fileStorage.writeFile(path, screenshot)
+                    path
+                }.getOrNull()
+            } else null
             val rowId = pendingUploadRepository.enqueue(
                 sessionId = sessionId,
                 kind = com.spela.player.domain.model.PendingUploadKind.Manual,
@@ -594,12 +602,9 @@ class SaveManager(
                 compression = staged.compression,
                 filePath = staged.path,
                 fileSize = staged.size,
-                screenshotPath = null,
-                createdAt = kotlin.time.Clock.System.now().toEpochMilliseconds(),
+                screenshotPath = screenshotPath,
+                createdAt = now,
             )
-            if (screenshot != null) {
-                pendingScreenshots[rowId] = screenshot
-            }
             withContext(dispatchers.main) {
                 _state.update {
                     it.copy(
@@ -641,12 +646,14 @@ class SaveManager(
             try {
                 while (true) {
                     val pending = pendingUploadRepository.getAll()
+                    publishStuckCount(pending)
                     if (pending.isEmpty()) {
                         withContext(dispatchers.main) {
                             _state.update {
                                 it.copy(
                                     hasPendingUploads = false,
                                     saveStateJustSucceeded = true,
+                                    stuckUploadCount = 0,
                                 )
                             }
                         }
@@ -660,15 +667,23 @@ class SaveManager(
                         return@launch
                     }
                     val row = pending.first()
-                    val screenshot = pendingScreenshots[row.id]
+                    val screenshot: ByteArray? = row.screenshotPath?.let { path ->
+                        runCatching { fileStorage.readFile(path) }.getOrNull()
+                    }
                     val result = uploadPendingRow(row, screenshot)
                     if (result.isSuccess) {
                         pendingUploadRepository.delete(row.id)
-                        pendingScreenshots.remove(row.id)
                         runCatching { fileStorage.deleteFile(row.filePath) }
+                        row.screenshotPath?.let {
+                            runCatching { fileStorage.deleteFile(it) }
+                        }
                     } else {
                         val msg = result.exceptionOrNull()?.message ?: "upload failed"
                         pendingUploadRepository.markRetry(row.id, msg)
+                        // Re-read the queue so the stuck count
+                        // reflects the bumped retry counter on the
+                        // failed row before we exit the drain loop.
+                        publishStuckCount(pendingUploadRepository.getAll())
                         println("[SaveManager] drain: row ${row.id} failed: $msg — leaving in queue")
                         return@launch
                     }
@@ -676,6 +691,23 @@ class SaveManager(
             } finally {
                 drainMutex.unlock()
             }
+        }
+    }
+
+    /**
+     * Pushes the current "stuck" count to [EmulationState] so the
+     * in-game overlay can surface a "Sync paused — N saves waiting"
+     * line. A row is stuck once its retry counter reaches
+     * [STUCK_RETRY_THRESHOLD] — three transient failures is enough
+     * to suspect a server-side issue (quota, 5xx) rather than just
+     * packet loss. See #804 phase 6 slice 4.
+     */
+    private suspend fun publishStuckCount(
+        pending: List<com.spela.player.domain.model.PendingSaveUpload>,
+    ) {
+        val stuck = pending.count { it.retryCount >= STUCK_RETRY_THRESHOLD }
+        withContext(dispatchers.main) {
+            _state.update { it.copy(stuckUploadCount = stuck) }
         }
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerDeferredSyncTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerDeferredSyncTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -151,6 +152,75 @@ class SaveManagerDeferredSyncTest {
 
         assertEquals(0L, fx.pending.count())
         assertEquals(0, fx.sessionRepo.uploadSessionSaveCallCount)
+        assertFalse(fx.state.value.hasPendingUploads)
+    }
+
+    @Test
+    fun stuckUploadCountFlipsOnceAttemptCountReachesThreshold() = runTest {
+        // The threshold is 3; first two failures keep stuckUploadCount=0,
+        // the third pushes it to 1, the indicator surfaces. See #804
+        // phase 6 slice 4.
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+        fx.sessionRepo.uploadSessionSaveResult =
+            Result.failure(RuntimeException("test: 503 unavailable"))
+
+        // Initial save fails — retryCount=1, still under threshold.
+        fx.manager.saveState()
+        advanceUntilIdle()
+        assertEquals(1, fx.pending.getAll().single().retryCount)
+        assertEquals(0, fx.state.value.stuckUploadCount,
+            "one retry isn't enough to call the row stuck — could be packet loss")
+
+        // Second drain — retryCount=2, still under threshold.
+        fx.manager.drainPendingUploads()
+        advanceUntilIdle()
+        assertEquals(2, fx.pending.getAll().single().retryCount)
+        assertEquals(0, fx.state.value.stuckUploadCount)
+
+        // Third drain — retryCount=3, threshold reached, indicator
+        // surfaces.
+        fx.manager.drainPendingUploads()
+        advanceUntilIdle()
+        assertEquals(3, fx.pending.getAll().single().retryCount)
+        assertEquals(1, fx.state.value.stuckUploadCount,
+            "third failure flips the row to stuck so the user gets a 'Sync paused' nudge")
+    }
+
+    @Test
+    fun stuckUploadCountClearsWhenQueueDrains() = runTest {
+        // Verifies the recovery path: a stuck row that finally
+        // uploads (network came back, server quota cleared) flips
+        // the indicator off so the overlay stops nagging the user.
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+
+        // Build the state we want via direct DB writes — three
+        // failed retries on a row sitting in the queue.
+        fx.pending.enqueue(
+            sessionId = "s1",
+            kind = com.spela.player.domain.model.PendingUploadKind.Manual,
+            slot = null,
+            name = "Manual Save",
+            coreName = "nestopia",
+            compression = "",
+            filePath = "/tmp/.tmp-save-s1",
+            fileSize = 1024L,
+            screenshotPath = null,
+            createdAt = 1L,
+        )
+        repeat(3) { fx.pending.markRetry(1L, "stuck") }
+        fx.state.update { it.copy(hasPendingUploads = true, stuckUploadCount = 1) }
+
+        // Now the upload succeeds.
+        fx.manager.drainPendingUploads()
+        advanceUntilIdle()
+
+        assertEquals(0L, fx.pending.count())
+        assertEquals(0, fx.state.value.stuckUploadCount,
+            "queue empty → indicator off")
         assertFalse(fx.state.value.hasPendingUploads)
     }
 


### PR DESCRIPTION
Final slice of phase 6 — and of the whole #804 umbrella. Two pieces of polish that close the deferred-sync flow:

## 1. Screenshot persistence

\`saveState()\` now stages the captured screenshot to disk alongside the save bytes (\`.tmp-shot-<sessionId>-<timestamp>.png\`) and stores the path on the queue row. The drain reads the file at upload time and deletes it on success. Drops the in-memory \`pendingScreenshots\` map that slice 2 used as a stop-gap.

App-kill survival is now complete: a force-quit between save and upload no longer drops the thumbnail. The next launch's drain uploads the row with the original screenshot intact.

## 2. Stuck-uploads indicator

New \`EmulationState.stuckUploadCount\` counts queued rows whose \`retry_count\` has reached \`STUCK_RETRY_THRESHOLD\` (3). The drain publishes the count after every queue read and after every \`markRetry\`. The in-game overlay surfaces a small **"Sync paused — N saves waiting"** line below the action buttons when the count is > 0.

The threshold is conservative on purpose: one or two failures could be packet loss; three is a server-side issue (quota, 5xx) the user wants to know about. Below the threshold the user just sees the existing **"Saved locally · syncing"** label without alarm.

## Tests (584 desktop, 0 failures)

- **\`stuckUploadCountFlipsOnceAttemptCountReachesThreshold\`** — three consecutive failures push the indicator from 0 → 1.
- **\`stuckUploadCountClearsWhenQueueDrains\`** — a stuck row that finally uploads (network came back, quota cleared) clears the indicator and \`hasPendingUploads\`.

Android compile + detekt clean.

## #804 umbrella status

After this merges, the issue is structurally complete:

- ~~Phase 1 — lift 64 MB cap (#806)~~
- ~~Phase 2 — client-side compression (#814 + #815)~~
- ~~Phase 3 — \`SaveStatePolicy\` tier + seeding (#816)~~
- ~~Phase 4a — server \`ConsoleSaveStatePolicy\` table + endpoint (#817)~~
- ~~Phase 4b plumbing (#818) + overlay greying (#819) + first-launch prompt (#820) + Settings entry (#821)~~
- ~~Phase 5 — slot-primary UX for medium / large consoles (#822)~~
- ~~Phase 6 slice 1 — queue infrastructure (#823)~~
- ~~Phase 6 slice 2 — SaveManager enqueues (#824)~~
- ~~Phase 6 slice 3 — explicit drain triggers (#825)~~
- **Phase 6 slice 4 — this PR**

What's optionally left, none of it blocking:
- The "named save as secondary affordance for medium tier" sub-bullet from phase 5.
- A game-detail per-game opt-out toggle (spec point c of phase 4b) — small additional surface.
- The "manage slots" affordance to rename / delete individual slots from the in-game picker.

Each of these is a separate, small follow-up that can ship independently if there's user demand.