### PR TITLE
test(player): UI test for OverlayActionButtons opt-out hiding (#833)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/OverlayActionButtonsOptOutTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/OverlayActionButtonsOptOutTest.kt
@@ -1,0 +1,80 @@
+package com.spela.player.desktop.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.ui.feature.ingame.OverlayActionButtons
+import kotlin.test.Test
+
+/**
+ * UI coverage for the in-game overlay's save-state opt-out gate
+ * (#804 phase 4 spec point d). The pure-function gate
+ * [com.spela.player.presentation.ui.feature.ingame.shouldShowSaveStateActions]
+ * is already covered by SaveStateActionsGateTest in :shared:commonTest;
+ * this asserts the rendered effect on actual button visibility.
+ */
+@OptIn(ExperimentalTestApi::class)
+class OverlayActionButtonsOptOutTest {
+
+    @Test
+    fun showsSaveLoadChallengeWhenSupportedAndNotOptedOut() = runComposeUiTest {
+        setContent {
+            Row {
+                OverlayActionButtons(
+                    isFastForward = false,
+                    supportsSaveStates = true,
+                    saveStatesOptedOut = false,
+                    onSave = {}, onLoad = {}, onScreenshot = {},
+                    onToggleFastForward = {}, onChallenge = {}, onControls = {},
+                )
+            }
+        }
+
+        onNodeWithText("Save").assertIsDisplayed()
+        onNodeWithText("Load").assertIsDisplayed()
+        onNodeWithText("Challenge").assertIsDisplayed()
+    }
+
+    @Test
+    fun hidesSaveLoadChallengeWhenOptedOut() = runComposeUiTest {
+        setContent {
+            Row {
+                OverlayActionButtons(
+                    isFastForward = false,
+                    supportsSaveStates = true,
+                    saveStatesOptedOut = true,
+                    onSave = {}, onLoad = {}, onScreenshot = {},
+                    onToggleFastForward = {}, onChallenge = {}, onControls = {},
+                )
+            }
+        }
+
+        onNodeWithText("Save").assertDoesNotExist()
+        onNodeWithText("Load").assertDoesNotExist()
+        onNodeWithText("Challenge").assertDoesNotExist()
+        // Sanity check — non-save actions must still render.
+        onNodeWithText("Screenshot").assertIsDisplayed()
+        onNodeWithText("Controls").assertIsDisplayed()
+    }
+
+    @Test
+    fun hidesSaveLoadChallengeWhenCoreDoesNotSupportSaveStates() = runComposeUiTest {
+        // Belt-and-braces: pre-opt-out behaviour also hides the row when
+        // the core itself can't serialise (e.g. ScummVM). Lock this in
+        // so the new opt-out flag doesn't accidentally re-enable buttons
+        // for unsupported cores.
+        setContent {
+            Row {
+                OverlayActionButtons(
+                    isFastForward = false,
+                    supportsSaveStates = false,
+                    saveStatesOptedOut = false,
+                    onSave = {}, onLoad = {}, onScreenshot = {},
+                    onToggleFastForward = {}, onChallenge = {}, onControls = {},
+                )
+            }
+        }
+
+        onNodeWithText("Save").assertDoesNotExist()
+        onNodeWithText("Screenshot").assertIsDisplayed()
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
@@ -400,7 +400,7 @@ internal fun shouldShowSaveStateActions(
 ): Boolean = supportsSaveStates && !saveStatesOptedOut
 
 @Composable
-internal fun RowScope.OverlayActionButtons(
+fun RowScope.OverlayActionButtons(
     isFastForward: Boolean,
     supportsSaveStates: Boolean,
     saveStatesOptedOut: Boolean = false,


### PR DESCRIPTION
Closes #833.

Asserts the rendered effect of the save-state opt-out gate at the actual button level. The pure-function gate (\`shouldShowSaveStateActions\`) is already covered by \`SaveStateActionsGateTest\` in \`:shared:commonTest\`; this completes the test pyramid by pinning the render contract.

## Coverage

- \`showsSaveLoadChallengeWhenSupportedAndNotOptedOut\` — happy path
- \`hidesSaveLoadChallengeWhenOptedOut\` — \`saveStatesOptedOut = true\` hides Save / Load / Challenge while Screenshot / Controls remain (regression guard)
- \`hidesSaveLoadChallengeWhenCoreDoesNotSupportSaveStates\` — pre-existing \`supportsSaveStates = false\` path keeps working with the new opt-out flag in place

## Visibility change

\`OverlayActionButtons\` was \`internal\` to \`:shared\` — \`:desktop:desktopTest\` couldn't see it. Dropped the modifier; the composable is a reusable UI primitive (sibling composables in the same family are public).

## Why now

Deferred from #819 because \`:desktop:compileTestKotlinDesktop\` was broken at the time and the only way to ship coverage was to extract the gate as a pure function. #829 unblocked desktop test compile, and #833 was filed to track this cleanup.

## Validation

\`\`\`
./gradlew :desktop:desktopTest --tests "...OverlayActionButtonsOptOutTest"
PASSED  hidesSaveLoadChallengeWhenCoreDoesNotSupportSaveStates (0.64s)
PASSED  showsSaveLoadChallengeWhenSupportedAndNotOptedOut       (0.039s)
PASSED  hidesSaveLoadChallengeWhenOptedOut                       (0.029s)
\`\`\`