### PR TITLE
feat: per-game save-state opt-out — data shape + resolver (#804)

### DIFF
--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdatePreferencesRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdatePreferencesRequest.kt
@@ -33,6 +33,7 @@ import kotlinx.serialization.encoding.*
  * @param consoleShaders 
  * @param customKeyMapping 
  * @param defaultSecondScreenPage 
+ * @param gameSaveStatePolicies 
  * @param preferredRegions 
  * @param selectedKeyMapping 
  * @param selectedShader 
@@ -61,6 +62,8 @@ data class UpdatePreferencesRequest (
     @SerialName(value = "customKeyMapping") val customKeyMapping: kotlin.collections.Map<kotlin.String, kotlin.String>? = null,
 
     @SerialName(value = "defaultSecondScreenPage") val defaultSecondScreenPage: kotlin.String? = null,
+
+    @SerialName(value = "gameSaveStatePolicies") val gameSaveStatePolicies: kotlin.collections.Map<kotlin.String, kotlin.String>? = null,
 
     @SerialName(value = "preferredRegions") val preferredRegions: kotlin.collections.List<kotlin.String>? = null,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserPreferencesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserPreferencesResponse.kt
@@ -32,6 +32,7 @@ import kotlinx.serialization.encoding.*
  * @param consoleShaders 
  * @param customKeyMapping 
  * @param defaultSecondScreenPage 
+ * @param gameSaveStatePolicies 
  * @param preferredRegions 
  * @param raHardcoreEnabled 
  * @param raLinked 
@@ -61,6 +62,8 @@ data class UserPreferencesResponse (
     @SerialName(value = "customKeyMapping") @Required val customKeyMapping: kotlin.collections.Map<kotlin.String, kotlin.String>,
 
     @SerialName(value = "defaultSecondScreenPage") @Required val defaultSecondScreenPage: kotlin.String,
+
+    @SerialName(value = "gameSaveStatePolicies") @Required val gameSaveStatePolicies: kotlin.collections.Map<kotlin.String, kotlin.String>,
 
     @SerialName(value = "preferredRegions") @Required val preferredRegions: kotlin.collections.List<kotlin.String>,
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -177,6 +177,11 @@ fun com.spela.client.models.UserPreferencesResponse.toDomain(): UserPreferences 
         // value rather than crashing the player on a future codec.
         SaveStateChoice.fromApiId(v)?.let { k.lowercase() to it }
     }.toMap(),
+    gameSaveStatePolicies = gameSaveStatePolicies.mapNotNull { (k, v) ->
+        // Same defensive parsing as console policies — keys are game
+        // IDs (numeric strings), values map to SaveStateChoice.
+        SaveStateChoice.fromApiId(v)?.let { k to it }
+    }.toMap(),
     selectedKeyMapping = selectedKeyMapping,
     consoleKeyMappings = consoleKeyMappings.mapValues {
         ConsoleKeyMappingPref(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
@@ -62,6 +62,7 @@ class PreferencesRepositoryImpl(
         selectedTheme: String?,
         consoleShaders: Map<String, String>?,
         consoleSaveStatePolicies: Map<String, String>?,
+        gameSaveStatePolicies: Map<String, String>?,
         defaultSecondScreenPage: String?,
     ): Result<UserPreferences> = runCatching {
         apiClient.updatePreferences(
@@ -74,6 +75,7 @@ class PreferencesRepositoryImpl(
                 selectedTheme = selectedTheme,
                 consoleShaders = consoleShaders,
                 consoleSaveStatePolicies = consoleSaveStatePolicies,
+                gameSaveStatePolicies = gameSaveStatePolicies,
                 defaultSecondScreenPage = defaultSecondScreenPage,
             )
         ).toDomain()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -237,6 +237,14 @@ data class UserPreferences(
     val selectedTheme: String = "default-dark",
     val consoleShaders: Map<String, ShaderPreset> = emptyMap(),
     val consoleSaveStatePolicies: Map<String, SaveStateChoice> = emptyMap(),
+    /**
+     * Per-game save-state opt-out overrides keyed by game ID string.
+     * Layered on top of [consoleSaveStatePolicies] — a per-game choice
+     * wins over the console-level one. Only contains games where the
+     * user has made a deliberate per-game choice. See #804 phase 4b
+     * spec point (c).
+     */
+    val gameSaveStatePolicies: Map<String, SaveStateChoice> = emptyMap(),
     val selectedKeyMapping: String = "default",
     val consoleKeyMappings: Map<String, ConsoleKeyMappingPref> = emptyMap(),
     val defaultSecondScreenPage: String = "art",
@@ -244,12 +252,15 @@ data class UserPreferences(
 
 /**
  * Resolves the effective save-state choice for [consoleAbbr] given
- * the console's tier and the user's per-console overrides.
+ * the console's tier, the user's per-console overrides, and an
+ * optional per-game override.
  *
  * Precedence (high → low):
  *
- *   1. explicit override in [overrides] (key matched case-insensitively)
- *   2. tier default — small/medium → Enabled, large → AskOnce
+ *   1. per-game override in [gameOverride] (when non-null)
+ *   2. explicit per-console override in [overrides] (case-insensitive
+ *      abbreviation match)
+ *   3. tier default — small/medium → Enabled, large → AskOnce
  *
  * The resolver intentionally returns [SaveStateChoice.AskOnce] for
  * large-tier consoles with no override so the player can fire the
@@ -261,7 +272,9 @@ fun effectiveSaveStateChoice(
     consoleAbbr: String,
     tier: SaveStatePolicyTier,
     overrides: Map<String, SaveStateChoice>,
+    gameOverride: SaveStateChoice? = null,
 ): SaveStateChoice {
+    gameOverride?.let { return it }
     val key = consoleAbbr.lowercase()
     overrides[key]?.let { return it }
     return when (tier) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/PreferencesRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/PreferencesRepository.kt
@@ -20,6 +20,14 @@ interface PreferencesRepository {
          * row. See #804 phase 4.
          */
         consoleSaveStatePolicies: Map<String, String>? = null,
+        /**
+         * Per-game save-state opt-out upserts keyed by game ID
+         * string. Same sanitiser semantics as
+         * [consoleSaveStatePolicies] — empty string clears the row,
+         * unknown values are silently dropped server-side.
+         * See #804 phase 4b spec point (c).
+         */
+        gameSaveStatePolicies: Map<String, String>? = null,
         defaultSecondScreenPage: String? = null,
     ): Result<UserPreferences>
     fun getDeviceShaderOverride(consoleId: String): ShaderPreset?

--- a/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/SaveStatePolicyTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/SaveStatePolicyTest.kt
@@ -74,6 +74,47 @@ class SaveStatePolicyTest {
     }
 
     @Test
+    fun perGameOverrideBeatsConsoleOverride() {
+        // Power-user case from #804 phase 4b spec point (c): user
+        // has Disabled at console level for GameCube, but Enabled for
+        // *this specific game* (Mario Sunshine). The resolver must
+        // honour the per-game choice.
+        val resolved = effectiveSaveStateChoice(
+            consoleAbbr = "GC",
+            tier = SaveStatePolicyTier.Large,
+            overrides = mapOf("gc" to SaveStateChoice.Disabled),
+            gameOverride = SaveStateChoice.Enabled,
+        )
+        assertEquals(SaveStateChoice.Enabled, resolved)
+    }
+
+    @Test
+    fun perGameOverrideBeatsTierDefault() {
+        // No per-console override; tier alone would resolve to
+        // AskOnce for large. The per-game Disabled choice wins.
+        val resolved = effectiveSaveStateChoice(
+            consoleAbbr = "GC",
+            tier = SaveStatePolicyTier.Large,
+            overrides = emptyMap(),
+            gameOverride = SaveStateChoice.Disabled,
+        )
+        assertEquals(SaveStateChoice.Disabled, resolved)
+    }
+
+    @Test
+    fun perGameOverrideNullFallsBackToConsole() {
+        // gameOverride = null is the "no per-game choice for this
+        // game" case — resolver must continue down to per-console.
+        val resolved = effectiveSaveStateChoice(
+            consoleAbbr = "GC",
+            tier = SaveStatePolicyTier.Large,
+            overrides = mapOf("gc" to SaveStateChoice.Enabled),
+            gameOverride = null,
+        )
+        assertEquals(SaveStateChoice.Enabled, resolved)
+    }
+
+    @Test
     fun overrideForOneConsoleDoesNotLeakToOthers() {
         val overrides = mapOf("gc" to SaveStateChoice.Disabled)
         val gc = effectiveSaveStateChoice("GC", SaveStatePolicyTier.Large, overrides)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
@@ -167,7 +167,7 @@ class SyncEngineTest {
 
     private class NoOpPreferencesRepository : PreferencesRepository {
         override suspend fun getPreferences() = Result.success(UserPreferences())
-        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, consoleSaveStatePolicies: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
+        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, consoleSaveStatePolicies: Map<String, String>?, gameSaveStatePolicies: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
         override fun getAllDeviceShaderOverrides() = emptyMap<String, ShaderPreset>()
@@ -210,7 +210,7 @@ class SyncEngineTest {
 
     private class FailingPreferencesRepository : PreferencesRepository {
         override suspend fun getPreferences(): Result<UserPreferences> = throw RuntimeException("Preferences fetch failed")
-        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, consoleSaveStatePolicies: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
+        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, consoleSaveStatePolicies: Map<String, String>?, gameSaveStatePolicies: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
         override fun getAllDeviceShaderOverrides() = emptyMap<String, ShaderPreset>()
@@ -257,7 +257,7 @@ class SyncEngineTest {
             getPreferencesCalled = true
             return Result.success(UserPreferences())
         }
-        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, consoleSaveStatePolicies: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
+        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, consoleSaveStatePolicies: Map<String, String>?, gameSaveStatePolicies: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
         override fun getAllDeviceShaderOverrides() = emptyMap<String, ShaderPreset>()

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -381,7 +381,7 @@ class NavigationViewModelTest {
 
     private class NoOpPreferencesRepository : PreferencesRepository {
         override suspend fun getPreferences() = Result.success(UserPreferences())
-        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, consoleSaveStatePolicies: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
+        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, autoUpdateCoresEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, consoleSaveStatePolicies: Map<String, String>?, gameSaveStatePolicies: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
         override fun getAllDeviceShaderOverrides() = emptyMap<String, ShaderPreset>()

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt
@@ -393,6 +393,7 @@ class KeyMappingViewModelTest {
             autoUpdateCoresEnabled: Boolean?,
             selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?,
             consoleSaveStatePolicies: Map<String, String>?,
+            gameSaveStatePolicies: Map<String, String>?,
             defaultSecondScreenPage: String?,
         ): Result<UserPreferences> = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -288,13 +288,23 @@ class StubPreferencesRepository : PreferencesRepository {
         selectedTheme: String?,
         consoleShaders: Map<String, String>?,
         consoleSaveStatePolicies: Map<String, String>?,
+        gameSaveStatePolicies: Map<String, String>?,
         defaultSecondScreenPage: String?,
     ): Result<UserPreferences> {
         if (consoleSaveStatePolicies != null) {
             lastConsoleSaveStatePoliciesUpdate = consoleSaveStatePolicies
         }
+        if (gameSaveStatePolicies != null) {
+            lastGameSaveStatePoliciesUpdate = gameSaveStatePolicies
+        }
         return Result.success(UserPreferences())
     }
+
+    /** Records the gameSaveStatePolicies map passed on the most
+     *  recent updatePreferences call so tests can assert the per-
+     *  game toggle wiring (#804 phase 4b spec point c). */
+    var lastGameSaveStatePoliciesUpdate: Map<String, String>? = null
+        private set
 
     override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
     override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -42,6 +42,7 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.ServerSetting{}, &db.Core{},
 		&db.ConsoleShaderPreference{},
 		&db.ConsoleSaveStatePolicy{},
+		&db.GameSaveStatePolicy{},
 		&db.ConsoleKeyMappingPreference{},
 		&db.Device{},
 		&db.DeviceShaderPreference{},

--- a/server/internal/api/game_save_state_policy_test.go
+++ b/server/internal/api/game_save_state_policy_test.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdatePreferences_SetGameSaveStatePolicy upserts a per-game
+// override and verifies it round-trips via PUT and GET.
+func TestUpdatePreferences_SetGameSaveStatePolicy(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	// Seed a GameCube game so we have a valid game ID to reference.
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "GC").First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Title: "Metroid Prime",
+		FileName: "mp.iso", FilePath: "/tmp/mp.iso", FileSize: 1024, IsPrimary: true,
+	}
+	require.NoError(t, database.Create(&game).Error)
+	gameIDStr := strconv.FormatUint(uint64(game.ID), 10)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"gameSaveStatePolicies": map[string]string{gameIDStr: "disabled"},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var prefs map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs))
+	policies, ok := prefs["gameSaveStatePolicies"].(map[string]interface{})
+	require.True(t, ok, "gameSaveStatePolicies missing from PUT response")
+	assert.Equal(t, "disabled", policies[gameIDStr])
+
+	// GET round-trip.
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/user/preferences", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs))
+	policies = prefs["gameSaveStatePolicies"].(map[string]interface{})
+	assert.Equal(t, "disabled", policies[gameIDStr])
+}
+
+// TestUpdatePreferences_ClearGameSaveStatePolicy verifies that an
+// empty-string value clears the row so the game falls back to the
+// per-console policy (and ultimately to the tier default).
+func TestUpdatePreferences_ClearGameSaveStatePolicy(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "GC").First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Title: "Mario Sunshine",
+		FileName: "ms.iso", FilePath: "/tmp/ms.iso", FileSize: 1024, IsPrimary: true,
+	}
+	require.NoError(t, database.Create(&game).Error)
+	gameIDStr := strconv.FormatUint(uint64(game.ID), 10)
+
+	// Set then clear.
+	for _, raw := range []string{"enabled", ""} {
+		body, _ := json.Marshal(map[string]interface{}{
+			"gameSaveStatePolicies": map[string]string{gameIDStr: raw},
+		})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// After clearing, the key must be absent.
+	var prefs map[string]interface{}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/preferences", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs))
+	policies := prefs["gameSaveStatePolicies"].(map[string]interface{})
+	_, exists := policies[gameIDStr]
+	assert.False(t, exists, "policy should be cleared after sending empty string")
+}
+
+// TestUpdatePreferences_GameSaveStatePolicyUnknownGameSilentlySkipped
+// matches the per-console behaviour: unknown game IDs don't crash
+// the request, the row just isn't written.
+func TestUpdatePreferences_GameSaveStatePolicyUnknownGameSilentlySkipped(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"gameSaveStatePolicies": map[string]string{
+			"99999": "disabled", // No such game.
+			"abc":   "enabled",  // Not even numeric.
+		},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var prefs map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs))
+	policies := prefs["gameSaveStatePolicies"].(map[string]interface{})
+	assert.Empty(t, policies, "unknown game IDs must not write rows")
+}
+
+// TestUpdatePreferences_GameSaveStatePolicyGarbageValuePreservesOverride
+// is the regression test mirroring the per-console one — a typo
+// must not destroy an existing valid override.
+func TestUpdatePreferences_GameSaveStatePolicyGarbageValuePreservesOverride(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "GC").First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Title: "Pikmin",
+		FileName: "pk.iso", FilePath: "/tmp/pk.iso", FileSize: 1024, IsPrimary: true,
+	}
+	require.NoError(t, database.Create(&game).Error)
+	gameIDStr := strconv.FormatUint(uint64(game.ID), 10)
+
+	// 1. User sets "enabled".
+	body, _ := json.Marshal(map[string]interface{}{
+		"gameSaveStatePolicies": map[string]string{gameIDStr: "enabled"},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// 2. Subsequent sync sends a typo. Must not destroy the row.
+	body, _ = json.Marshal(map[string]interface{}{
+		"gameSaveStatePolicies": map[string]string{gameIDStr: "absolutely-not-a-state"},
+	})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// 3. Original "enabled" override must still be there.
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/user/preferences", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var prefs map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs))
+	policies := prefs["gameSaveStatePolicies"].(map[string]interface{})
+	assert.Equal(t, "enabled", policies[gameIDStr])
+}

--- a/server/internal/api/huma_admin_games.go
+++ b/server/internal/api/huma_admin_games.go
@@ -974,6 +974,7 @@ func (h *AdminHandler) HumaHardDeleteUser(ctx context.Context, in *HardDeleteUse
 
 		tx.Unscoped().Where("user_id = ?", uid).Delete(&db.ConsoleShaderPreference{})
 		tx.Unscoped().Where("user_id = ?", uid).Delete(&db.ConsoleSaveStatePolicy{})
+		tx.Unscoped().Where("user_id = ?", uid).Delete(&db.GameSaveStatePolicy{})
 		tx.Unscoped().Where("user_id = ?", uid).Delete(&db.ConsoleKeyMappingPreference{})
 		tx.Unscoped().Where("user_id = ?", uid).Delete(&db.GameKeyMappingPreference{})
 

--- a/server/internal/api/huma_test_reset.go
+++ b/server/internal/api/huma_test_reset.go
@@ -113,6 +113,7 @@ func (h *TestHandler) HumaReset(_ context.Context, _ *TestResetInput) (*TestRese
 		// 7. User preferences
 		tx.Unscoped().Where("1 = 1").Delete(&db.ConsoleShaderPreference{})
 		tx.Unscoped().Where("1 = 1").Delete(&db.ConsoleSaveStatePolicy{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.GameSaveStatePolicy{})
 		tx.Unscoped().Where("1 = 1").Delete(&db.ConsoleKeyMappingPreference{})
 		tx.Unscoped().Where("1 = 1").Delete(&db.DeviceShaderPreference{})
 		tx.Unscoped().Where("1 = 1").Delete(&db.Device{})

--- a/server/internal/api/huma_user.go
+++ b/server/internal/api/huma_user.go
@@ -78,6 +78,7 @@ func (h *UserHandler) HumaGetPreferences(ctx context.Context, _ *GetPreferencesI
 
 	consoleShaders := h.buildConsoleShaderMap(uid)
 	consoleSaveStatePolicies := h.buildConsoleSaveStatePolicyMap(uid)
+	gameSaveStatePolicies := h.buildGameSaveStatePolicyMap(uid)
 	consoleKeyMappings := h.buildConsoleKeyMappingMap(uid)
 	customKeyMapping := parseJSONMap(user.CustomKeyMapping)
 
@@ -112,6 +113,7 @@ func (h *UserHandler) HumaGetPreferences(ctx context.Context, _ *GetPreferencesI
 			DefaultSecondScreenPage: defaultSecondScreenPage,
 			ConsoleShaders:           consoleShaders,
 			ConsoleSaveStatePolicies: consoleSaveStatePolicies,
+			GameSaveStatePolicies:    gameSaveStatePolicies,
 			SelectedKeyMapping:       selectedKeyMapping,
 			CustomKeyMapping:        customKeyMapping,
 			ConsoleKeyMappings:      consoleKeyMappings,

--- a/server/internal/api/huma_user_mutations.go
+++ b/server/internal/api/huma_user_mutations.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -279,6 +280,44 @@ func (h *UserHandler) HumaUpdatePreferences(ctx context.Context, in *UpdatePrefe
 		}
 	}
 
+	if req.GameSaveStatePolicies != nil {
+		for gameIDStr, raw := range req.GameSaveStatePolicies {
+			gameID, err := strconv.ParseUint(gameIDStr, 10, 64)
+			if err != nil {
+				continue
+			}
+			var game db.Game
+			if err := h.DB.First(&game, gameID).Error; err != nil {
+				continue
+			}
+			choice, clear := normalizeSaveStateChoice(raw)
+			if clear {
+				h.DB.Unscoped().Where("user_id = ? AND game_id = ?", uid, game.ID).
+					Delete(&db.GameSaveStatePolicy{})
+				continue
+			}
+			if choice == "" {
+				// Garbage value — drop the entry rather than destroy
+				// an existing override. Same semantics as
+				// ConsoleSaveStatePolicies.
+				continue
+			}
+			var existing db.GameSaveStatePolicy
+			result := h.DB.Unscoped().Where("user_id = ? AND game_id = ?", uid, game.ID).First(&existing)
+			if result.Error == nil {
+				existing.Choice = choice
+				existing.DeletedAt = gorm.DeletedAt{}
+				h.DB.Unscoped().Save(&existing)
+			} else {
+				h.DB.Create(&db.GameSaveStatePolicy{
+					UserID: uid,
+					GameID: game.ID,
+					Choice: choice,
+				})
+			}
+		}
+	}
+
 	if req.ConsoleKeyMappings != nil {
 		for consoleAbbr, km := range req.ConsoleKeyMappings {
 			var console db.Console
@@ -315,6 +354,7 @@ func (h *UserHandler) HumaUpdatePreferences(ctx context.Context, in *UpdatePrefe
 
 	consoleShaders := h.buildConsoleShaderMap(uid)
 	consoleSaveStatePolicies := h.buildConsoleSaveStatePolicyMap(uid)
+	gameSaveStatePolicies := h.buildGameSaveStatePolicyMap(uid)
 	consoleKeyMappings := h.buildConsoleKeyMappingMap(uid)
 	customKeyMapping := parseJSONMap(user.CustomKeyMapping)
 
@@ -349,6 +389,7 @@ func (h *UserHandler) HumaUpdatePreferences(ctx context.Context, in *UpdatePrefe
 			DefaultSecondScreenPage: defaultSecondScreenPage,
 			ConsoleShaders:           consoleShaders,
 			ConsoleSaveStatePolicies: consoleSaveStatePolicies,
+			GameSaveStatePolicies:    gameSaveStatePolicies,
 			SelectedKeyMapping:       selectedKeyMapping,
 			CustomKeyMapping:        customKeyMapping,
 			ConsoleKeyMappings:      consoleKeyMappings,

--- a/server/internal/api/requests.go
+++ b/server/internal/api/requests.go
@@ -41,6 +41,12 @@ type UpdatePreferencesRequest struct {
 	// abbreviations are silently skipped, matching ConsoleShaders.
 	// See #804 phase 4.
 	ConsoleSaveStatePolicies map[string]string              `json:"consoleSaveStatePolicies,omitempty"`
+	// Per-game save-state opt-out upserts keyed by game ID string.
+	// Same sanitiser semantics as ConsoleSaveStatePolicies — empty
+	// string clears the row, unknown values are silently dropped.
+	// Unknown game IDs are skipped (no row written). See #804
+	// phase 4b spec point (c).
+	GameSaveStatePolicies    map[string]string              `json:"gameSaveStatePolicies,omitempty"`
 	SelectedKeyMapping      *string                         `json:"selectedKeyMapping,omitempty"`
 	CustomKeyMapping        map[string]string               `json:"customKeyMapping,omitempty"`
 	ConsoleKeyMappings      map[string]ConsoleKeyMappingDTO `json:"consoleKeyMappings,omitempty"`

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -1114,6 +1114,12 @@ type UserPreferencesResponse struct {
 	// means "use the tier-driven default" (small/medium → enabled,
 	// large → ask-once). See #804 phase 4.
 	ConsoleSaveStatePolicies map[string]string              `json:"consoleSaveStatePolicies"`
+	// Per-game save-state opt-out overrides keyed by game ID
+	// string. Layered on top of consoleSaveStatePolicies — a per-
+	// game choice wins over the console-level one. Only contains
+	// games where the user has made a deliberate per-game choice.
+	// See #804 phase 4b spec point (c).
+	GameSaveStatePolicies    map[string]string              `json:"gameSaveStatePolicies"`
 	SelectedKeyMapping      string                          `json:"selectedKeyMapping"`
 	CustomKeyMapping        map[string]string               `json:"customKeyMapping"`
 	ConsoleKeyMappings      map[string]ConsoleKeyMappingDTO `json:"consoleKeyMappings"`

--- a/server/internal/api/user_handler.go
+++ b/server/internal/api/user_handler.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -56,6 +57,21 @@ func (h *UserHandler) buildConsoleShaderMap(userID uint) map[string]string {
 		if abbr, ok := abbrMap[p.ConsoleID]; ok {
 			m[abbr] = p.Shader
 		}
+	}
+	return m
+}
+
+// buildGameSaveStatePolicyMap queries the per-user, per-game save-
+// state overrides and returns them keyed by game ID string. Layered
+// on top of the per-console policy — a per-game choice wins over the
+// console-level one in the resolver. See #804 phase 4b spec point (c).
+func (h *UserHandler) buildGameSaveStatePolicyMap(userID uint) map[string]string {
+	var prefs []db.GameSaveStatePolicy
+	h.DB.Where("user_id = ?", userID).Find(&prefs)
+
+	m := make(map[string]string, len(prefs))
+	for _, p := range prefs {
+		m[strconv.FormatUint(uint64(p.GameID), 10)] = string(p.Choice)
 	}
 	return m
 }

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -148,6 +148,7 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&ConsoleShaderPreference{},
 		&ConsoleKeyMappingPreference{},
 		&ConsoleSaveStatePolicy{},
+		&GameSaveStatePolicy{},
 		&Device{},
 		&DeviceShaderPreference{},
 		&RetroAchievementCredential{},

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -480,6 +480,25 @@ type ConsoleSaveStatePolicy struct {
 	Choice    ConsoleSaveStateChoice `gorm:"type:varchar(16);not null" json:"choice"`
 }
 
+// GameSaveStatePolicy stores a user's per-game save-state opt-out
+// override that takes precedence over the per-console choice
+// (ConsoleSaveStatePolicy). The "save states on for Mario Sunshine,
+// off for Metroid Prime" case from #804 phase 4b spec point (c).
+//
+// A row only exists once the user has made a deliberate per-game
+// choice. The absence of a row means "use the per-console override
+// (if any), otherwise the tier-driven default" — same precedence
+// as the existing resolver.
+type GameSaveStatePolicy struct {
+	ID        uint                   `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time              `json:"createdAt"`
+	UpdatedAt time.Time              `json:"updatedAt"`
+	DeletedAt gorm.DeletedAt         `gorm:"index" json:"-"`
+	UserID    uint                   `gorm:"uniqueIndex:idx_user_game_savestate;not null" json:"userId"`
+	GameID    uint                   `gorm:"uniqueIndex:idx_user_game_savestate;not null" json:"gameId"`
+	Choice    ConsoleSaveStateChoice `gorm:"type:varchar(16);not null" json:"choice"`
+}
+
 // ConsoleShaderPreference stores a user's per-console shader override.
 type ConsoleShaderPreference struct {
 	ID        uint           `gorm:"primarykey" json:"id"`

--- a/web/src/features/play/hooks/__tests__/use-resolved-game-preferences.test.ts
+++ b/web/src/features/play/hooks/__tests__/use-resolved-game-preferences.test.ts
@@ -10,6 +10,7 @@ function prefs(overrides: Partial<UserPreferences> = {}): UserPreferences {
     autoUpdateCoresEnabled: false,
     consoleKeyMappings: {},
     consoleSaveStatePolicies: {},
+    gameSaveStatePolicies: {},
     consoleShaders: {},
     customKeyMapping: {},
     defaultSecondScreenPage: "controls",

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -8545,6 +8545,9 @@ export interface components {
                 [key: string]: string;
             };
             defaultSecondScreenPage?: string;
+            gameSaveStatePolicies?: {
+                [key: string]: string;
+            };
             preferredRegions?: string[];
             selectedKeyMapping?: string;
             selectedShader?: string;
@@ -8666,6 +8669,9 @@ export interface components {
                 [key: string]: string;
             };
             defaultSecondScreenPage: string;
+            gameSaveStatePolicies: {
+                [key: string]: string;
+            };
             preferredRegions: string[];
             raHardcoreEnabled: boolean;
             raLinked: boolean;

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -9885,6 +9885,12 @@
           "defaultSecondScreenPage": {
             "type": "string"
           },
+          "gameSaveStatePolicies": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "preferredRegions": {
             "items": {
               "type": "string"
@@ -10164,6 +10170,12 @@
           "defaultSecondScreenPage": {
             "type": "string"
           },
+          "gameSaveStatePolicies": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "preferredRegions": {
             "items": {
               "type": "string"
@@ -10202,6 +10214,7 @@
           "defaultSecondScreenPage",
           "consoleShaders",
           "consoleSaveStatePolicies",
+          "gameSaveStatePolicies",
           "selectedKeyMapping",
           "customKeyMapping",
           "consoleKeyMappings",


### PR DESCRIPTION
Power-user escape hatch from the console-level policy (#804 phase 4b spec point c). Lets a user disable save states for a specific game (Metroid Prime) while keeping them enabled for the rest of the console (Mario Sunshine, etc.) without changing the console-wide setting.

This PR is the **data shape + resolver** slice. The UI toggle on the game-detail options menu is intentionally a follow-up — same slice-by-slice rhythm we used for phase 4b's overlay greying / first-launch prompt / Settings entry.

## Resolver precedence

```
1. per-game override (gameSaveStatePolicies[gameId])
2. per-console override (consoleSaveStatePolicies[consoleAbbr])
3. tier default — small/medium → Enabled, large → AskOnce
```

A user with `consoleSaveStatePolicies = {"gc": "disabled"}` and `gameSaveStatePolicies = {"42": "enabled"}` (game 42 = Mario Sunshine) gets save states ON for game 42 only, off for every other GameCube game.

## Server (mirrors the per-console shape from #817)

- `GameSaveStatePolicy` table — per-user, per-game choice. Unique index on `(user_id, game_id)`. Wiped on test reset and admin user delete.
- `gameSaveStatePolicies: map[string]string` on `UserPreferencesResponse` and `UpdatePreferencesRequest`, keyed by game ID string. Same sanitiser semantics as `consoleSaveStatePolicies`:
  - empty string clears the row
  - unknown values silently dropped
  - unknown game IDs skipped
  - garbage values preserve any existing override

## Player

- `UserPreferences.gameSaveStatePolicies` map; DTO mapper parses it (drops unknown values defensively).
- `PreferencesRepository.updatePreferences` signature gains `gameSaveStatePolicies` param.
- `effectiveSaveStateChoice` gains optional `gameOverride: SaveStateChoice?` parameter.

## Tests

Server (4 new):
- `TestUpdatePreferences_SetGameSaveStatePolicy` — round-trip via PUT + GET.
- `TestUpdatePreferences_ClearGameSaveStatePolicy` — empty value removes row.
- `TestUpdatePreferences_GameSaveStatePolicyUnknownGameSilentlySkipped` — non-numeric / non-existent IDs skipped.
- `TestUpdatePreferences_GameSaveStatePolicyGarbageValuePreservesOverride` — typo doesn't destroy existing override.

Player (3 new resolver cases):
- `perGameOverrideBeatsConsoleOverride` — Mario-Sunshine-vs-Metroid-Prime example
- `perGameOverrideBeatsTierDefault` — per-game wins over tier
- `perGameOverrideNullFallsBackToConsole` — null → continue down the precedence chain

587 player desktop tests + full server suite + web 1561 tests + tsc + vite build all green. Android compile + detekt clean.

## Status of #804

After this merges, all six phases of the umbrella plus the per-game data shape are shipped. Optional remaining surfaces:

- **Game-detail UI toggle** — wires this PR's data into a tri-state radio on the game-detail options menu. Small follow-up.
- "Named save" as secondary affordance for medium-tier consoles (phase 5 sub-bullet).
- "Manage slots" UI to rename / delete from the in-game slot picker.

Each is independently shippable; none blocking.