### PR TITLE
fix(player): land on Controls page initially for ScummVM games (#861)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
@@ -104,12 +104,24 @@ fun SecondaryScreenContent(
         label = "burnInAlpha",
     )
 
-    val initialPage = remember(state.defaultSecondScreenPage) {
-        when (state.defaultSecondScreenPage) {
-            "controls" -> PAGE_CONTROLS
-            "dashboard" -> PAGE_DASHBOARD
-            "save_slots" -> PAGE_SAVE_SLOTS
-            else -> PAGE_ART
+    val initialPage = remember(state.defaultSecondScreenPage, state.consoleId) {
+        // Mouse-driven cores (ScummVM today; DOSBox / NDS-with-mouse later)
+        // override the user's default landing page to land on Controls. The
+        // trackpad lives there, the trackpad is the primary input on
+        // single-screen handhelds with no real mouse, and "swipe right
+        // until you find the trackpad" is poor first-launch UX. See #861
+        // — this is the MVP override; the per-device-per-console
+        // "trackpadOnboarded" persistence (silence the override after the
+        // user makes one drag) is filed as follow-up scope.
+        if (state.consoleId.equals("scummvm", ignoreCase = true)) {
+            PAGE_CONTROLS
+        } else {
+            when (state.defaultSecondScreenPage) {
+                "controls" -> PAGE_CONTROLS
+                "dashboard" -> PAGE_DASHBOARD
+                "save_slots" -> PAGE_SAVE_SLOTS
+                else -> PAGE_ART
+            }
         }
     }
     val pagerState = rememberPagerState(


### PR DESCRIPTION
## Summary

ScummVM is mouse-driven, has no first-class touch UI, and the secondary-screen **Trackpad tab** is the primary input on single-screen handhelds with no real mouse. Pre-this-change the user landed on the Art page on game start with no visible cue that the screen is swipeable or that page 1 contains a trackpad. First-time experience of booting Monkey Island: pretty artwork, no obvious way to move the cursor, possible quit.

## Change

When the active console is \`scummvm\`, override the user's stored \`defaultSecondScreenPage\` preference at runtime and land on **Controls** (which contains the Trackpad tab). The override is purely runtime — the user's preference is never overwritten — so other consoles keep honouring it.

## Scope

MVP override from #861. Three explicit non-goals filed as follow-ups:

- **Per-device-per-console \`trackpadOnboarded\` flag.** Silence the override after the user produces one trackpad \`onMouseMove\` event. Needs a new SQLDelight table.
- **Page indicator "label-on-active pill" upgrade.** Permanent benefit for all pages, all cores.
- **Trackpad surface affordance + one-shot first-launch hint pill.** UX nicety.

Each can land independently; the override alone gets the immediate discoverability win for ScummVM users today.

## Test plan

- [x] Build clean: \`./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid\`
- [ ] CI gate.
- [ ] On-device verify on AYN Thor: launch ScummVM game, secondary screen lands on Controls page (trackpad visible). Launch SNES game, secondary screen still respects the user's default-page preference.

Refs #861.