### PR TITLE
fix(server): register PPSSPP ppge_atlas.zim in BIOS registry (#906)

### DIFF
--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -118,6 +118,23 @@ var registry = []Entry{
 	// "Failed to start emulation" error (#891).
 	{ConsoleID: "fds", FileName: "disksys.rom", Description: "Famicom Disk System BIOS", MD5: "ca30b50f880eb660a320674ed365ef7a", Required: true},
 
+	// PlayStation Portable (PSP) — ppsspp_libretro.info.
+	//
+	// PPSSPP needs `ppge_atlas.zim` under `<system_dir>/PPSSPP/` to
+	// render its own UI overlays; the canonical MD5 is published in
+	// the libretro core-info notes for this core. Without it games
+	// often launch but the in-engine UI / pause overlay shows
+	// missing glyphs.
+	//
+	// PPSSPP also wants a `flash0/` directory of system fonts and a
+	// `lang/` directory of UI localisation files under the same
+	// `PPSSPP/` parent. Those are directory trees rather than single
+	// files, so they don't fit the current per-file registry shape;
+	// tracked separately in #906 follow-up so a future
+	// "bundle / extract" path can drop them in cleanly without
+	// turning every font into its own row.
+	{ConsoleID: "psp", FileName: "ppge_atlas.zim", Description: "PPSSPP Data ROM (UI atlas)", MD5: "866855cc330b9b95cc69135fb7b41d38", Required: true, SubDir: "PPSSPP"},
+
 	// Magnavox Odyssey 2 / Philips Videopac (O2) — o2em_libretro.info.
 	// o2rom.bin is required by the core to boot any cartridge; the
 	// other three are regional / variant BIOSes the core can use when

--- a/server/internal/bios/registry_test.go
+++ b/server/internal/bios/registry_test.go
@@ -57,10 +57,11 @@ func TestByConsole(t *testing.T) {
 		{"Saturn has 2 entries", "sat", 2},
 		{"Dreamcast has 2 entries", "dc", 2},
 		{"NDS has 3 entries", "nds", 3},
-		// Newly registered missing-BIOS consoles — see #889 / #890 / #891.
+		// Newly registered missing-BIOS consoles — see #889 / #890 / #891 / #906.
 		{"FDS has 1 entry (disksys.rom)", "fds", 1},
 		{"Odyssey 2 has 4 entries", "o2", 4},
 		{"Channel F has 3 entries", "chaf", 3},
+		{"PSP has 1 entry (ppge_atlas.zim)", "psp", 1},
 		{"Unknown console returns empty", "unknown", 0},
 	}
 	for _, tt := range tests {
@@ -80,7 +81,7 @@ func TestConsoleIDs(t *testing.T) {
 	for _, id := range ids {
 		idSet[id] = true
 	}
-	for _, expected := range []string{"psx", "sat", "scd", "dc", "gba", "nds", "pce", "pcecd", "neogeo", "neocd", "lynx", "3do", "amiga", "pcfx", "cv", "cdi", "fds", "o2", "chaf"} {
+	for _, expected := range []string{"psx", "sat", "scd", "dc", "gba", "nds", "pce", "pcecd", "neogeo", "neocd", "lynx", "3do", "amiga", "pcfx", "cv", "cdi", "fds", "o2", "chaf", "psp"} {
 		assert.True(t, idSet[expected], "expected console %s in registry", expected)
 	}
 }
@@ -130,6 +131,21 @@ func TestFds_DisksysMD5(t *testing.T) {
 		}
 	}
 	t.Fatal("fds/disksys.rom not found")
+}
+
+// PSP — ppge_atlas.zim is required and must land in the PPSSPP/
+// subdir for the libretro core to find it. Lock the published MD5.
+// See #906.
+func TestPsp_PpgeAtlasZim(t *testing.T) {
+	for _, e := range ByConsole("psp") {
+		if e.FileName == "ppge_atlas.zim" {
+			assert.True(t, e.Required, "ppge_atlas.zim must be required")
+			assert.Equal(t, "866855cc330b9b95cc69135fb7b41d38", e.MD5)
+			assert.Equal(t, "PPSSPP", e.SubDir)
+			return
+		}
+	}
+	t.Fatal("psp/ppge_atlas.zim not found")
 }
 
 func TestRepoFolder(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add PSP \`ppge_atlas.zim\` to the BIOS registry under \`SubDir = \"PPSSPP\"\` with the canonical MD5 from \`ppsspp_libretro.info\` notes.
- Tests pin Required + MD5 + SubDir; \`ConsoleIDs\` / \`ByConsole\` tests gain the new \`psp\` entry.

## Why
Same pattern as #889 / #890 / #891 (FDS / O2 / CHAF). With the entry registered the missing-BIOS UI fires for PSP games — and the user can be told what to drop into \`system/PPSSPP/\` instead of seeing partial / glitchy rendering with no clue why.

## Out of scope (filed as #911)
\`flash0/\` (system fonts) + \`lang/\` (UI localisation) are directory trees that don't fit the current per-file registry shape. Filed separately so a future bundle / extract path can land them cleanly without 50+ per-file rows.

## Test plan
- [x] \`go test ./internal/bios/...\` — green
- [ ] CI green
- [ ] Manual: launch a PSP game without \`ppge_atlas.zim\` — standard \"BIOS required\" UI fires (was: silent garbled UI)

Refs #906. Tracks #911.