### PR TITLE
fix(player): wire desktop pointer events into libretro RETRO_DEVICE_MOUSE (#857)

### DIFF
--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopEmulationSurface.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopEmulationSurface.kt
@@ -26,11 +26,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asComposeImageBitmap
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isPrimaryPressed
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -124,6 +129,56 @@ fun DesktopEmulationSurface(
                 .background(Color.Black)
                 .focusRequester(focusRequester)
                 .focusable()
+                .pointerInput(controller) {
+                    // Forward Compose pointer events to the libretro
+                    // RETRO_DEVICE_MOUSE pipeline (#857). Mirror of the
+                    // MetalOffscreenSurface block — same scaling logic
+                    // but reads frame size via controller.getVideoWidth/
+                    // getVideoHeight since this surface doesn't keep a
+                    // RenderedFrame snapshot around.
+                    awaitPointerEventScope {
+                        var prev: Offset? = null
+                        var leftHeld = false
+                        var rightHeld = false
+                        while (true) {
+                            val event = awaitPointerEvent()
+                            val change = event.changes.firstOrNull() ?: continue
+                            val frameW = controller.getVideoWidth()
+                            val frameH = controller.getVideoHeight()
+                            val canvasW = size.width.toFloat()
+                            val canvasH = size.height.toFloat()
+                            val scaleX = if (frameW > 0 && canvasW > 0f) frameW.toFloat() / canvasW else 1f
+                            val scaleY = if (frameH > 0 && canvasH > 0f) frameH.toFloat() / canvasH else 1f
+                            when (event.type) {
+                                PointerEventType.Move -> {
+                                    val p = prev
+                                    if (p != null) {
+                                        val dx = ((change.position.x - p.x) * scaleX).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+                                        val dy = ((change.position.y - p.y) * scaleY).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+                                        if (dx != 0.toShort() || dy != 0.toShort()) {
+                                            controller.setMouse(0, dx, dy, leftHeld, rightHeld)
+                                        }
+                                    }
+                                    prev = change.position
+                                }
+                                PointerEventType.Press -> {
+                                    leftHeld = event.buttons.isPrimaryPressed
+                                    rightHeld = event.buttons.isSecondaryPressed
+                                    controller.setMouse(0, 0, 0, leftHeld, rightHeld)
+                                    prev = change.position
+                                }
+                                PointerEventType.Release -> {
+                                    leftHeld = event.buttons.isPrimaryPressed
+                                    rightHeld = event.buttons.isSecondaryPressed
+                                    controller.setMouse(0, 0, 0, leftHeld, rightHeld)
+                                }
+                                PointerEventType.Enter, PointerEventType.Exit -> {
+                                    prev = null
+                                }
+                            }
+                        }
+                    }
+                }
                 .onPreviewKeyEvent { event ->
                     // Handle Escape key to toggle overlay
                     if (event.key == Key.Escape && event.type == KeyEventType.KeyDown) {

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/MetalOffscreenSurface.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/MetalOffscreenSurface.kt
@@ -25,11 +25,16 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asComposeImageBitmap
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isPrimaryPressed
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
@@ -104,6 +109,63 @@ fun MetalOffscreenSurface(
             modifier = Modifier
                 .fillMaxSize()
                 .background(Color.Black)
+                .pointerInput(controller) {
+                    // Forward Compose pointer events to the libretro
+                    // RETRO_DEVICE_MOUSE pipeline (#857). The native
+                    // ingest + JNI binding + setMouse setter all
+                    // existed; what was missing was the UI layer
+                    // calling them. ScummVM and other mouse-driven
+                    // cores receive nothing without this block.
+                    //
+                    // Deltas are scaled from canvas-pixel space to
+                    // core-framebuffer-pixel space so cursor speed
+                    // feels correct regardless of how the user
+                    // resized the window.
+                    awaitPointerEventScope {
+                        var prev: Offset? = null
+                        var leftHeld = false
+                        var rightHeld = false
+                        while (true) {
+                            val event = awaitPointerEvent()
+                            val change = event.changes.firstOrNull() ?: continue
+                            val frame = controller.latestRenderedFrame
+                            val canvasW = size.width.toFloat()
+                            val canvasH = size.height.toFloat()
+                            val scaleX = if (frame != null && canvasW > 0f) frame.width.toFloat() / canvasW else 1f
+                            val scaleY = if (frame != null && canvasH > 0f) frame.height.toFloat() / canvasH else 1f
+                            when (event.type) {
+                                PointerEventType.Move -> {
+                                    val p = prev
+                                    if (p != null) {
+                                        val dx = ((change.position.x - p.x) * scaleX).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+                                        val dy = ((change.position.y - p.y) * scaleY).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+                                        if (dx != 0.toShort() || dy != 0.toShort()) {
+                                            controller.setMouse(0, dx, dy, leftHeld, rightHeld)
+                                        }
+                                    }
+                                    prev = change.position
+                                }
+                                PointerEventType.Press -> {
+                                    leftHeld = event.buttons.isPrimaryPressed
+                                    rightHeld = event.buttons.isSecondaryPressed
+                                    controller.setMouse(0, 0, 0, leftHeld, rightHeld)
+                                    prev = change.position
+                                }
+                                PointerEventType.Release -> {
+                                    leftHeld = event.buttons.isPrimaryPressed
+                                    rightHeld = event.buttons.isSecondaryPressed
+                                    controller.setMouse(0, 0, 0, leftHeld, rightHeld)
+                                }
+                                PointerEventType.Enter, PointerEventType.Exit -> {
+                                    // Reset on enter so the first delta after
+                                    // re-entering the canvas isn't a giant jump
+                                    // from wherever the cursor was off-canvas.
+                                    prev = null
+                                }
+                            }
+                        }
+                    }
+                }
                 .onSizeChanged { size ->
                     // Report canvas size to GPU renderer so shaders render
                     // at display resolution instead of a static multiplier


### PR DESCRIPTION
## Summary

The native ingest (\`libretro_input.c\`), JNI binding (\`nativeSetInputMouse\`), and \`DesktopLibretroController.setMouse\` all existed end-to-end. The missing link: no Compose surface ever called \`setMouse\`, so ScummVM and other mouse-driven libretro cores received zero pointer input on desktop.

## Change

Add a \`pointerInput\` block to both desktop emulation surfaces:

- \`MetalOffscreenSurface\` (macOS Metal path)
- \`DesktopEmulationSurface\` (CPU path)

The block:

- **Tracks the previous pointer position** so Move events compute relative dx/dy. ScummVM uses \`RETRO_DEVICE_MOUSE\` which expects deltas, not absolute coordinates.
- **Scales pointer deltas** from canvas-pixel space to core-framebuffer-pixel space. Without this, cursor speed depends on window size. With it, felt sensitivity stays constant regardless of how the user resized the window.
- **Tracks button state** via \`PointerEvent.buttons.isPrimaryPressed\` / \`isSecondaryPressed\` and forwards on every Press / Release.
- **Resets prev-position on Enter / Exit** so re-entering the canvas doesn't produce a giant jump.
- **Clamps the scaled delta to \`Short\` range** before passing to \`setMouse\`, which takes Shorts (libretro's RETRO_DEVICE_MOUSE delta type).

The two surfaces have near-identical blocks; they differ only in how they read the current frame size (\`latestRenderedFrame\` on Metal, \`controller.getVideoWidth/Height\` on the CPU path).

## Test plan

- [x] Build clean: \`./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid :shared:compileTestKotlinDesktop\`
- [ ] CI gate.
- [ ] Manual: run desktop player against \`testdata/roms/scummvm/monkey/\`, verify Monkey Island responds to mouse — walk, click items, navigate F5 menu, drag inventory.

Closes #857.