### PR TITLE
chore(player): drop !! lint warning in SlotManageDialogs

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SlotManageDialogs.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SlotManageDialogs.kt
@@ -50,9 +50,15 @@ fun InGameSlotActionsSheet(
     val title = buildString {
         append("Slot ")
         append(slot)
-        if (!slotInfo?.name.isNullOrBlank()) {
+        // `slotInfo?.name.isNullOrBlank()` returns false either when
+        // slotInfo itself is null OR when its name is null/blank — so
+        // smart-casting slotInfo to non-null inside the negated branch
+        // is guaranteed by the previous expression already. Explicit
+        // null-check eliminates the !! the compiler was complaining
+        // about while keeping the same evaluation order.
+        if (slotInfo != null && !slotInfo.name.isNullOrBlank()) {
             append(" — ")
-            append(slotInfo!!.name)
+            append(slotInfo.name)
         } else if (slotInfo?.timestamp != null) {
             append(" — ")
             append(slotInfo.timestamp)


### PR DESCRIPTION
Cleans the recurring `Unnecessary non-null assertion (!!)` warning from `SlotManageDialogs.kt:55` that was firing on every build. Pure refactor — same evaluation order, same output.