### PR TITLE
fix(player): stream libretro core .so.zip to disk to avoid OOM (#849)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -454,6 +454,7 @@ private class HarnessFileStorage : com.spela.player.util.FileStorage {
     override suspend fun isDirectory(path: String): Boolean = java.io.File(path).isDirectory
     override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
     override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+    override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
     override suspend fun sha256File(path: String): String? = null
 }
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -712,6 +712,7 @@ class FakeFileStorage : FileStorage {
     override suspend fun isDirectory(path: String): Boolean = false
     override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
     override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+    override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
     override suspend fun sha256File(path: String): String? = null
 }
 

--- a/player/shared/src/androidMain/kotlin/com/spela/player/platform/AndroidFileStorage.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/platform/AndroidFileStorage.kt
@@ -106,6 +106,29 @@ class AndroidFileStorage(private val context: Context) : FileStorage {
         }
     }
 
+    override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {
+        withContext(Dispatchers.IO) {
+            val src = File(zipPath)
+            val dest = File(destPath)
+            dest.parentFile?.mkdirs()
+            // Use ZipFile rather than ZipInputStream so we don't have to
+            // walk the archive sequentially — buildbot cores are stored
+            // uncompressed, so ZipFile lets us copy the entry's
+            // InputStream straight to the destination FileOutputStream
+            // with a small buffer (java.io.InputStream.copyTo defaults
+            // to 8 KB), keeping the heap allocation bounded.
+            java.util.zip.ZipFile(src).use { zf ->
+                val entry = zf.entries().asSequence().firstOrNull()
+                    ?: throw IllegalStateException("ZIP archive is empty: $zipPath")
+                zf.getInputStream(entry).use { input ->
+                    dest.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
+                }
+            }
+        }
+    }
+
     override suspend fun sha256File(path: String): String? = withContext(Dispatchers.IO) {
         val file = File(path)
         if (!file.exists() || !file.isFile) return@withContext null

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CoreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CoreRepositoryImpl.kt
@@ -16,6 +16,8 @@ import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.core.*
 
 class CoreRepositoryImpl(
     private val apiClient: SpelaApiClient,
@@ -42,20 +44,41 @@ class CoreRepositoryImpl(
     override suspend fun downloadCore(coreName: String, customDownloadUrl: String?, onProgress: (Float) -> Unit): Result<String> = runCatching {
         val fileName = coreFileName(coreName)
         val destPath = fileStorage.getCoresDir() + "/$fileName"
+        val tempZipPath = "$destPath.zip.tmp"
         val url = if (!customDownloadUrl.isNullOrBlank()) resolveDownloadUrl(customDownloadUrl) else buildbotCoreUrl(coreName)
         println("[CoreRepo] downloadCore($coreName) → $url")
 
-        val response: HttpResponse = httpClient.get(url) {
-            onDownload { bytesSentTotal, contentLength ->
-                if (contentLength != null && contentLength > 0) onProgress(bytesSentTotal.toFloat() / contentLength)
+        // Stream the response to a temp .zip on disk and unzip from
+        // there, never holding the full payload in memory. The largest
+        // libretro cores (scummvm ~134 MB) overflow Android's default
+        // heap (~87 MB free) when the response body is materialised as
+        // a ByteArray. See #849.
+        try {
+            httpClient.prepareGet(url) {
+                onDownload { bytesSentTotal, contentLength ->
+                    if (contentLength != null && contentLength > 0) onProgress(bytesSentTotal.toFloat() / contentLength)
+                }
+            }.execute { response ->
+                if (!response.status.isSuccess()) {
+                    throw RuntimeException("Core download failed: HTTP ${response.status.value} from $url")
+                }
+                val channel = response.bodyAsChannel()
+                fileStorage.writeFileStreaming(tempZipPath) { append ->
+                    val buffer = ByteArray(64 * 1024)
+                    while (true) {
+                        val read = channel.readAvailable(buffer, 0, buffer.size)
+                        if (read == -1) break
+                        append(buffer, 0, read)
+                    }
+                }
             }
+            fileStorage.extractFirstZipEntryFromFile(tempZipPath, destPath)
+        } finally {
+            // Best-effort cleanup of the temp .zip. If the download
+            // throws mid-flight the partial file would otherwise sit
+            // in cores/ until the next download for the same core.
+            runCatching { fileStorage.deleteFile(tempZipPath) }
         }
-        if (!response.status.isSuccess()) {
-            throw RuntimeException("Core download failed: HTTP ${response.status.value} from $url")
-        }
-        val zipData: ByteArray = response.body()
-        val coreData = extractFirstZipEntry(zipData)
-        fileStorage.writeFile(destPath, coreData)
         destPath
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/FileStorage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/FileStorage.kt
@@ -27,6 +27,16 @@ interface FileStorage {
     suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String)
 
     /**
+     * Streams the first entry of the zip at [zipPath] to [destPath]
+     * without buffering the entire payload in memory. Used for the
+     * libretro core download path: buildbot serves each core as a
+     * `.so.zip` (one entry, no compression on the .so itself), and
+     * the largest cores (e.g. scummvm at ~134 MB) overflow the
+     * default Android heap when buffered as a `ByteArray`. See #849.
+     */
+    suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String)
+
+    /**
      * Streaming SHA-256 of the file at [path], returned as a lowercase hex
      * string. Returns `null` when the path doesn't exist or can't be read —
      * callers treat that as "cannot decide" and should fall back to the

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/platform/DesktopFileStorage.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/platform/DesktopFileStorage.kt
@@ -113,6 +113,27 @@ class DesktopFileStorage : FileStorage {
         }
     }
 
+    override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {
+        withContext(Dispatchers.IO) {
+            val src = File(zipPath)
+            val dest = File(destPath)
+            dest.parentFile?.mkdirs()
+            // See AndroidFileStorage for rationale — the ZipFile +
+            // streamed copy keeps the heap allocation bounded so the
+            // largest libretro cores (#849, scummvm ~134 MB) don't OOM
+            // when buffered as a ByteArray.
+            java.util.zip.ZipFile(src).use { zf ->
+                val entry = zf.entries().asSequence().firstOrNull()
+                    ?: throw IllegalStateException("ZIP archive is empty: $zipPath")
+                zf.getInputStream(entry).use { input ->
+                    dest.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
+                }
+            }
+        }
+    }
+
     override suspend fun sha256File(path: String): String? = withContext(Dispatchers.IO) {
         val file = File(path)
         if (!file.exists() || !file.isFile) return@withContext null

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/DownloadRepositoryCleanupTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/DownloadRepositoryCleanupTest.kt
@@ -192,5 +192,6 @@ private class InMemoryFileStorage : FileStorage {
 
     override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
     override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+    override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
     override suspend fun sha256File(path: String): String? = null
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerCompressionTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerCompressionTest.kt
@@ -78,6 +78,7 @@ class SaveManagerCompressionTest {
         override suspend fun isDirectory(path: String): Boolean = File(path).isDirectory
         override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
         override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+        override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
         override suspend fun sha256File(path: String): String? = null
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerDeferredSyncTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerDeferredSyncTest.kt
@@ -279,6 +279,7 @@ class SaveManagerDeferredSyncTest {
         override suspend fun isDirectory(path: String): Boolean = false
         override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
         override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+        override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
         override suspend fun sha256File(path: String): String? = null
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerNamedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerNamedSaveTest.kt
@@ -132,6 +132,7 @@ class SaveManagerNamedSaveTest {
         override suspend fun isDirectory(path: String): Boolean = false
         override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
         override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+        override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
         override suspend fun sha256File(path: String): String? = null
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
@@ -132,6 +132,7 @@ class SaveManagerRehearsalTest {
         override suspend fun isDirectory(path: String): Boolean = false
         override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
         override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+        override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
         override suspend fun sha256File(path: String): String? = null
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerSlotManageTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerSlotManageTest.kt
@@ -218,6 +218,7 @@ class SaveManagerSlotManageTest {
         override suspend fun isDirectory(path: String): Boolean = false
         override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
         override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+        override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
         override suspend fun sha256File(path: String): String? = null
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -642,6 +642,7 @@ private class StubFileStorage : com.spela.player.util.FileStorage {
     override suspend fun isDirectory(path: String): Boolean = false
     override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
     override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+    override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
     override suspend fun sha256File(path: String): String? = null
 }
 


### PR DESCRIPTION
## Summary

Tapping Play on a game whose libretro core wasn't cached locally (e.g. The Secret of Monkey Island → scummvm core, ~134 MB compressed zip → 99 MB decompressed .so) crashed with:

\`\`\`
OutOfMemoryError: Failed to allocate a 134217744 byte allocation
with 91855544 free bytes and 87MB until OOM
\`\`\`

The old `CoreRepositoryImpl.downloadCore` path called `response.body() : ByteArray`, which buffered the entire compressed payload, then `extractFirstZipEntry(zipData)` allocated another `ByteArray` for the decompressed .so. Two large allocations on an Android heap with ~87 MB headroom is fatal for the bigger cores.

## Fix

Stream the response to a temp `.zip` file on disk, then unzip that file directly to the destination path with `java.util.zip.ZipFile` + a small (8 KB) buffer copy. Memory stays bounded regardless of core size.

- Add `FileStorage.extractFirstZipEntryFromFile(zipPath, destPath)` with Android + Desktop actual implementations using `ZipFile` so the entry is streamed straight to a `FileOutputStream`.
- Rewrite `downloadCore` to `prepareGet` + `execute` + `bodyAsChannel`, `writeFileStreaming` the bytes to a `$destPath.zip.tmp`, then call `extractFirstZipEntryFromFile`, then delete the temp file in a `finally` block.
- Update all `FileStorage` test fakes / stubs with the new override (no-op).

## On-device verification (AYN Thor `54071896`)

1. Cleared `cores/`, tapped Play on Monkey Island.
2. scummvm core download completed **without OOM**.
3. 99 MB `scummvm_libretro_android.so` present in `cores/` after extraction.
4. Temp `.zip` cleaned up automatically (no `*.zip.tmp` left behind).
5. Core was loaded by `libretroController.start()` — a separate scummvm `retro_run` SIGSEGV is filed as #852 (ScummVM core itself crashing, not the loader; out of scope here).

## Known follow-up

The companion `downloadCoreByHash` path still uses ByteArray buffering via `SpelaApiClient.downloadCoreByHash`. Refactoring that path needs API client changes; tracked as a known followup. The OOM only triggers on first-play of a not-yet-cached core (the affected path is `downloadCore`), so this PR resolves the user-reported scenario.

## Test plan

- [x] `./run-desktop-tests.sh` — full suite green
- [x] `./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid` — clean
- [x] On-device repro (AYN Thor) — scummvm core downloads, extracts, loads without OOM

Closes #849