### PR TITLE
fix(player): compensate DAR for cropped DS top-screen on Android (#887)

### DIFF
--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/EmulationSurface.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/EmulationSurface.kt
@@ -73,12 +73,28 @@ private fun DrawScope.drawScaledBitmap(
     val srcHeight = if (isDualScreenSplit && splitY > 0) splitY else bitmap.height
     val srcOffset = IntOffset.Zero
 
+    // The core reports a display aspect ratio for the *full* frame
+    // (both DS screens stacked = 256×384, DAR ≈ 0.667). When we crop
+    // to the top half (splitY = 192), feeding that full-frame DAR
+    // into computeScaledFrame produces a wrong-aspect destination —
+    // it derives `displayWidth = srcHeight × DAR` from the cropped
+    // height, giving a tall narrow shape (128×192) instead of the
+    // correct 256×192. The visible result is the top screen
+    // horizontally squashed / vertically stretched. Compensate by
+    // scaling the DAR up by the inverse of the crop ratio so the
+    // arithmetic lands on the cropped source's true aspect. See #887.
+    val effectiveDar = if (isDualScreenSplit && splitY > 0 && displayAspectRatio > 0f) {
+        displayAspectRatio * (bitmap.height.toFloat() / splitY)
+    } else {
+        displayAspectRatio
+    }
+
     val scaled = computeScaledFrame(
         srcWidth = srcWidth,
         srcHeight = srcHeight,
         canvasWidth = size.width,
         canvasHeight = size.height,
-        displayAspectRatio = displayAspectRatio,
+        displayAspectRatio = effectiveDar,
     )
 
     val dstOffset = IntOffset(scaled.offsetX, scaled.offsetY)

--- a/player/shared/src/commonTest/kotlin/com/spela/player/libretro/EmulationScalingTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/libretro/EmulationScalingTest.kt
@@ -147,4 +147,74 @@ class EmulationScalingTest {
         assertTrue(result.offsetX >= 0)
         assertTrue(result.offsetY >= 0)
     }
+
+    // ── #887 — DS top-screen split (cropped DAR) ──
+    //
+    // The DS reports a full-frame DAR on a 256×384 stacked source
+    // (≈0.667). When the secondary-display Android path crops to the
+    // top half (splitY = 192), the call site multiplies the DAR by
+    // bitmap.height / splitY = 2 to compensate. These tests exercise
+    // the resulting (srcHeight, effectiveDar) input to computeScaledFrame.
+
+    @Test
+    fun `DS full frame stacked - both screens render at 4 to 3 stacked`() {
+        // Regression-protect the existing behaviour when split is OFF.
+        // Source 256×384, DAR ≈ 0.667 (256 wide / 384 tall) — the core
+        // reports the stacked-screens aspect, and the renderer should
+        // fit both screens on a 1920×1080 canvas without distortion.
+        val result = computeScaledFrame(
+            srcWidth = 256, srcHeight = 384,
+            canvasWidth = 1920f, canvasHeight = 1080f,
+            displayAspectRatio = 256f / 384f,
+        )
+        // Display dimensions: 384 × 0.667 = 256 wide, 384 tall.
+        // Scale: min(1920/256, 1080/384) = min(7.5, 2.8125) = 2.8125.
+        // Scaled: 256 × 2.8125 = 720, 384 × 2.8125 = 1080.
+        assertEquals(720, result.width)
+        assertEquals(1080, result.height)
+        assertEquals(600, result.offsetX) // (1920 - 720) / 2
+        assertEquals(0, result.offsetY)
+    }
+
+    @Test
+    fun `DS top screen cropped - effective DAR yields 4 to 3 not stretched`() {
+        // Source 256×192 (top screen only). Full-frame DAR was 0.667;
+        // the call site compensates by multiplying by 384/192 = 2,
+        // giving effectiveDar ≈ 1.333. computeScaledFrame should now
+        // produce a 4:3 destination (1440×1080 on a 1920×1080 canvas)
+        // — letterboxed on the sides, not vertically stretched.
+        val effectiveDar = (256f / 384f) * (384f / 192f) // = 256/192 = 1.333
+        val result = computeScaledFrame(
+            srcWidth = 256, srcHeight = 192,
+            canvasWidth = 1920f, canvasHeight = 1080f,
+            displayAspectRatio = effectiveDar,
+        )
+        // Display dimensions: 192 × 1.333 = 256 wide, 192 tall.
+        // Scale: min(1920/256, 1080/192) = min(7.5, 5.625) = 5.625.
+        // Scaled: 256 × 5.625 = 1440, 192 × 5.625 = 1080.
+        assertEquals(1440, result.width)
+        assertEquals(1080, result.height)
+        assertEquals(240, result.offsetX) // (1920 - 1440) / 2
+        assertEquals(0, result.offsetY)
+    }
+
+    @Test
+    fun `3DS top screen cropped at native 5 to 3 aspect`() {
+        // Forward-protection: a future 3DS-style core reporting non-
+        // square pixels for the top screen alone (e.g. 400×240, 5:3
+        // DAR with the top-half crop trick) should also land on the
+        // right destination.
+        val result = computeScaledFrame(
+            srcWidth = 400, srcHeight = 240,
+            canvasWidth = 1920f, canvasHeight = 1080f,
+            displayAspectRatio = 5f / 3f,
+        )
+        // Display dimensions: 240 × (5/3) = 400 wide, 240 tall.
+        // Scale: min(1920/400, 1080/240) = min(4.8, 4.5) = 4.5.
+        // Scaled: 400 × 4.5 = 1800, 240 × 4.5 = 1080.
+        assertEquals(1800, result.width)
+        assertEquals(1080, result.height)
+        assertEquals(60, result.offsetX) // (1920 - 1800) / 2
+        assertEquals(0, result.offsetY)
+    }
 }


### PR DESCRIPTION
## Summary
- \`drawScaledBitmap\` now multiplies the core-reported DAR by \`bitmap.height / splitY\` when the dual-screen split is active, so the arithmetic lands on the cropped source's true aspect (DS top: 0.667 × 2 = 1.333).
- Three new \`EmulationScaling\` unit tests cover the math: full DS stacked (regression), DS top cropped (the bug), 3DS-style 5:3 crop (forward-protection).

## Why this is the bug
The DS reports DAR for the full two-screen frame (256×384). The Android secondary-display path crops the source to the top half (splitY = 192) but was passing the full-frame DAR through, so \`displayWidth = srcHeight × DAR\` derived from the cropped 192 height gave a 128×192 destination — exactly the horizontal squash / vertical stretch the user reported.

## Test plan
- [x] \`./gradlew :shared:desktopTest --tests EmulationScalingTest\` — green
- [x] \`./gradlew :shared:compileDebugKotlinAndroid\` — clean
- [ ] CI green
- [ ] Manual on AYN Thor: launch a DS game with secondary display active, top screen renders 4:3 letterboxed (not stretched)
- [ ] No regression on full-frame DS rendering when secondary display is off

Closes #887.