### PR TITLE
fix(player): clear retro_* function pointers in nativeDeinit (#852)

### DIFF
--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -1118,6 +1118,40 @@ JNI_FUNC(void, nativeDeinit)(JNIEnv *env, jobject thiz) {
         sp_dlclose(g_core.handle);
         g_core.handle = NULL;
     }
+
+    /* Clear every retro_* function pointer in g_core. After dlclose the
+     * code those pointers reference is unmapped, but the bytes in the
+     * pointer slots still look non-NULL — every JNI entry that guards
+     * with "if (g_core.retro_xxx)" then dereferences garbage. Pre-fix,
+     * this surfaced as a crash at nativeSetControllerPortDevice when
+     * the user exited a ScummVM game and started a new one in the same
+     * process: the game-launch path calls setControllerPortDevice(0,
+     * MOUSE) BEFORE the next core's loadCore rebuilds these slots. See
+     * the #852 follow-up. */
+    g_core.retro_init = NULL;
+    g_core.retro_deinit = NULL;
+    g_core.retro_api_version = NULL;
+    g_core.retro_get_system_info = NULL;
+    g_core.retro_get_system_av_info = NULL;
+    g_core.retro_set_environment = NULL;
+    g_core.retro_set_video_refresh = NULL;
+    g_core.retro_set_audio_sample = NULL;
+    g_core.retro_set_audio_sample_batch = NULL;
+    g_core.retro_set_input_poll = NULL;
+    g_core.retro_set_input_state = NULL;
+    g_core.retro_set_controller_port_device = NULL;
+    g_core.retro_reset = NULL;
+    g_core.retro_run = NULL;
+    g_core.retro_load_game = NULL;
+    g_core.retro_unload_game = NULL;
+    g_core.retro_serialize_size = NULL;
+    g_core.retro_serialize = NULL;
+    g_core.retro_unserialize = NULL;
+    g_core.retro_get_memory_data = NULL;
+    g_core.retro_get_memory_size = NULL;
+    g_core.retro_cheat_reset = NULL;
+    g_core.retro_cheat_set = NULL;
+
     LOGI("Core deinitialized");
 }
 


### PR DESCRIPTION
## Summary

Third (and final) follow-up to #852. After \`sp_dlclose\` the bytes in \`g_core\`'s 23 \`retro_*\` function pointer slots still look non-NULL — they point into the unmapped library segment. Every JNI entry that guards with \`if (g_core.retro_xxx)\` then dereferences garbage on the *next* core's launch.

Surfaced as a SIGSEGV at \`nativeSetControllerPortDevice+68\` (fault addr \`0x782c7600b8\` — high heap, not NULL) when the user exited a ScummVM game and started a new game in the same process. The launch flow at \`EmulationViewModel:902\` calls \`setControllerPortDevice(0, MOUSE)\` *before* the next \`loadCore\` rebuilds \`g_core\` — guard sees non-NULL, dereferences, dies.

## Fix

In \`nativeDeinit\`'s step 6 (after \`sp_dlclose\`), explicitly NULL each of the 23 \`retro_*\` function pointers. The next \`nativeLoadCore\`'s \`LOAD_SYM\` macros refill them; the guards in unrelated JNI entry points correctly fall through to no-op until that happens.

## Why this only surfaced for ScummVM

The bug exists for any core, but the launch flow only calls \`setControllerPortDevice\` *between* \`stop()\` and \`loadCore\` for ScummVM (line 901-903 sets port 0 to \`RETRO_DEVICE_MOUSE\` for point-and-click input). For SRAM cores, the controller setup happens *after* \`loadCore\` has rebuilt \`g_core\`. The exit-and-relaunch flow for those cores never tripped the dangling pointer.

## Verification

AYN Thor: Maniac Mansion → Exit → tap Resume on the same game → boots cleanly. Same for ScummVM → other-core and other-core → ScummVM swaps. No regressions on SRAM-core flows.

Refs #852.