### PR TITLE
feat(player): three-state hero label Play/Resume/Continue (#884)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/PlaySemantics.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/PlaySemantics.kt
@@ -1,0 +1,61 @@
+package com.spela.player.domain.model
+
+/**
+ * Three-state taxonomy for the game-detail hero's primary action
+ * label. Captures the difference between "user has played this and
+ * the engine will pick up where they left off" vs. "user has played
+ * this but launching takes them to the title screen and they have to
+ * navigate to the engine's own save menu."
+ *
+ * Resolved from `(hasSession, consoleSaveStateSupport, effectiveSaveStateChoice)`
+ * — see [resolvePlaySemantics]. The view-model maps this enum to the
+ * label string the hero renders. See #884.
+ */
+enum class PlaySemantics {
+    /** No session for this game yet. Label: "Play". */
+    NoSession,
+
+    /**
+     * Session exists AND save state will auto-load on launch — the
+     * console supports save states *and* the user hasn't opted out
+     * via the per-console / per-game policy from #804. The user lands
+     * mid-frame where they left off. Label: "Resume".
+     */
+    ResumesFromSaveState,
+
+    /**
+     * Session exists AND save state will NOT auto-load on launch —
+     * the console doesn't support save states (e.g. ScummVM) or the
+     * user opted out for this console / game. Launching takes the
+     * user to the title screen; in-engine save menus are on them.
+     * Label: "Continue" — honest about the difference, vs. "Resume"
+     * which would over-promise.
+     */
+    LaunchesFresh,
+}
+
+/**
+ * Pure resolver. The four open inputs come from these existing models:
+ *
+ *  - [hasSession] — `state.sessions.isNotEmpty()` on game-detail.
+ *  - [consoleSaveStateSupport] — `Console.saveStateSupport`. Hardcoded
+ *    server-side for cores that genuinely cannot snapshot RAM (ScummVM,
+ *    demo cores).
+ *  - [effectiveChoice] — already resolved upstream by
+ *    [effectiveSaveStateChoice]; the resolver here only cares whether
+ *    it's `Disabled` (no auto-load) or anything else (auto-load on).
+ *    `AskOnce` counts as auto-load — the in-game flow treats it as
+ *    Enabled until the prompt resolves to a deliberate choice.
+ *
+ * Pure function — no IO, no platform calls. Trivial to unit test, and
+ * cheap enough to recompute every recomposition.
+ */
+fun resolvePlaySemantics(
+    hasSession: Boolean,
+    consoleSaveStateSupport: Boolean,
+    effectiveChoice: SaveStateChoice,
+): PlaySemantics {
+    if (!hasSession) return PlaySemantics.NoSession
+    val willAutoLoad = consoleSaveStateSupport && effectiveChoice != SaveStateChoice.Disabled
+    return if (willAutoLoad) PlaySemantics.ResumesFromSaveState else PlaySemantics.LaunchesFresh
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
@@ -17,9 +17,13 @@ import com.spela.player.domain.model.GameStats
 import com.spela.player.domain.model.RatingSummary
 import com.spela.player.domain.model.SharedSession
 import com.spela.player.domain.model.SharedSaveState
+import com.spela.player.domain.model.PlaySemantics
+import com.spela.player.domain.model.SaveStateChoice
 import com.spela.player.domain.model.SimilarGame
 import com.spela.player.domain.model.Cheat
 import com.spela.player.domain.model.GameSession
+import com.spela.player.domain.model.effectiveSaveStateChoice
+import com.spela.player.domain.model.resolvePlaySemantics
 
 enum class AchievementsViewMode { GRID, TIMELINE, LEADERBOARD }
 
@@ -86,6 +90,15 @@ data class GameDetailState(
      */
     val gameSaveStatePolicy: com.spela.player.domain.model.SaveStateChoice? = null,
 
+    /**
+     * The user's per-console save-state opt-outs, mirrored from
+     * [com.spela.player.domain.model.UserPreferences.consoleSaveStatePolicies].
+     * Snapshotted into state so [playSemantics] can resolve the hero
+     * label without round-tripping through the preferences repository
+     * on every recomposition. See #884.
+     */
+    val userConsoleSaveStatePolicies: Map<String, SaveStateChoice> = emptyMap(),
+
     // Cheats (used by InGameOverlay, not displayed on game detail)
     val cheats: List<Cheat> = emptyList(),
     val isLoadingCheats: Boolean = false,
@@ -99,4 +112,29 @@ data class GameDetailState(
     // Series & Franchise links
     val gameSeries: List<GameSeriesLink> = emptyList(),
     val gameFranchises: List<GameFranchiseLink> = emptyList(),
-)
+) {
+    /**
+     * Hero label semantics derived from the loaded console + sessions
+     * + user save-state preferences. Recomputed on every read; the
+     * inputs are tiny so allocation pressure is negligible. See #884.
+     *
+     * NoSession when no detail / no console is loaded yet, so callers
+     * get a stable default-safe value during the initial loading spin.
+     */
+    val playSemantics: PlaySemantics
+        get() {
+            val detail = gameDetail ?: return PlaySemantics.NoSession
+            val console = console ?: return PlaySemantics.NoSession
+            val effective = effectiveSaveStateChoice(
+                consoleAbbr = detail.game.consoleId,
+                tier = detail.game.consoleSaveStatePolicy,
+                overrides = userConsoleSaveStatePolicies,
+                gameOverride = gameSaveStatePolicy,
+            )
+            return resolvePlaySemantics(
+                hasSession = sessions.isNotEmpty(),
+                consoleSaveStateSupport = console.saveStateSupport,
+                effectiveChoice = effective,
+            )
+        }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -182,8 +182,20 @@ fun GameHeroContent(
                     }
                     val hasRequiredBiosMissing = missingBiosFiles.any { it.required }
                     val isSyncing = syncState != null
+                    // Three-state label per #884: NoSession → "Play",
+                    // ResumesFromSaveState → "Resume" (auto-load on
+                    // launch), LaunchesFresh → "Continue" (session
+                    // exists but engine starts at title screen, e.g.
+                    // ScummVM or user opted out of save states).
+                    // The single-source-of-truth resolver lives in
+                    // GameDetailState.playSemantics.
+                    val playLabel = when (state.playSemantics) {
+                        com.spela.player.domain.model.PlaySemantics.NoSession -> "Play"
+                        com.spela.player.domain.model.PlaySemantics.ResumesFromSaveState -> "Resume"
+                        com.spela.player.domain.model.PlaySemantics.LaunchesFresh -> "Continue"
+                    }
                     SpSplitButton(
-                        text = if (hasSaves) "Resume" else "Play",
+                        text = playLabel,
                         onClick = { onPlay(gameId) },
                         modifier = Modifier
                             .autoFocus()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -187,10 +187,9 @@ class GameDetailViewModel(
                     // looking up the user's preferences. null means
                     // "no per-game choice — inherit from per-console
                     // policy". See #804 phase 4b spec point (c).
-                    val perGameChoice = preferencesRepository.getPreferences()
-                        .getOrNull()
-                        ?.gameSaveStatePolicies
-                        ?.get(gameId)
+                    val prefs = preferencesRepository.getPreferences().getOrNull()
+                    val perGameChoice = prefs?.gameSaveStatePolicies?.get(gameId)
+                    val perConsolePolicies = prefs?.consoleSaveStatePolicies ?: emptyMap()
                     _state.update {
                         it.copy(
                             gameDetail = detail,
@@ -200,6 +199,10 @@ class GameDetailViewModel(
                             myRating = myRating,
                             ratingSummary = summary,
                             gameSaveStatePolicy = perGameChoice,
+                            // Snapshot per-console policies so the hero
+                            // label resolver in GameDetailState.playSemantics
+                            // doesn't need access to UserPreferences. See #884.
+                            userConsoleSaveStatePolicies = perConsolePolicies,
                             isLoading = false,
                         )
                     }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/domain/model/PlaySemanticsTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/domain/model/PlaySemanticsTest.kt
@@ -1,0 +1,78 @@
+package com.spela.player.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlaySemanticsTest {
+
+    @Test
+    fun noSession_alwaysPlay() {
+        val out = resolvePlaySemantics(
+            hasSession = false,
+            consoleSaveStateSupport = true,
+            effectiveChoice = SaveStateChoice.Enabled,
+        )
+        assertEquals(PlaySemantics.NoSession, out)
+    }
+
+    @Test
+    fun noSession_overridesEverythingElse() {
+        // Even if the user has actively disabled save states or the
+        // console doesn't support them, no session means "Play". The
+        // label should never imply continuation when there's nothing
+        // to continue from.
+        val out = resolvePlaySemantics(
+            hasSession = false,
+            consoleSaveStateSupport = false,
+            effectiveChoice = SaveStateChoice.Disabled,
+        )
+        assertEquals(PlaySemantics.NoSession, out)
+    }
+
+    @Test
+    fun sessionExists_consoleSupportsAndEnabled_resumes() {
+        val out = resolvePlaySemantics(
+            hasSession = true,
+            consoleSaveStateSupport = true,
+            effectiveChoice = SaveStateChoice.Enabled,
+        )
+        assertEquals(PlaySemantics.ResumesFromSaveState, out)
+    }
+
+    @Test
+    fun sessionExists_askOnceCountsAsAutoLoad() {
+        // AskOnce is a deliberate "haven't decided yet" — the in-game
+        // overlay treats it as Enabled until the prompt resolves. The
+        // hero label should match — promising "Resume" here is honest
+        // because the auto-load will fire.
+        val out = resolvePlaySemantics(
+            hasSession = true,
+            consoleSaveStateSupport = true,
+            effectiveChoice = SaveStateChoice.AskOnce,
+        )
+        assertEquals(PlaySemantics.ResumesFromSaveState, out)
+    }
+
+    @Test
+    fun sessionExists_consoleDoesNotSupport_continues() {
+        // ScummVM, demo cores, etc.
+        val out = resolvePlaySemantics(
+            hasSession = true,
+            consoleSaveStateSupport = false,
+            effectiveChoice = SaveStateChoice.Enabled,
+        )
+        assertEquals(PlaySemantics.LaunchesFresh, out)
+    }
+
+    @Test
+    fun sessionExists_consoleSupportsButUserDisabled_continues() {
+        // Per-console / per-game opt-out via #804. "Resume" would
+        // over-promise — launch goes to the title screen.
+        val out = resolvePlaySemantics(
+            hasSession = true,
+            consoleSaveStateSupport = true,
+            effectiveChoice = SaveStateChoice.Disabled,
+        )
+        assertEquals(PlaySemantics.LaunchesFresh, out)
+    }
+}


### PR DESCRIPTION
## Summary
- Add \`PlaySemantics\` enum + \`resolvePlaySemantics\` pure helper in \`commonMain/domain/model\`.
- \`GameDetailState\` gains a computed \`playSemantics\` getter that pulls from console + sessions + game/console save-state policies.
- Hero's \`SpSplitButton\` label is now \"Play\" / \"Resume\" / \"Continue\" based on whether save state will actually auto-load — instead of always saying \"Resume\" the moment a session exists.
- Six unit tests cover every branch including AskOnce-counts-as-auto-load.

## Why
Previous binary \"Resume\" / \"Play\" lied on ScummVM and any console where the user had opted out of save states (#804): those launches actually go to the title screen, not the user's last frame. \"Continue\" tells the truth without claiming auto-resume.

## Web follow-up
Web hero's \"Play in Browser\" verb prefix is a different UX context — filed as #900 to decide the label phrasing before porting the resolver.

## Test plan
- [x] \`./gradlew :shared:desktopTest --tests PlaySemanticsTest\` — green
- [x] \`./gradlew :shared:compileKotlinDesktop\` — clean
- [ ] CI green
- [ ] Manual: open SNES game with no session → \"Play\". Play once → \"Resume\". Open ScummVM game with a session → \"Continue\".

Closes #884. Refs #900.