### PR TITLE
fix(player): empty state on Save Slots page for cores without save-state support (#863)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
@@ -275,19 +276,29 @@ fun SecondaryScreenContent(
                             )
                         }
                         PAGE_SAVE_SLOTS -> {
-                            SecondarySaveSlotsPage(
-                                activeSlot = state.activeSlot,
-                                saveSlots = state.saveSlots,
-                                onSelectSlot = { slot ->
-                                    viewModel.onIntent(EmulationIntent.SelectSlot(slot))
-                                },
-                                onSaveToSlot = { slot ->
-                                    viewModel.onIntent(EmulationIntent.SaveToSlot(slot))
-                                },
-                                onLoadFromSlot = { slot ->
-                                    viewModel.onIntent(EmulationIntent.LoadFromSlot(slot))
-                                },
-                            )
+                            // Page-3 content adapts based on whether the active core
+                            // supports libretro save states. Cores like ScummVM and
+                            // DOSBox declare savestate=false in their info file —
+                            // their save_dir is the persistence layer instead, and
+                            // the slot picker is meaningless. Show an honest empty
+                            // state rather than a dead picker. See #863.
+                            if (state.supportsSaveStates) {
+                                SecondarySaveSlotsPage(
+                                    activeSlot = state.activeSlot,
+                                    saveSlots = state.saveSlots,
+                                    onSelectSlot = { slot ->
+                                        viewModel.onIntent(EmulationIntent.SelectSlot(slot))
+                                    },
+                                    onSaveToSlot = { slot ->
+                                        viewModel.onIntent(EmulationIntent.SaveToSlot(slot))
+                                    },
+                                    onLoadFromSlot = { slot ->
+                                        viewModel.onIntent(EmulationIntent.LoadFromSlot(slot))
+                                    },
+                                )
+                            } else {
+                                SecondarySaveStatesUnsupportedPage()
+                            }
                         }
                     }
                 }
@@ -503,6 +514,45 @@ private fun formatPauseDuration(totalSeconds: Long): String {
  * Horizontal row of page indicator dots. Active page dot uses [SpColor.Primary],
  * inactive dots use [SpColor.OnBackgroundTertiary] at reduced alpha.
  */
+/**
+ * Empty-state for the Save Slots page when the active core declares
+ * `savestate = "false"` (ScummVM, DOSBox, ~60 others). The slot picker
+ * doesn't apply — those cores persist via their own on-disk save_dir,
+ * which Spela now bundles per-session (#864). Show the user honestly
+ * that libretro save states aren't a thing here, rather than a dead
+ * grid of empty slots. See #863.
+ *
+ * State 4 ("terminal-unsupported") of the resolution order in #863.
+ * States 2 (user opted out) and 3 (ScummVM Tools page) are filed as
+ * follow-ups — this MVP just covers the unconditional case.
+ */
+@Composable
+private fun SecondarySaveStatesUnsupportedPage() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(SpSpacing.Default),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            Text(
+                text = "Save states not available",
+                style = SpTypography.TitleMedium,
+                color = SpColor.OnBackground,
+            )
+            Text(
+                text = "This core writes its saves to disk through the game's own menu (try F5 in-game). They're preserved across sessions by Spela.",
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackgroundSecondary,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
 @Composable
 private fun PageIndicatorDots(
     pagerState: PagerState,


### PR DESCRIPTION
## Summary

The secondary-screen pager always renders 4 pages, the rightmost being **Save Slots**. For ScummVM and DOSBox-class cores that declare \`savestate = "false"\`, the slot picker is meaningless — those cores persist via their own on-disk \`save_dir\`, which Spela now bundles per-session (#864). Pre-this-change the user got a dead 1–10 grid and could plausibly conclude the software was broken.

## Change

Switch the page-3 content based on \`state.supportsSaveStates\`:

- **Supported** → render the existing \`SecondarySaveSlotsPage\`. No change for SRAM cores.
- **Unsupported** → render a new \`SecondarySaveStatesUnsupportedPage\` — a centered *"Save states not available"* headline plus a one-line explainer pointing the user at the in-game F5 menu (the ScummVM convention for save/load) and noting Spela preserves those saves across sessions.

## Scope

This is **state 4** ("terminal unsupported") of the resolution order in #863. Explicit non-goals here, filed as follow-up:

- **State 2** (user opted out via #804) — needs the per-console save-state policy already in place plus an "Enable in Settings" deep-link CTA.
- **State 3** (ScummVM Tools page with F5/F7/F8 tiles) — needs the keyboard-scancode plumbing that #859 introduces.

The pager stays at a fixed 4 pages so muscle memory ("rightmost page = saves/tools") and screenshot baselines are stable.

## Test plan

- [x] Build clean: \`./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid :shared:compileTestKotlinDesktop\`
- [ ] CI gate.
- [ ] On-device verify on AYN Thor: launch ScummVM game, swipe to rightmost secondary-screen page → see the new empty state. Launch SNES game, swipe to rightmost → see the existing slot picker.

Refs #863.