### PR TITLE
fix(player): re-tap active tab pops its stack to root (#846)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
@@ -96,11 +96,29 @@ class NavigationViewModel(
             is NavigationIntent.SwitchTab -> {
                 val targetTab = tabForRootScreen(intent.screen) ?: BottomNavTab.HOME
                 _state.update { current ->
-                    current.copy(
-                        activeTab = targetTab,
-                        isGoingBack = false,
-                        isTabSwitch = true,
-                    )
+                    if (targetTab == current.activeTab) {
+                        // Re-tap on the active tab. Universal "take me back to
+                        // the root of this section" gesture (matches iOS, X,
+                        // Bluesky, Instagram). Pop this tab's stack to its
+                        // root unless it's already there — see #846.
+                        val rootStack = listOf(intent.screen)
+                        val currentStack = current.tabStacks[targetTab]
+                        if (currentStack == rootStack) {
+                            current
+                        } else {
+                            current.copy(
+                                tabStacks = current.tabStacks + (targetTab to rootStack),
+                                isGoingBack = true,
+                                isTabSwitch = false,
+                            )
+                        }
+                    } else {
+                        current.copy(
+                            activeTab = targetTab,
+                            isGoingBack = false,
+                            isTabSwitch = true,
+                        )
+                    }
                 }
             }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -147,6 +147,67 @@ class NavigationViewModelTest {
     }
 
     @Test
+    fun reTapActiveTabPopsStackToRootWhenDeep() = runTest(testDispatcher) {
+        // Universal tab convention (#846): tapping a tab the user is
+        // already on resets that tab's stack to its root. Without this
+        // the gesture is a silent no-op and the user is stuck in deep
+        // navigation with no obvious way back besides repeated GoBack.
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Consoles))
+        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("snes")))
+        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.GameDetail("17")))
+        assertEquals(SpScreen.GameDetail("17"), vm.state.value.currentScreen)
+
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Consoles))
+
+        assertEquals(BottomNavTab.CONSOLES, vm.state.value.activeTab)
+        assertEquals(SpScreen.Consoles, vm.state.value.currentScreen)
+        // The pop should look like a GoBack to the screen-transition
+        // animation, not a tab-switch — the user hasn't switched tabs.
+        assertTrue(vm.state.value.isGoingBack, "active-tab re-tap renders as a back transition")
+        assertFalse(vm.state.value.isTabSwitch, "active-tab re-tap is not a tab switch")
+    }
+
+    @Test
+    fun reTapActiveTabAtRootIsNoOp() = runTest(testDispatcher) {
+        // Edge case from the issue's design: when the stack is already
+        // a single root entry, the re-tap should not emit a GoBack
+        // animation or otherwise produce observable change.
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Consoles))
+        val before = vm.state.value
+
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Consoles))
+
+        assertEquals(before, vm.state.value, "no state change when active tab is already at its root")
+    }
+
+    @Test
+    fun reTapActiveTabPopsOnlyThatTabsStack() = runTest(testDispatcher) {
+        // Each tab maintains its own independent stack — re-tapping the
+        // active tab must not disturb other tabs' stacks. Regression
+        // protection for the SwitchTab branch I just changed.
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.GameDetail("home-deep")))
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Consoles))
+        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("gba")))
+
+        // Re-tap Consoles → only the Consoles stack pops.
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Consoles))
+        assertEquals(SpScreen.Consoles, vm.state.value.currentScreen)
+
+        // Switching to Home shows the still-deep Home stack untouched.
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Home))
+        assertEquals(SpScreen.GameDetail("home-deep"), vm.state.value.currentScreen)
+    }
+
+    @Test
     fun activeTabStaysCorrectThroughDeepNavigation() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()


### PR DESCRIPTION
## Summary

Tapping a main-menu tab the user is *already on* was a silent no-op. The user, deep inside a section (Consoles → SNES → game detail), would tap **Consoles** again expecting to be taken back to the section root — and nothing would happen.

iOS, X, Bluesky, Instagram all treat re-tap on the active tab as the universal *"take me back to the root of this section"* gesture. The absence is one of those small UX omissions users feel without being able to articulate.

## Change

In `NavigationViewModel.SwitchTab`, when `targetTab == current.activeTab`, replace that tab's stack with `[intent.screen]` instead of leaving it untouched. The transition reads as a back animation (`isGoingBack = true`, `isTabSwitch = false`) since no tab switch actually happened.

### Edge cases

- **Stack already at root** → identity update. The outer `state.update` returns the same instance, so `StateFlow` doesn't notify subscribers and no animation kicks off.
- **Other tabs' stacks untouched.** Each tab's stack persists across the re-tap, regression-protected by the new `reTapActiveTabPopsOnlyThatTabsStack` test.

The two `SwitchTab` call sites in `SpelaApp` (rail and bottom bar) already fire the same intent unconditionally, so this single change covers both surfaces.

## Tests

- `reTapActiveTabPopsStackToRootWhenDeep` — 3-deep stack pops to root and renders as a back transition.
- `reTapActiveTabAtRootIsNoOp` — identity state on no-op re-tap.
- `reTapActiveTabPopsOnlyThatTabsStack` — other tabs unaffected.
- Existing `switchTabPreservesStacks` remains green.
- Full desktop suite: **786 tests, 0 failures**.

## Test plan

- [x] `./run-desktop-tests.sh` (full suite green)
- [x] `./gradlew :shared:desktopTest --tests NavigationViewModelTest` (focused suite green)
- [ ] On-device sanity (deferred): on AYN Thor, navigate Consoles → SNES → game detail, tap Consoles again, verify pop to consoles list.

Closes #846