### PR TITLE
feat(player): persist ScummVM trackpad onboarding hint (#861)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/local/ExpectedSchema.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/local/ExpectedSchema.kt
@@ -35,5 +35,6 @@ object ExpectedSchema {
             "file_path", "file_size", "screenshot_path", "created_at",
             "retry_count", "last_error",
         ),
+        "OnboardingHintEntity" to setOf("hint_key", "dismissed_at"),
     )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/OnboardingRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/OnboardingRepositoryImpl.kt
@@ -1,0 +1,41 @@
+package com.spela.player.data.repository
+
+import com.spela.player.data.local.SpelaDatabase
+import com.spela.player.domain.repository.OnboardingRepository
+
+/**
+ * SQLDelight-backed implementation of [OnboardingRepository].
+ *
+ * Hint-dismissal rows are tiny (just a key + epoch-millis timestamp)
+ * so we don't bother caching — every call hits SQLite. SQLite reads
+ * on a primary key are sub-millisecond, well below any threshold a
+ * user would feel.
+ *
+ * Idempotent semantics:
+ *
+ *   markDismissed twice with the same key → the second call updates
+ *     the timestamp; the row stays a row.
+ *   clearDismissed on an unknown key → no-op, no error.
+ *   isDismissed on an unknown key → false.
+ */
+class OnboardingRepositoryImpl(
+    database: SpelaDatabase,
+) : OnboardingRepository {
+
+    private val queries = database.spelaDatabaseQueries
+
+    override suspend fun isDismissed(key: String): Boolean {
+        return queries.isOnboardingHintDismissed(key).executeAsOne() > 0
+    }
+
+    override suspend fun markDismissed(key: String) {
+        queries.markOnboardingHintDismissed(
+            hint_key = key,
+            dismissed_at = kotlin.time.Clock.System.now().toEpochMilliseconds(),
+        )
+    }
+
+    override suspend fun clearDismissed(key: String) {
+        queries.clearOnboardingHint(key)
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -68,6 +68,7 @@ val commonModule = module {
     single<GameStatsRepository> { GameStatsRepositoryImpl(get()) }
     single<CheatRepository> { CheatRepositoryImpl(get(), get()) }
     single<PendingSaveUploadRepository> { PendingSaveUploadRepositoryImpl(get()) }
+    single<OnboardingRepository> { OnboardingRepositoryImpl(get()) }
     single<SessionRepository> { SessionRepositoryImpl(get(), get()) }
     single<ExploreRepository> { ExploreRepositoryImpl(get()) }
     single<SearchRepository> { SearchRepositoryImpl(get(), get()) }
@@ -235,6 +236,7 @@ val commonModule = module {
             biosRepository = get(),
             cheatRepository = get(),
             gameStatsRepository = get(),
+            onboardingRepository = get(),
         )
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/OnboardingRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/OnboardingRepository.kt
@@ -1,0 +1,41 @@
+package com.spela.player.domain.repository
+
+/**
+ * Device-local "the user has seen and dismissed this hint" tracker (#861).
+ *
+ * Hint keys are free-form strings; convention is dotted, namespaced by
+ * feature: `scummvm.trackpad.dragged`, `secondary.swipe.hint`,
+ * `core.upgrade.chip`, etc. Backed by SQLDelight, so dismissals
+ * persist across app launches but never sync to the server — these
+ * are signals about device-specific affordances ("you've found the
+ * trackpad on this device's bottom screen"), not about the user.
+ *
+ * The repository is intentionally narrow:
+ *
+ *   isDismissed(key)    → has the user seen + dismissed this hint?
+ *   markDismissed(key)  → record that they have
+ *   clearDismissed(key) → reset (rev-the-key pattern: when a hint's
+ *                         copy changes substantially, bump the key
+ *                         OR clear the row to re-onboard)
+ */
+interface OnboardingRepository {
+    suspend fun isDismissed(key: String): Boolean
+    suspend fun markDismissed(key: String)
+    suspend fun clearDismissed(key: String)
+}
+
+/**
+ * Stable hint-key constants. Adding a key here is the contract a
+ * caller commits to: rendering the hint and dispatching
+ * markDismissed when the user dismisses it.
+ */
+object OnboardingHintKeys {
+    /**
+     * Set the first time the user produces an onMouseMove event from
+     * the secondary-screen trackpad while a ScummVM game is running.
+     * While unset, the secondary screen overrides the user's default
+     * landing page to land on Controls. Once set, the user's
+     * preference is honored. See #861.
+     */
+    const val SCUMMVM_TRACKPAD_DRAGGED = "scummvm.trackpad.dragged"
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -281,4 +281,13 @@ sealed interface EmulationIntent {
      * the next session launch will re-enter the upgrade decision flow.
      */
     data object RehearsalCrashDismiss : EmulationIntent
+
+    /**
+     * Fired the first time the user produces a drag on the
+     * secondary-screen trackpad while a ScummVM game is running.
+     * Marks the trackpad-onboarded hint as dismissed so the
+     * secondary screen stops overriding the user's default landing
+     * page on subsequent ScummVM launches. See #861.
+     */
+    data object MarkScummVmTrackpadOnboarded : EmulationIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -289,6 +289,17 @@ data class EmulationState(
     /** Default second screen page from user preferences. */
     val defaultSecondScreenPage: String = "art",
 
+    /**
+     * Set when the user has produced at least one drag on the
+     * secondary-screen trackpad while a ScummVM game was running on
+     * any past launch. While false, the secondary-screen pager
+     * overrides the user's defaultSecondScreenPage and lands on
+     * Controls so the trackpad is the first thing the user sees on a
+     * mouse-driven core. Persisted via OnboardingRepository — see
+     * #861 OnboardingHintKeys.SCUMMVM_TRACKPAD_DRAGGED.
+     */
+    val scummvmTrackpadOnboarded: Boolean = false,
+
     /** Cheats */
     val hasCheats: Boolean = false,
     val enabledCheatCount: Int = 0,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
@@ -109,16 +109,14 @@ fun SecondaryScreenContent(
         label = "burnInAlpha",
     )
 
-    val initialPage = remember(state.defaultSecondScreenPage, state.consoleId) {
+    val initialPage = remember(state.defaultSecondScreenPage, state.consoleId, state.scummvmTrackpadOnboarded) {
         // Mouse-driven cores (ScummVM today; DOSBox / NDS-with-mouse later)
-        // override the user's default landing page to land on Controls. The
-        // trackpad lives there, the trackpad is the primary input on
-        // single-screen handhelds with no real mouse, and "swipe right
-        // until you find the trackpad" is poor first-launch UX. See #861
-        // — this is the MVP override; the per-device-per-console
-        // "trackpadOnboarded" persistence (silence the override after the
-        // user makes one drag) is filed as follow-up scope.
-        if (state.consoleId.equals("scummvm", ignoreCase = true)) {
+        // land on Controls *only* until the user has produced their first
+        // trackpad drag. After that, the OnboardingRepository row makes
+        // the override silent and the user's saved default page wins. See
+        // #861.
+        val isScummvm = state.consoleId.equals("scummvm", ignoreCase = true)
+        if (isScummvm && !state.scummvmTrackpadOnboarded) {
             PAGE_CONTROLS
         } else {
             when (state.defaultSecondScreenPage) {
@@ -243,6 +241,15 @@ fun SecondaryScreenContent(
                                 },
                                 onMouseMove = { dx, dy ->
                                     controller.setMouse(0, dx.toInt().toShort(), dy.toInt().toShort(), false, false)
+                                    // #861 — first ScummVM trackpad drag of any
+                                    // session dismisses the override hint, so
+                                    // future ScummVM launches respect the
+                                    // user's saved default page.
+                                    if (state.consoleId.equals("scummvm", ignoreCase = true) &&
+                                        !state.scummvmTrackpadOnboarded
+                                    ) {
+                                        viewModel.onIntent(EmulationIntent.MarkScummVmTrackpadOnboarded)
+                                    }
                                 },
                                 onMouseButton = { left, right ->
                                     controller.setMouse(0, 0, 0, left, right)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -70,6 +70,14 @@ class EmulationViewModel(
     private val biosRepository: BiosRepository? = null,
     private val cheatRepository: CheatRepository? = null,
     private val gameStatsRepository: GameStatsRepository? = null,
+    /**
+     * Optional onboarding-hints repository (#861). When present, the
+     * VM gates the ScummVM-lands-on-Controls override on the user
+     * NOT having dismissed the trackpad-dragged hint, and dispatches
+     * the dismissal on first drag. Optional so test fakes that don't
+     * exercise onboarding don't have to wire it up.
+     */
+    private val onboardingRepository: com.spela.player.domain.repository.OnboardingRepository? = null,
 ) {
     val state: StateFlow<EmulationState> = _state.asStateFlow()
 
@@ -427,6 +435,31 @@ class EmulationViewModel(
                 }
             EmulationIntent.RehearsalCrashStartFresh -> rehearsalCrashStartFresh()
             EmulationIntent.RehearsalCrashDismiss -> rehearsalCrashDismiss()
+
+            EmulationIntent.MarkScummVmTrackpadOnboarded -> markScummVmTrackpadOnboarded()
+        }
+    }
+
+    /**
+     * #861 — first trackpad drag in a ScummVM session marks the hint
+     * as dismissed so subsequent ScummVM launches stop overriding the
+     * user's saved default secondary-screen page. Fire-and-forget on
+     * IO; failure is silently swallowed because the worst case is the
+     * override fires once more next launch.
+     */
+    private fun markScummVmTrackpadOnboarded() {
+        val current = _state.value
+        if (current.scummvmTrackpadOnboarded) return
+        _state.update { it.copy(scummvmTrackpadOnboarded = true) }
+        val repo = onboardingRepository ?: return
+        scope.launch(dispatchers.io) {
+            try {
+                repo.markDismissed(
+                    com.spela.player.domain.repository.OnboardingHintKeys.SCUMMVM_TRACKPAD_DRAGGED,
+                )
+            } catch (_: Throwable) {
+                // Best effort.
+            }
         }
     }
 
@@ -777,6 +810,23 @@ class EmulationViewModel(
             stopJob = null
             libretroController.stop()
             println("[Emulation] Previous emulation stopped (if any)")
+
+            // #861 — hydrate the per-launch onboarded snapshot before
+            // the secondary-screen pager composes. If the user has
+            // already produced a trackpad drag in a prior ScummVM
+            // session, SecondaryScreenContent skips the
+            // lands-on-Controls override and respects their saved
+            // default page.
+            val onboardedSnapshot = onboardingRepository?.let { repo ->
+                try {
+                    repo.isDismissed(
+                        com.spela.player.domain.repository.OnboardingHintKeys.SCUMMVM_TRACKPAD_DRAGGED,
+                    )
+                } catch (_: Throwable) {
+                    false
+                }
+            } ?: false
+            _state.update { it.copy(scummvmTrackpadOnboarded = onboardedSnapshot) }
 
             // Fetch user preferences (fallback to defaults on error)
             println("[Emulation] Fetching preferences")

--- a/player/shared/src/commonMain/sqldelight/com/spela/player/SpelaDatabase.sq
+++ b/player/shared/src/commonMain/sqldelight/com/spela/player/SpelaDatabase.sq
@@ -374,3 +374,35 @@ incrementPendingSaveUploadRetry:
 UPDATE PendingSaveUploadEntity
 SET retry_count = retry_count + 1, last_error = ?
 WHERE id = ?;
+
+
+-- Onboarding hints (#861).
+--
+-- Generic device-local "the user has seen and dismissed this hint" tracker.
+-- Examples of keys: "scummvm.trackpad.dragged" (silence the secondary-screen
+-- ScummVM trackpad-onboarding override after the user makes one drag), future
+-- "secondary.swipe.hint", "core.upgrade.chip", etc.
+--
+-- Absence of a row means "the user has not seen / dismissed this hint yet."
+-- Storing the dismissal timestamp lets future code reset hints if their copy
+-- changes substantially (rev-the-key pattern), or expire stale dismissals.
+--
+-- Device-local: hints relate to local-device affordances (which screen is
+-- which, where physical controls are). They don't sync across devices.
+CREATE TABLE OnboardingHintEntity (
+    hint_key      TEXT NOT NULL PRIMARY KEY,
+    dismissed_at  INTEGER NOT NULL
+);
+
+isOnboardingHintDismissed:
+SELECT COUNT(*) FROM OnboardingHintEntity WHERE hint_key = ?;
+
+markOnboardingHintDismissed:
+INSERT OR REPLACE INTO OnboardingHintEntity(hint_key, dismissed_at)
+VALUES (?, ?);
+
+clearOnboardingHint:
+DELETE FROM OnboardingHintEntity WHERE hint_key = ?;
+
+clearAllOnboardingHints:
+DELETE FROM OnboardingHintEntity;

--- a/player/shared/src/commonMain/sqldelight/com/spela/player/migrations/3.sqm
+++ b/player/shared/src/commonMain/sqldelight/com/spela/player/migrations/3.sqm
@@ -1,0 +1,9 @@
+-- Migration from schema version 3 to 4: add OnboardingHintEntity table
+-- so device-local "user dismissed this hint" rows survive across launches
+-- without forcing the override path. Generic by design — keyed on a
+-- dotted-namespace string so future hints (BIOS prompts, save-state
+-- intro tooltips, etc.) can reuse the same table. See #861.
+CREATE TABLE OnboardingHintEntity (
+    hint_key      TEXT NOT NULL PRIMARY KEY,
+    dismissed_at  INTEGER NOT NULL
+);


### PR DESCRIPTION
## Summary
- Adds a generic device-local `OnboardingHintEntity` SQLDelight table keyed on dotted-namespace strings so future hints (BIOS prompts, save-state intros, etc.) can reuse the row shape.
- First ScummVM trackpad drag now writes `scummvm.trackpad.dragged` through a new `OnboardingRepository`, hydrated into `EmulationState.scummvmTrackpadOnboarded` at the start of every launch.
- `SecondaryScreenContent` only forces the lands-on-Controls override while the user has not yet onboarded; once they've dragged the trackpad once, their saved default page wins on every subsequent ScummVM launch.

## Why
The MVP override (#861) helped first-time ScummVM users find the trackpad, but it made the experience worse for returning users who'd configured a different default page. Persisting the dismissal flips the override into a one-time hint.

## Test plan
- [x] Desktop tests pass (one unrelated `AppLaunchAndConnectionTest.addServerRetryAfterFailure` flake)
- [ ] Manual: launch ScummVM the first time → secondary screen lands on Controls; drag the trackpad once; quit; re-launch → secondary lands on the user's saved default page
- [ ] Manual: settings page reset (or `clearAllOnboardingHints`) re-arms the hint

Closes #861.