### PR TITLE
fix(player): unblock desktop module test compile (750 silently-skipped tests now run)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreConsoleShowcaseTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreConsoleShowcaseTest.kt
@@ -6,7 +6,6 @@ import com.spela.player.domain.model.ConsoleShowcase
 import com.spela.player.domain.model.Console
 import com.spela.player.domain.model.DeveloperSummary
 import com.spela.player.domain.model.Game
-import com.spela.player.domain.model.GenreCount
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.SpScreen
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -63,7 +62,6 @@ class ExploreConsoleShowcaseTest {
         essentials = emptyList(),
         hiddenGems = emptyList(),
         launchGames = emptyList(),
-        genreBreakdown = emptyList(),
         topDevelopers = emptyList(),
         recentlyPlayed = emptyList(),
         recentlyAdded = emptyList(),

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreDeveloperTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreDeveloperTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.test.*
 import com.spela.player.domain.model.ActiveYears
 import com.spela.player.domain.model.CompanyInfo
 import com.spela.player.domain.model.DeveloperDetail
-import com.spela.player.domain.model.DeveloperDetailGenreBreakdown
 import com.spela.player.domain.model.DeveloperDetailPlatformBreakdown
 import com.spela.player.domain.model.DeveloperDetailPublisher
 import com.spela.player.domain.model.DeveloperDetailUserStats
@@ -113,11 +112,6 @@ class ExploreDeveloperTest {
                 genre = "RPG",
                 igdbCriticsRating = 78.0,
             ),
-        ),
-        genreBreakdown = listOf(
-            DeveloperDetailGenreBreakdown(name = "Platformer", gameCount = 4),
-            DeveloperDetailGenreBreakdown(name = "Fighting", gameCount = 3),
-            DeveloperDetailGenreBreakdown(name = "Action", gameCount = 1),
         ),
         platformBreakdown = listOf(
             DeveloperDetailPlatformBreakdown("SNES", "snes", 5),

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/PauseHintTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/PauseHintTest.kt
@@ -123,6 +123,14 @@ class PauseHintTest {
     @Test
     fun fpsHudVisibleWhenOverlayIsDismissed() = runComposeUiTest {
         val harness = createHarnessWithGameReady()
+        // FpsHud is gated on the user's showPerformanceOverlay
+        // preference (off by default for casual play); flip it on
+        // before navigating so the HUD renders during the test.
+        // See InGameOverlay.kt comment "Off by default since casual
+        // users don't need to see frame timing while playing".
+        harness.preferencesRepo.preferencesResult = Result.success(
+            com.spela.player.domain.model.UserPreferences(showPerformanceOverlay = true),
+        )
 
         setContent { harness.App() }
         advance(harness)
@@ -131,8 +139,8 @@ class PauseHintTest {
         onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
-        // FPS HUD should be visible (the small badge in top-right)
-        // The FPS text node has content description like "X FPS, tap to open game menu"
+        // FPS HUD should be visible (the small badge in top-right).
+        // The FPS text node has content description like "X FPS, tap to open game menu".
         onAllNodes(hasContentDescription("FPS", substring = true))
             .fetchSemanticsNodes()
             .let { nodes ->

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -147,6 +147,7 @@ class SpelaTestHarness(
         challengeRepository = challengeRepo,
         sharedSessionRepository = sharedSessionRepo,
         gameRepository = gameRepo,
+        preferencesRepository = preferencesRepo,
         apiClient = fakeApiClient,
         scrapeService = scrapeService,
         dispatchers = dispatchers,
@@ -178,6 +179,8 @@ class SpelaTestHarness(
         dispatchers = dispatchers,
         scope = scope,
         sessionRepository = sessionRepo,
+        fileStorage = HarnessFileStorage(),
+        pendingUploadRepository = HarnessPendingSaveUploadRepository(),
     )
     private val challengeManager = ChallengeManager(
         challengeRepository = challengeRepo,
@@ -401,5 +404,99 @@ class SpelaTestHarness(
             ),
         )
         }
+    }
+}
+
+/** Real-FS FileStorage backed by a per-harness temp directory. Used so
+ *  SaveManager's file-streaming load/save paths in #798 / #804 phase 6
+ *  actually round-trip through disk in the harness — without this the
+ *  load tests in InGameOverlayTest / SaveLoadStateTest can't see
+ *  unserialize fire. The temp dir is leaked at test-class scope and
+ *  cleaned up by the JVM's tmp-dir cleaner. */
+private class HarnessFileStorage : com.spela.player.util.FileStorage {
+    private val root: java.io.File = kotlin.io.path.createTempDirectory("spela-harness-").toFile()
+    init { root.deleteOnExit() }
+    override fun getGamesDir(): String = ensure("games")
+    override fun getCoresDir(): String = ensure("cores")
+    override fun getSavesDir(): String = ensure("saves")
+    override fun getBiosDir(): String = ensure("bios")
+    private fun ensure(name: String): String =
+        java.io.File(root, name).apply { mkdirs() }.absolutePath
+    override suspend fun createDirectory(path: String) { java.io.File(path).mkdirs() }
+    override suspend fun writeFile(path: String, data: ByteArray) {
+        val f = java.io.File(path)
+        f.parentFile?.mkdirs()
+        f.writeBytes(data)
+    }
+    override suspend fun readFile(path: String): ByteArray =
+        runCatching { java.io.File(path).readBytes() }.getOrDefault(byteArrayOf())
+    override suspend fun fileExists(path: String): Boolean = java.io.File(path).exists()
+    override suspend fun deleteFile(path: String) { java.io.File(path).delete() }
+    override suspend fun deleteDirectory(path: String) { java.io.File(path).deleteRecursively() }
+    override suspend fun getDirectorySize(path: String): Long = 0
+    override suspend fun writeFileStreaming(
+        path: String,
+        writer: suspend (append: suspend (ByteArray, Int, Int) -> Unit) -> Unit,
+    ) {
+        val f = java.io.File(path)
+        f.parentFile?.mkdirs()
+        val out = f.outputStream()
+        try {
+            writer { bytes, offset, length -> out.write(bytes, offset, length) }
+        } finally {
+            out.close()
+        }
+    }
+    override suspend fun getFileSize(path: String): Long = java.io.File(path).length()
+    override suspend fun listFiles(path: String): List<String> =
+        java.io.File(path).listFiles()?.map { it.absolutePath } ?: emptyList()
+    override suspend fun isDirectory(path: String): Boolean = java.io.File(path).isDirectory
+    override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
+    override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+    override suspend fun sha256File(path: String): String? = null
+}
+
+/** In-memory pending-upload queue for the harness. SaveManager
+ *  enqueues here on the deferred-sync path; the harness doesn't
+ *  exercise drain so the queue is essentially write-only in tests. */
+private class HarnessPendingSaveUploadRepository :
+    com.spela.player.domain.repository.PendingSaveUploadRepository {
+    private val rows = mutableListOf<com.spela.player.domain.model.PendingSaveUpload>()
+    private var nextId = 1L
+    override suspend fun enqueue(
+        sessionId: String,
+        kind: com.spela.player.domain.model.PendingUploadKind,
+        slot: Int?,
+        name: String,
+        coreName: String,
+        compression: String,
+        filePath: String,
+        fileSize: Long,
+        screenshotPath: String?,
+        createdAt: Long,
+    ): Long {
+        val id = nextId++
+        rows.add(
+            com.spela.player.domain.model.PendingSaveUpload(
+                id, sessionId, kind, slot, name, coreName, compression,
+                filePath, fileSize, screenshotPath, createdAt, 0, null,
+            ),
+        )
+        return id
+    }
+    override suspend fun getAll() = rows.toList()
+    override suspend fun getForSession(sessionId: String) =
+        rows.filter { it.sessionId == sessionId }
+    override suspend fun getById(id: Long) = rows.find { it.id == id }
+    override suspend fun count(): Long = rows.size.toLong()
+    override suspend fun delete(id: Long) {
+        rows.removeAll { it.id == id }
+    }
+    override suspend fun markRetry(id: Long, lastError: String?) {
+        val idx = rows.indexOfFirst { it.id == id }
+        if (idx >= 0) rows[idx] = rows[idx].copy(
+            retryCount = rows[idx].retryCount + 1,
+            lastError = lastError,
+        )
     }
 }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -643,6 +643,23 @@ class FakeLibretroController : LibretroController {
         return true
     }
 
+    // Streaming hooks added with the #798 staging fast-path. The
+    // harness reads the file the FakeSessionRepository wrote and
+    // forwards to unserialize / serialize so loadCallCount and
+    // saveCallCount keep working through the new file-based paths.
+    override fun serializeToFile(path: String): Long? {
+        val data = serialize() ?: return null
+        return runCatching {
+            java.io.File(path).also { it.parentFile?.mkdirs() }.writeBytes(data)
+            data.size.toLong()
+        }.getOrNull()
+    }
+
+    override fun unserializeFromFile(path: String): Boolean {
+        val data = runCatching { java.io.File(path).readBytes() }.getOrNull() ?: return false
+        return unserialize(data)
+    }
+
     override fun setFastForward(enabled: Boolean) {
         isFastForward = enabled
     }
@@ -700,7 +717,13 @@ class FakePreferencesRepository : PreferencesRepository {
     var syncKeyMappingsCalled = false
     var pushKeyMappingsCalled = false
 
-    override suspend fun getPreferences(): Result<UserPreferences> = Result.success(UserPreferences())
+    /** Override the preferences returned by [getPreferences]. Tests
+     *  configure this when they need a non-default preference (e.g.
+     *  PauseHintTest flipping showPerformanceOverlay on so the FPS HUD
+     *  renders). */
+    var preferencesResult: Result<UserPreferences> = Result.success(UserPreferences())
+
+    override suspend fun getPreferences(): Result<UserPreferences> = preferencesResult
     override suspend fun updatePreferences(
         showPerformanceOverlay: Boolean?,
         autoSaveEnabled: Boolean?,
@@ -709,6 +732,8 @@ class FakePreferencesRepository : PreferencesRepository {
         selectedShader: String?,
         selectedTheme: String?,
         consoleShaders: Map<String, String>?,
+        consoleSaveStatePolicies: Map<String, String>?,
+        gameSaveStatePolicies: Map<String, String>?,
         defaultSecondScreenPage: String?,
     ): Result<UserPreferences> = Result.success(UserPreferences())
     override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
@@ -1391,6 +1416,71 @@ class FakeSessionRepository : SessionRepository {
         val key = "$sessionId:$slot"
         return slotSaves[key]?.let { Result.success(it) }
             ?: Result.failure(Exception("No save in slot $slot"))
+    }
+
+    // Streaming variants added in #798 / #804 phase 2 / phase 6 slice 3.
+    // Upload paths read the file from disk (the harness's real FS) and
+    // dispatch to the in-memory variants. Download paths write the
+    // bytes back out so the libretro stub's unserializeFromFile can
+    // re-read them — required for the harness's load-from-auto-save
+    // tests in InGameOverlayTest / SaveLoadStateTest.
+    override suspend fun uploadSessionSaveFromFile(
+        sessionId: String,
+        name: String,
+        savePath: String,
+        saveSize: Long,
+        screenshot: ByteArray?,
+        coreName: String,
+        compression: String,
+    ): Result<SaveState> {
+        val data = runCatching { java.io.File(savePath).readBytes() }.getOrDefault(ByteArray(0))
+        return uploadSessionSave(sessionId, name, data, screenshot, coreName)
+    }
+
+    override suspend fun uploadSessionAutoSaveFromFile(
+        sessionId: String,
+        savePath: String,
+        saveSize: Long,
+        screenshot: ByteArray?,
+        coreName: String,
+        compression: String,
+    ): Result<Unit> {
+        val data = runCatching { java.io.File(savePath).readBytes() }.getOrDefault(ByteArray(0))
+        return uploadSessionAutoSave(sessionId, data, screenshot, coreName)
+    }
+
+    override suspend fun downloadSessionAutoSaveToFile(
+        sessionId: String,
+        outputPath: String,
+    ): Result<Unit> = downloadSessionAutoSave(sessionId).map { bytes ->
+        runCatching {
+            java.io.File(outputPath).also { it.parentFile?.mkdirs() }.writeBytes(bytes)
+        }
+        Unit
+    }
+
+    override suspend fun uploadSlotSaveFromFile(
+        sessionId: String,
+        slot: Int,
+        savePath: String,
+        saveSize: Long,
+        screenshot: ByteArray?,
+        coreName: String,
+        compression: String,
+    ): Result<SaveState> {
+        val data = runCatching { java.io.File(savePath).readBytes() }.getOrDefault(ByteArray(0))
+        return uploadSlotSave(sessionId, slot, data, screenshot, coreName)
+    }
+
+    override suspend fun downloadSlotSaveToFile(
+        sessionId: String,
+        slot: Int,
+        outputPath: String,
+    ): Result<Unit> = downloadSlotSave(sessionId, slot).map { bytes ->
+        runCatching {
+            java.io.File(outputPath).also { it.parentFile?.mkdirs() }.writeBytes(bytes)
+        }
+        Unit
     }
 
     override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String): Result<Unit> {


### PR DESCRIPTION
## What was broken

`:desktop:compileTestKotlinDesktop` has been silently failing for a while. 15 compile errors caused Gradle to skip everything in the desktop module's test source set, so `./run-desktop-tests.sh` reported only **9 desktop tests** (the ones in modules that did compile) when the suite actually contains **759**. The `Player unit tests` CI job only runs `:shared:desktopTest`, so the breakage never showed up there either.

I noticed it during phase 5 of #804 (#822) when I tried to add a Compose UI test for the new overlay greying — the desktop module test compile failed and I had to fall back to a pure-function unit test. Flagged it in the PR body at the time and the umbrella was already big, so I left it for a follow-up.

## What changed

Three drift categories, all pre-existing:

### 1. Removed types referenced by tests
- `GenreCount` (in `ExploreConsoleShowcaseTest`) — `ConsoleShowcase.genreBreakdown` was deleted long ago.
- `DeveloperDetailGenreBreakdown` (in `ExploreDeveloperTest`) — same deletion on `DeveloperDetail`.

Drop the imports and the now-stale field arguments. Tests stay otherwise intact.

### 2. SaveManager / SessionRepository constructor + method drift
- `SpelaTestHarness` was calling `SaveManager` and `GameDetailViewModel` with the pre-#823 (no `fileStorage` / `pendingUploadRepository`) and pre-#828 (no `preferencesRepository`) signatures. Wire the new params; add a per-harness `HarnessFileStorage` backed by a real temp directory and an in-memory `HarnessPendingSaveUploadRepository`.
- `FakeSessionRepository` was missing the streaming variants added in #798 (FromFile uploads), #804 phase 2 (compression param), #804 phase 6 slice 3 (`downloadSlotSaveToFile`). Add them all, dispatching to the existing in-memory variants but actually reading/writing real files so the load tests can re-trigger unserialize.
- `FakePreferencesRepository.updatePreferences` was missing the `consoleSaveStatePolicies` (#817) and `gameSaveStatePolicies` (#827) params.

### 3. Test bugs surfaced by the new file-streaming load path
- `PauseHintTest.fpsHudVisibleWhenOverlayIsDismissed` assumed the FPS HUD was visible by default. The HUD was gated on `showPerformanceOverlay` (off by default for casual play) at some point. Flip the pref on in the test setup.
- `SaveLoadStateTest` / `InGameOverlayTest` expected `unserialize` to fire when Load is tapped. The new file-streaming load path reads bytes from disk, so the harness's `FakeSessionRepository` now actually writes the auto-save bytes to disk in `downloadSessionAutoSaveToFile`, and `FakeLibretroController` implements `unserializeFromFile` by reading them back.

## Results

| Before | After |
|---|---|
| 9 desktop tests run | 759 desktop tests run |
| `:desktop:compileTestKotlinDesktop` FAILED | passes |
| ~750 tests silently skipped | 0 silently skipped |

Full sanity:

- Player shared: 589 tests, 0 failures
- Player desktop: 759 tests, 0 failures
- Android compile: clean across all three modules
- detekt: clean across `:shared`, `:desktop`, `:android`

## Why this matters going forward

The desktop module is where Compose UI tests live (e.g. the existing `RehearsalBannerTest`, `SpDecisionSheetTest`). With it now compiling, future PRs that add UI tests for new components don't need to invent workarounds — they can use `runComposeUiTest` against the shared composables directly. Phase 5 of #804 had to use a pure-function unit test because of this; the new game-detail save-state toggle in #828 has Compose tags ready for UI assertions but no test yet — that's now a small follow-up rather than a blocked task.