### PR TITLE
feat: per-session save_dir bundle (#864)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/DesktopAudioPlayerTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/DesktopAudioPlayerTest.kt
@@ -32,7 +32,7 @@ class DesktopAudioPlayerTest {
         private var _sampleRate = 44100.0
         var audioBufferData: ShortArray? = ShortArray(1024) { (it % 32767).toShort() }
 
-        override fun loadCore(corePath: String) {}
+        override fun loadCore(corePath: String, saveDir: String?) {}
         override fun loadGame(gamePath: String) {}
         override fun start() {}
         override fun pause() {}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InputLagMeasurementTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InputLagMeasurementTest.kt
@@ -66,7 +66,7 @@ class InputLagMeasurementTest {
         var isRunning = false
             private set
 
-        override fun loadCore(corePath: String) {}
+        override fun loadCore(corePath: String, saveDir: String?) {}
         override fun loadGame(gamePath: String) {}
         override fun start() { isRunning = true }
         override fun pause() {}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -455,6 +455,8 @@ private class HarnessFileStorage : com.spela.player.util.FileStorage {
     override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
     override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
     override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
+    override suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long = 0L
+    override suspend fun extractTarFile(tarPath: String, destDir: String) {}
     override suspend fun sha256File(path: String): String? = null
 }
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -606,7 +606,7 @@ class FakeLibretroController : LibretroController {
     var loadCallCount = 0
         private set
 
-    override fun loadCore(corePath: String) {
+    override fun loadCore(corePath: String, saveDir: String?) {
         loadedCore = corePath
     }
 
@@ -713,6 +713,8 @@ class FakeFileStorage : FileStorage {
     override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
     override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
     override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
+    override suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long = 0L
+    override suspend fun extractTarFile(tarPath: String, destDir: String) {}
     override suspend fun sha256File(path: String): String? = null
 }
 
@@ -1525,6 +1527,12 @@ class FakeSessionRepository : SessionRepository {
     override suspend fun downloadSessionSram(sessionId: String): Result<ByteArray> =
         sram[sessionId]?.let { Result.success(it) }
             ?: Result.failure(Exception("No SRAM"))
+
+    override suspend fun uploadSessionSaveDirBundleFromFile(sessionId: String, tarPath: String, tarSize: Long): Result<Unit> =
+        Result.success(Unit)
+
+    override suspend fun downloadSessionSaveDirBundleToFile(sessionId: String, fileStorage: com.spela.player.util.FileStorage, outputPath: String): Result<Unit> =
+        Result.failure(Exception("no save_dir bundle"))
 
     override suspend fun getSessionCheats(sessionId: String): Result<SessionCheatConfig> =
         Result.success(sessionCheats[sessionId] ?: SessionCheatConfig(cheatsEnabled = false, enabledIndices = emptyList()))

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
@@ -114,9 +114,9 @@ class AndroidLibretroController(
     /* Handler for posting state updates to the main thread (avoids Compose multithreading crash) */
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    override fun loadCore(corePath: String) {
+    override fun loadCore(corePath: String, saveDir: String?) {
         jni.nativeSetSystemDir(fileStorage.getBiosDir())
-        jni.nativeSetSaveDir(fileStorage.getSavesDir())
+        jni.nativeSetSaveDir(saveDir ?: fileStorage.getSavesDir())
 
         if (!jni.nativeLoadCore(corePath)) {
             throw RuntimeException("Failed to load core: $corePath")

--- a/player/shared/src/androidMain/kotlin/com/spela/player/platform/AndroidFileStorage.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/platform/AndroidFileStorage.kt
@@ -129,6 +129,68 @@ class AndroidFileStorage(private val context: Context) : FileStorage {
         }
     }
 
+    override suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long =
+        withContext(Dispatchers.IO) {
+            val src = File(dirPath)
+            if (!src.exists() || !src.isDirectory) return@withContext 0L
+            val dest = File(destPath)
+            dest.parentFile?.mkdirs()
+            val files = src.walkTopDown().filter { it.isFile }.toList()
+            if (files.isEmpty()) return@withContext 0L
+            dest.outputStream().buffered().use { out ->
+                for (f in files) {
+                    val rel = f.relativeTo(src).invariantSeparatorsPath
+                    writeUstarHeader(out, rel, f.length())
+                    f.inputStream().use { input -> input.copyTo(out) }
+                    val pad = ((512 - (f.length() % 512)) % 512).toInt()
+                    if (pad > 0) out.write(ByteArray(pad))
+                }
+                // Two zero blocks mark the end of the archive.
+                out.write(ByteArray(1024))
+            }
+            dest.length()
+        }
+
+    override suspend fun extractTarFile(tarPath: String, destDir: String) =
+        withContext(Dispatchers.IO) {
+            val src = File(tarPath)
+            if (!src.exists() || src.length() == 0L) return@withContext
+            val dest = File(destDir)
+            dest.mkdirs()
+            src.inputStream().buffered().use { input ->
+                while (true) {
+                    val header = ByteArray(512)
+                    if (!readFully(input, header)) break
+                    if (header.all { it == 0.toByte() }) break
+                    val name = parseTarString(header, 0, 100)
+                    if (name.isEmpty()) break
+                    val sizeStr = parseTarString(header, 124, 12)
+                    val size = sizeStr.toLongOrNull(8) ?: 0L
+                    if (size > 0) {
+                        val outFile = File(dest, name)
+                        outFile.parentFile?.mkdirs()
+                        outFile.outputStream().buffered().use { out ->
+                            var remaining = size
+                            val buf = ByteArray(64 * 1024)
+                            while (remaining > 0) {
+                                val toRead = minOf(remaining, buf.size.toLong()).toInt()
+                                val read = input.read(buf, 0, toRead)
+                                if (read <= 0) break
+                                out.write(buf, 0, read)
+                                remaining -= read
+                            }
+                        }
+                        // Skip padding to next 512-byte boundary.
+                        val pad = ((512 - (size % 512)) % 512).toInt()
+                        if (pad > 0) {
+                            val skip = ByteArray(pad)
+                            readFully(input, skip)
+                        }
+                    }
+                }
+            }
+        }
+
     override suspend fun sha256File(path: String): String? = withContext(Dispatchers.IO) {
         val file = File(path)
         if (!file.exists() || !file.isFile) return@withContext null
@@ -145,4 +207,67 @@ class AndroidFileStorage(private val context: Context) : FileStorage {
             digest.digest().joinToString("") { "%02x".format(it) }
         }.getOrNull()
     }
+}
+
+/**
+ * Writes a USTAR-format header for a single file entry. Hand-rolled so we
+ * don't pull in Apache Commons Compress just for this; the format is well-
+ * defined (POSIX 1003.1-1988) and the subset we use (regular files only,
+ * no symlinks, no hardlinks, paths ≤ 100 chars) fits in a few lines.
+ *
+ * If [name] exceeds 100 bytes it's truncated — keep paths short. The
+ * fixed-format checksum is computed by summing every byte of the header
+ * with the checksum field treated as eight ASCII spaces, then writing the
+ * sum as a six-digit octal followed by NUL + space.
+ */
+private fun writeUstarHeader(out: java.io.OutputStream, name: String, size: Long) {
+    val hdr = ByteArray(512)
+    val nameBytes = name.encodeToByteArray()
+    val nameLen = minOf(nameBytes.size, 100)
+    System.arraycopy(nameBytes, 0, hdr, 0, nameLen)
+    // 420 dec == 0644 oct (Kotlin has no octal literal). Standard rw-r--r--
+    // permission bits — match what RetroArch writes to its save dir tarballs.
+    putOctal(hdr, 100, 8, 420L)               // mode
+    putOctal(hdr, 108, 8, 0L)                 // uid
+    putOctal(hdr, 116, 8, 0L)                 // gid
+    putOctal(hdr, 124, 12, size)              // size
+    putOctal(hdr, 136, 12, 0L)                // mtime — irrelevant for save bundles, keep stable
+    // checksum field is initially 8 spaces while computing
+    for (i in 148 until 156) hdr[i] = ' '.code.toByte()
+    hdr[156] = '0'.code.toByte()              // typeflag = regular file
+    val ustar = "ustar "
+    val ver = "00"
+    for ((i, c) in ustar.withIndex()) hdr[257 + i] = c.code.toByte()
+    for ((i, c) in ver.withIndex()) hdr[263 + i] = c.code.toByte()
+    var sum = 0
+    for (b in hdr) sum += (b.toInt() and 0xFF)
+    val sumStr = "%06o".format(sum)
+    for ((i, c) in sumStr.withIndex()) hdr[148 + i] = c.code.toByte()
+    hdr[154] = 0
+    hdr[155] = ' '.code.toByte()
+    out.write(hdr)
+}
+
+private fun putOctal(buf: ByteArray, off: Int, len: Int, value: Long) {
+    val s = "%0${len - 1}o".format(value)
+    val bytes = s.encodeToByteArray()
+    val n = minOf(bytes.size, len - 1)
+    System.arraycopy(bytes, 0, buf, off, n)
+    buf[off + len - 1] = 0
+}
+
+private fun parseTarString(buf: ByteArray, off: Int, len: Int): String {
+    var end = off
+    while (end < off + len && buf[end] != 0.toByte()) end++
+    return String(buf, off, end - off).trim()
+}
+
+private fun readFully(input: java.io.InputStream, buf: ByteArray): Boolean {
+    var read = 0
+    while (read < buf.size) {
+        val n = input.read(buf, read, buf.size - read)
+        if (n < 0) return read > 0 && read == buf.size
+        read += n
+    }
+    return true
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1829,6 +1829,42 @@ class SpelaApiClient(
         }
     }
 
+    /**
+     * Uploads the per-session save_dir tarball, atomically replacing any
+     * prior bundle. Streams the file from disk via ChannelProvider so the
+     * tar is never fully materialised in memory. See #864.
+     */
+    suspend fun uploadSessionSaveDirBundleFromFile(sessionId: String, tarPath: String, tarSize: Long) {
+        client.submitFormWithBinaryData(
+            url = "$baseUrl/api/sessions/$sessionId/save-dir",
+            formData = formData {
+                append("file", io.ktor.client.request.forms.ChannelProvider(tarSize) {
+                    com.spela.player.util.openFileReadChannel(tarPath)
+                }, Headers.build {
+                    append(HttpHeaders.ContentDisposition, "filename=\"save-dir.tar\"")
+                    append(HttpHeaders.ContentType, "application/x-tar")
+                })
+            }
+        )
+    }
+
+    /**
+     * Streams the session's save_dir tarball to [outputPath]. Throws on
+     * non-2xx responses; in particular a 404 means the session has never
+     * had a save_dir bundle and the caller should treat the local dir as
+     * fresh-empty rather than failing the launch. See #864.
+     */
+    suspend fun downloadSessionSaveDirBundleToFile(sessionId: String, fileStorage: FileStorage, outputPath: String) {
+        client.prepareGet("$baseUrl/api/sessions/$sessionId/save-dir") {
+            timeout { requestTimeoutMillis = Long.MAX_VALUE }
+        }.execute { response ->
+            if (!response.status.isSuccess()) {
+                throw RuntimeException("save_dir bundle download failed: HTTP ${response.status.value}")
+            }
+            streamSaveResponseToFile(response, fileStorage, outputPath)
+        }
+    }
+
     suspend fun downloadSessionSaveToFile(sessionId: String, saveId: String, fileStorage: FileStorage, outputPath: String) {
         client.prepareGet("$baseUrl/api/sessions/$sessionId/saves/$saveId") {
             timeout { requestTimeoutMillis = Long.MAX_VALUE }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
@@ -116,6 +116,22 @@ class SessionRepositoryImpl(
         apiClient.uploadSessionAutoSaveFromFile(sessionId, savePath, saveSize, screenshot, coreName, compression)
     }
 
+    override suspend fun uploadSessionSaveDirBundleFromFile(
+        sessionId: String,
+        tarPath: String,
+        tarSize: Long,
+    ): Result<Unit> = runCatching {
+        apiClient.uploadSessionSaveDirBundleFromFile(sessionId, tarPath, tarSize)
+    }
+
+    override suspend fun downloadSessionSaveDirBundleToFile(
+        sessionId: String,
+        fileStorage: com.spela.player.util.FileStorage,
+        outputPath: String,
+    ): Result<Unit> = runCatching {
+        apiClient.downloadSessionSaveDirBundleToFile(sessionId, fileStorage, outputPath)
+    }
+
     override suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray> = runCatching {
         apiClient.downloadSessionAutoSave(sessionId)
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
@@ -61,6 +61,21 @@ interface SessionRepository {
     suspend fun downloadSlotSaveToFile(sessionId: String, slot: Int, outputPath: String): Result<Unit>
     suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String = ""): Result<Unit>
     suspend fun downloadSessionSram(sessionId: String): Result<ByteArray>
+
+    /**
+     * Uploads the per-session save_dir tarball to the server (replaces any
+     * previous bundle for this session). Used by cores that write their
+     * own save files to disk (ScummVM, DOSBox). See #864.
+     */
+    suspend fun uploadSessionSaveDirBundleFromFile(sessionId: String, tarPath: String, tarSize: Long): Result<Unit>
+
+    /**
+     * Streams the session's save_dir tarball to [outputPath]. Returns
+     * Result.failure for any non-2xx response — in particular a 404
+     * means the session has never had a bundle (the caller should treat
+     * the local dir as fresh and empty). See #864.
+     */
+    suspend fun downloadSessionSaveDirBundleToFile(sessionId: String, fileStorage: com.spela.player.util.FileStorage, outputPath: String): Result<Unit>
     suspend fun getSessionCheats(sessionId: String): Result<SessionCheatConfig>
     suspend fun updateSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int>): Result<SessionCheatConfig>
     /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -1096,8 +1096,21 @@ class EmulationViewModel(
                             libretroController.setCoreVariable("desmume_pointer_mouse", "enabled")
                         }
 
-                        println("[Emulation] About to loadCore($corePath)")
-                        libretroController.loadCore(corePath)
+                        // Per-session save_dir: cores that write their saves to disk
+                        // (ScummVM, DOSBox) get their own subdirectory under
+                        // saves/sessions/{sessionId}/. SRAM cores don't touch the
+                        // save_dir — for them the per-session path is empty
+                        // throughout the session, which is harmless. We download
+                        // the previous bundle (if any) and untar it into the dir
+                        // before loadCore so the core sees its prior saves on
+                        // resume. See #864.
+                        val sessionSaveDir = saveManager.getSessionSaveDir(saveManager.currentSessionId)
+                        if (sessionSaveDir != null) {
+                            saveManager.populateSessionSaveDir(saveManager.currentSessionId, sessionSaveDir)
+                        }
+
+                        println("[Emulation] About to loadCore($corePath, saveDir=$sessionSaveDir)")
+                        libretroController.loadCore(corePath, sessionSaveDir)
                         println("[Emulation] loadCore returned")
 
                         // On Android emulators (SwiftShader), paraLLEl-RDP Vulkan crashes
@@ -1921,7 +1934,14 @@ private fun coreDeclaresNoSaveStates(resolvedCoreName: String): Boolean {
  * Implemented on Android (via JNI/NDK) and Desktop (via JNI).
  */
 interface LibretroController {
-    fun loadCore(corePath: String)
+    /**
+     * Loads the libretro core at [corePath]. [saveDir] overrides the default
+     * libretro save directory; pass the per-session path for cores that
+     * write their saves to disk (ScummVM, DOSBox), or null to use the
+     * platform default. The save_dir is honoured via
+     * `RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY`. See #864.
+     */
+    fun loadCore(corePath: String, saveDir: String? = null)
     fun loadGame(gamePath: String)
     fun start()
     fun pause()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -408,6 +408,94 @@ class SaveManager(
     }
 
     /**
+     * Pulls the session's save_dir bundle from the server and untars it
+     * into [destDir]. Called by the emulation start flow before loadCore
+     * so cores that scan their save_dir on init (ScummVM, DOSBox) see
+     * their previously-saved files. Best-effort: any failure leaves the
+     * dir in whatever state it's in (typically empty for a fresh session
+     * or a session whose previous run wrote nothing). See #864.
+     */
+    /**
+     * Returns the on-disk save_dir path for the given [sessionId] (creating
+     * the directory if missing) or null when no session is active. Used by
+     * the emulation start flow to compute the path that's passed to
+     * [LibretroController.loadCore]. See #864.
+     */
+    suspend fun getSessionSaveDir(sessionId: String?): String? {
+        if (sessionId == null) return null
+        val path = "${fileStorage.getSavesDir()}/sessions/$sessionId"
+        fileStorage.createDirectory(path)
+        return path
+    }
+
+    suspend fun populateSessionSaveDir(sessionId: String?, destDir: String) {
+        if (sessionId == null) return
+        val tarPath = "${fileStorage.getSavesDir()}/.tmp-savedir-load-$sessionId.tar"
+        try {
+            val result = sessionRepository.downloadSessionSaveDirBundleToFile(
+                sessionId, fileStorage, tarPath,
+            )
+            if (result.isFailure) {
+                val msg = result.exceptionOrNull()?.message ?: ""
+                if (msg.contains("404")) {
+                    println("[SaveManager] populateSessionSaveDir: no bundle yet for session $sessionId")
+                } else {
+                    println("[SaveManager] populateSessionSaveDir: download failed: $msg")
+                }
+                return
+            }
+            val tarSize = runCatching { fileStorage.getFileSize(tarPath) }.getOrDefault(0L)
+            if (tarSize <= 0L) {
+                println("[SaveManager] populateSessionSaveDir: empty bundle for session $sessionId, leaving dir as-is")
+                return
+            }
+            try {
+                fileStorage.extractTarFile(tarPath, destDir)
+                println("[SaveManager] populateSessionSaveDir: extracted ${tarSize}B bundle into $destDir")
+            } catch (e: Exception) {
+                println("[SaveManager] populateSessionSaveDir: extract failed: ${e.message}")
+            }
+        } finally {
+            runCatching { fileStorage.deleteFile(tarPath) }
+        }
+    }
+
+    /**
+     * Tars the session's on-disk save_dir and uploads the bundle to the
+     * server, atomically replacing any previous bundle. Called by the
+     * emulation stop flow after the libretro auto-save has been written.
+     * Best-effort: a failure leaves the local dir intact (it's the source
+     * of truth on this device until the next successful upload). See #864.
+     */
+    private suspend fun saveDirOnStop(sessionId: String) {
+        val srcDir = "${fileStorage.getSavesDir()}/sessions/$sessionId"
+        val tarPath = "${fileStorage.getSavesDir()}/.tmp-savedir-upload-$sessionId.tar"
+        try {
+            val tarSize = try {
+                fileStorage.tarDirectoryToFile(srcDir, tarPath)
+            } catch (e: Exception) {
+                println("[SaveManager] saveDirOnStop: tar failed: ${e.message}")
+                return
+            }
+            if (tarSize <= 0L) {
+                println("[SaveManager] saveDirOnStop: empty dir, nothing to upload for session $sessionId")
+                return
+            }
+            val result = sessionRepository.uploadSessionSaveDirBundleFromFile(
+                sessionId, tarPath, tarSize,
+            )
+            if (result.isSuccess) {
+                println("[SaveManager] saveDirOnStop: uploaded ${tarSize}B bundle for session $sessionId")
+            } else {
+                val msg = result.exceptionOrNull()?.message ?: "unknown"
+                println("[SaveManager] saveDirOnStop: upload failed: $msg")
+            }
+        } finally {
+            runCatching { fileStorage.deleteFile(tarPath) }
+        }
+    }
+
+    /**
      * Auto-save on stop (if enabled and not in challenge mode).
      * Always serializes via the libretro controller; uploads to session when available.
      * Called from within an IO coroutine.
@@ -423,6 +511,12 @@ class SaveManager(
             null
         } ?: run {
             println("[SaveManager] autoSaveOnStop: stageSaveToTempFile returned null")
+            // Some cores (ScummVM, DOSBox) declare savestate=false and
+            // return null here. They still need their on-disk save_dir
+            // bundle uploaded, so don't bail before saveDirOnStop. See
+            // #864 — save_dir is the parallel persistent path that's
+            // independent of the libretro memory snapshot.
+            currentSessionId?.let { saveDirOnStop(it) }
             return
         }
         println("[SaveManager] autoSaveOnStop: staged ${staged.size} bytes at ${staged.path}, uploading…")
@@ -459,6 +553,12 @@ class SaveManager(
         // queued during gameplay are still on disk waiting for an
         // opportunity. This is that opportunity.
         drainPendingUploads()
+
+        // Per-session save_dir bundle (#864). Done after the libretro
+        // auto-save so the in-memory snapshot wins if both succeed —
+        // some cores write to BOTH (DOSBox writes config to save_dir
+        // but its memory state lives in the libretro state).
+        currentSessionId?.let { saveDirOnStop(it) }
     }
 
     /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/FileStorage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/FileStorage.kt
@@ -37,6 +37,25 @@ interface FileStorage {
     suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String)
 
     /**
+     * Tars the contents of [dirPath] (recursively) into [destPath]. The
+     * tar contains entries named relative to [dirPath] — `dirPath/foo/bar`
+     * lands in the tar as `foo/bar`. Streams to disk; the tar isn't
+     * materialized in memory. Used to bundle a libretro save_dir for
+     * upload (#864). Returns the size in bytes of the written tar.
+     * Returns 0 when [dirPath] doesn't exist or is empty.
+     */
+    suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long
+
+    /**
+     * Extracts a tar file at [tarPath] into [destDir] (recursively).
+     * Companion to [tarDirectoryToFile] for the save_dir bundle download
+     * path (#864). Streams from disk — tar is never fully buffered in
+     * memory. The destination dir is created if missing; existing files
+     * with the same path are overwritten.
+     */
+    suspend fun extractTarFile(tarPath: String, destDir: String)
+
+    /**
      * Streaming SHA-256 of the file at [path], returned as a lowercase hex
      * string. Returns `null` when the path doesn't exist or can't be read —
      * callers treat that as "cannot decide" and should fall back to the

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModelTest.kt
@@ -296,6 +296,12 @@ private class FakeSessionRepo : SessionRepository {
     override suspend fun downloadSessionSram(sessionId: String): Result<ByteArray> =
         Result.failure(UnsupportedOperationException("not exercised"))
 
+    override suspend fun uploadSessionSaveDirBundleFromFile(sessionId: String, tarPath: String, tarSize: Long): Result<Unit> =
+        Result.success(Unit)
+
+    override suspend fun downloadSessionSaveDirBundleToFile(sessionId: String, fileStorage: com.spela.player.util.FileStorage, outputPath: String): Result<Unit> =
+        Result.failure(Exception("no save_dir bundle"))
+
     override suspend fun getSessionCheats(sessionId: String): Result<SessionCheatConfig> =
         Result.success(SessionCheatConfig(cheatsEnabled = false, enabledIndices = emptyList()))
 

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
@@ -89,9 +89,9 @@ class DesktopLibretroController(
     var latestRenderedFrame: RenderedFrame? = null
         private set
 
-    override fun loadCore(corePath: String) {
+    override fun loadCore(corePath: String, saveDir: String?) {
         jni.nativeSetSystemDir(fileStorage.getBiosDir())
-        jni.nativeSetSaveDir(fileStorage.getSavesDir())
+        jni.nativeSetSaveDir(saveDir ?: fileStorage.getSavesDir())
 
         if (!jni.nativeLoadCore(corePath)) {
             throw RuntimeException("Failed to load core: $corePath")

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/platform/DesktopFileStorage.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/platform/DesktopFileStorage.kt
@@ -150,6 +150,120 @@ class DesktopFileStorage : FileStorage {
             digest.digest().joinToString("") { "%02x".format(it) }
         }.getOrNull()
     }
+
+    override suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long =
+        withContext(Dispatchers.IO) {
+            val src = File(dirPath)
+            if (!src.exists() || !src.isDirectory) return@withContext 0L
+            val dest = File(destPath)
+            dest.parentFile?.mkdirs()
+            val files = src.walkTopDown().filter { it.isFile }.toList()
+            if (files.isEmpty()) return@withContext 0L
+            dest.outputStream().buffered().use { out ->
+                for (f in files) {
+                    val rel = f.relativeTo(src).invariantSeparatorsPath
+                    writeUstarHeader(out, rel, f.length())
+                    f.inputStream().use { input -> input.copyTo(out) }
+                    val pad = ((512 - (f.length() % 512)) % 512).toInt()
+                    if (pad > 0) out.write(ByteArray(pad))
+                }
+                out.write(ByteArray(1024))
+            }
+            dest.length()
+        }
+
+    override suspend fun extractTarFile(tarPath: String, destDir: String) =
+        withContext(Dispatchers.IO) {
+            val src = File(tarPath)
+            if (!src.exists() || src.length() == 0L) return@withContext
+            val dest = File(destDir)
+            dest.mkdirs()
+            src.inputStream().buffered().use { input ->
+                while (true) {
+                    val header = ByteArray(512)
+                    if (!readFully(input, header)) break
+                    if (header.all { it == 0.toByte() }) break
+                    val name = parseTarString(header, 0, 100)
+                    if (name.isEmpty()) break
+                    val sizeStr = parseTarString(header, 124, 12)
+                    val size = sizeStr.toLongOrNull(8) ?: 0L
+                    if (size > 0) {
+                        val outFile = File(dest, name)
+                        outFile.parentFile?.mkdirs()
+                        outFile.outputStream().buffered().use { out ->
+                            var remaining = size
+                            val buf = ByteArray(64 * 1024)
+                            while (remaining > 0) {
+                                val toRead = minOf(remaining, buf.size.toLong()).toInt()
+                                val read = input.read(buf, 0, toRead)
+                                if (read <= 0) break
+                                out.write(buf, 0, read)
+                                remaining -= read
+                            }
+                        }
+                        val pad = ((512 - (size % 512)) % 512).toInt()
+                        if (pad > 0) {
+                            val skip = ByteArray(pad)
+                            readFully(input, skip)
+                        }
+                    }
+                }
+            }
+        }
+}
+
+// Tar helpers — see AndroidFileStorage for rationale on the hand-rolled
+// USTAR writer / reader. Duplicated here so both platforms can ship the
+// save_dir bundle (#864) without adding Apache Commons Compress.
+
+private fun writeUstarHeader(out: java.io.OutputStream, name: String, size: Long) {
+    val hdr = ByteArray(512)
+    val nameBytes = name.encodeToByteArray()
+    val nameLen = minOf(nameBytes.size, 100)
+    System.arraycopy(nameBytes, 0, hdr, 0, nameLen)
+    // 420 dec == 0644 oct (Kotlin has no octal literal).
+    putOctal(hdr, 100, 8, 420L)
+    putOctal(hdr, 108, 8, 0L)
+    putOctal(hdr, 116, 8, 0L)
+    putOctal(hdr, 124, 12, size)
+    putOctal(hdr, 136, 12, 0L)
+    for (i in 148 until 156) hdr[i] = ' '.code.toByte()
+    hdr[156] = '0'.code.toByte()
+    val ustar = "ustar "
+    val ver = "00"
+    for ((i, c) in ustar.withIndex()) hdr[257 + i] = c.code.toByte()
+    for ((i, c) in ver.withIndex()) hdr[263 + i] = c.code.toByte()
+    var sum = 0
+    for (b in hdr) sum += (b.toInt() and 0xFF)
+    val sumStr = "%06o".format(sum)
+    for ((i, c) in sumStr.withIndex()) hdr[148 + i] = c.code.toByte()
+    hdr[154] = 0
+    hdr[155] = ' '.code.toByte()
+    out.write(hdr)
+}
+
+private fun putOctal(buf: ByteArray, off: Int, len: Int, value: Long) {
+    val s = "%0${len - 1}o".format(value)
+    val bytes = s.encodeToByteArray()
+    val n = minOf(bytes.size, len - 1)
+    System.arraycopy(bytes, 0, buf, off, n)
+    buf[off + len - 1] = 0
+}
+
+private fun parseTarString(buf: ByteArray, off: Int, len: Int): String {
+    var end = off
+    while (end < off + len && buf[end] != 0.toByte()) end++
+    return String(buf, off, end - off).trim()
+}
+
+private fun readFully(input: java.io.InputStream, buf: ByteArray): Boolean {
+    var read = 0
+    while (read < buf.size) {
+        val n = input.read(buf, read, buf.size - read)
+        if (n < 0) return read > 0 && read == buf.size
+        read += n
+    }
+    return true
 }
 
 internal fun resolveLinuxDataDir(home: String, xdgDataHome: String? = System.getenv("XDG_DATA_HOME")): File {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/DownloadRepositoryCleanupTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/DownloadRepositoryCleanupTest.kt
@@ -193,5 +193,7 @@ private class InMemoryFileStorage : FileStorage {
     override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
     override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
     override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
+    override suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long = 0L
+    override suspend fun extractTarFile(tarPath: String, destDir: String) {}
     override suspend fun sha256File(path: String): String? = null
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/LibretroControllerTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/LibretroControllerTest.kt
@@ -197,7 +197,7 @@ private class FakeLibretroController : LibretroController {
     var loadCallCount = 0
         private set
 
-    override fun loadCore(corePath: String) {
+    override fun loadCore(corePath: String, saveDir: String?) {
         loadedCore = corePath
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -195,6 +195,8 @@ private class FakePlayFromSharedSaveSessionRepository : SessionRepository {
     override suspend fun downloadSlotSaveToFile(sessionId: String, slot: Int, outputPath: String) = Result.failure<Unit>(Exception("stub"))
     override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String) = Result.success(Unit)
     override suspend fun downloadSessionSram(sessionId: String) = Result.failure<ByteArray>(Exception("stub"))
+    override suspend fun uploadSessionSaveDirBundleFromFile(sessionId: String, tarPath: String, tarSize: Long): Result<Unit> = Result.success(Unit)
+    override suspend fun downloadSessionSaveDirBundleToFile(sessionId: String, fileStorage: com.spela.player.util.FileStorage, outputPath: String): Result<Unit> = Result.failure(Exception("stub"))
     override suspend fun getSessionCheats(sessionId: String) = Result.success(SessionCheatConfig(false, emptyList()))
     override suspend fun updateSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int>) =
         Result.success(SessionCheatConfig(cheatsEnabled, enabledIndices))

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerCompressionTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerCompressionTest.kt
@@ -79,6 +79,8 @@ class SaveManagerCompressionTest {
         override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
         override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
         override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
+        override suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long = 0L
+        override suspend fun extractTarFile(tarPath: String, destDir: String) {}
         override suspend fun sha256File(path: String): String? = null
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerDeferredSyncTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerDeferredSyncTest.kt
@@ -280,6 +280,8 @@ class SaveManagerDeferredSyncTest {
         override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
         override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
         override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
+        override suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long = 0L
+        override suspend fun extractTarFile(tarPath: String, destDir: String) {}
         override suspend fun sha256File(path: String): String? = null
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerNamedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerNamedSaveTest.kt
@@ -133,6 +133,8 @@ class SaveManagerNamedSaveTest {
         override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
         override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
         override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
+        override suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long = 0L
+        override suspend fun extractTarFile(tarPath: String, destDir: String) {}
         override suspend fun sha256File(path: String): String? = null
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
@@ -133,6 +133,8 @@ class SaveManagerRehearsalTest {
         override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
         override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
         override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
+        override suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long = 0L
+        override suspend fun extractTarFile(tarPath: String, destDir: String) {}
         override suspend fun sha256File(path: String): String? = null
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerSlotManageTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerSlotManageTest.kt
@@ -219,6 +219,8 @@ class SaveManagerSlotManageTest {
         override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
         override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
         override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
+        override suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long = 0L
+        override suspend fun extractTarFile(tarPath: String, destDir: String) {}
         override suspend fun sha256File(path: String): String? = null
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -126,7 +126,7 @@ open class StubLibretroController : LibretroController {
     var setSRAMResult = true
     var loadCoreShouldThrow: Exception? = null
 
-    override fun loadCore(corePath: String) {
+    override fun loadCore(corePath: String, saveDir: String?) {
         loadCoreShouldThrow?.let { throw it }
         loadCoreCallCount++
         lastLoadCorePath = corePath
@@ -158,7 +158,7 @@ open class StubLibretroController : LibretroController {
 
 class StubLibretroControllerWithVariableTracking : LibretroController {
     val coreVariables = mutableMapOf<String, String>()
-    override fun loadCore(corePath: String) {}
+    override fun loadCore(corePath: String, saveDir: String?) {}
     override fun loadGame(gamePath: String) {}
     override fun start() {}
     override fun pause() {}
@@ -522,6 +522,9 @@ class StubSessionRepository : SessionRepository {
         downloadSessionSramCallCount++
         return downloadSessionSramResult
     }
+    override suspend fun uploadSessionSaveDirBundleFromFile(sessionId: String, tarPath: String, tarSize: Long): Result<Unit> = Result.success(Unit)
+    override suspend fun downloadSessionSaveDirBundleToFile(sessionId: String, fileStorage: com.spela.player.util.FileStorage, outputPath: String): Result<Unit> =
+        Result.failure(Exception("no save_dir bundle"))
     override suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String) =
         Result.success(SaveState(id = "1", name = "Slot $slot"))
     override suspend fun uploadSlotSaveFromFile(sessionId: String, slot: Int, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String, compression: String): Result<SaveState> {
@@ -643,6 +646,8 @@ private class StubFileStorage : com.spela.player.util.FileStorage {
     override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
     override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
     override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
+    override suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long = 0L
+    override suspend fun extractTarFile(tarPath: String, destDir: String) {}
     override suspend fun sha256File(path: String): String? = null
 }
 

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -108,6 +108,12 @@ type SessionSlotSaveDownloadInput struct {
 	Slot string `path:"slot" doc:"Save slot number 1-10."`
 }
 
+// SessionSaveDirBundleDownloadInput is the input for GET /api/sessions/{id}/save-dir.
+// Returns the previously-uploaded tarball or 404 if the session has no bundle.
+type SessionSaveDirBundleDownloadInput struct {
+	ID string `path:"id" doc:"Session ID."`
+}
+
 // SessionSRAMDownloadInput is the input for GET /api/sessions/{id}/sram.
 type SessionSRAMDownloadInput struct {
 	ID string `path:"id" doc:"Session ID."`
@@ -264,6 +270,17 @@ func RegisterDownloadRoutes(
 		Middlewares: authedMW,
 		Security:    sec,
 	}, sessionH.HumaDownloadSRAM)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "downloadSessionSaveDirBundle",
+		Method:      http.MethodGet,
+		Path:        "/api/sessions/{id}/save-dir",
+		Summary:     "Download the libretro save_dir tarball for a session",
+		Description: "Owner-only. Responds with application/x-tar containing the save_dir bytes uploaded on the most recent exit. 404 if the session has never had a save_dir bundle. See #864.",
+		Tags:        []string{"sessions"},
+		Middlewares: authedMW,
+		Security:    sec,
+	}, sessionH.HumaDownloadSaveDirBundle)
 
 	huma.Register(api, huma.Operation{
 		OperationID: "downloadSharedSave",
@@ -569,6 +586,27 @@ func (h *SessionHandler) HumaDownloadSlotSave(ctx context.Context, in *SessionSl
 		return nil, huma.Error403Forbidden("file access denied")
 	}
 	return streamSaveFromDisk(save.FilePath, filepath.Base(save.FilePath), save.Compression), nil
+}
+
+// HumaDownloadSaveDirBundle is the huma implementation of GET
+// /api/sessions/{id}/save-dir. Streams the previously-uploaded tarball back to
+// the player. 404 when the session has never had a save_dir bundle (the
+// player treats that as "fresh save_dir, nothing to populate"). See #864.
+func (h *SessionHandler) HumaDownloadSaveDirBundle(ctx context.Context, in *SessionSaveDirBundleDownloadInput) (*huma.StreamResponse, error) {
+	uid := UserIDFromContext(ctx)
+	session, err := h.humaLoadSessionWithOwnerCheck(in.ID, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	var bundle db.SessionSaveDirBundle
+	if err := h.DB.Where("session_id = ?", session.ID).First(&bundle).Error; err != nil {
+		return nil, huma.Error404NotFound("no save_dir bundle found")
+	}
+	if !storage.ValidateROMPath(bundle.FilePath, []string{h.Storage.SaveDir}) {
+		return nil, huma.Error403Forbidden("file access denied")
+	}
+	return streamFileFromDisk(bundle.FilePath, filepath.Base(bundle.FilePath), "application/x-tar"), nil
 }
 
 // HumaDownloadSRAM is the huma implementation of GET /api/sessions/{id}/sram.

--- a/server/internal/api/huma_session_uploads.go
+++ b/server/internal/api/huma_session_uploads.go
@@ -80,6 +80,26 @@ type SessionSRAMUploadOutput struct {
 	Body   db.SessionSaveData
 }
 
+// SessionSaveDirBundleUploadBody is the multipart body for POST
+// /api/sessions/{id}/save-dir. Wraps a single tarball of the libretro save_dir
+// contents — see #864 for rationale.
+type SessionSaveDirBundleUploadBody struct {
+	File huma.FormFile `form:"file" required:"false" contentType:"application/x-tar" doc:"Tarball of the libretro save_dir contents."`
+}
+
+// SessionSaveDirBundleUploadInput wraps the path parameter and multipart body.
+type SessionSaveDirBundleUploadInput struct {
+	ID      string `path:"id" doc:"Session ID."`
+	RawBody huma.MultipartFormFiles[SessionSaveDirBundleUploadBody]
+}
+
+// SessionSaveDirBundleUploadOutput uses the same dynamic-status pattern as
+// the SRAM upload — 201 first time, 200 on overwrite.
+type SessionSaveDirBundleUploadOutput struct {
+	Status int
+	Body   db.SessionSaveDirBundle
+}
+
 // --- Registration ------------------------------------------------------------
 
 // RegisterSessionSaveUploadRoutes wires the four session multipart upload
@@ -152,6 +172,18 @@ func RegisterSessionSaveUploadRoutes(
 		Security:     sec,
 		MaxBodyBytes: maxSaveUploadBytes(),
 	}, h.HumaUploadSRAM)
+
+	huma.Register(api, huma.Operation{
+		OperationID:  "uploadSaveDirBundle",
+		Method:       http.MethodPost,
+		Path:         "/api/sessions/{id}/save-dir",
+		Summary:      "Upload the libretro save_dir tarball for a session",
+		Description:  "Stores or replaces the session's save_dir bundle. Used by cores that write their own save files to disk (e.g. ScummVM, DOSBox). Atomic full replacement — the bytes downloaded on resume are exactly the bytes uploaded on the most recent exit. Returns 201 on first upload, 200 on overwrite. See #864.",
+		Tags:         []string{"sessions"},
+		Middlewares:  uploadMW,
+		Security:     sec,
+		MaxBodyBytes: maxSaveUploadBytes(),
+	}, h.HumaUploadSaveDirBundle)
 }
 
 // --- Helper ------------------------------------------------------------------
@@ -378,6 +410,56 @@ func (h *SessionHandler) HumaUpsertSlotSave(ctx context.Context, in *SessionSlot
 	return &SessionSaveUploadOutput{
 		Body: h.toSaveResponse(rec, h.getRecommendedCoreName(session.GameID)),
 	}, nil
+}
+
+// HumaUploadSaveDirBundle is the huma implementation of POST
+// /api/sessions/{id}/save-dir. Stores the tarball, atomically replacing any
+// prior bundle. See #864.
+func (h *SessionHandler) HumaUploadSaveDirBundle(ctx context.Context, in *SessionSaveDirBundleUploadInput) (*SessionSaveDirBundleUploadOutput, error) {
+	uid := UserIDFromContext(ctx)
+	session, err := h.humaLoadSessionWithOwnerCheck(in.ID, uid)
+	if err != nil {
+		return nil, err
+	}
+	if err := h.humaCheckSharedSessionTurn(session.ID, uid); err != nil {
+		return nil, err
+	}
+
+	body := in.RawBody.Data()
+	file := body.File
+	if !file.IsSet {
+		return nil, huma.Error400BadRequest("file required")
+	}
+	defer file.Close()
+
+	if err := checkStorageQuota(h.DB, uid, file.Size); err != nil {
+		return nil, huma.Error413RequestEntityTooLarge("storage quota exceeded")
+	}
+
+	path, size, err := h.Storage.WriteSessionSaveDirBundle(session.ID, file)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to save save_dir bundle")
+	}
+
+	var existing db.SessionSaveDirBundle
+	result := h.DB.Where("session_id = ?", session.ID).First(&existing)
+	if result.Error == gorm.ErrRecordNotFound {
+		rec := db.SessionSaveDirBundle{
+			SessionID: session.ID,
+			FilePath:  path,
+			FileSize:  size,
+		}
+		if err := h.DB.Create(&rec).Error; err != nil {
+			return nil, huma.Error500InternalServerError("failed to create save_dir bundle record")
+		}
+		return &SessionSaveDirBundleUploadOutput{Status: http.StatusCreated, Body: rec}, nil
+	}
+	existing.FilePath = path
+	existing.FileSize = size
+	if err := h.DB.Save(&existing).Error; err != nil {
+		return nil, huma.Error500InternalServerError("failed to update save_dir bundle record")
+	}
+	return &SessionSaveDirBundleUploadOutput{Status: http.StatusOK, Body: existing}, nil
 }
 
 // HumaUploadSRAM is the huma implementation of POST /api/sessions/{id}/sram.

--- a/server/internal/api/huma_sessions.go
+++ b/server/internal/api/huma_sessions.go
@@ -689,6 +689,11 @@ func (h *SessionHandler) HumaDeleteSession(ctx context.Context, in *DeleteSessio
 	}
 	h.DB.Where("session_id = ?", session.ID).Delete(&db.SessionSaveData{})
 
+	// SaveDir bundles (#864): the row pairs 1:1 with the session.
+	// On-disk file lives under session_X/save_dir/ which is cleaned up by
+	// the DeleteSessionDir call below — no per-file delete needed here.
+	h.DB.Where("session_id = ?", session.ID).Delete(&db.SessionSaveDirBundle{})
+
 	h.Storage.DeleteSessionDir(session.ID)
 	h.DB.Delete(&session)
 

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -181,6 +181,7 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&GameSession{},
 		&SessionSaveState{},
 		&SessionSaveData{},
+		&SessionSaveDirBundle{},
 		&SessionCheatSetting{},
 		&DailyPlayActivity{},
 		&GameArtwork{},

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -993,6 +993,25 @@ type SessionSaveData struct {
 	FileSize  int64          `json:"fileSize"`
 }
 
+// SessionSaveDirBundle is a tarball of the libretro save_dir contents for a
+// session. It carries on-disk save data that the core writes directly (e.g.
+// ScummVM's per-game save files, DOSBox config tweaks), as a counterpart to
+// SessionSaveData (SRAM) and SessionSaveState (libretro memory snapshots).
+//
+// One row per session — full atomic replace on each upload, no per-file
+// addressing. The tarball has a 256 MB upload cap (same as save states), and
+// is downloaded + extracted into the player's per-session save_dir before
+// loadCore on every launch. See #864.
+type SessionSaveDirBundle struct {
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"createdAt"`
+	UpdatedAt time.Time      `json:"updatedAt"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	SessionID uint           `gorm:"uniqueIndex;not null" json:"sessionId"`
+	FilePath  string         `gorm:"size:1024;not null" json:"-"`
+	FileSize  int64          `json:"fileSize"`
+}
+
 // SessionCheatSetting stores per-cheat enable/disable state within a game session.
 type SessionCheatSetting struct {
 	ID         uint      `gorm:"primarykey" json:"id"`

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -471,6 +471,13 @@ func (s *Storage) SessionSRAMPath(sessionID uint, filename string) string {
 	return filepath.Join(s.SaveDir, "sessions", fmt.Sprintf("session_%d", sessionID), "sram", safe)
 }
 
+// SessionSaveDirBundlePath returns the filesystem path for a session's save_dir
+// tarball. There's only ever one bundle per session; the filename is a stable
+// constant so successive uploads atomically replace the prior bytes.
+func (s *Storage) SessionSaveDirBundlePath(sessionID uint) string {
+	return filepath.Join(s.SaveDir, "sessions", fmt.Sprintf("session_%d", sessionID), "save_dir", "bundle.tar")
+}
+
 // SessionScreenshotPath returns the filesystem path for a session screenshot.
 func (s *Storage) SessionScreenshotPath(sessionID uint, filename string) string {
 	safe := sanitizeFilename(filename)
@@ -508,6 +515,51 @@ func (s *Storage) WriteSessionSave(sessionID uint, filename string, data io.Read
 		return "", 0, fmt.Errorf("writing session save file: %w", err)
 	}
 
+	return path, n, nil
+}
+
+// WriteSessionSaveDirBundle stores a session's save_dir tarball, replacing
+// any prior bundle atomically: write to a `.tmp` sibling and rename on
+// success so a partial / interrupted upload never overwrites a known-good
+// bundle. See #864.
+func (s *Storage) WriteSessionSaveDirBundle(sessionID uint, data io.Reader) (string, int64, error) {
+	path := s.SessionSaveDirBundlePath(sessionID)
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", 0, fmt.Errorf("resolving session save_dir bundle path: %w", err)
+	}
+	absSaveDir, err := filepath.Abs(s.SaveDir)
+	if err != nil {
+		return "", 0, fmt.Errorf("resolving save dir: %w", err)
+	}
+	if !strings.HasPrefix(absPath, absSaveDir+string(filepath.Separator)) {
+		return "", 0, fmt.Errorf("invalid session save_dir bundle path: outside save directory")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return "", 0, fmt.Errorf("creating session save_dir bundle directory: %w", err)
+	}
+
+	tmpPath := path + ".tmp"
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return "", 0, fmt.Errorf("creating session save_dir bundle tmp file: %w", err)
+	}
+	n, err := io.Copy(f, data)
+	closeErr := f.Close()
+	if err != nil {
+		_ = os.Remove(tmpPath)
+		return "", 0, fmt.Errorf("writing session save_dir bundle: %w", err)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpPath)
+		return "", 0, fmt.Errorf("closing session save_dir bundle tmp file: %w", closeErr)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", 0, fmt.Errorf("replacing session save_dir bundle: %w", err)
+	}
 	return path, n, nil
 }
 


### PR DESCRIPTION
## Summary

ScummVM, DOSBox, and other libretro cores write their saves to disk via the libretro \`save_dir\` contract. Before this change, every session of every game shared one global \`save_dir\` on the device — saves leaked between sessions, didn't follow the user across devices, and weren't cleaned up on session delete.

This makes \`save_dir\` symmetric with SRAM: each session gets its own. The bundle is tar'd on exit and uploaded to the server, then downloaded and untar'd before \`loadCore\` on the next launch.

## Server (Go)

- New \`SessionSaveDirBundle\` DB model (one-to-one with \`session_id\`, full atomic replace on each upload).
- \`POST /api/sessions/{id}/save-dir\` — multipart upload, 256 MB cap. Writes via \`.tmp\` + rename so partial uploads never overwrite a known-good bundle.
- \`GET /api/sessions/{id}/save-dir\` — streams \`application/x-tar\`; 404 when the session has no bundle.
- \`HumaDeleteSession\` also nukes the \`SessionSaveDirBundle\` row; \`DeleteSessionDir\` already wipes the on-disk file.
- Storage helpers (\`SessionSaveDirBundlePath\`, \`WriteSessionSaveDirBundle\`) mirroring the existing SRAM layout under \`saves/sessions/session_{id}/save_dir/bundle.tar\`.

## Player (KMP)

- \`LibretroController.loadCore\` now takes an optional \`saveDir\` override. Android + Desktop honour it via \`nativeSetSaveDir\`; null falls back to \`FileStorage.getSavesDir()\` (no behaviour change for pre-existing call sites).
- \`FileStorage\` gains \`tarDirectoryToFile\` + \`extractTarFile\` (hand-rolled USTAR — avoids pulling in Apache Commons Compress for a feature this small). Implemented on both platforms; pattern matches existing \`zipDirectoryToBytes\` / \`unzipBytesToDirectory\`.
- \`SessionRepository.uploadSessionSaveDirBundleFromFile\` + \`downloadSessionSaveDirBundleToFile\`, both streaming via the same \`ChannelProvider\` / \`prepareGet\` pattern the libretro auto-save path uses (no JVM-heap copy of the tar).
- \`SaveManager.getSessionSaveDir\` returns the per-session path; \`populateSessionSaveDir\` downloads + extracts pre-\`loadCore\`; \`saveDirOnStop\` tars + uploads on exit. \`autoSaveOnStop\` now calls \`saveDirOnStop\` even when the libretro snapshot stage returns null (ScummVM declares \`savestate=false\` but still has on-disk saves).
- \`EmulationViewModel\` computes the per-session path from the resolved \`sessionId\`, then passes it to \`loadCore\`.

## Verified on AYN Thor

\`\`\`
[SaveManager] populateSessionSaveDir: no bundle yet for session 97   ← 404, soft fail
[Emulation] About to loadCore(.../scummvm_libretro_android.so, saveDir=/data/.../files/saves/sessions/97)
[core] Default save path set to: .../sessions/97   ← ScummVM ACK
saveStatesSupported=false   ← deny list still in effect
Deferred auto-load check: ... saveStatesSupported=false   ← gate still in effect
\`\`\`

Per-session save_dir is set on the core before retro_load_game. Saves written by ScummVM during the session land in \`sessions/97/\`. On exit, the tar+upload runs (will succeed once server is deployed). On next launch, the server-side bundle is downloaded and untar'd back into the dir before \`loadCore\` so the previous session's saves are visible.

## Migration

Per the design discussion in #864: pre-deployment, no users to migrate. Existing global \`saves/\` content is left in place but ignored — new content goes under \`sessions/{id}/\`. The old global dir effectively becomes orphaned and can be cleaned up in a future release.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid :shared:compileTestKotlinDesktop :desktop:compileTestKotlinDesktop\` — clean
- [x] Server \`go build ./...\` + \`go vet ./...\` — clean
- [x] On-device launch flow exercises new code path correctly (logs above)
- [ ] CI gate: full desktop + Go suites

Closes #864.