### PR TITLE
fix(player): session-list '...' button looks like an icon, not a chip (#854)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpIconButton.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpIconButton.kt
@@ -24,12 +24,28 @@ import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.ui.theme.SpColor
 
 /**
+ * Visual variant for [SpIconButton]. Most call sites want [Filled]
+ * (a chip-shaped icon button that's visually distinct from
+ * surrounding content). Use [Transparent] when the icon is part of
+ * a row whose background already gives it a visual frame —
+ * particularly inline overflow / kebab buttons inside list rows
+ * (#854) where a chip would compete with the row affordance.
+ */
+enum class SpIconButtonVariant {
+    /** Default — circular SurfaceVariant background, icon tinted OnSurface. */
+    Filled,
+    /** Transparent background, icon tinted OnSurface — looks like just an icon. */
+    Transparent,
+}
+
+/**
  * A circular icon button used in top bars and action areas.
  *
  * @param icon The icon to display
  * @param contentDescription Accessibility description for the button
  * @param onClick Called when the button is clicked
  * @param modifier Modifier for the root Box
+ * @param variant Background style — see [SpIconButtonVariant]
  * @param badge Optional composable rendered as a badge overlay (e.g. notification dot)
  */
 @Composable
@@ -39,9 +55,15 @@ fun SpIconButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     onGradient: Boolean = false,
+    variant: SpIconButtonVariant = SpIconButtonVariant.Filled,
     badge: @Composable (BoxScope.() -> Unit)? = null,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    val background = when (variant) {
+        SpIconButtonVariant.Transparent -> Color.Transparent
+        SpIconButtonVariant.Filled ->
+            if (onGradient) Color.Black.copy(alpha = 0.30f) else SpColor.SurfaceVariant
+    }
     // Merge descendants on the outer Box so a caller-supplied testTag /
     // contentDescription on `modifier` ends up on the same merged node as
     // the inner Box's click action. Without this, a test that finds the
@@ -52,7 +74,7 @@ fun SpIconButton(
             modifier = Modifier
                 .size(40.dp)
                 .clip(CircleShape)
-                .background(if (onGradient) Color.Black.copy(alpha = 0.30f) else SpColor.SurfaceVariant)
+                .background(background)
                 .clickable(interactionSource = interactionSource, indication = null, onClick = onClick)
                 .gamepadFocusable(shape = CircleShape, interactionSource = interactionSource)
                 .semantics {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.GameSession
 import com.spela.player.presentation.ui.components.SpAvatar
 import com.spela.player.presentation.ui.components.SpIconButton
+import com.spela.player.presentation.ui.components.SpIconButtonVariant
 import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpStatusChip
@@ -345,7 +346,7 @@ private fun SessionItem(
                 )
             }
 
-            Row {
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 // Session-level actions go into a single `…` overflow menu.
                 // Rename/Delete/Clone are all secondary — only Play is
                 // surfaced as a primary button in this row. Clone in
@@ -353,10 +354,15 @@ private fun SessionItem(
                 // a menu, never as its own CTA.
                 Box {
                     var showActionsMenu by remember { mutableStateOf(false) }
+                    // Transparent variant so the kebab reads as just an icon
+                    // on the row background, not a chip-on-a-chip — matches
+                    // the visual treatment of the Play button next to it.
+                    // See #854.
                     SpIconButton(
                         icon = Icons.Filled.MoreVert,
                         contentDescription = "Session actions",
                         onClick = { showActionsMenu = true },
+                        variant = SpIconButtonVariant.Transparent,
                         modifier = Modifier.testTag("session_actions_menu_${session.id}"),
                     )
                     DropdownMenu(


### PR DESCRIPTION
## Summary

The session-row overflow (\`...\`) button was rendering a \`SurfaceVariant\` chip background that competed with the row affordance, and was vertically misaligned with the rest of the row because the wrapping \`Row\` didn't pin \`Alignment.CenterVertically\`.

## Changes

1. **\`SpIconButton\` gets a \`variant\` parameter.** Two variants:
   - \`Filled\` (default) — the existing chip look. No call-site changes needed.
   - \`Transparent\` — no background, icon tinted \`OnSurface\`, reads as just an icon.

   Per \`AGENT_TEAM.md\` design discipline, this lives in the design system rather than each call site picking its own background, so other inline-overflow surfaces can share the same variant going forward.

2. **The session-list kebab uses \`Transparent\`.** Visually belongs to the row, not to a separate floating button.

3. **\`verticalAlignment = Alignment.CenterVertically\`** on the actions \`Row\`, so the kebab and Play button share the row's center line regardless of right-column content.

## Test plan

- [x] Build clean: \`./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid :shared:compileTestKotlinDesktop\`
- [ ] CI gate
- [ ] On-device sanity (next time the AYN Thor is up): kebab should look like an icon, not a chip; should align with Play button.

Closes #854.