### PR TITLE
test(player): Compose UI test for GameSaveStatePolicyToggle (#832)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/GameSaveStatePolicyToggleTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/GameSaveStatePolicyToggleTest.kt
@@ -1,0 +1,85 @@
+package com.spela.player.desktop.components
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.spela.player.domain.model.SaveStateChoice
+import com.spela.player.presentation.ui.feature.gamedetail.GameSaveStatePolicyToggle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * UI coverage for [GameSaveStatePolicyToggle], the per-game tri-state
+ * radio shown on the game-detail options area (Console default /
+ * Always enabled / Always disabled). VM-side wiring is covered by
+ * GameDetailViewModelTest; this locks in the rendering contract and
+ * the choice each radio dispatches.
+ */
+@OptIn(ExperimentalTestApi::class)
+class GameSaveStatePolicyToggleTest {
+
+    @Test
+    fun rendersAllThreeOptions() = runComposeUiTest {
+        setContent {
+            GameSaveStatePolicyToggle(
+                current = SaveStateChoice.Disabled,
+                onChange = {},
+            )
+        }
+
+        onNodeWithTag("game-save-state-policy-toggle").assertIsDisplayed()
+        onNodeWithTag("game-save-state-default").assertIsDisplayed()
+        onNodeWithTag("game-save-state-enabled").assertIsDisplayed()
+        onNodeWithTag("game-save-state-disabled").assertIsDisplayed()
+    }
+
+    @Test
+    fun tappingConsoleDefaultDispatchesNullChoice() = runComposeUiTest {
+        var captured: SaveStateChoice? = SaveStateChoice.Disabled
+        var captureCount = 0
+        setContent {
+            GameSaveStatePolicyToggle(
+                current = SaveStateChoice.Disabled,
+                onChange = { captured = it; captureCount++ },
+            )
+        }
+
+        onNodeWithTag("game-save-state-default").performClick()
+
+        assertNull(captured, "tapping 'Console default' clears the override")
+        assertEquals(1, captureCount)
+    }
+
+    @Test
+    fun tappingAlwaysEnabledDispatchesEnabledChoice() = runComposeUiTest {
+        var captured: SaveStateChoice? = null
+        setContent {
+            GameSaveStatePolicyToggle(
+                current = null,
+                onChange = { captured = it },
+            )
+        }
+
+        onNodeWithTag("game-save-state-enabled").performClick()
+
+        assertEquals(SaveStateChoice.Enabled, captured)
+    }
+
+    @Test
+    fun tappingAlwaysDisabledDispatchesDisabledChoice() = runComposeUiTest {
+        var captured: SaveStateChoice? = null
+        setContent {
+            GameSaveStatePolicyToggle(
+                current = null,
+                onChange = { captured = it },
+            )
+        }
+
+        onNodeWithTag("game-save-state-disabled").performClick()
+
+        assertEquals(SaveStateChoice.Disabled, captured)
+    }
+}


### PR DESCRIPTION
Closes #832.

Locks in the rendering contract for the per-game save-state opt-out radio shipped in #828: all three options render, and each radio click dispatches the correct \`SaveStateChoice\` (or \`null\` for "Console default").

## Coverage

- \`rendersAllThreeOptions\` — root card + all 3 radio test tags visible
- \`tappingConsoleDefaultDispatchesNullChoice\` — clears the override
- \`tappingAlwaysEnabledDispatchesEnabledChoice\`
- \`tappingAlwaysDisabledDispatchesDisabledChoice\`

## Why now

The UI test was deferred from #828 because \`:desktop:compileTestKotlinDesktop\` was broken at the time. #829 unblocked it, and #832 was filed to track this cleanup.

VM-side wiring was already covered by \`GameDetailViewModelTest\` (\`setGameSaveStatePolicyOptimisticallyUpdatesStateAndWritesPreference\`, \`setGameSaveStatePolicyNullClearsTheOverride\`); this completes the test pyramid.

## Validation

\`\`\`
./run-desktop-tests.sh GameSaveStatePolicyToggleTest
PASS  com.spela.player.desktop.components.GameSaveStatePolicyToggleTest (4 tests) 0.916s
\`\`\`

Full desktop suite still green (759 tests).