### PR TITLE
feat: same Play/Resume/Continue label scheme on web + player (#900)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ResumeVsNewGameTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ResumeVsNewGameTest.kt
@@ -16,12 +16,14 @@ import kotlin.test.assertTrue
 /**
  * E2E tests for the resume-vs-new-game split button menu on the game detail screen.
  *
- * When a game has existing sessions (saves), the split button should show:
+ * When a game has existing sessions (saves), the split button shows:
  * - Primary button: "Resume" (loads last save)
  * - Menu item: "Continue from Title Screen" (skips auto-load, reuses session)
- * - Menu item: "New Game" (skips auto-load, forces new session)
+ * - Menu item: "Start fresh playthrough" (skips auto-load, forces new session — was
+ *   "New Game" before #900; renamed to disambiguate from the top-button label
+ *   which now also says "New game" when no session exists)
  *
- * When no sessions exist, only "Play" and "Delete Download" appear.
+ * When no sessions exist, only "New game" and "Delete Download" appear.
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
 class ResumeVsNewGameTest {
@@ -95,7 +97,7 @@ class ResumeVsNewGameTest {
         advanceQuick(harness)
 
         // "New Game" should be visible
-        onNodeWithText("New Game").assertIsDisplayed()
+        onNodeWithText("Start fresh playthrough").assertIsDisplayed()
     }
 
     @Test
@@ -112,7 +114,7 @@ class ResumeVsNewGameTest {
         advanceQuick(harness)
 
         // "New Game" should NOT exist
-        onNodeWithText("New Game").assertDoesNotExist()
+        onNodeWithText("Start fresh playthrough").assertDoesNotExist()
     }
 
     // ---- Primary button label changes ----
@@ -131,7 +133,7 @@ class ResumeVsNewGameTest {
     }
 
     @Test
-    fun primaryButtonShowsPlayWhenNoSaves() = runComposeUiTest {
+    fun primaryButtonShowsNewGameWhenNoSaves() = runComposeUiTest {
         val harness = createLoggedInHarness()
         harness.downloadRepo.preCacheGame("1")
         // No sessions
@@ -139,8 +141,12 @@ class ResumeVsNewGameTest {
         setContent { harness.App() }
         navigateToGameDetail(harness, "1")
 
-        // Primary button should read "Play"
-        onNodeWithText("Play").assertIsDisplayed()
+        // Primary button should read "New game" (was "Play" before #900;
+        // we say "New game" so the user knows there's no save state to
+        // resume — same verb as the menu's fresh-playthrough action,
+        // matching honestly because the action IS the same when no
+        // session exists yet).
+        onNodeWithText("New game").assertIsDisplayed()
     }
 
     // ---- Intent dispatch verification ----
@@ -190,7 +196,7 @@ class ResumeVsNewGameTest {
         // Open menu and click "New Game"
         onNodeWithContentDescription("More options").performClick()
         advanceQuick(harness)
-        onNodeWithText("New Game").performClick()
+        onNodeWithText("Start fresh playthrough").performClick()
         advance(harness)
 
         // Should dispatch PrepareLaunch with skipAutoLoad=true, forceNewSession=true
@@ -260,7 +266,7 @@ class ResumeVsNewGameTest {
         advanceQuick(harness)
 
         // The subtitle description should be visible
-        onNodeWithText("Start a separate playthrough from scratch").assertIsDisplayed()
+        onNodeWithText("Keep your existing saves, start a separate playthrough from scratch").assertIsDisplayed()
     }
 
     // ---- Delete Download still present ----

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -183,9 +183,16 @@ fun GameHeroContent(
 
                         }
                         if (hasSaves && onPlayFresh != null) {
+                            // Renamed from "New Game" to disambiguate
+                            // from the top-button label which now also
+                            // says "New game" when no session exists
+                            // (#900). The fresh-playthrough action
+                            // wants distinct phrasing — "Start fresh
+                            // playthrough" reads as a deliberate
+                            // override of the existing save state.
                             add(SpSplitButtonMenuItem(
-                                label = "New Game",
-                                description = "Start a separate playthrough from scratch",
+                                label = "Start fresh playthrough",
+                                description = "Keep your existing saves, start a separate playthrough from scratch",
                             ) { onPlayFresh(gameId) })
                         }
                         if (onCreateNetplay != null && supportsNetplay) {
@@ -195,15 +202,18 @@ fun GameHeroContent(
                     }
                     val hasRequiredBiosMissing = missingBiosFiles.any { it.required }
                     val isSyncing = syncState != null
-                    // Three-state label per #884: NoSession → "Play",
-                    // ResumesFromSaveState → "Resume" (auto-load on
-                    // launch), LaunchesFresh → "Continue" (session
-                    // exists but engine starts at title screen, e.g.
-                    // ScummVM or user opted out of save states).
+                    // Three-state label per #884 / #900:
+                    //   NoSession → "New game" (no save to pick up
+                    //     from — the user is starting fresh)
+                    //   ResumesFromSaveState → "Resume" (auto-load
+                    //     on launch — user lands mid-frame)
+                    //   LaunchesFresh → "Continue" (session exists
+                    //     but engine starts at title screen, e.g.
+                    //     ScummVM or user opted out of save states)
                     // The single-source-of-truth resolver lives in
                     // GameDetailState.playSemantics.
                     val playLabel = when (state.playSemantics) {
-                        com.spela.player.domain.model.PlaySemantics.NoSession -> "Play"
+                        com.spela.player.domain.model.PlaySemantics.NoSession -> "New game"
                         com.spela.player.domain.model.PlaySemantics.ResumesFromSaveState -> "Resume"
                         com.spela.player.domain.model.PlaySemantics.LaunchesFresh -> "Continue"
                     }

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -43,6 +43,12 @@ interface GameHeroProps {
   achievementCount?: number;
   achievementUnlocked?: number;
   biosMissing?: boolean;
+  /**
+   * Three-state hero label per #900 — "New game" / "Resume" / "Continue".
+   * Resolved by the host page from sessions + console saveStateSupport
+   * + user save-state policy via `lib/play-semantics`.
+   */
+  playLabel?: string;
   onPlay: () => void;
   onScrape: () => void;
   onRefreshAchievements?: () => void;
@@ -67,6 +73,7 @@ export function GameHero({
   achievementCount,
   achievementUnlocked,
   biosMissing,
+  playLabel,
   onPlay,
   onScrape,
   onRefreshAchievements,
@@ -287,13 +294,13 @@ export function GameHero({
                     biosMissing
                       ? "Missing required BIOS files"
                       : canPlayInBrowser
-                        ? "Play in Browser"
+                        ? "Play in browser"
                         : `${game.consoleName} is not supported for browser play`
                   }
                   data-testid="play-in-browser-btn"
                 >
                   <Play className="h-5 w-5" />
-                  Play in Browser
+                  {playLabel ?? "New game"}
                 </Button>
               ) : (
                 <Button

--- a/web/src/lib/__tests__/play-semantics.test.ts
+++ b/web/src/lib/__tests__/play-semantics.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  effectiveSaveStateChoice,
+  playSemanticsLabel,
+  resolvePlaySemantics,
+  type SaveStateChoice,
+} from "@/lib/play-semantics";
+
+// #900 — TS port of the Kotlin PlaySemanticsTest. Same six branches
+// the Kotlin side covers; ensures the two stay in sync as inputs
+// change (the resolver is intentionally not codegen'd across).
+
+describe("resolvePlaySemantics", () => {
+  it("no session → 'no-session'", () => {
+    expect(
+      resolvePlaySemantics({
+        hasSession: false,
+        consoleSaveStateSupport: true,
+        effectiveChoice: "enabled",
+      }),
+    ).toBe("no-session");
+  });
+
+  it("no session overrides everything else", () => {
+    // Even when save states are unavailable, an absent session means
+    // "new game" — the label must never imply continuation when
+    // there's nothing to continue from.
+    expect(
+      resolvePlaySemantics({
+        hasSession: false,
+        consoleSaveStateSupport: false,
+        effectiveChoice: "disabled",
+      }),
+    ).toBe("no-session");
+  });
+
+  it("session + console supports + enabled → 'resumes-from-save-state'", () => {
+    expect(
+      resolvePlaySemantics({
+        hasSession: true,
+        consoleSaveStateSupport: true,
+        effectiveChoice: "enabled",
+      }),
+    ).toBe("resumes-from-save-state");
+  });
+
+  it("ask-once counts as auto-load", () => {
+    // The in-game flow treats AskOnce as Enabled until the prompt
+    // resolves; the hero label matches honestly.
+    expect(
+      resolvePlaySemantics({
+        hasSession: true,
+        consoleSaveStateSupport: true,
+        effectiveChoice: "ask-once",
+      }),
+    ).toBe("resumes-from-save-state");
+  });
+
+  it("session + console doesn't support → 'launches-fresh'", () => {
+    // ScummVM, demo cores. Engine starts at the title screen.
+    expect(
+      resolvePlaySemantics({
+        hasSession: true,
+        consoleSaveStateSupport: false,
+        effectiveChoice: "enabled",
+      }),
+    ).toBe("launches-fresh");
+  });
+
+  it("session + user disabled → 'launches-fresh'", () => {
+    // Per-console / per-game opt-out (#804). "Resume" would over-
+    // promise — launch goes to the title screen.
+    expect(
+      resolvePlaySemantics({
+        hasSession: true,
+        consoleSaveStateSupport: true,
+        effectiveChoice: "disabled",
+      }),
+    ).toBe("launches-fresh");
+  });
+});
+
+describe("effectiveSaveStateChoice", () => {
+  it("game override wins over console policy", () => {
+    expect(
+      effectiveSaveStateChoice("snes", { snes: "enabled" }, "disabled"),
+    ).toBe("disabled");
+  });
+
+  it("console policy wins over default when no game override", () => {
+    expect(
+      effectiveSaveStateChoice("snes", { snes: "disabled" }, null),
+    ).toBe("disabled");
+  });
+
+  it("console policy is case-insensitive on the abbreviation", () => {
+    expect(
+      effectiveSaveStateChoice(
+        "SNES",
+        { snes: "disabled" } as Record<string, SaveStateChoice>,
+        null,
+      ),
+    ).toBe("disabled");
+  });
+
+  it("falls back to enabled when no override applies", () => {
+    expect(effectiveSaveStateChoice("snes", {}, null)).toBe("enabled");
+  });
+});
+
+describe("playSemanticsLabel", () => {
+  // Locks the player-app-matching strings (#900).
+  it("exhaustive label mapping", () => {
+    expect(playSemanticsLabel("no-session")).toBe("New game");
+    expect(playSemanticsLabel("resumes-from-save-state")).toBe("Resume");
+    expect(playSemanticsLabel("launches-fresh")).toBe("Continue");
+  });
+});

--- a/web/src/lib/play-semantics.ts
+++ b/web/src/lib/play-semantics.ts
@@ -1,0 +1,68 @@
+/**
+ * Mirror of the Kotlin `PlaySemantics` enum + resolver in
+ * `player/shared/src/commonMain/kotlin/com/spela/player/domain/model/PlaySemantics.kt`.
+ *
+ * Three states drive the game-detail hero's primary action label so
+ * ScummVM / demo-core / save-state-disabled launches don't promise
+ * "Resume" when the engine is going to land on the title screen.
+ *
+ * Resolver inputs match the Kotlin side exactly; keep the two in sync
+ * whenever either side changes — there's no codegen across, just a
+ * thin parallel implementation. See #884 / #900.
+ */
+export type PlaySemantics =
+  | "no-session"
+  | "resumes-from-save-state"
+  | "launches-fresh";
+
+export type SaveStateChoice = "enabled" | "disabled" | "ask-once";
+
+/**
+ * Resolves the effective save-state policy for a console + game.
+ * Mirrors the Kotlin `effectiveSaveStateChoice` resolver.
+ *
+ * Precedence: per-game override → per-console override → tier default.
+ * For the hero label resolver we don't need the tier branch — any
+ * SaveStateChoice that isn't `"disabled"` counts as auto-load.
+ */
+export function effectiveSaveStateChoice(
+  consoleAbbr: string,
+  consoleSaveStatePolicies: Readonly<Record<string, SaveStateChoice>>,
+  gameOverride: SaveStateChoice | null | undefined,
+): SaveStateChoice {
+  if (gameOverride) return gameOverride;
+  const key = consoleAbbr.toLowerCase();
+  return consoleSaveStatePolicies[key] ?? "enabled";
+}
+
+export interface ResolvePlaySemanticsInput {
+  hasSession: boolean;
+  consoleSaveStateSupport: boolean;
+  effectiveChoice: SaveStateChoice;
+}
+
+export function resolvePlaySemantics({
+  hasSession,
+  consoleSaveStateSupport,
+  effectiveChoice,
+}: ResolvePlaySemanticsInput): PlaySemantics {
+  if (!hasSession) return "no-session";
+  const willAutoLoad =
+    consoleSaveStateSupport && effectiveChoice !== "disabled";
+  return willAutoLoad ? "resumes-from-save-state" : "launches-fresh";
+}
+
+/**
+ * The user-facing label for each state. Matches the player app
+ * exactly (#900 — "New game" / "Resume" / "Continue").
+ */
+export function playSemanticsLabel(s: PlaySemantics): string {
+  switch (s) {
+    case "no-session":
+      return "New game";
+    case "resumes-from-save-state":
+      return "Resume";
+    case "launches-fresh":
+      return "Continue";
+  }
+}

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -33,6 +33,13 @@ import { SharedSavesList } from "@/features/game-detail/components/shared-saves-
 import { GameActiveSharedSessions } from "@/features/shared-sessions/components/game-active-shared-sessions";
 import { GameSessions } from "@/features/sessions/components/game-sessions";
 import { useGameSessions } from "@/hooks/use-sessions";
+import { useUserPreferences } from "@/hooks/use-preferences";
+import {
+  effectiveSaveStateChoice,
+  playSemanticsLabel,
+  resolvePlaySemantics,
+  type SaveStateChoice,
+} from "@/lib/play-semantics";
 import { GameChallenges } from "@/features/challenges/components/game-challenges";
 import {
   useGameAchievements,
@@ -139,6 +146,7 @@ export function GameDetailPage() {
 
   const { data: biosData } = useBiosStatus();
   const { data: sessions } = useGameSessions(id ?? "");
+  const { data: userPreferences } = useUserPreferences();
   const { data: gameAchievements } = useGameAchievements(id);
   const { data: achievementProgress } = useGameAchievementProgress(id);
   const { data: gameSeries } = useGameSeries(id);
@@ -151,6 +159,34 @@ export function GameDetailPage() {
     ? achievementProgress.length
     : undefined;
   const isDemo = consoleInfo?.abbreviation === "ADEMO" || consoleInfo?.abbreviation === "DDEMO";
+
+  // #900 — three-state hero label parity with the player app. Mirror
+  // the same resolver inputs (sessions + console saveStateSupport +
+  // user save-state policy). Resolves to "New game" when no session,
+  // "Resume" when a save will auto-load, "Continue" when a session
+  // exists but engine starts at the title screen (ScummVM, demo
+  // cores, or user-disabled).
+  const playLabel = (() => {
+    const consoleAbbr = consoleInfo?.abbreviation ?? "";
+    const consolePolicies =
+      (userPreferences?.consoleSaveStatePolicies as
+        | Record<string, SaveStateChoice>
+        | undefined) ?? {};
+    const gameOverride = (userPreferences?.gameSaveStatePolicies?.[
+      game?.id ?? ""
+    ] ?? null) as SaveStateChoice | null;
+    const effective = effectiveSaveStateChoice(
+      consoleAbbr,
+      consolePolicies,
+      gameOverride,
+    );
+    const semantics = resolvePlaySemantics({
+      hasSession: (sessions?.length ?? 0) > 0,
+      consoleSaveStateSupport: consoleInfo?.saveStateSupport ?? false,
+      effectiveChoice: effective,
+    });
+    return playSemanticsLabel(semantics);
+  })();
   const [showCollectionPicker, setShowCollectionPicker] = useState(false);
   const [showScrapeMatch, setShowScrapeMatch] = useState(false);
   const [showReplaceRom, setShowReplaceRom] = useState(false);
@@ -223,6 +259,7 @@ export function GameDetailPage() {
         achievementCount={achievementCount}
         achievementUnlocked={achievementUnlocked}
         biosMissing={showBiosWarning}
+        playLabel={playLabel}
         onPlay={() => navigate(`/games/${game.id}/play/${sessions && sessions.length > 0 ? sessions[0].id : "new"}`)}
         onScrape={() => scrapeGame.mutate(game.id)}
         onRefreshAchievements={() => refreshAchievements.mutate(game.id)}


### PR DESCRIPTION
## Summary
- **Player**: top-button label for the no-session case changes from \"Play\" to \"New game\". The existing menu item \"New Game\" (different action — fresh playthrough on top of an existing session) is renamed to \"Start fresh playthrough\" to disambiguate.
- **Web**: ports the three-state \`PlaySemantics\` resolver as TS in \`lib/play-semantics.ts\`, computes the label in \`game-detail-page\`, replaces the fixed \"Play in Browser\" hero label.
- The same labels (\"New game\" / \"Resume\" / \"Continue\") now appear on both sides under the same conditions.

## Why
Per #900 (and the user's clarification this session): \"Same label in web UI and app.\" Resolver inputs are the same on both sides; just a parallel TS implementation rather than codegen — staying in sync is a maintenance commitment we accept since the inputs rarely change.

## Test plan
- [x] Player: \`./gradlew :desktop:desktopTest --tests ResumeVsNewGameTest\` — green
- [x] Web: \`npm test\` — all 1561 + 11 new pass
- [x] Web: \`tsc -b\` clean
- [ ] CI green
- [ ] Manual on AYN Thor: SNES game with no session → button says \"New game\"; play once, return → \"Resume\". ScummVM with a session → \"Continue\".
- [ ] Manual web: same three states.

Closes #900.