### PR TITLE
fix(server): register missing BIOS for FDS, Odyssey 2, Channel F (#889 #890 #891)

### DIFF
--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -111,6 +111,32 @@ var registry = []Entry{
 	{ConsoleID: "cdi", FileName: "cdimono2.zip", Description: "CD-i Mono-II BIOS", MD5: "", Required: false, OverrideURL: "https://archive.org/download/MAME208RomsOnlyMerged/cdimono2.zip", SubDir: "same_cdi/bios"},
 	{ConsoleID: "cdi", FileName: "cdibios.zip", Description: "CD-i BIOS (generic)", MD5: "", Required: false, OverrideURL: "https://archive.org/download/MAME208RomsOnlyMerged/cdibios.zip", SubDir: "same_cdi/bios"},
 
+	// Famicom Disk System (FDS) — nestopia_libretro.info. NES proper
+	// doesn't need a BIOS, but disksys.rom is mandatory for any .fds
+	// disk image to boot. Without this entry registered, the missing-
+	// BIOS UI couldn't fire and FDS launches surfaced a generic
+	// "Failed to start emulation" error (#891).
+	{ConsoleID: "fds", FileName: "disksys.rom", Description: "Famicom Disk System BIOS", MD5: "ca30b50f880eb660a320674ed365ef7a", Required: true},
+
+	// Magnavox Odyssey 2 / Philips Videopac (O2) — o2em_libretro.info.
+	// o2rom.bin is required by the core to boot any cartridge; the
+	// other three are regional / variant BIOSes the core can use when
+	// present. MD5s are not published in o2em_libretro.info — match
+	// only by filename. See #889.
+	{ConsoleID: "o2", FileName: "o2rom.bin", Description: "Odyssey 2 BIOS (US, G7000)", MD5: "", Required: true},
+	{ConsoleID: "o2", FileName: "c52.bin", Description: "Videopac French BIOS (G7000)", MD5: "", Required: false},
+	{ConsoleID: "o2", FileName: "g7400.bin", Description: "Videopac+ European BIOS (G7400)", MD5: "", Required: false},
+	{ConsoleID: "o2", FileName: "jopac.bin", Description: "JOPAC BIOS (G7400 variant)", MD5: "", Required: false},
+
+	// Fairchild Channel F (CHAF) — freechaf_libretro.info. Both
+	// sl31253.bin and sl31254.bin are required — Channel F can't
+	// start without either chip ROM, and the symptom on
+	// missing-BIOS-without-registry-entry is a silent black screen
+	// (no error, no missing-BIOS prompt). See #890.
+	{ConsoleID: "chaf", FileName: "sl31253.bin", Description: "Channel F system ROM 1 (chip 1)", MD5: "", Required: true},
+	{ConsoleID: "chaf", FileName: "sl31254.bin", Description: "Channel F system ROM 2 (chip 2)", MD5: "", Required: true},
+	{ConsoleID: "chaf", FileName: "sl90025.bin", Description: "Channel F II system ROM", MD5: "", Required: false},
+
 	// ScummVM — Roland MT-32 / CM-32L MIDI ROMs. The libretro scummvm core
 	// hardcodes its "extrapath" to <system_dir>/scummvm/extra/, so that's
 	// where ScummVM picks up these ROMs to enable MT-32 sound emulation

--- a/server/internal/bios/registry_test.go
+++ b/server/internal/bios/registry_test.go
@@ -57,6 +57,10 @@ func TestByConsole(t *testing.T) {
 		{"Saturn has 2 entries", "sat", 2},
 		{"Dreamcast has 2 entries", "dc", 2},
 		{"NDS has 3 entries", "nds", 3},
+		// Newly registered missing-BIOS consoles — see #889 / #890 / #891.
+		{"FDS has 1 entry (disksys.rom)", "fds", 1},
+		{"Odyssey 2 has 4 entries", "o2", 4},
+		{"Channel F has 3 entries", "chaf", 3},
 		{"Unknown console returns empty", "unknown", 0},
 	}
 	for _, tt := range tests {
@@ -76,9 +80,56 @@ func TestConsoleIDs(t *testing.T) {
 	for _, id := range ids {
 		idSet[id] = true
 	}
-	for _, expected := range []string{"psx", "sat", "scd", "dc", "gba", "nds", "pce", "pcecd", "neogeo", "neocd", "lynx", "3do", "amiga", "pcfx", "cv", "cdi"} {
+	for _, expected := range []string{"psx", "sat", "scd", "dc", "gba", "nds", "pce", "pcecd", "neogeo", "neocd", "lynx", "3do", "amiga", "pcfx", "cv", "cdi", "fds", "o2", "chaf"} {
 		assert.True(t, idSet[expected], "expected console %s in registry", expected)
 	}
+}
+
+// Regression — #889 / #890 / #891. Newly registered consoles must
+// flag their core-mandatory ROMs as Required so the missing-BIOS UI
+// fires; without this the player surfaces a generic emulation error
+// (FDS, O2) or a silent black screen (Channel F) instead.
+func TestNewlyRegisteredConsoles_RequiredFlags(t *testing.T) {
+	tests := []struct {
+		consoleID    string
+		fileName     string
+		wantRequired bool
+	}{
+		{"fds", "disksys.rom", true},
+		{"o2", "o2rom.bin", true},
+		{"o2", "c52.bin", false},
+		{"o2", "g7400.bin", false},
+		{"o2", "jopac.bin", false},
+		{"chaf", "sl31253.bin", true},
+		{"chaf", "sl31254.bin", true},
+		{"chaf", "sl90025.bin", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.consoleID+"/"+tt.fileName, func(t *testing.T) {
+			var match *Entry
+			for _, e := range ByConsole(tt.consoleID) {
+				if e.FileName == tt.fileName {
+					cp := e
+					match = &cp
+					break
+				}
+			}
+			if assert.NotNil(t, match, "registry must contain %s/%s", tt.consoleID, tt.fileName) {
+				assert.Equal(t, tt.wantRequired, match.Required)
+			}
+		})
+	}
+}
+
+// FDS publishes a known MD5 in nestopia_libretro.info; lock it.
+func TestFds_DisksysMD5(t *testing.T) {
+	for _, e := range ByConsole("fds") {
+		if e.FileName == "disksys.rom" {
+			assert.Equal(t, "ca30b50f880eb660a320674ed365ef7a", e.MD5)
+			return
+		}
+	}
+	t.Fatal("fds/disksys.rom not found")
 }
 
 func TestRepoFolder(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add BIOS registry entries for **FDS** (\`disksys.rom\`), **Odyssey 2** (\`o2rom.bin\` + 3 variants), and **Channel F** (\`sl31253.bin\` + \`sl31254.bin\` + \`sl90025.bin\`).
- All three consoles previously had no registry rows, so the missing-BIOS UI silently never fired — launches surfaced as generic errors (FDS, O2) or a black screen (CHAF).
- Tests pin the Required flags and the well-known FDS MD5.

## MD5 sources
- FDS: \`ca30b50f880eb660a320674ed365ef7a\` from \`nestopia_libretro.info\` notes.
- O2 / CHAF: not published in their \`*_libretro.info\` files, so \`MD5: \"\"\` — matches precedent for ps2/scd/neogeo/cdi/cv. The missing-BIOS UI keys on filename presence; verification still passes the file along to the core.

## Test plan
- [x] \`go test ./internal/bios/...\` — green
- [ ] CI green
- [ ] Manual: launch a Channel F / O2 / FDS game with no BIOS → standard \"BIOS required\" UI fires (not a black screen / generic error)

Closes #889, #890, #891.