### PR TITLE
fix(server): drop IPF from AMIGA + ATARIST extensions (#892)

### DIFF
--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -923,13 +923,21 @@ func SeedConsoles(db *gorm.DB) error {
 		{Name: "Nintendo Game & Watch", Abbreviation: "GW", Extensions: ".mgw", DefaultCore: "gw", EmulatorJSCore: "", FolderName: "gameandwatch", ColorTheme: "#c0392b", CoverAspect: "1:1", Generation: 1, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		// Home Computers (generation = 100)
 		{Name: "Atari 8-bit", Abbreviation: "A800", Extensions: ".a52,.atr,.atx,.bas,.bin,.car,.cas,.com,.rom,.xex,.xfd", DefaultCore: "atari800", EmulatorJSCore: "", FolderName: "atari800", ColorTheme: "#8b4513", Generation: 100, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
-		{Name: "Atari ST", Abbreviation: "ATARIST", Extensions: ".st,.stx,.msa,.dim,.ipf,.m3u", DefaultCore: "hatari", EmulatorJSCore: "", FolderName: "atarist", ColorTheme: "#8b4513", Generation: 100, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
+		// Atari ST: .ipf intentionally excluded — same proprietary
+		// CAPSImg requirement as Amiga; the Hatari core can be built
+		// with CAPSImg, but our distribution doesn't include it. See #892.
+		{Name: "Atari ST", Abbreviation: "ATARIST", Extensions: ".st,.stx,.msa,.dim,.m3u", DefaultCore: "hatari", EmulatorJSCore: "", FolderName: "atarist", ColorTheme: "#8b4513", Generation: 100, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		{Name: "Commodore 64", Abbreviation: "C64", Extensions: ".d64,.t64,.prg,.crt,.tap", DefaultCore: "vice_x64sc", EmulatorJSCore: "vice_x64sc", FolderName: "c64", ColorTheme: "#6c5eb5", Generation: 100, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		{Name: "Commodore 128", Abbreviation: "C128", Extensions: ".d64,.d71,.d81,.t64,.prg,.crt", DefaultCore: "vice_x128", EmulatorJSCore: "vice_x128", FolderName: "c128", ColorTheme: "#6c5eb5", Generation: 100, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		{Name: "Commodore PET", Abbreviation: "PET", Extensions: ".prg,.d64,.t64", DefaultCore: "vice_xpet", EmulatorJSCore: "vice_xpet", FolderName: "pet", ColorTheme: "#6c5eb5", Generation: 100, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		{Name: "Commodore Plus/4", Abbreviation: "PLUS4", Extensions: ".prg,.d64,.t64", DefaultCore: "vice_xplus4", EmulatorJSCore: "vice_xplus4", FolderName: "plus4", ColorTheme: "#6c5eb5", Generation: 100, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		{Name: "Commodore VIC-20", Abbreviation: "VIC20", Extensions: ".prg,.d64,.t64,.crt", DefaultCore: "vice_xvic", EmulatorJSCore: "vice_xvic", FolderName: "vic20", ColorTheme: "#6c5eb5", Generation: 100, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
-		{Name: "Commodore Amiga", Abbreviation: "AMIGA", Extensions: ".adf,.hdf,.lha,.ipf,.dms,.zip", DefaultCore: "puae", EmulatorJSCore: "puae", FolderName: "amiga", ColorTheme: "#6c5eb5", Generation: 100, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
+		// Amiga: .ipf intentionally excluded — IPF support requires the
+		// proprietary CAPSImg library that our PUAE builds don't ship.
+		// Indexing IPF files surfaces them in the library and they fail
+		// silently at launch (Kickstart boots, no game disk loads).
+		// Users with .ipf files should convert to .adf or remove. See #892.
+		{Name: "Commodore Amiga", Abbreviation: "AMIGA", Extensions: ".adf,.hdf,.lha,.dms,.zip", DefaultCore: "puae", EmulatorJSCore: "puae", FolderName: "amiga", ColorTheme: "#6c5eb5", Generation: 100, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		{Name: "Amiga Demos", Abbreviation: "ADEMO", Extensions: ".adf,.hdf,.lha,.dms,.zip", DefaultCore: "puae", EmulatorJSCore: "puae", FolderName: "amiga-demos", ColorTheme: "#8b7fc7", Generation: 100, SaveStateSupport: false, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		{Name: "DOS", Abbreviation: "DOS", Extensions: ".zip,.dosz,.conf", DefaultCore: "dosbox_pure", EmulatorJSCore: "dosbox_pure", FolderName: "dos", ColorTheme: "#000000", Generation: 100, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		{Name: "DOS Demos", Abbreviation: "DDEMO", Extensions: ".zip,.dosz,.conf", DefaultCore: "dosbox_pure", EmulatorJSCore: "dosbox_pure", FolderName: "dos-demos", ColorTheme: "#333333", Generation: 100, SaveStateSupport: false, SaveStatePolicy: SaveStatePolicySmall, Playable: true},

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -192,7 +192,11 @@ var RomExtensions = map[string]bool{
 	".col": true,
 	".d64": true, ".d71": true, ".d81": true, ".t64": true, ".prg": true, ".crt": true, ".tap": true,
 	".conf": true, ".dosz": true,
-	".adf": true, ".hdf": true, ".lha": true, ".ipf": true, ".dms": true,
+	// .ipf intentionally excluded — proprietary CAPSImg requirement
+	// (#892). PUAE/Hatari builds without CAPSImg silently fail to load
+	// IPF disks; better to skip indexing them than to surface a broken
+	// library entry.
+	".adf": true, ".hdf": true, ".lha": true, ".dms": true,
 	".min": true,
 	".j64": true, ".jag": true,
 	".32x": true,
@@ -331,9 +335,9 @@ var discPattern = regexp.MustCompile(`(?i)[\(\[]\s*(?:disc|disk|cd)\s*(\d+)\s*[\
 // extension, so we anchor on `<space><LETTER><end>` (the extension is
 // stripped before this is matched). Captures the letter in group 1.
 //
-// Only checked for .adf / .ipf files (Amiga floppy formats); other
-// consoles' ROM names occasionally end in a letter for legitimate
-// non-disc reasons.
+// Only checked for .adf files (Amiga floppy format); other consoles'
+// ROM names occasionally end in a letter for legitimate non-disc
+// reasons. .ipf files are no longer indexed (see #892).
 var amigaDiscPattern = regexp.MustCompile(`\s([A-Z])$`)
 
 // trackPattern matches CD audio track markers in filenames, e.g. "(Track 06)", "(Track 1)".
@@ -973,7 +977,7 @@ func (s *Scanner) scanMultiDisc(dir string, consoleMap map[string]*db.Console, f
 			baseTitle := stripDiscMarker(nameNoExt)
 			key := discGroupKey{Dir: parentDir, Title: baseTitle}
 			discGroups[key] = append(discGroups[key], path)
-		} else if (ext == ".adf" || ext == ".ipf") && amigaDiscPattern.MatchString(strings.TrimSuffix(info.Name(), ext)) {
+		} else if ext == ".adf" && amigaDiscPattern.MatchString(strings.TrimSuffix(info.Name(), ext)) {
 			// Amiga floppy convention: "Title (Pub) A.adf" / "Title (Pub) B.adf" — letter suffix.
 			parentDir := filepath.Dir(path)
 			nameNoExt := strings.TrimSuffix(info.Name(), filepath.Ext(info.Name()))


### PR DESCRIPTION
## Summary
Drops \`.ipf\` from the AMIGA + ATARIST extension lists, the scanner's allow-list, and the Amiga disc-grouping regex. IPF files no longer get indexed.

## Why
PUAE / Hatari need the proprietary \`CAPSImg\` library to read IPF disks. Our distributed core builds don't include it (license-incompatible), so indexing IPF files just produces broken library entries — \"Kickstart boots, no game disk loads\" exactly per #892.

## Migration
Existing \`.ipf\` library rows get unindexed on the next scan. Users with IPF files convert to ADF or remove.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./internal/scanner/... ./internal/db/...\` green
- [ ] CI green

Closes #892.