### PR TITLE
fix(server): parent-platform logo fallback for ADEMO / DDEMO (#888)

### DIFF
--- a/server/internal/api/console_handler_test.go
+++ b/server/internal/api/console_handler_test.go
@@ -994,3 +994,63 @@ func TestGetTopRatedGlobal_DeduplicatePrefersLocalLibraryMatch(t *testing.T) {
 	// Should have a localGameId because the SNES version matches a library game
 	assert.NotNil(t, result[0].LocalGameId, "should prefer the console entry that has a local library match")
 }
+
+// #888 — child consoles without their own logo asset fall back to
+// the parent platform's logo. Avoids the placeholder/blank state in
+// the player app when the child asset hasn't been shipped yet.
+func TestGetConsoleLogo_ParentFallback(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	tests := []struct {
+		name        string
+		childAbbr   string
+		parentAbbr  string
+		contentType string
+	}{
+		{"Amiga Demos falls back to Amiga (svg)", "ademo", "amiga", "image/svg+xml"},
+		{"DOS Demos falls back to DOS (svg)", "ddemo", "dos", "image/svg+xml"},
+		{"Amiga Demos falls back to Amiga (png)", "ademo", "amiga", "image/png"},
+		{"DOS Demos falls back to DOS (png)", "ddemo", "dos", "image/png"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suffix := "/logo"
+			if tt.contentType == "image/png" {
+				suffix = "/logo.png"
+			}
+
+			// Fetch the parent's bytes for byte-equality.
+			pw := httptest.NewRecorder()
+			preq := httptest.NewRequest("GET", "/api/consoles/"+tt.parentAbbr+suffix, nil)
+			router.ServeHTTP(pw, preq)
+			require.Equal(t, http.StatusOK, pw.Code, "parent logo must be available")
+			parentBody := pw.Body.Bytes()
+			require.NotEmpty(t, parentBody)
+
+			// Fetch the child's bytes — must succeed and equal parent.
+			cw := httptest.NewRecorder()
+			creq := httptest.NewRequest("GET", "/api/consoles/"+tt.childAbbr+suffix, nil)
+			router.ServeHTTP(cw, creq)
+			assert.Equal(t, http.StatusOK, cw.Code, "child logo should fall back, not 404")
+			assert.Equal(t, tt.contentType, cw.Header().Get("Content-Type"))
+			assert.Equal(t, parentBody, cw.Body.Bytes(), "child should serve identical bytes to parent")
+		})
+	}
+}
+
+// Consoles with no fallback configured AND no asset still 404 — the
+// fallback map is opt-in, not a generic catch-all.
+func TestGetConsoleLogo_NoFallbackStill404s(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	// ARCADE has no parent platform; the issue notes it needs a fresh
+	// asset and remains 404 until one is shipped.
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/consoles/arcade/logo", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -696,6 +696,21 @@ func (h *ConsoleHandler) HumaGetConsoleIcon(_ context.Context, in *ConsoleAssetI
 	return streamBytesInline(data, "image/png"), nil
 }
 
+// consoleLogoFallbacks maps a console abbreviation (lowercase) to the
+// abbreviation of the parent platform whose logo should be served when
+// the child console has no dedicated asset yet. Demo-scene consoles
+// inherit their parent platform's logo by default — Amiga Demos uses
+// the Amiga logo, DOS Demos uses the DOS logo. Adding a row here only
+// affects consoles that don't have their own SVG / PNG in the embedded
+// asset dirs; once an asset is shipped for the child, it wins.
+//
+// Future child consoles get a sensible default with one map entry.
+// See #888.
+var consoleLogoFallbacks = map[string]string{
+	"ademo": "amiga",
+	"ddemo": "dos",
+}
+
 // HumaGetConsoleLogo is the huma implementation of GET /api/consoles/{id}/logo.
 // Inlines CSS styles in the SVG so renderers without CSS support (e.g. Coil
 // on JVM) display colors correctly — same post-processing as the gin version.
@@ -704,8 +719,17 @@ func (h *ConsoleHandler) HumaGetConsoleLogo(_ context.Context, in *ConsoleAssetI
 	if err := h.DB.Where("LOWER(abbreviation) = LOWER(?) OR code = ?", in.ID, in.ID).First(&console).Error; err != nil {
 		return nil, huma.Error404NotFound("console not found")
 	}
-	filename := strings.ToLower(console.Abbreviation) + ".svg"
-	data, err := consoleLogos.ReadFile("static/console-logos/" + filename)
+	abbr := strings.ToLower(console.Abbreviation)
+	data, err := consoleLogos.ReadFile("static/console-logos/" + abbr + ".svg")
+	if err != nil {
+		// Fall back to a parent-platform logo when registered (#888).
+		if parent, ok := consoleLogoFallbacks[abbr]; ok {
+			if pdata, perr := consoleLogos.ReadFile("static/console-logos/" + parent + ".svg"); perr == nil {
+				data = pdata
+				err = nil
+			}
+		}
+	}
 	if err != nil {
 		return nil, huma.Error404NotFound("logo not available for this console")
 	}
@@ -720,8 +744,17 @@ func (h *ConsoleHandler) HumaGetConsoleLogoPng(_ context.Context, in *ConsoleAss
 	if err := h.DB.Where("LOWER(abbreviation) = LOWER(?) OR code = ?", in.ID, in.ID).First(&console).Error; err != nil {
 		return nil, huma.Error404NotFound("console not found")
 	}
-	filename := strings.ToLower(console.Abbreviation) + ".png"
-	data, err := consoleLogosPng.ReadFile("static/console-logos-png/" + filename)
+	abbr := strings.ToLower(console.Abbreviation)
+	data, err := consoleLogosPng.ReadFile("static/console-logos-png/" + abbr + ".png")
+	if err != nil {
+		// Same parent-platform fallback as the SVG variant (#888).
+		if parent, ok := consoleLogoFallbacks[abbr]; ok {
+			if pdata, perr := consoleLogosPng.ReadFile("static/console-logos-png/" + parent + ".png"); perr == nil {
+				data = pdata
+				err = nil
+			}
+		}
+	}
 	if err != nil {
 		return nil, huma.Error404NotFound("logo not available for this console")
 	}


### PR DESCRIPTION
## Summary
- Add an opt-in \`consoleLogoFallbacks\` map (\`ademo → amiga\`, \`ddemo → dos\`) consulted when the child console has no embedded asset.
- Both SVG and PNG handlers now serve the parent's bytes for ADEMO / DDEMO instead of 404-ing.
- ARCADE keeps 404-ing (no parent platform) — fallback is opt-in, not catch-all, so legitimately-orphan consoles still surface a gap the provisioning team can act on. ARCADE needs a fresh asset, filed separately if it doesn't already have an issue.

## Test plan
- [x] \`go test ./internal/api/ -run TestGetConsoleLogo\` — 5/5 green
- [ ] CI green
- [ ] Manual: player app's console list renders Amiga Demos and DOS Demos with their parent logos; ARCADE still shows the placeholder

Closes #888.