### PR TITLE
fix(player): latch determinate progress bar on first real sample (#894)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpDownloadProgressBarTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpDownloadProgressBarTest.kt
@@ -1,0 +1,56 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import com.spela.player.presentation.ui.components.SpDownloadProgressBar
+import kotlin.test.Test
+
+/**
+ * Regression coverage for #894 / #797: a transient `progress = -1f`
+ * emission mid-download (e.g. an IDLE re-emit, or a multi-disc
+ * transition where totalBytes momentarily resets to -1) used to
+ * unmount the determinate bar — the inner SpProgressBar lost its
+ * remembered maxProgress and the bar visibly dropped to 0 every
+ * frame. The fix latches the determinate path on first non-negative
+ * progress, so subsequent -1 emissions don't collapse the bar height
+ * back to the indeterminate stripe.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SpDownloadProgressBarTest {
+
+    @Test
+    fun determinateLatchSurvivesTransientNegativeProgress() = runComposeUiTest {
+        var progress by mutableStateOf(-1f)
+        setContent {
+            SpDownloadProgressBar(
+                progress = progress,
+                bytesDownloaded = 0L,
+                totalBytes = -1L,
+            )
+        }
+
+        // Initial: indeterminate path is rendered.
+        onNodeWithTag("sp_download_progress_bar_indeterminate").assertExists()
+
+        // First real progress emission flips us to determinate.
+        progress = 0.25f
+        waitForIdle()
+        onNodeWithTag("sp_download_progress_bar_determinate").assertExists()
+
+        // Transient -1 (e.g. IDLE re-emit, multi-disc transition).
+        // Determinate path must stay mounted; without the latch this
+        // is exactly when the bar would visually drop to 0.
+        progress = -1f
+        waitForIdle()
+        onNodeWithTag("sp_download_progress_bar_determinate").assertExists()
+
+        // Subsequent real progress also stays determinate.
+        progress = 0.7f
+        waitForIdle()
+        onNodeWithTag("sp_download_progress_bar_determinate").assertExists()
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -22,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.ui.theme.SpColor
@@ -117,24 +119,41 @@ fun SpDownloadProgressBar(
     val indeterminateTrackColor = if (onGradient) SpColor.OnGradientTrack else SpColor.SurfaceBright
     val indeterminateColor = if (onGradient) SpColor.OnGradientPrimary else SpColor.Accent
 
+    // Latch the determinate path once we see a non-negative progress
+    // value. Without this, a transient `progress = -1f` emission (e.g.
+    // a brief IDLE re-emit, or a multi-disc transition where totalBytes
+    // momentarily resets to -1) unmounts the inner SpProgressBar — which
+    // loses its remembered maxProgress and animates back from 0 the next
+    // frame. That's the same shape of flicker as #797: the *bar* doesn't
+    // change visibility, but its height drops from 8.dp (determinate) to
+    // 6.dp (indeterminate) and back, giving the page a "jumping every
+    // frame" feel. Once we have a real progress value, stick with the
+    // determinate bar even if subsequent emissions briefly go negative.
+    // See #894.
+    var sawDeterminate by remember { mutableStateOf(false) }
+    if (progress >= 0f) sawDeterminate = true
+
     Column(modifier = modifier) {
-        if (progress < 0f) {
+        if (!sawDeterminate) {
             if (com.spela.player.presentation.ui.components.LocalAnimationsEnabled.current) {
                 LinearProgressIndicator(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(6.dp)
-                        .clip(RoundedCornerShape(3.dp)),
+                        .clip(RoundedCornerShape(3.dp))
+                        .testTag("sp_download_progress_bar_indeterminate"),
                     color = indeterminateColor,
                     trackColor = indeterminateTrackColor,
                 )
             }
         } else {
-            SpProgressBar(
-                progress = progress,
-                progressColors = listOf(SpColor.Accent, SpColor.AccentLight),
-                onGradient = onGradient,
-            )
+            Column(modifier = Modifier.testTag("sp_download_progress_bar_determinate")) {
+                SpProgressBar(
+                    progress = progress.coerceAtLeast(0f),
+                    progressColors = listOf(SpColor.Accent, SpColor.AccentLight),
+                    onGradient = onGradient,
+                )
+            }
         }
         Spacer(Modifier.height(SpSpacing.XSmall))
         Row(modifier = Modifier.fillMaxWidth()) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -319,8 +319,18 @@ fun GameHeroContent(
             else -> null
         }
         if (statusText != null) {
+            // fillMaxWidth + widthIn cap the column at 320dp wide and
+            // give it a stable measured width every recomposition.
+            // Without fillMaxWidth, the column's intrinsic width tracks
+            // the widest child (the bar's bytes-downloaded / speed text
+            // row), which changes with every progress emission and
+            // ripples into the bar's fillMaxWidth — contributing to the
+            // #894 reflow-per-frame symptom on top of the bar-height
+            // latch fix in SpDownloadProgressBar.
             Column(
-                modifier = Modifier.widthIn(max = 320.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .widthIn(max = 320.dp),
                 verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
             ) {
                 Row(


### PR DESCRIPTION
## Summary
- \`SpDownloadProgressBar\` now latches the determinate bar on first non-negative \`progress\`. Subsequent transient \`-1\` emissions (IDLE re-emit, multi-disc \`totalBytes\` reset, etc.) keep the bar mounted instead of unmounting and re-animating from 0.
- Stabilise the status block's container width with \`fillMaxWidth().widthIn(max = 320.dp)\` so it doesn't re-measure on every progress emission.
- Adds \`SpDownloadProgressBarTest\` with the -1 → 0.25 → -1 → 0.7 sequence the issue called out.

## Why this is the #797 flicker shape
Once the inner \`SpProgressBar\` is unmounted, its \`remember\`-ed \`maxProgress\` is gone. When it remounts, the bar visibly drops to 0 and animates back. The unmount/remount happens whenever the parent's \`if (progress < 0f)\` branch flips, and that flip can happen on any -1 emission mid-download. The original #797 fix moved the status block out of the FlowRow, but didn't immunise the bar itself against transient -1 emissions.

## Test plan
- [x] \`./gradlew :desktop:desktopTest --tests SpDownloadProgressBarTest\` — green
- [x] \`./gradlew :shared:compileKotlinDesktop\` — clean
- [ ] CI green
- [ ] Manual: download a game from game-detail, observe progress bar streaming bytes — bar height stays stable, no jumping to 0.

Closes #894.