### PR TITLE
test(player): drain dispatcher post-recompose to fix add-server flake (#880)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/AppLaunchAndConnectionTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/AppLaunchAndConnectionTest.kt
@@ -191,10 +191,15 @@ class AppLaunchAndConnectionTest {
         // Should show error
         onNodeWithText("Could not connect to server. Check the URL and try again.").assertIsDisplayed()
 
-        // Fix the validation result and retry
+        // Fix the validation result and retry. `advanceFully` (not the
+        // standard `advance`) for the same reason as
+        // [addServerValidatesAndSavesOnSuccess]: the success retry path
+        // runs validateServer → addServer → state-flow re-emission →
+        // form auto-close, and the standard 4-iteration helper was
+        // borderline under parallel-fork CPU contention.
         harness.serverRepo.validateServerResult = true
         onNodeWithText("Connect").performClick()
-        advance(harness)
+        advanceFully(harness)
 
         // Server should now be added and form closed
         onNodeWithText("My Server").assertIsDisplayed()

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -69,6 +69,16 @@ private fun ComposeUiTest.advanceN(harness: SpelaTestHarness, iterations: Int) {
         harness.testDispatcher.scheduler.advanceTimeBy(1_000)
         harness.testDispatcher.scheduler.runCurrent()
         mainClock.advanceTimeBy(1_000)
+        // Compose's recomposer runs on the main clock, and recomposition
+        // can spawn fresh coroutines via LaunchedEffect / produceState /
+        // collectAsState.  Those land back on the test dispatcher, so we
+        // drain it once more *after* the main-clock tick to settle the
+        // composition→state→composition feedback loop within a single
+        // iteration. Without this second drain, state-flow reactor chains
+        // (e.g. validateServer → addServer → form auto-close) are
+        // borderline-stable under parallel-fork CPU contention even at 6
+        // iterations.
+        harness.testDispatcher.scheduler.runCurrent()
         waitForIdle()
     }
     mainClock.autoAdvance = true


### PR DESCRIPTION
## Summary
- \`advanceN\` now drains the test dispatcher once more *after* the main-clock tick, so coroutines that Compose recomposition spawned during the same iteration land before \`waitForIdle\`.
- \`addServerRetryAfterFailure\` now uses \`advanceFully\` on its retry-click, matching the success-case test that was already pinned at 6 iterations for the same reason.

## Why
Both \`addServerValidatesAndSavesOnSuccess\` and \`addServerRetryAfterFailure\` flake locally on \`./run-desktop-tests.sh\` with \"could not find ... 'My Server'/'Test Server'\". The reactor chain is \`validateServer → addServer → _servers.update {} → form auto-close\`, spanning the test dispatcher *and* Compose's main-clock recomposer. Effects launched during recomposition land back on the dispatcher after that iteration's only \`runCurrent()\`, so under CPU contention the chain ended up one resumption short when the assertion fired.

## Test plan
- [x] \`for i in 1..5; ./gradlew :desktop:desktopTest --tests AppLaunchAndConnectionTest.addServerRetryAfterFailure --tests AppLaunchAndConnectionTest.addServerValidatesAndSavesOnSuccess --rerun-tasks\` — 5/5 green
- [ ] Full \`./run-desktop-tests.sh\` clean (in flight)
- [ ] CI green

Closes #880.