### PR TITLE
fix(test-infra): bound nav-helper back-loop to prevent 7-min hangs (#835)

### DIFF
--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -2215,29 +2215,44 @@ fun ComposeRule.navigateToGameAndPlay(preferredGameTitle: String? = "Balloon Fig
     Thread.sleep(500)
     // The Consoles tab restores its last visited screen (e.g. NES detail
     // if a previous test landed there) instead of the consoles list root.
-    // Pop back-stack within the Consoles tab until the NES card testTag
-    // is visible on screen (= we're on the consoles list).
+    // Pop back-stack within the Consoles tab until the NES card is on
+    // screen (= we're on the consoles list). The probe uses Compose's
+    // semantic-tree query, which routes through the test rule's idleness
+    // sync — that *can* hang on never-completing background coroutines
+    // (e.g. a libretro core left warming after the prior test). Bound the
+    // whole phase with a wall-clock deadline so a stuck idleness sync
+    // surfaces a useful error in <60s instead of timing out the entire
+    // gradle test slot. Also bail out early if back-press has popped us
+    // off the app entirely. See issue #835 for the 7-min-hang trace.
+    val landStart = System.currentTimeMillis()
+    val landDeadlineMs = 60_000L
     var landedOnList = false
-    repeat(8) {
+    var pops = 0
+    while (System.currentTimeMillis() - landStart < landDeadlineMs && pops < 8) {
+        val pkg = device.currentPackageName
+        if (pkg != null && pkg != "com.spela.player") {
+            android.util.Log.d(tag, "navigateToGameAndPlay: popped out of Spela (pkg=$pkg); aborting back-loop")
+            break
+        }
         try {
             if (onAllNodes(hasTestTag(nesTag)).fetchSemanticsNodes().isNotEmpty()) {
                 landedOnList = true
-                return@repeat
+                break
             }
         } catch (_: Exception) {}
+        android.util.Log.d(tag, "navigateToGameAndPlay: NES card not visible (pop=$pops, pkg=$pkg); pressing back")
         pressBack()
+        pops++
         Thread.sleep(400)
     }
     if (!landedOnList) {
-        try {
-            pollUntil(timeoutMillis = 5_000L) {
-                try { onAllNodes(hasTestTag(nesTag)).fetchSemanticsNodes().isNotEmpty() }
-                catch (_: Exception) { false }
-            }
-        } catch (_: androidx.compose.ui.test.ComposeTimeoutException) {
-            throw IllegalStateException("Could not reach Consoles list — NES card testTag not visible after Home→Consoles bounce + 8 back presses")
-        }
+        val elapsed = System.currentTimeMillis() - landStart
+        throw IllegalStateException(
+            "Could not reach Consoles list — NES card '$nesTag' not visible after $pops back press(es) " +
+                "(${elapsed}ms elapsed, current package=${device.currentPackageName})"
+        )
     }
+    android.util.Log.d(tag, "navigateToGameAndPlay: landed on Consoles list after $pops pop(s)")
     onAllNodes(hasTestTag(nesTag))[0].performClick()
     waitForIdle()
     Thread.sleep(500)


### PR DESCRIPTION
Fixes #835.

## Problem

The second pop-back loop in \`navigateToGameAndPlay\` called \`onAllNodes(hasTestTag(nesTag)).fetchSemanticsNodes()\` each iteration. That call routes through the Compose test rule's idleness sync, which blocks until the tree goes idle. When a background coroutine (libretro core warmup, FPS HUD timer) prevents idleness, the call hangs indefinitely — turning \`repeat(8)\` into one infinite-blocking iteration.

Observed in the wild: 6m58s of silence between \`tapped Consoles\` and the per-test gradle timeout in \`ChallengeCreationTest\`. See #835 for the full E2E_NAV trace.

## Fix

- Wrap the whole landing phase in a 60s wall-clock deadline
- Log every back-press iteration with current package
- Abort the loop early if \`pressBack\` popped us off the Spela app
- Drop the redundant 5s \`pollUntil\` failsafe (the wall-clock budget already covers it) and emit a useful error message including elapsed time + current package

Net effect: when the screen genuinely doesn't land on the consoles list, we surface a useful error inside ~60s instead of hanging the gradle slot for 7 minutes. The Compose semantic-tree probe itself is unchanged — it's what made the original navigation succeed for hundreds of test runs before this regression.

## Validation

Ran \`./run-e2e.sh --skip-reset com.spela.player.android.ChallengeCreationTest\` against the AYN Thor:

- All 6 \`navigateToGameAndPlay\` calls landed on Consoles list within 0–1 pops
- Each test ran in ~25–30s (vs 7m+ hangs before)
- 5/6 tests pass; the 6th (\`createChallengeSuccessfully\`) fails on a separate \`waitForText('Challenge created!')\` 8s timeout that's unrelated to this nav helper — worth its own follow-up issue.

Desktop suite (759 tests) still 100% green — this change is Android-only.

## Why not testTagsAsResourceId

I tried wrapping the shared \`SpelaApp\` content in \`Box(Modifier.semantics { testTagsAsResourceId = true })\` so UiAutomator could find Compose nodes by resource ID directly (no idleness sync at all). The propagation didn't reach the console card — \`UiSelector().resourceId(\"console_card_nes\")\` returned false even when we were on the consoles list. Reverted; would need deeper investigation into Compose's resource-id semantic plumbing on this app's screen tree. The wall-clock-bound approach is simpler and validated working.

## Logging

Per project policy in CLAUDE.md ("Logging is the primary debugging tool"), all existing \`E2E_NAV\` Log.d trace lines are preserved, and a new one is added for each back-press iteration. The next time this code path misbehaves, the trace will say exactly where.