### PR TITLE
refactor(player): move per-game Save-states control to a Game settings sheet (#855)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -12,11 +12,18 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -79,8 +86,15 @@ fun GameHeroContent(
     onNavigateToAchievements: () -> Unit = {},
     onAdminScrape: (() -> Unit)? = null,
     onAdminRefreshAchievements: (() -> Unit)? = null,
+    /**
+     * Per-game save-state policy override. The control lives behind a
+     * gear icon in this hero action row → Game settings sheet (#855),
+     * not inline in the info column where it used to be.
+     */
+    onSetGameSaveStatePolicy: (com.spela.player.domain.model.SaveStateChoice?) -> Unit = {},
 ) {
     val supportsNetplay = game.playable && game.consoleId.lowercase() in NETPLAY_SUPPORTED_CONSOLES
+    var showGameSettingsSheet by remember { mutableStateOf(false) }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
@@ -235,6 +249,20 @@ fun GameHeroContent(
                 isAdminActionLoading = state.isAdminActionLoading,
             )
 
+            // Game settings — currently only the per-game save-state
+            // policy override (#855). Lives behind a gear icon, not
+            // inline, so the rare-use override doesn't compete with
+            // Play / Resume for vertical real-estate. Future per-game
+            // policies (shader, core, input remap) can land in the
+            // same sheet without re-litigating placement.
+            com.spela.player.presentation.ui.components.SpIconButton(
+                icon = Icons.Filled.Settings,
+                contentDescription = "Game settings",
+                onClick = { showGameSettingsSheet = true },
+                onGradient = true,
+                modifier = Modifier.testTag("game_detail_settings_button"),
+            )
+
             // Playtime + last played grouped so they wrap together
             if (game.totalPlayTime > 0 || game.lastPlayedAt != null) {
                 Row(horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small)) {
@@ -331,6 +359,25 @@ fun GameHeroContent(
                 }
             }
         }
+    }
+
+    if (showGameSettingsSheet) {
+        AlertDialog(
+            onDismissRequest = { showGameSettingsSheet = false },
+            title = { Text("Game settings") },
+            text = {
+                GameSaveStatePolicyToggle(
+                    current = state.gameSaveStatePolicy,
+                    onChange = onSetGameSaveStatePolicy,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { showGameSettingsSheet = false }) {
+                    Text("Done")
+                }
+            },
+            modifier = Modifier.testTag("game_detail_settings_sheet"),
+        )
     }
 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameInfoContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameInfoContent.kt
@@ -60,12 +60,6 @@ fun GameInfoContent(
     onNavigateToDeveloper: ((name: String) -> Unit)? = null,
     onNavigateToPublisher: ((name: String) -> Unit)? = null,
     onNavigateToAchievements: (() -> Unit)? = null,
-    /**
-     * Tri-state per-game save-state opt-out callback (#804 phase 4b
-     * spec point c). null = inherit from per-console policy. The
-     * GameSaveStatePolicyToggle composable handles the radio UI.
-     */
-    onSetGameSaveStatePolicy: (com.spela.player.domain.model.SaveStateChoice?) -> Unit = {},
 ) {
     // BIOS warning chip
     if (missingBiosFiles.isNotEmpty()) {
@@ -168,13 +162,8 @@ fun GameInfoContent(
         )
     }
 
-    // Per-game save-state opt-out toggle (#804 phase 4b spec point c).
-    // Slotted at the end of the info block, near other game-level
-    // settings — close enough to the play actions to be discoverable
-    // without disrupting the cover/screenshot flow above.
-    Spacer(Modifier.height(SpSpacing.Default))
-    GameSaveStatePolicyToggle(
-        current = state.gameSaveStatePolicy,
-        onChange = onSetGameSaveStatePolicy,
-    )
+    // The per-game Save-states toggle that used to live here was moved
+    // into the hero action row's gear icon → Game settings sheet (#855).
+    // The info column is now exclusively facts about the game; mutable
+    // per-game policy is one tap away in the Game settings sheet.
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -141,6 +141,9 @@ fun GameDetailScreen(
                     onNavigateToAchievements = { onNavigateToAchievements?.invoke(gameId) },
                     onAdminScrape = if (state.isAdmin) {{ viewModel.onIntent(GameDetailIntent.AdminScrapeGame) }} else null,
                     onAdminRefreshAchievements = if (state.isAdmin) {{ viewModel.onIntent(GameDetailIntent.AdminRefreshAchievements) }} else null,
+                    onSetGameSaveStatePolicy = { choice ->
+                        viewModel.onIntent(GameDetailIntent.SetGameSaveStatePolicy(choice))
+                    },
                 )
             },
             coverArt = { modifier, isPortrait ->
@@ -202,9 +205,6 @@ fun GameDetailScreen(
                     onNavigateToAchievements = if (state.achievements.isNotEmpty()) {
                         { onNavigateToAchievements?.invoke(gameId) }
                     } else null,
-                    onSetGameSaveStatePolicy = { choice ->
-                        viewModel.onIntent(GameDetailIntent.SetGameSaveStatePolicy(choice))
-                    },
                 )
 
                 // Series & Franchise links


### PR DESCRIPTION
## Summary

The per-game Save-states radio used to render at the bottom of the right-hand info column on the game-detail screen. Three problems flagged by the PO + UX agent reviews:

- **Wrong column.** The info column is for *facts about the game* (title, console, genre, release year). Mutable per-game preferences are a different category.
- **Wrong width.** Half-width for a settings-shaped control next to a heading that reads like a section title looks like a layout bug, regardless of intent.
- **Wrong hierarchy.** This is a low-frequency, set-once-and-forget override. Play / Continue / Sessions / Achievements are the screen's high-engagement nouns and deserve the vertical real-estate.

## Change

Move it behind a gear \`SpIconButton\` on the hero action row. Tapping it opens a *"Game settings"* \`AlertDialog\` containing the existing \`GameSaveStatePolicyToggle\`. Same intent, same wire format — just a different surface.

- \`GameHeroContent\` gains a \`Settings\` icon (gear) button next to the existing Actions overflow, and an \`AlertDialog\` body holding the toggle. State for the open/close is local.
- \`GameInfoContent\` no longer renders the toggle and no longer takes \`onSetGameSaveStatePolicy\` — its parameter list is now exclusively facts-about-the-game callbacks.
- \`GameDetailScreen\` wires \`onSetGameSaveStatePolicy\` to \`GameHeroContent\` instead.

Future per-game policies (shader override, core selection, input remap) can land in the same sheet without re-litigating placement — that was a third of the rationale for picking a sheet over an in-column tweak.

## Test plan

- [x] Build clean: \`./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid :shared:compileTestKotlinDesktop\`
- [x] Local desktop suite — only failure is unrelated \`AppLaunchAndConnectionTest.addServerRetryAfterFailure\` (known flake; my changes are scoped to game-detail).
- [ ] CI gate.
- [ ] On-device verify: gear icon visible on hero action row, opens "Game settings" sheet with the radio, choosing an option dispatches the same intent and re-opening shows the new selection.

Closes #855.