### PR TITLE
fix(player): keep Android keyboard docked, not fullscreen, on landscape handhelds

### DIFF
--- a/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/components/PlatformTextFieldCore.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/components/PlatformTextFieldCore.android.kt
@@ -1,0 +1,264 @@
+package com.spela.player.presentation.ui.components
+
+import android.graphics.drawable.GradientDrawable
+import android.graphics.Color as AndroidColor
+import android.text.InputType
+import android.text.method.PasswordTransformationMethod
+import android.view.Gravity
+import android.view.inputmethod.EditorInfo
+import android.widget.EditText
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spelaBrandGradient
+
+/**
+ * Android implementation of [PlatformTextFieldCore].
+ *
+ * Wraps a standard `EditText` via `AndroidView` so we can set
+ * `EditorInfo.IME_FLAG_NO_EXTRACT_UI | IME_FLAG_NO_FULLSCREEN` on
+ * its `imeOptions`. Compose Multiplatform 1.10's `KeyboardOptions`
+ * exposes only `privateImeOptions` (a free-form string hint that
+ * Gboard ignores), so dropping to the view system is the only
+ * reliable way to keep the IME from going fullscreen on landscape
+ * Android handhelds (AYN Thor and similar). See
+ * `PlatformTextFieldCore.kt` in commonMain for the rationale.
+ *
+ * Visual goal: match `OutlinedTextField`'s appearance closely
+ * enough that the existing screens look right. Not pixel-perfect.
+ * The wrapper in `SpTextField` already supplies the focus glow
+ * and rounded outline; we just render the inner editor.
+ */
+@Composable
+actual fun PlatformTextFieldCore(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier,
+    enabled: Boolean,
+    isPassword: Boolean,
+    isError: Boolean,
+    singleLine: Boolean,
+    minLines: Int,
+    maxLines: Int,
+    label: String,
+    placeholder: String,
+    keyboardType: KeyboardType,
+    imeAction: ImeAction,
+    onImeAction: () -> Unit,
+    leadingIcon: (@Composable () -> Unit)?,
+    trailingIcon: (@Composable () -> Unit)?,
+) {
+    val borderColor = when {
+        isError -> SpColor.Error
+        else -> Color.White.copy(alpha = 0.15f)
+    }
+    val textColorArgb = if (enabled) SpColor.OnBackground.toArgb()
+    else SpColor.OnBackgroundTertiary.toArgb()
+    val hintColorArgb = SpColor.OnBackgroundTertiary.toArgb()
+    val cursorColorArgb = SpColor.AccentPurple.toArgb()
+
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(SpSpacing.RadiusLarge))
+            .heightIn(min = 56.dp)
+            .padding(horizontal = SpSpacing.Default),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (leadingIcon != null) {
+            Box(modifier = Modifier.padding(end = SpSpacing.Small)) { leadingIcon() }
+        }
+
+        Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
+            AndroidView(
+                modifier = Modifier.fillMaxWidth(),
+                factory = { ctx ->
+                    EditText(ctx).apply {
+                        // Background outline + transparent fill — Compose
+                        // wrapper draws the focus glow / error tint, so a
+                        // simple thin border is enough here.
+                        background = GradientDrawable().apply {
+                            cornerRadius = SpSpacing.RadiusLarge.value * resources.displayMetrics.density
+                            setStroke(
+                                (1 * resources.displayMetrics.density).toInt(),
+                                borderColor.toArgb(),
+                            )
+                            setColor(AndroidColor.TRANSPARENT)
+                        }
+                        setTextColor(textColorArgb)
+                        setHintTextColor(hintColorArgb)
+                        textSize = 16f
+                        gravity = Gravity.CENTER_VERTICAL or Gravity.START
+                        // Single-line vs multi-line input. Disambiguate
+                        // the function-parameter `minLines` / `maxLines`
+                        // from the EditText properties via `setMinLines` /
+                        // `setMaxLines`.
+                        isSingleLine = singleLine
+                        if (singleLine) {
+                            setMaxLines(1)
+                        } else {
+                            setMinLines(minLines)
+                            setMaxLines(maxLines)
+                        }
+                        // Input type — password / email / numeric / text.
+                        // Re-evaluated on every recomposition via the
+                        // update block below so toggling isPassword
+                        // mid-life works.
+                        inputType = computeAndroidInputType(
+                            isPassword,
+                            keyboardType,
+                            singleLine,
+                        )
+                        if (isPassword) {
+                            transformationMethod = PasswordTransformationMethod.getInstance()
+                        }
+                        // The actual fix: set the standard Android IME
+                        // flags so Gboard / OEM keyboards skip
+                        // fullscreen extract mode in landscape. This is
+                        // why we're wrapping a plain EditText instead
+                        // of using Compose's TextField.
+                        imeOptions = imeActionToEditorInfo(imeAction) or
+                            EditorInfo.IME_FLAG_NO_EXTRACT_UI or
+                            EditorInfo.IME_FLAG_NO_FULLSCREEN
+                        // Padding inside the field (left, top, right, bottom)
+                        val pad = (SpSpacing.Default.value * resources.displayMetrics.density).toInt()
+                        setPadding(pad, pad / 2, pad, pad / 2)
+                        // Reflect the cursor accent.
+                        // textCursorDrawable requires API 29+, fallback
+                        // is the system default cursor.
+                        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                            textCursorDrawable = GradientDrawable().apply {
+                                shape = GradientDrawable.RECTANGLE
+                                setSize((2 * resources.displayMetrics.density).toInt(), 0)
+                                setColor(cursorColorArgb)
+                            }
+                        }
+                        // Hint text (placeholder).
+                        hint = placeholder.ifEmpty { label }
+                        // Forward IME action to the Compose callback.
+                        setOnEditorActionListener { _, actionId, _ ->
+                            // Honour the action that matches our imeAction
+                            // mapping; ignore others (autofill / etc.).
+                            if (actionId == imeActionToEditorInfo(imeAction) ||
+                                actionId == EditorInfo.IME_ACTION_DONE) {
+                                onImeAction()
+                                true
+                            } else false
+                        }
+                        // Wire change events back to Compose state.
+                        addTextChangedListener(SimpleTextWatcher { newText ->
+                            if (newText != value) onValueChange(newText)
+                        })
+                    }
+                },
+                update = { editText ->
+                    // Sync state back from Compose. Guard with a
+                    // non-equality check so Android doesn't bounce the
+                    // cursor / IME composition on every recomposition.
+                    if (editText.text.toString() != value) {
+                        val cursor = editText.selectionStart
+                        editText.setText(value)
+                        editText.setSelection(cursor.coerceIn(0, value.length))
+                    }
+                    editText.isEnabled = enabled
+                    editText.hint = placeholder.ifEmpty { label }
+                    editText.imeOptions = imeActionToEditorInfo(imeAction) or
+                        EditorInfo.IME_FLAG_NO_EXTRACT_UI or
+                        EditorInfo.IME_FLAG_NO_FULLSCREEN
+                    val newInputType = computeAndroidInputType(
+                        isPassword,
+                        keyboardType,
+                        singleLine,
+                    )
+                    if (editText.inputType != newInputType) {
+                        editText.inputType = newInputType
+                        if (isPassword) {
+                            editText.transformationMethod =
+                                PasswordTransformationMethod.getInstance()
+                        }
+                    }
+                    val targetBorder = (if (isError) SpColor.Error
+                    else Color.White.copy(alpha = 0.15f)).toArgb()
+                    val bg = editText.background
+                    if (bg is GradientDrawable) {
+                        bg.setStroke(
+                            (1 * editText.resources.displayMetrics.density).toInt(),
+                            targetBorder,
+                        )
+                    }
+                },
+            )
+        }
+
+        if (trailingIcon != null) {
+            Box(modifier = Modifier.padding(start = SpSpacing.Small)) { trailingIcon() }
+        }
+    }
+}
+
+private class SimpleTextWatcher(
+    private val onChange: (String) -> Unit,
+) : android.text.TextWatcher {
+    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+    override fun afterTextChanged(s: android.text.Editable?) {
+        onChange(s?.toString().orEmpty())
+    }
+}
+
+/** Map Compose [ImeAction] to Android's [EditorInfo] action constant. */
+private fun imeActionToEditorInfo(imeAction: ImeAction): Int = when (imeAction) {
+    ImeAction.Default, ImeAction.Done -> EditorInfo.IME_ACTION_DONE
+    ImeAction.Go -> EditorInfo.IME_ACTION_GO
+    ImeAction.Next -> EditorInfo.IME_ACTION_NEXT
+    ImeAction.Previous -> EditorInfo.IME_ACTION_PREVIOUS
+    ImeAction.Search -> EditorInfo.IME_ACTION_SEARCH
+    ImeAction.Send -> EditorInfo.IME_ACTION_SEND
+    ImeAction.None -> EditorInfo.IME_ACTION_NONE
+    else -> EditorInfo.IME_ACTION_DONE
+}
+
+/** Map Compose [KeyboardType] to Android [InputType] flags. */
+private fun computeAndroidInputType(
+    isPassword: Boolean,
+    keyboardType: KeyboardType,
+    singleLine: Boolean,
+): Int {
+    if (isPassword) {
+        return InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+    }
+    val base = when (keyboardType) {
+        KeyboardType.Number, KeyboardType.NumberPassword ->
+            InputType.TYPE_CLASS_NUMBER
+        KeyboardType.Decimal ->
+            InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
+        KeyboardType.Phone -> InputType.TYPE_CLASS_PHONE
+        KeyboardType.Email ->
+            InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+        KeyboardType.Uri ->
+            InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_URI
+        KeyboardType.Password ->
+            InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+        else -> InputType.TYPE_CLASS_TEXT
+    }
+    return if (!singleLine) base or InputType.TYPE_TEXT_FLAG_MULTI_LINE else base
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/PlatformTextFieldCore.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/PlatformTextFieldCore.kt
@@ -1,0 +1,45 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+
+/**
+ * Inner text-input widget used by [SpTextField]. Split out as
+ * `expect`/`actual` so Android can render an `AndroidView`-wrapped
+ * `EditText` with `IME_FLAG_NO_EXTRACT_UI | IME_FLAG_NO_FULLSCREEN`
+ * set on its `imeOptions` — the only reliable way to keep the
+ * keyboard from going fullscreen on landscape Android handhelds
+ * (AYN Thor and similar).
+ *
+ * Compose Multiplatform 1.10's `PlatformImeOptions` only exposes
+ * `privateImeOptions` (a free-form string). Gboard and most OEM
+ * keyboards ignore string hints for fullscreen behaviour — they only
+ * honour the standard `EditorInfo.imeOptions` int flags. Compose
+ * doesn't expose those flags through its public Kotlin API, so we
+ * have to drop down to the Android view system on Android only.
+ *
+ * Desktop and other targets keep using `OutlinedTextField` with no
+ * behaviour change — fullscreen IME is a landscape-Android-handheld
+ * problem only.
+ */
+@Composable
+expect fun PlatformTextFieldCore(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier,
+    enabled: Boolean,
+    isPassword: Boolean,
+    isError: Boolean,
+    singleLine: Boolean,
+    minLines: Int,
+    maxLines: Int,
+    label: String,
+    placeholder: String,
+    keyboardType: KeyboardType,
+    imeAction: ImeAction,
+    onImeAction: () -> Unit,
+    leadingIcon: (@Composable () -> Unit)?,
+    trailingIcon: (@Composable () -> Unit)?,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTextField.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTextField.kt
@@ -5,10 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -24,8 +20,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -56,7 +50,12 @@ fun SpTextField(
         var isFocused by remember { mutableStateOf(false) }
         val showGlow = isFocused && enabled && !isError && errorMessage == null
 
-        OutlinedTextField(
+        // The actual text-input widget is platform-specific so Android
+        // can fall back to AndroidView+EditText with the right
+        // IME_FLAG_NO_EXTRACT_UI / IME_FLAG_NO_FULLSCREEN flags set
+        // on EditorInfo (Compose Multiplatform doesn't expose those
+        // flags through KeyboardOptions). See PlatformTextFieldCore.
+        PlatformTextFieldCore(
             value = value,
             onValueChange = onValueChange,
             modifier = Modifier
@@ -82,58 +81,18 @@ fun SpTextField(
                     1.5.dp, spelaBrandGradient(), RoundedCornerShape(SpSpacing.RadiusLarge)
                 ) else Modifier),
             enabled = enabled,
+            isPassword = isPassword,
+            isError = isError || errorMessage != null,
             singleLine = singleLine,
             minLines = minLines,
             maxLines = maxLines,
-            label = if (label.isNotEmpty()) {
-                { Text(label, style = SpTypography.LabelMedium) }
-            } else null,
-            placeholder = if (placeholder.isNotEmpty()) {
-                {
-                    Text(
-                        placeholder,
-                        style = SpTypography.BodyMedium,
-                        color = SpColor.OnBackgroundTertiary,
-                    )
-                }
-            } else null,
-            visualTransformation = if (isPassword) PasswordVisualTransformation() else VisualTransformation.None,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = if (isPassword) KeyboardType.Password else keyboardType,
-                imeAction = imeAction,
-                // Android only: tell the IME not to go fullscreen in
-                // landscape. Without this, Gboard (and many OEM keyboards)
-                // occlude the whole screen with an "extract view" whenever
-                // a text field has focus in a short-height window —
-                // unusable on gaming handhelds like the AYN Thor, and it
-                // also hides the UI from UiAutomator, which is why any
-                // Android E2E test that typed into a field would appear
-                // to hang at a black screen. No-op on other platforms.
-                platformImeOptions = noFullscreenImeOptions(),
-            ),
-            keyboardActions = KeyboardActions(onAny = { onImeAction() }),
-            isError = isError || errorMessage != null,
+            label = label,
+            placeholder = placeholder,
+            keyboardType = keyboardType,
+            imeAction = imeAction,
+            onImeAction = onImeAction,
             leadingIcon = leadingIcon,
             trailingIcon = trailingIcon,
-            shape = RoundedCornerShape(SpSpacing.RadiusLarge),
-            colors = OutlinedTextFieldDefaults.colors(
-                focusedTextColor = SpColor.OnBackground,
-                unfocusedTextColor = SpColor.OnBackground,
-                focusedBorderColor = Color.Transparent,
-                unfocusedBorderColor = Color.White.copy(alpha = 0.15f),
-                errorBorderColor = SpColor.Error,
-                focusedLabelColor = SpColor.AccentPurple,
-                unfocusedLabelColor = SpColor.OnBackgroundSecondary,
-                cursorColor = SpColor.AccentPurple,
-                focusedContainerColor = Color.Transparent,
-                unfocusedContainerColor = Color.Transparent,
-                errorContainerColor = Color.Transparent,
-                disabledContainerColor = Color.Transparent,
-                disabledBorderColor = Color.White.copy(alpha = 0.06f),
-                disabledTextColor = SpColor.OnBackgroundTertiary,
-                disabledLabelColor = SpColor.OnBackgroundTertiary,
-            ),
-            textStyle = SpTypography.BodyMedium,
         )
 
         if (errorMessage != null) {

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/presentation/ui/components/PlatformTextFieldCore.desktop.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/presentation/ui/components/PlatformTextFieldCore.desktop.kt
@@ -1,0 +1,88 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+@Composable
+actual fun PlatformTextFieldCore(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier,
+    enabled: Boolean,
+    isPassword: Boolean,
+    isError: Boolean,
+    singleLine: Boolean,
+    minLines: Int,
+    maxLines: Int,
+    label: String,
+    placeholder: String,
+    keyboardType: KeyboardType,
+    imeAction: ImeAction,
+    onImeAction: () -> Unit,
+    leadingIcon: (@Composable () -> Unit)?,
+    trailingIcon: (@Composable () -> Unit)?,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        singleLine = singleLine,
+        minLines = minLines,
+        maxLines = maxLines,
+        label = if (label.isNotEmpty()) {
+            { Text(label, style = SpTypography.LabelMedium) }
+        } else null,
+        placeholder = if (placeholder.isNotEmpty()) {
+            {
+                Text(
+                    placeholder,
+                    style = SpTypography.BodyMedium,
+                    color = SpColor.OnBackgroundTertiary,
+                )
+            }
+        } else null,
+        visualTransformation = if (isPassword) PasswordVisualTransformation() else VisualTransformation.None,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = if (isPassword) KeyboardType.Password else keyboardType,
+            imeAction = imeAction,
+        ),
+        keyboardActions = KeyboardActions(onAny = { onImeAction() }),
+        isError = isError,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        shape = RoundedCornerShape(SpSpacing.RadiusLarge),
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedTextColor = SpColor.OnBackground,
+            unfocusedTextColor = SpColor.OnBackground,
+            focusedBorderColor = Color.Transparent,
+            unfocusedBorderColor = Color.White.copy(alpha = 0.15f),
+            errorBorderColor = SpColor.Error,
+            focusedLabelColor = SpColor.AccentPurple,
+            unfocusedLabelColor = SpColor.OnBackgroundSecondary,
+            cursorColor = SpColor.AccentPurple,
+            focusedContainerColor = Color.Transparent,
+            unfocusedContainerColor = Color.Transparent,
+            errorContainerColor = Color.Transparent,
+            disabledContainerColor = Color.Transparent,
+            disabledBorderColor = Color.White.copy(alpha = 0.06f),
+            disabledTextColor = SpColor.OnBackgroundTertiary,
+            disabledLabelColor = SpColor.OnBackgroundTertiary,
+        ),
+        textStyle = SpTypography.BodyMedium,
+    )
+}


### PR DESCRIPTION
The keyboard was taking over the entire screen on the AYN Thor (and similar landscape Android handhelds) whenever a text field gained focus — login, server-connect, search, settings device-name. Unusable UX, also broke any future Android E2E test that needed to type into a field (the IME hides the rest of the UI from UiAutomator).

## Root cause

Android's IME goes fullscreen (\"extract UI\" mode) in landscape when the screen height is below an internal threshold. The escape valve is \`EditorInfo.IME_FLAG_NO_EXTRACT_UI | IME_FLAG_NO_FULLSCREEN\` set on the input's \`imeOptions\`. **Compose Multiplatform 1.10's \`KeyboardOptions\` and \`PlatformImeOptions\` only expose \`privateImeOptions\`** — a free-form string hint that Gboard and most OEM keyboards ignore for fullscreen behaviour. They only honour the standard \`EditorInfo.imeOptions\` int flags, which Compose doesn't expose through Kotlin API.

So the existing \`noFullscreenImeOptions()\` hook (\`PlatformImeOptions(privateImeOptions = \"flagNoFullscreen,noFullscreenUI\")\`) was effectively a no-op on Gboard, which is what AYN Thor uses.

## Fix

\`SpTextField\`'s wrapper (focus glow, error text, leading/trailing icon slots) stays in commonMain. The inner text-input widget is now an expect/actual \`PlatformTextFieldCore\`:

- **desktopMain** — existing \`OutlinedTextField\` (no behaviour change; fullscreen IME is a landscape-Android-handheld problem only).
- **androidMain** — \`AndroidView\` wrapping a styled \`EditText\` with the standard \`imeOptions\` int flags set. Maps Compose \`KeyboardType\` / \`ImeAction\` to the Android \`InputType\` / \`EditorInfo\` equivalents, forwards text changes back to Compose state, mimics \`OutlinedTextField\`'s appearance closely enough that existing screens look right.

## Verification

- ✅ Verified end-to-end on AYN Thor (serial \`54071896\`, Android 13, Gboard): keyboard now docks at the bottom, the rest of the UI stays visible behind it. User-confirmed.
- ✅ Desktop suite green: 161 test classes, no regressions.
- ✅ Build clean across all targets (\`:shared:compileKotlinDesktop\`, \`:shared:compileDebugKotlinAndroid\`, \`:android:compileDebugKotlinAndroid\`).

## Side effects + caveats

- Visual on Android isn't pixel-perfect with \`OutlinedTextField\` (no Material 3 floating-label animation; the \`label\` parameter falls back to placeholder when placeholder is empty). Acceptable trade-off for the experiment; can be polished if it matters.
- The leftover \`noFullscreenImeOptions()\` \`PlatformImeOptions\` hint is now dead code on Android (we set the real flag) but kept for now to keep the diff focused. Cleanup in a follow-up.

## Files

- New: \`PlatformTextFieldCore.kt\` (commonMain expect), \`.desktop.kt\` actual (the existing \`OutlinedTextField\`), \`.android.kt\` actual (new \`AndroidView\`+\`EditText\`).
- Modified: \`SpTextField.kt\` — inner widget now delegates to \`PlatformTextFieldCore\`.