### PR TITLE
fix(player): don't flag core_variables dirty during SET_VARIABLES init (#852)

### DIFF
--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -321,6 +321,20 @@ static bool environment_callback(unsigned cmd, void *data) {
                     }
                 }
 
+                /* Clear the dirty flag after initial population. The flag is
+                 * meant to signal *user-initiated* variable changes (so the
+                 * core can re-read its options), but core_variables_set bumps
+                 * it on every insert — including the 36 initial defaults the
+                 * core itself just declared via SET_VARIABLES. Leaving it
+                 * true causes retro_run's first frame to call back into
+                 * GET_VARIABLE_UPDATE, get true, and trigger an options-
+                 * reload before the core's engine thread has finished
+                 * initialising state like _graphicsManager. ScummVM crashes
+                 * deterministically here (#852) because refreshRetroSettings
+                 * dereferences a NULL graphics manager. Other cores tolerate
+                 * the spurious reload; ScummVM does not.
+                 */
+                core_variables_dirty = false;
             }
             return true;
         }


### PR DESCRIPTION
## Summary

ScummVM games crashed on the first \`retro_run\` with a SIGSEGV at \`WindowedGraphicsManager::getWindowWidth()+0x0\` (NULL \`this\`) — on both Android and desktop.

## Root cause

The desktop JVM \`hs_err_pid\` log gave the symbolicated trail:

\`\`\`
WindowedGraphicsManager::getWindowWidth() const+0x0
OSystem_libretro::refreshRetroSettings()+0x28
retro_update_options_display()+0x78
retro_run+0x18
\`\`\`

\`retro_run\`'s first action was an options-reload, which dereferenced \`OSystem_libretro::_graphicsManager\` before the engine thread created it.

The bug is in our env handling, not the core:

1. \`SET_VARIABLES\` is called by the core during \`retro_load_game\` to declare its options + defaults.
2. Our handler calls \`core_variables_set()\` for each entry, which bumps \`core_variables_dirty = true\`.
3. By the time \`retro_run\` runs, the flag is still \`true\`.
4. The core's first \`GET_VARIABLE_UPDATE\` callback gets \`true\` → "user changed variables, reload!" → calls \`retro_update_options_display\` → \`refreshRetroSettings\` → crash.

Most libretro cores tolerate a spurious initial reload (they early-return if the engine isn't ready). ScummVM doesn't — it reaches the graphics manager unconditionally.

## Fix

Clear \`core_variables_dirty\` at the end of \`SET_VARIABLES\` handling. The flag is meant to signal *user-initiated* changes (the player mutating an option through the in-game settings UI), not the core's own initial declaration of defaults.

\`\`\`c
core_variables_dirty = false;
\`\`\`

One line + the comment explaining why.

## Verification

- **AYN Thor**: Monkey Island and Maniac Mansion now boot past \`retro_run\`, render their title screens, and reach the in-game overlay layer.
- **Desktop**: same fix; the symbolicated trail came from there.
- Other cores (NES/SNES/N64/PS1/Dolphin/etc.) tolerate the initial spurious reload, so this is non-regressive for them.

## Test plan

- [x] Build APK + install + launch ScummVM game on AYN Thor — boots and renders.
- [x] Cross-platform reasoning: same C bridge runs on Android + desktop.
- [ ] Full desktop suite + CI gate.

Closes #852