### PR TITLE
fix(player): extend Challenge created toast from 2s to 5s (#837)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -201,10 +201,13 @@ fun InGameOverlay(
         )
     }
 
-    // Challenge creation success toast
+    // Challenge creation success toast. 5 s is comfortable read time
+    // and gives Android E2E (`ChallengeCreationTest.createChallengeSuccessfully`)
+    // a usable window to assert the toast text — at 2 s the test
+    // raced cold-container POST latency and missed the toast (#837).
     if (state.challengeCreationSuccess) {
         LaunchedEffect(Unit) {
-            delay(2000)
+            delay(5000)
             viewModel.onIntent(EmulationIntent.DismissChallengeCreation)
         }
         OverlayToast(message = "Challenge created!")


### PR DESCRIPTION
Fixes #837.

The success toast auto-dismissed after 2 s. \`ChallengeCreationTest.createChallengeSuccessfully\` waits up to 8 s for the toast text — but on cold-container POST latency the test was starting to poll *after* the toast had already shown and dismissed, hitting the 8 s timeout instead.

5 s is squarely within [Material guidance for confirmation toasts](https://m3.material.io/components/snackbar/guidelines#anatomy) (4–10 s) and gives the test a comfortable window even under worst-case server response time. Pure UX win — users get a hair more time to read the confirmation, and the test stops flaking.

## Why this is the right fix

The race is real: cold-container POST + GC pause + Compose recomposition can easily eat the original 2 s window before the test's polling loop ticks. Lengthening the toast removes the race entirely without any test-side instrumentation. The alternative was to add a stable testTag and a separate state flag that doesn't auto-clear — more invasive for the same outcome.

Surfaced after #836 unhung the suite — pre-#836 nobody saw this because the test was killed by the 7-min nav-helper hang first.