### PR TITLE
feat(player): in-game slot manage actions — rename / delete (#831)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/SlotManageDialogsTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/SlotManageDialogsTest.kt
@@ -1,0 +1,213 @@
+package com.spela.player.desktop.components
+
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.state.SaveSlotInfo
+import com.spela.player.presentation.ui.feature.ingame.InGameSlotActionsSheet
+import com.spela.player.presentation.ui.feature.ingame.InGameSlotDeleteConfirmDialog
+import com.spela.player.presentation.ui.feature.ingame.InGameSlotRenameDialog
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * UI coverage for the slot-manage modals shown on long-press of a
+ * filled slot cell on the in-game slot picker (#831). Tests the
+ * three composables in isolation — long-press wiring is exercised
+ * by the slot picker test class. Each modal:
+ *
+ *   InGameSlotActionsSheet    — Rename / Delete / Cancel routing
+ *   InGameSlotRenameDialog    — text input + confirm/cancel
+ *   InGameSlotDeleteConfirmDialog — two-step destructive confirm
+ */
+@OptIn(ExperimentalTestApi::class)
+class SlotManageDialogsTest {
+
+    // ── InGameSlotActionsSheet ─────────────────────────────────────
+
+    @Test
+    fun actionsSheetRendersTitleWithSlotAndTimestampWhenNoName() = runComposeUiTest {
+        setContent {
+            InGameSlotActionsSheet(
+                slot = 7,
+                slotInfo = SaveSlotInfo(timestamp = "13:42", isFilled = true, saveId = "abc"),
+                onRename = {}, onDelete = {}, onDismiss = {},
+            )
+        }
+
+        onNodeWithText("Slot 7 — 13:42").assertIsDisplayed()
+        onNodeWithTag("slot-actions-rename").assertIsDisplayed()
+        onNodeWithTag("slot-actions-delete").assertIsDisplayed()
+        onNodeWithTag("slot-actions-cancel").assertIsDisplayed()
+    }
+
+    @Test
+    fun actionsSheetTitlePrefersUserNameOverTimestamp() = runComposeUiTest {
+        setContent {
+            InGameSlotActionsSheet(
+                slot = 3,
+                slotInfo = SaveSlotInfo(
+                    timestamp = "10:00",
+                    name = "Before final boss",
+                    isFilled = true,
+                    saveId = "id",
+                ),
+                onRename = {}, onDelete = {}, onDismiss = {},
+            )
+        }
+
+        onNodeWithText("Slot 3 — Before final boss").assertIsDisplayed()
+    }
+
+    @Test
+    fun actionsSheetRenameButtonRoutesToOnRename() = runComposeUiTest {
+        var renamed = 0
+        setContent {
+            InGameSlotActionsSheet(
+                slot = 1,
+                slotInfo = SaveSlotInfo(isFilled = true, saveId = "id"),
+                onRename = { renamed++ },
+                onDelete = {},
+                onDismiss = {},
+            )
+        }
+
+        onNodeWithTag("slot-actions-rename").performClick()
+
+        assertEquals(1, renamed)
+    }
+
+    @Test
+    fun actionsSheetDeleteButtonRoutesToOnDelete() = runComposeUiTest {
+        var deleted = 0
+        setContent {
+            InGameSlotActionsSheet(
+                slot = 1,
+                slotInfo = SaveSlotInfo(isFilled = true, saveId = "id"),
+                onRename = {},
+                onDelete = { deleted++ },
+                onDismiss = {},
+            )
+        }
+
+        onNodeWithTag("slot-actions-delete").performClick()
+
+        assertEquals(1, deleted)
+    }
+
+    @Test
+    fun actionsSheetCancelDismisses() = runComposeUiTest {
+        var dismissed = 0
+        setContent {
+            InGameSlotActionsSheet(
+                slot = 1,
+                slotInfo = SaveSlotInfo(isFilled = true, saveId = "id"),
+                onRename = {},
+                onDelete = {},
+                onDismiss = { dismissed++ },
+            )
+        }
+
+        onNodeWithTag("slot-actions-cancel").performClick()
+
+        assertEquals(1, dismissed)
+    }
+
+    // ── InGameSlotRenameDialog ─────────────────────────────────────
+
+    @Test
+    fun renameDialogPrefillsExistingName() = runComposeUiTest {
+        setContent {
+            InGameSlotRenameDialog(
+                slot = 5,
+                slotInfo = SaveSlotInfo(isFilled = true, saveId = "id", name = "Existing"),
+                onConfirm = {},
+                onDismiss = {},
+            )
+        }
+
+        onNodeWithText("Rename slot 5").assertIsDisplayed()
+        onNodeWithText("Existing").assertIsDisplayed()
+    }
+
+    @Test
+    fun renameDialogConfirmDispatchesEditedText() = runComposeUiTest {
+        var captured: String? = null
+        setContent {
+            InGameSlotRenameDialog(
+                slot = 5,
+                slotInfo = SaveSlotInfo(isFilled = true, saveId = "id", name = ""),
+                onConfirm = { captured = it },
+                onDismiss = {},
+            )
+        }
+
+        onNode(hasSetTextAction()).performTextInput("New name")
+        onNodeWithTag("slot-rename-confirm").performClick()
+
+        assertEquals("New name", captured)
+    }
+
+    @Test
+    fun renameDialogCancelDismissesWithoutFiringConfirm() = runComposeUiTest {
+        var confirmCount = 0
+        var dismissCount = 0
+        setContent {
+            InGameSlotRenameDialog(
+                slot = 5,
+                slotInfo = SaveSlotInfo(isFilled = true, saveId = "id", name = "x"),
+                onConfirm = { confirmCount++ },
+                onDismiss = { dismissCount++ },
+            )
+        }
+
+        onNodeWithTag("slot-rename-cancel").performClick()
+
+        assertEquals(0, confirmCount)
+        assertEquals(1, dismissCount)
+    }
+
+    // ── InGameSlotDeleteConfirmDialog ──────────────────────────────
+
+    @Test
+    fun deleteConfirmRendersSlotInTitle() = runComposeUiTest {
+        setContent {
+            InGameSlotDeleteConfirmDialog(slot = 7, onConfirm = {}, onDismiss = {})
+        }
+
+        onNodeWithText("Delete slot 7?").assertIsDisplayed()
+        onNodeWithText("This can't be undone.").assertIsDisplayed()
+    }
+
+    @Test
+    fun deleteConfirmConfirmFiresOnConfirm() = runComposeUiTest {
+        var confirmed = 0
+        setContent {
+            InGameSlotDeleteConfirmDialog(
+                slot = 7,
+                onConfirm = { confirmed++ },
+                onDismiss = {},
+            )
+        }
+
+        onNodeWithTag("slot-delete-confirm").performClick()
+
+        assertEquals(1, confirmed)
+    }
+
+    @Test
+    fun deleteConfirmCancelDismissesWithoutFiringConfirm() = runComposeUiTest {
+        var confirmed = 0
+        var dismissed = 0
+        setContent {
+            InGameSlotDeleteConfirmDialog(
+                slot = 7,
+                onConfirm = { confirmed++ },
+                onDismiss = { dismissed++ },
+            )
+        }
+
+        onNodeWithTag("slot-delete-cancel").performClick()
+
+        assertEquals(0, confirmed)
+        assertEquals(1, dismissed)
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1377,6 +1377,37 @@ class FakeSessionRepository : SessionRepository {
     override suspend fun getSessionSaves(sessionId: String): Result<List<SaveState>> =
         Result.success(sessionSaves[sessionId] ?: emptyList())
 
+    /** Records the most recent rename + delete calls so tests can
+     *  assert wiring without a real network. See #831. */
+    var lastRenameCall: Triple<String, String, String>? = null
+        private set
+    var lastDeleteCall: Pair<String, String>? = null
+        private set
+
+    override suspend fun updateSessionSave(
+        sessionId: String,
+        saveId: String,
+        name: String,
+    ): Result<SaveState> {
+        lastRenameCall = Triple(sessionId, saveId, name)
+        val saves = sessionSaves[sessionId] ?: return Result.failure(NoSuchElementException(sessionId))
+        val idx = saves.indexOfFirst { it.id == saveId }
+        if (idx < 0) return Result.failure(NoSuchElementException(saveId))
+        val updated = saves[idx].copy(name = name)
+        sessionSaves[sessionId] = saves.toMutableList().also { it[idx] = updated }
+        return Result.success(updated)
+    }
+
+    override suspend fun deleteSessionSave(
+        sessionId: String,
+        saveId: String,
+    ): Result<Unit> {
+        lastDeleteCall = sessionId to saveId
+        val saves = sessionSaves[sessionId] ?: return Result.success(Unit)
+        sessionSaves[sessionId] = saves.filterNot { it.id == saveId }.toMutableList()
+        return Result.success(Unit)
+    }
+
     override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<SaveState> {
         val save = SaveState(
             id = ((sessionSaves[sessionId]?.size ?: 0) + 1).toString(),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1630,6 +1630,22 @@ class SpelaApiClient(
         return sessionsApi.listSessionSaves(sessionId).body()
     }
 
+    suspend fun updateSessionSave(
+        sessionId: String,
+        saveId: String,
+        name: String,
+    ): com.spela.client.models.SessionSaveResponse {
+        return sessionsApi.updateSessionSave(
+            sessionId,
+            saveId,
+            com.spela.client.models.UpdateSessionSaveRequest(name = name),
+        ).body()
+    }
+
+    suspend fun deleteSessionSave(sessionId: String, saveId: String) {
+        sessionsApi.deleteSessionSave(sessionId, saveId)
+    }
+
     suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): com.spela.client.models.SessionSaveResponse {
         return client.submitFormWithBinaryData(
             url = "$baseUrl/api/sessions/$sessionId/saves",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
@@ -55,6 +55,21 @@ class SessionRepositoryImpl(
         apiClient.getSessionSaves(sessionId).map { it.toDomain() }
     }
 
+    override suspend fun updateSessionSave(
+        sessionId: String,
+        saveId: String,
+        name: String,
+    ): Result<SaveState> = runCatching {
+        apiClient.updateSessionSave(sessionId, saveId, name).toDomain()
+    }
+
+    override suspend fun deleteSessionSave(
+        sessionId: String,
+        saveId: String,
+    ): Result<Unit> = runCatching {
+        apiClient.deleteSessionSave(sessionId, saveId)
+    }
+
     override suspend fun uploadSessionSave(
         sessionId: String,
         name: String,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
@@ -25,6 +25,13 @@ interface SessionRepository {
     ): Result<GameSession>
     suspend fun deleteSession(sessionId: String): Result<Unit>
     suspend fun getSessionSaves(sessionId: String): Result<List<SaveState>>
+    /** Rename a single session save (slot or named). Server returns the
+     *  updated row. Used by the in-game slot manage UI (#831). */
+    suspend fun updateSessionSave(sessionId: String, saveId: String, name: String): Result<SaveState>
+    /** Delete a single session save by id. Server returns 200 with a
+     *  message body on success. Used by the in-game slot manage UI
+     *  (#831) to free a filled slot mid-session. */
+    suspend fun deleteSessionSave(sessionId: String, saveId: String): Result<Unit>
     suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): Result<SaveState>
     /** Streaming variant: reads save bytes from [savePath] without loading
      *  the full state into a JVM ByteArray. Required for cores like

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -98,6 +98,24 @@ sealed interface EmulationIntent {
     /** Dismiss the slot-primary slot picker modal without saving or
      *  loading. The user is bailing out of the choice. See #804 phase 5. */
     data object DismissSlotPicker : EmulationIntent
+    /** Long-press on a filled slot cell — opens the actions bottom
+     *  sheet (Rename / Delete / Cancel). See #831. */
+    data class ShowSlotActionsSheet(val slot: Int) : EmulationIntent
+    data object DismissSlotActionsSheet : EmulationIntent
+    /** Open the rename dialog for the slot. Pre-fills with the
+     *  slot's existing name. See #831. */
+    data class ShowSlotRenameDialog(val slot: Int) : EmulationIntent
+    data object DismissSlotRenameDialog : EmulationIntent
+    /** Commit a rename. Optimistically updates the local saveSlots
+     *  map; server is the source of truth on next refresh. See #831. */
+    data class RenameSlot(val slot: Int, val name: String) : EmulationIntent
+    /** Open the delete-confirmation dialog for the slot. The actual
+     *  network call doesn't happen until the user confirms. See #831. */
+    data class ShowSlotDeleteConfirm(val slot: Int) : EmulationIntent
+    data object DismissSlotDeleteConfirm : EmulationIntent
+    /** Confirmed delete — fires the DELETE call and clears the slot
+     *  from the local map on success. See #831. */
+    data class DeleteSlot(val slot: Int) : EmulationIntent
 
     // Rewind
     data object RewindStep : EmulationIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -50,6 +50,13 @@ data class SaveSlotInfo(
     val screenshotUrl: String? = null,
     val timestamp: String? = null,
     val isFilled: Boolean = false,
+    /** Server save id backing this slot. Null when the slot is empty
+     *  or when the source predates the slot-id wiring (#831). Required
+     *  for the rename / delete actions on the in-game slot picker. */
+    val saveId: String? = null,
+    /** Existing user-supplied save name, if any. Surfaced into the
+     *  rename dialog as the prefill (#831). */
+    val name: String? = null,
 )
 
 /**
@@ -111,6 +118,23 @@ data class EmulationState(
      * phase 5.
      */
     val slotPickerMode: SlotPickerMode? = null,
+    /**
+     * Non-null when the user long-presses a filled slot cell on the
+     * in-game slot picker. Drives the slot-actions bottom sheet
+     * (Rename / Delete / Cancel). See #831.
+     */
+    val slotActionsSheetSlot: Int? = null,
+    /**
+     * Non-null when the rename dialog is open for the given slot.
+     * Pre-fills with the slot's existing name. See #831.
+     */
+    val slotRenameTarget: Int? = null,
+    /**
+     * Non-null when the delete-confirmation dialog is open for the
+     * given slot. Two-step delete is deliberate — the user can dismiss
+     * before the irreversible call hits the server. See #831.
+     */
+    val slotDeleteConfirmSlot: Int? = null,
     /**
      * True when the user is launching a large-tier console game for
      * the first time (no override + tier == large → AskOnce). Drives

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameSlotPickerDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameSlotPickerDialog.kt
@@ -1,7 +1,9 @@
 package com.spela.player.presentation.ui.feature.ingame
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -50,6 +52,7 @@ fun InGameSlotPickerDialog(
     onSaveToSlot: (Int) -> Unit,
     onLoadFromSlot: (Int) -> Unit,
     onDismiss: () -> Unit,
+    onSlotLongPress: ((Int) -> Unit)? = null,
 ) {
     val title = when (mode) {
         SlotPickerMode.Save -> "Save to slot"
@@ -107,6 +110,13 @@ fun InGameSlotPickerDialog(
                                     SlotPickerMode.Load -> onLoadFromSlot(slot)
                                 }
                             },
+                            // Long-press only matters when the slot is filled —
+                            // empty slots have nothing to rename or delete. The
+                            // child checks slotInfo before invoking the handler
+                            // so the gesture is silently inert on empty cells
+                            // (rather than opening an actions sheet that has
+                            // nothing to do). See #831.
+                            onLongPress = onSlotLongPress,
                         )
                     }
                 }
@@ -139,12 +149,14 @@ fun InGameSlotPickerDialog(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SlotPickerCell(
     slot: Int,
     slotInfo: SaveSlotInfo?,
     mode: SlotPickerMode,
     onClick: () -> Unit,
+    onLongPress: ((Int) -> Unit)? = null,
 ) {
     val filled = slotInfo?.isFilled == true
     // Load-from-empty is a no-op so we render those cells as inert
@@ -161,13 +173,30 @@ private fun SlotPickerCell(
         filled -> SpColor.OnPrimary
         else -> SpColor.OnBackground
     }
+    // Only filled slots get a long-press handler — empty slots have
+    // nothing to rename or delete (#831).
+    val longPressHandler: (() -> Unit)? = if (filled && onLongPress != null) {
+        { onLongPress(slot) }
+    } else {
+        null
+    }
+    val cellModifier = Modifier
+        .size(64.dp)
+        .clip(RoundedCornerShape(SpSpacing.RadiusMedium))
+        .background(background)
+        .let { base ->
+            when {
+                !enabled -> base
+                longPressHandler != null -> base.combinedClickable(
+                    onClick = onClick,
+                    onLongClick = longPressHandler,
+                )
+                else -> base.clickable(onClick = onClick)
+            }
+        }
+        .testTag("slot-picker-cell-$slot")
     Box(
-        modifier = Modifier
-            .size(64.dp)
-            .clip(RoundedCornerShape(SpSpacing.RadiusMedium))
-            .background(background)
-            .let { if (enabled) it.clickable(onClick = onClick) else it }
-            .testTag("slot-picker-cell-$slot"),
+        modifier = cellModifier,
         contentAlignment = Alignment.Center,
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SlotManageDialogs.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SlotManageDialogs.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.state.SaveSlotInfo
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpSecondaryButton

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SlotManageDialogs.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SlotManageDialogs.kt
@@ -1,0 +1,261 @@
+package com.spela.player.presentation.ui.feature.ingame
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.state.SaveSlotInfo
+import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpSecondaryButton
+import com.spela.player.presentation.ui.components.SpTextField
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Bottom-sheet-style modal that opens on long-press of a filled slot
+ * cell on the in-game slot picker (#831). Lets the user rename or
+ * delete the slot without leaving the game.
+ *
+ * Rename / Delete are routed through the parent (EmulationViewModel
+ * intents) — this composable just decides which action the user picked.
+ * Cancel just dismisses.
+ */
+@Composable
+fun InGameSlotActionsSheet(
+    slot: Int,
+    slotInfo: SaveSlotInfo?,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val title = buildString {
+        append("Slot ")
+        append(slot)
+        if (!slotInfo?.name.isNullOrBlank()) {
+            append(" — ")
+            append(slotInfo!!.name)
+        } else if (slotInfo?.timestamp != null) {
+            append(" — ")
+            append(slotInfo.timestamp)
+        }
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SpColor.Scrim)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onDismiss,
+            )
+            .testTag("in-game-slot-actions-sheet"),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .clip(RoundedCornerShape(SpSpacing.RadiusXLarge))
+                .background(SpColor.SurfaceElevated)
+                .padding(SpSpacing.XLarge)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = {},
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = title,
+                style = SpTypography.HeadlineSmall,
+                color = SpColor.OnBackground,
+            )
+            SpButton(
+                text = "Rename",
+                onClick = onRename,
+                modifier = Modifier
+                    .padding(top = SpSpacing.Medium)
+                    .testTag("slot-actions-rename"),
+            )
+            SpButton(
+                text = "Delete",
+                onClick = onDelete,
+                modifier = Modifier
+                    .padding(top = SpSpacing.Small)
+                    .testTag("slot-actions-delete"),
+            )
+            SpSecondaryButton(
+                text = "Cancel",
+                onClick = onDismiss,
+                modifier = Modifier
+                    .padding(top = SpSpacing.Small)
+                    .testTag("slot-actions-cancel"),
+            )
+        }
+    }
+}
+
+/**
+ * Rename dialog — text input pre-filled with the slot's existing name.
+ * Empty submission is allowed (clears the user-supplied name; server
+ * keeps the slot's "Slot N" auto-label). See #831.
+ */
+@Composable
+fun InGameSlotRenameDialog(
+    slot: Int,
+    slotInfo: SaveSlotInfo?,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember(slot) { mutableStateOf(slotInfo?.name.orEmpty()) }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SpColor.Scrim)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onDismiss,
+            )
+            .testTag("in-game-slot-rename-dialog"),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .clip(RoundedCornerShape(SpSpacing.RadiusXLarge))
+                .background(SpColor.SurfaceElevated)
+                .padding(SpSpacing.XLarge)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = {},
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "Rename slot $slot",
+                style = SpTypography.HeadlineSmall,
+                color = SpColor.OnBackground,
+            )
+            SpTextField(
+                value = name,
+                onValueChange = { name = it },
+                placeholder = "Slot $slot",
+                modifier = Modifier
+                    .padding(top = SpSpacing.Medium)
+                    .fillMaxWidth()
+                    .testTag("slot-rename-input"),
+            )
+            Row(
+                modifier = Modifier
+                    .padding(top = SpSpacing.Medium)
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(
+                    SpSpacing.Small,
+                    Alignment.CenterHorizontally,
+                ),
+            ) {
+                SpSecondaryButton(
+                    text = "Cancel",
+                    onClick = onDismiss,
+                    modifier = Modifier.testTag("slot-rename-cancel"),
+                )
+                SpButton(
+                    text = "Save",
+                    onClick = { onConfirm(name) },
+                    modifier = Modifier.testTag("slot-rename-confirm"),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Two-step delete: a confirmation dialog before the irreversible
+ * DELETE call hits the server. See #831.
+ */
+@Composable
+fun InGameSlotDeleteConfirmDialog(
+    slot: Int,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SpColor.Scrim)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onDismiss,
+            )
+            .testTag("in-game-slot-delete-confirm"),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .clip(RoundedCornerShape(SpSpacing.RadiusXLarge))
+                .background(SpColor.SurfaceElevated)
+                .padding(SpSpacing.XLarge)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = {},
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "Delete slot $slot?",
+                style = SpTypography.HeadlineSmall,
+                color = SpColor.OnBackground,
+            )
+            Text(
+                text = "This can't be undone.",
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackgroundTertiary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(top = SpSpacing.Small)
+                    .fillMaxWidth(),
+            )
+            Row(
+                modifier = Modifier
+                    .padding(top = SpSpacing.Medium)
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(
+                    SpSpacing.Small,
+                    Alignment.CenterHorizontally,
+                ),
+            ) {
+                SpSecondaryButton(
+                    text = "Cancel",
+                    onClick = onDismiss,
+                    modifier = Modifier.testTag("slot-delete-cancel"),
+                )
+                SpButton(
+                    text = "Delete",
+                    onClick = onConfirm,
+                    modifier = Modifier.testTag("slot-delete-confirm"),
+                )
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -254,6 +254,35 @@ fun InGameOverlay(
             onSaveToSlot = { slot -> viewModel.onIntent(EmulationIntent.SaveToSlot(slot)) },
             onLoadFromSlot = { slot -> viewModel.onIntent(EmulationIntent.LoadFromSlot(slot)) },
             onDismiss = { viewModel.onIntent(EmulationIntent.DismissSlotPicker) },
+            onSlotLongPress = { slot -> viewModel.onIntent(EmulationIntent.ShowSlotActionsSheet(slot)) },
+        )
+    }
+
+    // Slot manage modals (#831). Stack on top of the slot picker so a
+    // long-press doesn't dismiss it — the sheet/dialog hides the picker
+    // behind a scrim while open and dismisses back to it on cancel.
+    state.slotActionsSheetSlot?.let { slot ->
+        com.spela.player.presentation.ui.feature.ingame.InGameSlotActionsSheet(
+            slot = slot,
+            slotInfo = state.saveSlots[slot],
+            onRename = { viewModel.onIntent(EmulationIntent.ShowSlotRenameDialog(slot)) },
+            onDelete = { viewModel.onIntent(EmulationIntent.ShowSlotDeleteConfirm(slot)) },
+            onDismiss = { viewModel.onIntent(EmulationIntent.DismissSlotActionsSheet) },
+        )
+    }
+    state.slotRenameTarget?.let { slot ->
+        com.spela.player.presentation.ui.feature.ingame.InGameSlotRenameDialog(
+            slot = slot,
+            slotInfo = state.saveSlots[slot],
+            onConfirm = { name -> viewModel.onIntent(EmulationIntent.RenameSlot(slot, name)) },
+            onDismiss = { viewModel.onIntent(EmulationIntent.DismissSlotRenameDialog) },
+        )
+    }
+    state.slotDeleteConfirmSlot?.let { slot ->
+        com.spela.player.presentation.ui.feature.ingame.InGameSlotDeleteConfirmDialog(
+            slot = slot,
+            onConfirm = { viewModel.onIntent(EmulationIntent.DeleteSlot(slot)) },
+            onDismiss = { viewModel.onIntent(EmulationIntent.DismissSlotDeleteConfirm) },
         )
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -301,6 +301,38 @@ class EmulationViewModel(
                 _state.update { it.copy(slotPickerMode = null) }
             }
 
+            // Slot manage actions (#831)
+            is EmulationIntent.ShowSlotActionsSheet ->
+                _state.update { it.copy(slotActionsSheetSlot = intent.slot) }
+            EmulationIntent.DismissSlotActionsSheet ->
+                _state.update { it.copy(slotActionsSheetSlot = null) }
+            is EmulationIntent.ShowSlotRenameDialog ->
+                _state.update {
+                    it.copy(
+                        slotActionsSheetSlot = null,
+                        slotRenameTarget = intent.slot,
+                    )
+                }
+            EmulationIntent.DismissSlotRenameDialog ->
+                _state.update { it.copy(slotRenameTarget = null) }
+            is EmulationIntent.RenameSlot -> {
+                _state.update { it.copy(slotRenameTarget = null) }
+                saveManager.renameSlot(intent.slot, intent.name)
+            }
+            is EmulationIntent.ShowSlotDeleteConfirm ->
+                _state.update {
+                    it.copy(
+                        slotActionsSheetSlot = null,
+                        slotDeleteConfirmSlot = intent.slot,
+                    )
+                }
+            EmulationIntent.DismissSlotDeleteConfirm ->
+                _state.update { it.copy(slotDeleteConfirmSlot = null) }
+            is EmulationIntent.DeleteSlot -> {
+                _state.update { it.copy(slotDeleteConfirmSlot = null) }
+                saveManager.deleteSlot(intent.slot)
+            }
+
             // Rewind
             EmulationIntent.RewindStep -> rewindStep()
             EmulationIntent.ToggleRewind -> toggleRewindEnabled()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -1028,6 +1028,58 @@ class SaveManager(
      * Each save state with a non-null slot is mapped to its corresponding slot number.
      * Called on game start and after manual save operations to keep thumbnails fresh.
      */
+    /**
+     * Rename a single slot save. Hits PUT /api/sessions/{id}/saves/{saveId}
+     * with the new name and updates the local saveSlots map optimistically.
+     * Used by the in-game slot manage UI (#831). Failures roll back the
+     * optimistic update — the slot picker will show the old name again so
+     * the user knows the change didn't stick.
+     */
+    fun renameSlot(slot: Int, name: String) {
+        val sessionId = currentSessionId ?: return
+        val current = _state.value.saveSlots
+        val info = current[slot] ?: return
+        val saveId = info.saveId ?: return
+        val previous = info
+        // Optimistic update — flip the local name immediately so the user
+        // sees the rename without waiting for the round-trip.
+        _state.update {
+            it.copy(saveSlots = it.saveSlots + (slot to info.copy(name = name.takeIf { it.isNotBlank() })))
+        }
+        scope.launch(dispatchers.io) {
+            sessionRepository.updateSessionSave(sessionId, saveId, name).onFailure {
+                // Roll back to the previous name.
+                _state.update { state ->
+                    state.copy(saveSlots = state.saveSlots + (slot to previous))
+                }
+            }
+        }
+    }
+
+    /**
+     * Delete a single slot save. Hits DELETE /api/sessions/{id}/saves/{saveId}
+     * and clears the slot from the local map on success. Used by the
+     * in-game slot manage UI (#831). Failures restore the slot.
+     */
+    fun deleteSlot(slot: Int) {
+        val sessionId = currentSessionId ?: return
+        val info = _state.value.saveSlots[slot] ?: return
+        val saveId = info.saveId ?: return
+        val previous = info
+        // Optimistic clear — picker re-renders the cell as empty
+        // immediately. Restored on failure.
+        _state.update {
+            it.copy(saveSlots = it.saveSlots - slot)
+        }
+        scope.launch(dispatchers.io) {
+            sessionRepository.deleteSessionSave(sessionId, saveId).onFailure {
+                _state.update { state ->
+                    state.copy(saveSlots = state.saveSlots + (slot to previous))
+                }
+            }
+        }
+    }
+
     fun refreshSaveSlots() {
         val sessionId = currentSessionId ?: return
         scope.launch(dispatchers.io) {
@@ -1044,6 +1096,8 @@ class SaveManager(
                                 "%02d:%02d".format(local.hour, local.minute)
                             },
                             isFilled = true,
+                            saveId = save.id,
+                            name = save.name.takeIf { it.isNotBlank() },
                         )
                     }
                 }

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModelTest.kt
@@ -212,6 +212,17 @@ private class FakeSessionRepo : SessionRepository {
     override suspend fun getSessionSaves(sessionId: String): Result<List<SaveState>> =
         Result.success(emptyList())
 
+    override suspend fun updateSessionSave(
+        sessionId: String,
+        saveId: String,
+        name: String,
+    ): Result<SaveState> = Result.failure(UnsupportedOperationException())
+
+    override suspend fun deleteSessionSave(
+        sessionId: String,
+        saveId: String,
+    ): Result<Unit> = Result.success(Unit)
+
     override suspend fun uploadSessionSave(
         sessionId: String,
         name: String,

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -175,6 +175,9 @@ private class FakePlayFromSharedSaveSessionRepository : SessionRepository {
     override suspend fun updateSessionCoreFlags(sessionId: String, userLockedCoreVersion: Boolean?, autoLoadSuppressed: Boolean?, rehearsalCrashPending: Boolean?) = Result.failure<GameSession>(Exception("stub"))
     override suspend fun deleteSession(sessionId: String) = Result.success(Unit)
     override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())
+    override suspend fun updateSessionSave(sessionId: String, saveId: String, name: String) =
+        Result.failure<SaveState>(UnsupportedOperationException())
+    override suspend fun deleteSessionSave(sessionId: String, saveId: String) = Result.success(Unit)
     override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String) =
         Result.success(SaveState(id = "1", name = name))
     override suspend fun uploadSessionSaveFromFile(sessionId: String, name: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String, compression: String) =

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerSlotManageTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerSlotManageTest.kt
@@ -1,0 +1,223 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.data.remote.ConnectivityMonitor
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.interceptor.TokenManager
+import com.spela.player.presentation.state.EmulationState
+import com.spela.player.presentation.state.SaveSlotInfo
+import com.spela.player.presentation.viewmodel.emulation.StubLibretroController
+import com.spela.player.presentation.viewmodel.emulation.StubMockEngineFactory
+import com.spela.player.presentation.viewmodel.emulation.StubPendingSaveUploadRepository
+import com.spela.player.presentation.viewmodel.emulation.StubSaveDataRepository
+import com.spela.player.presentation.viewmodel.emulation.StubSessionRepository
+import com.spela.player.util.DispatcherProvider
+import com.spela.player.util.FileStorage
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for SaveManager.renameSlot / deleteSlot — the in-game slot
+ * manage actions shipped in #831. Each action does an optimistic local
+ * update + a background server call with rollback on failure; this
+ * test pins both halves.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SaveManagerSlotManageTest {
+
+    private fun testDispatchers(dispatcher: CoroutineDispatcher): DispatcherProvider =
+        object : DispatcherProvider {
+            override val main: CoroutineDispatcher = dispatcher
+            override val io: CoroutineDispatcher = dispatcher
+            override val default: CoroutineDispatcher = dispatcher
+        }
+
+    private fun makeFixture(scope: CoroutineScope, dispatcher: CoroutineDispatcher): Fixture {
+        val dispatchers = testDispatchers(dispatcher)
+        val apiClient = SpelaApiClient(StubMockEngineFactory, TokenManager())
+        val connectivity = ConnectivityMonitor(apiClient, dispatchers, scope)
+        val sessionRepo = StubSessionRepository()
+        val state = MutableStateFlow(
+            EmulationState(
+                saveSlots = mapOf(
+                    7 to SaveSlotInfo(
+                        timestamp = "13:42",
+                        isFilled = true,
+                        saveId = "save-7",
+                        name = "Pre-boss",
+                    ),
+                ),
+            ),
+        )
+        val manager = SaveManager(
+            saveDataRepository = StubSaveDataRepository(),
+            connectivityMonitor = connectivity,
+            libretroController = StubLibretroController(),
+            screenshotCapture = null,
+            _state = state,
+            dispatchers = dispatchers,
+            scope = scope,
+            sessionRepository = sessionRepo,
+            fileStorage = TestFileStorage(),
+            pendingUploadRepository = StubPendingSaveUploadRepository(),
+        )
+        manager.currentSessionId = "session-1"
+        manager.currentCoreName = "nestopia"
+        return Fixture(manager, sessionRepo, state)
+    }
+
+    private data class Fixture(
+        val manager: SaveManager,
+        val sessionRepo: StubSessionRepository,
+        val state: MutableStateFlow<EmulationState>,
+    )
+
+    @Test
+    fun renameSlotOptimisticallyUpdatesAndCallsServer() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+
+        fx.manager.renameSlot(slot = 7, name = "After boss")
+        advanceUntilIdle()
+
+        assertEquals("After boss", fx.state.value.saveSlots[7]?.name)
+        assertEquals(
+            Triple("session-1", "save-7", "After boss"),
+            fx.sessionRepo.lastRenameCall,
+        )
+    }
+
+    @Test
+    fun renameSlotEmptyNameClearsLocalNameAndStillCallsServer() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+
+        fx.manager.renameSlot(slot = 7, name = "")
+        advanceUntilIdle()
+
+        // Local convention: blank → null on the SaveSlotInfo so the
+        // picker stops showing the user-supplied name.
+        assertNull(fx.state.value.saveSlots[7]?.name)
+        // Server call still happens — the user submitted the rename
+        // form deliberately, even with an empty value.
+        assertEquals(
+            Triple("session-1", "save-7", ""),
+            fx.sessionRepo.lastRenameCall,
+        )
+    }
+
+    @Test
+    fun renameSlotRollsBackOnServerFailure() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+        fx.sessionRepo.renameFailure = RuntimeException("server 500")
+
+        fx.manager.renameSlot(slot = 7, name = "Lost name")
+        advanceUntilIdle()
+
+        // Optimistic update reverted — the slot shows the original name.
+        assertEquals("Pre-boss", fx.state.value.saveSlots[7]?.name)
+    }
+
+    @Test
+    fun renameSlotIsNoOpForEmptyOrUnsavedSlot() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+
+        // Empty slot 8 — no SaveSlotInfo entry at all.
+        fx.manager.renameSlot(slot = 8, name = "Nope")
+        advanceUntilIdle()
+
+        assertNull(fx.sessionRepo.lastRenameCall, "no server call for an empty slot")
+
+        // Filled slot but no saveId (e.g. legacy entry) — also a no-op.
+        fx.state.update {
+            it.copy(saveSlots = it.saveSlots + (9 to SaveSlotInfo(isFilled = true, saveId = null)))
+        }
+        fx.manager.renameSlot(slot = 9, name = "Nope")
+        advanceUntilIdle()
+
+        assertNull(fx.sessionRepo.lastRenameCall, "no server call when saveId is missing")
+    }
+
+    @Test
+    fun deleteSlotOptimisticallyClearsAndCallsServer() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+
+        fx.manager.deleteSlot(slot = 7)
+        advanceUntilIdle()
+
+        assertTrue(7 !in fx.state.value.saveSlots)
+        assertEquals("session-1" to "save-7", fx.sessionRepo.lastDeleteCall)
+    }
+
+    @Test
+    fun deleteSlotRollsBackOnServerFailure() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+        fx.sessionRepo.deleteFailure = RuntimeException("server 500")
+
+        fx.manager.deleteSlot(slot = 7)
+        advanceUntilIdle()
+
+        // Slot restored — picker re-renders the cell as filled again.
+        val restored = fx.state.value.saveSlots[7]
+        assertEquals("save-7", restored?.saveId)
+        assertEquals("Pre-boss", restored?.name)
+    }
+
+    @Test
+    fun deleteSlotIsNoOpWhenSaveIdMissing() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeFixture(scope, dispatcher)
+        fx.state.update {
+            it.copy(
+                saveSlots = it.saveSlots + (9 to SaveSlotInfo(isFilled = true, saveId = null)),
+            )
+        }
+
+        fx.manager.deleteSlot(slot = 9)
+        advanceUntilIdle()
+
+        assertNull(fx.sessionRepo.lastDeleteCall)
+    }
+
+    private class TestFileStorage : FileStorage {
+        override fun getGamesDir(): String = "/tmp/games"
+        override fun getCoresDir(): String = "/tmp/cores"
+        override fun getSavesDir(): String = "/tmp/saves"
+        override fun getBiosDir(): String = "/tmp/bios"
+        override suspend fun createDirectory(path: String) {}
+        override suspend fun writeFile(path: String, data: ByteArray) {}
+        override suspend fun readFile(path: String): ByteArray = byteArrayOf()
+        override suspend fun fileExists(path: String): Boolean = false
+        override suspend fun deleteFile(path: String) {}
+        override suspend fun deleteDirectory(path: String) {}
+        override suspend fun getDirectorySize(path: String): Long = 0
+        override suspend fun writeFileStreaming(path: String, writer: suspend (append: suspend (ByteArray, Int, Int) -> Unit) -> Unit) {}
+        override suspend fun getFileSize(path: String): Long = 0
+        override suspend fun listFiles(path: String): List<String> = emptyList()
+        override suspend fun isDirectory(path: String): Boolean = false
+        override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
+        override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+        override suspend fun sha256File(path: String): String? = null
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -457,6 +457,28 @@ class StubSessionRepository : SessionRepository {
     }
     override suspend fun deleteSession(sessionId: String) = Result.success(Unit)
     override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())
+
+    /** Records the most recent rename / delete calls so #831 tests can
+     *  assert the SaveManager wiring without a real network. */
+    var lastRenameCall: Triple<String, String, String>? = null
+        private set
+    var lastDeleteCall: Pair<String, String>? = null
+        private set
+    /** When set, the next updateSessionSave / deleteSessionSave call
+     *  fails with this exception so the rollback path can be exercised. */
+    var renameFailure: Throwable? = null
+    var deleteFailure: Throwable? = null
+
+    override suspend fun updateSessionSave(sessionId: String, saveId: String, name: String): Result<SaveState> {
+        lastRenameCall = Triple(sessionId, saveId, name)
+        renameFailure?.let { return Result.failure(it) }
+        return Result.success(SaveState(id = saveId, name = name))
+    }
+    override suspend fun deleteSessionSave(sessionId: String, saveId: String): Result<Unit> {
+        lastDeleteCall = sessionId to saveId
+        deleteFailure?.let { return Result.failure(it) }
+        return Result.success(Unit)
+    }
     override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<SaveState> {
         uploadSessionSaveCallCount++
         return uploadSessionSaveResult


### PR DESCRIPTION
Closes #831.

Phase 5 of #804 shipped a slot-primary save/load picker on the in-game overlay (PR #822) — but users who fill all slots and want to free one up had to exit the game, navigate to the session detail screen, find the slot in the list, and delete it. That's a lot of friction for *"I'm in the middle of a boss fight and slot 7 is the wrong checkpoint."*

## UX

Long-press a filled slot cell on the in-game picker → bottom sheet:

- **Rename** → text-input dialog, pre-fills with the slot's existing name. Empty submission is allowed (clears the user-supplied name; server keeps the slot's "Slot N" auto-label).
- **Delete** → two-step confirm ("Delete slot 7? This can't be undone.") before the irreversible \`DELETE\` call.
- **Cancel** → dismiss back to the picker.

Both actions update \`state.saveSlots\` optimistically and roll back on server failure, so the picker re-renders immediately without waiting for a refresh round-trip.

Empty slots get no long-press handler — no actions sheet to open. Filled slots without a \`saveId\` (e.g. legacy entries from before #831) are a no-op too: rename / delete are silently inert rather than firing a 4xx-ing call.

## Server

No new endpoints. Wires \`DELETE /api/sessions/{id}/saves/{saveId}\` (already used by session detail) and \`PUT /api/sessions/{id}/saves/{saveId}\` (already exists for name updates) through the generated \`SessionsApi\` client.

## What changed

**New code paths:**
- \`SaveSlotInfo.saveId\` + \`name\` (was missing — required for the API calls)
- \`EmulationState.slotActionsSheetSlot\`, \`slotRenameTarget\`, \`slotDeleteConfirmSlot\` — non-null when each modal is open
- 7 new \`EmulationIntent\`s: \`Show/DismissSlotActionsSheet\`, \`Show/DismissSlotRenameDialog\`, \`RenameSlot\`, \`Show/DismissSlotDeleteConfirm\`, \`DeleteSlot\`
- \`SaveManager.renameSlot(slot, name)\` / \`deleteSlot(slot)\` — optimistic update + rollback
- \`SessionRepository.updateSessionSave\` / \`deleteSessionSave\` (interface + impl + API client wrapper)
- \`SlotManageDialogs.kt\` — three new composables (\`InGameSlotActionsSheet\`, \`InGameSlotRenameDialog\`, \`InGameSlotDeleteConfirmDialog\`)
- \`InGameSlotPickerDialog\` — long-press wiring on filled cells via \`combinedClickable\`
- \`InGameOverlay\` — renders the new modals when their state fields are non-null

**Coverage:**
- \`SaveManagerSlotManageTest\` (7 cases): optimistic update + rollback, no-op on empty / saveId-less slots, server wire format
- \`SlotManageDialogsTest\` (11 cases): sheet routing, rename prefill + confirm/cancel, delete confirm + cancel

## Validation

- \`./gradlew :shared:desktopTest --tests "...SaveManagerSlotManageTest"\` → 7/7 ✓
- \`./gradlew :desktop:desktopTest --tests "...SlotManageDialogsTest"\` → 11/11 ✓
- Full desktop suite (\`./run-desktop-tests.sh\`) green — 159 test classes, no regressions

This closes the last functional gap in the #804 umbrella's phase 5 (slot-primary UX).