### PR TITLE
test(web): pin play-later Actions locator to first match (#878)

### DIFF
--- a/web/e2e/play-later.spec.ts
+++ b/web/e2e/play-later.spec.ts
@@ -396,7 +396,11 @@ test.describe("Play Later on Game Detail Page", () => {
     await page.goto("/games/1");
 
     // Open the actions menu, then find the Play Later menu item
-    const actionsBtn = page.getByRole("button", { name: "Actions" });
+    // The page-level actions button shares aria-label="Actions" with
+    // session-card actions buttons (which can render after seed data
+    // changes). Pin to the first match so the locator stays
+    // strict-mode safe regardless of which sessions appear.
+    const actionsBtn = page.getByTestId("actions-menu-btn").first();
     await expect(actionsBtn).toBeVisible({ timeout: 10_000 });
     await actionsBtn.click();
 
@@ -412,7 +416,11 @@ test.describe("Play Later on Game Detail Page", () => {
 
     await page.goto("/games/1");
 
-    const actionsBtn = page.getByRole("button", { name: "Actions" });
+    // The page-level actions button shares aria-label="Actions" with
+    // session-card actions buttons (which can render after seed data
+    // changes). Pin to the first match so the locator stays
+    // strict-mode safe regardless of which sessions appear.
+    const actionsBtn = page.getByTestId("actions-menu-btn").first();
     await expect(actionsBtn).toBeVisible({ timeout: 10_000 });
     await actionsBtn.click();
 
@@ -442,7 +450,11 @@ test.describe("Play Later on Game Detail Page", () => {
 
     await page.goto("/games/1");
 
-    const actionsBtn = page.getByRole("button", { name: "Actions" });
+    // The page-level actions button shares aria-label="Actions" with
+    // session-card actions buttons (which can render after seed data
+    // changes). Pin to the first match so the locator stays
+    // strict-mode safe regardless of which sessions appear.
+    const actionsBtn = page.getByTestId("actions-menu-btn").first();
     await expect(actionsBtn).toBeVisible({ timeout: 10_000 });
     await actionsBtn.click();
 
@@ -476,7 +488,11 @@ test.describe("Play Later on Game Detail Page", () => {
 
     await page.goto("/games/1");
 
-    const actionsBtn = page.getByRole("button", { name: "Actions" });
+    // The page-level actions button shares aria-label="Actions" with
+    // session-card actions buttons (which can render after seed data
+    // changes). Pin to the first match so the locator stays
+    // strict-mode safe regardless of which sessions appear.
+    const actionsBtn = page.getByTestId("actions-menu-btn").first();
     await expect(actionsBtn).toBeVisible({ timeout: 10_000 });
     await actionsBtn.click();
 


### PR DESCRIPTION
## Summary
- Four \`web/e2e/play-later.spec.ts\` tests on the game-detail page fail with Playwright strict-mode violations as soon as any session card renders alongside the page-level Actions header button (both carry \`aria-label=\"Actions\"\`).
- Switching to \`page.getByTestId(\"actions-menu-btn\").first()\` keeps the locator strict-mode safe regardless of which sessions appear in seeded data.

## Test plan
- [x] \`SKIP_BUILD=1 ./run-e2e.sh play-later\` — 15 passed (23.5s)
- [ ] CI green

Closes #878.