### PR TITLE
feat(server): bundle/extract pipeline for BIOS registry (#911)

### DIFF
--- a/server/internal/bios/downloader.go
+++ b/server/internal/bios/downloader.go
@@ -1,6 +1,7 @@
 package bios
 
 import (
+	"archive/zip"
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spela/server/internal/db"
@@ -188,17 +190,62 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 			continue
 		}
 
-		// Rename to final path
-		if err := os.Rename(tmpPath, destPath); err != nil {
-			os.Remove(tmpPath)
-			progress.Status = "failed"
-			progress.Error = fmt.Sprintf("renaming temp file: %v", err)
-			result.Failed++
-			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
-			if onProgress != nil {
-				onProgress(progress)
+		// Bundle entries (#911): the bytes we just downloaded are a
+		// .zip archive — extract every file into <biosDir>/<SubDir>/
+		// then delete the archive. The sentinel file at destPath is
+		// expected to be one of the extracted files; the next pass of
+		// the "is installed" check uses os.Stat(destPath) to detect
+		// the bundle as installed. Failure rolls back the partial
+		// extraction so a half-extracted bundle doesn't get treated
+		// as installed on next launch.
+		if entry.Bundle {
+			extractRoot := biosDir
+			if entry.SubDir != "" {
+				extractRoot = filepath.Join(biosDir, entry.SubDir)
 			}
-			continue
+			if err := os.MkdirAll(extractRoot, 0755); err != nil {
+				os.Remove(tmpPath)
+				progress.Status = "failed"
+				progress.Error = fmt.Sprintf("creating bundle target: %v", err)
+				result.Failed++
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+				if onProgress != nil {
+					onProgress(progress)
+				}
+				continue
+			}
+			if err := extractZipBundle(tmpPath, extractRoot); err != nil {
+				// Best-effort cleanup of any partial files written
+				// before the failure so the bundle isn't half-
+				// installed. We don't try to undo every extracted
+				// path — just remove the sentinel if it landed,
+				// which forces a re-download next attempt.
+				os.Remove(destPath)
+				os.Remove(tmpPath)
+				progress.Status = "failed"
+				progress.Error = fmt.Sprintf("extracting bundle: %v", err)
+				result.Failed++
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+				if onProgress != nil {
+					onProgress(progress)
+				}
+				continue
+			}
+			// Archive is no longer needed.
+			os.Remove(tmpPath)
+		} else {
+			// Rename to final path (single-file entry)
+			if err := os.Rename(tmpPath, destPath); err != nil {
+				os.Remove(tmpPath)
+				progress.Status = "failed"
+				progress.Error = fmt.Sprintf("renaming temp file: %v", err)
+				result.Failed++
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+				if onProgress != nil {
+					onProgress(progress)
+				}
+				continue
+			}
 		}
 
 		progress.Status = "downloaded"
@@ -242,4 +289,75 @@ func StartAutoDownload(biosDir string, database *gorm.DB) {
 			}
 		}
 	}()
+}
+
+// extractZipBundle extracts every file in [archivePath] into [destDir],
+// preserving the archive's relative directory structure. Used by the
+// Bundle path in [DownloadMissing] (#911).
+//
+// Refuses to write outside destDir (defends against zip-slip — an
+// archive entry whose name resolves to "../etc/passwd" can't escape
+// the BIOS dir). Symlinks inside the archive are skipped, not
+// followed, for the same reason.
+func extractZipBundle(archivePath, destDir string) error {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return fmt.Errorf("opening archive: %w", err)
+	}
+	defer r.Close()
+
+	absDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return fmt.Errorf("resolving dest dir: %w", err)
+	}
+
+	for _, zf := range r.File {
+		// Reject absolute paths and traversal.
+		if filepath.IsAbs(zf.Name) || strings.Contains(zf.Name, "..") {
+			return fmt.Errorf("archive entry has unsafe path: %q", zf.Name)
+		}
+
+		target := filepath.Join(destDir, filepath.FromSlash(zf.Name))
+		absTarget, err := filepath.Abs(target)
+		if err != nil {
+			return fmt.Errorf("resolving target: %w", err)
+		}
+		if !strings.HasPrefix(absTarget, absDest+string(filepath.Separator)) && absTarget != absDest {
+			return fmt.Errorf("archive entry escapes target dir: %q", zf.Name)
+		}
+
+		// Skip symlinks and other non-regular file types.
+		if zf.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+
+		if zf.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", target, err)
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return fmt.Errorf("mkdir parent of %s: %w", target, err)
+		}
+
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+		if err != nil {
+			return fmt.Errorf("creating %s: %w", target, err)
+		}
+		in, err := zf.Open()
+		if err != nil {
+			out.Close()
+			return fmt.Errorf("opening archive entry %s: %w", zf.Name, err)
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			out.Close()
+			in.Close()
+			return fmt.Errorf("writing %s: %w", target, err)
+		}
+		out.Close()
+		in.Close()
+	}
+	return nil
 }

--- a/server/internal/bios/downloader_test.go
+++ b/server/internal/bios/downloader_test.go
@@ -1,6 +1,8 @@
 package bios
 
 import (
+	"archive/zip"
+	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"net/http"
@@ -218,4 +220,147 @@ func TestDownloadMissing_NilProgressCallback(t *testing.T) {
 	// Should not panic with nil callback
 	result := DownloadMissing(biosDir, "http://unused", nil)
 	assert.Equal(t, 1, result.Skipped)
+}
+
+// #911 — Bundle entries fetch a .zip and extract every file into
+// <biosDir>/<SubDir>/. The sentinel path at FilePath() is used for
+// already-installed detection, so future runs skip the redownload.
+
+// makeZipBytes builds an in-memory .zip with the given (path → bytes)
+// entries, used to feed the bundle path with a deterministic archive
+// fixture.
+func makeZipBytes(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	for name, data := range files {
+		f, err := w.Create(name)
+		require.NoError(t, err)
+		_, err = f.Write(data)
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+	return buf.Bytes()
+}
+
+func TestDownloadMissing_BundleExtracts(t *testing.T) {
+	biosDir := t.TempDir()
+	zipBytes := makeZipBytes(t, map[string][]byte{
+		"flash0/font/jpn0.pgf": []byte("font-bytes"),
+		"flash0/font/ltn0.pgf": []byte("latin-bytes"),
+		"lang/en_US.ini":       []byte("ui-strings"),
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(zipBytes)
+	}))
+	defer server.Close()
+
+	origRegistry := make([]Entry, len(registry))
+	copy(origRegistry, registry)
+	registry = []Entry{
+		{
+			ConsoleID:   "psp",
+			FileName:    "flash0/font/jpn0.pgf",
+			Description: "PPSSPP system bundle (test)",
+			Required:    true,
+			OverrideURL: server.URL,
+			SubDir:      "PPSSPP",
+			Bundle:      true,
+		},
+	}
+	defer func() { registry = origRegistry }()
+
+	result := DownloadMissing(biosDir, "http://unused", nil)
+	assert.Equal(t, 1, result.Downloaded)
+	assert.Equal(t, 0, result.Failed, "errors: %v", result.Errors)
+
+	// Sentinel + every other extracted file lands under SubDir.
+	for _, rel := range []string{
+		"flash0/font/jpn0.pgf",
+		"flash0/font/ltn0.pgf",
+		"lang/en_US.ini",
+	} {
+		path := filepath.Join(biosDir, "PPSSPP", filepath.FromSlash(rel))
+		_, err := os.Stat(path)
+		require.NoError(t, err, "expected extracted file at %s", path)
+	}
+
+	// Archive itself is cleaned up.
+	tmpZip := filepath.Join(biosDir, "PPSSPP", "flash0", "font", "jpn0.pgf.tmp")
+	_, err := os.Stat(tmpZip)
+	assert.True(t, os.IsNotExist(err), "tmp archive should be removed after extract")
+}
+
+func TestDownloadMissing_BundleSkipsWhenSentinelPresent(t *testing.T) {
+	biosDir := t.TempDir()
+
+	// Pre-create the sentinel file at the path FilePath(biosDir) would
+	// resolve to. The downloader's "already present" check should skip
+	// this entry rather than re-downloading the bundle.
+	sentinel := filepath.Join(biosDir, "PPSSPP", "flash0", "font", "jpn0.pgf")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sentinel), 0755))
+	// Has to be > 1KB or the downloader treats it as a partial.
+	require.NoError(t, os.WriteFile(sentinel, bytes.Repeat([]byte{0xAB}, 2048), 0644))
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	origRegistry := make([]Entry, len(registry))
+	copy(origRegistry, registry)
+	registry = []Entry{
+		{
+			ConsoleID:   "psp",
+			FileName:    "flash0/font/jpn0.pgf",
+			Description: "PPSSPP bundle (test)",
+			Required:    true,
+			OverrideURL: server.URL,
+			SubDir:      "PPSSPP",
+			Bundle:      true,
+		},
+	}
+	defer func() { registry = origRegistry }()
+
+	result := DownloadMissing(biosDir, "http://unused", nil)
+	assert.Equal(t, 1, result.Skipped)
+	assert.Equal(t, 0, result.Downloaded)
+	assert.Equal(t, 0, calls, "should not hit the URL when sentinel is present")
+}
+
+func TestDownloadMissing_BundleRefusesZipSlip(t *testing.T) {
+	biosDir := t.TempDir()
+	// Malicious archive — entry name escapes the dest dir.
+	zipBytes := makeZipBytes(t, map[string][]byte{
+		"../../etc/passwd": []byte("uh oh"),
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(zipBytes)
+	}))
+	defer server.Close()
+
+	origRegistry := make([]Entry, len(registry))
+	copy(origRegistry, registry)
+	registry = []Entry{
+		{
+			ConsoleID:   "test",
+			FileName:    "ok.txt",
+			Description: "Slippy bundle",
+			Required:    true,
+			OverrideURL: server.URL,
+			SubDir:      "test",
+			Bundle:      true,
+		},
+	}
+	defer func() { registry = origRegistry }()
+
+	result := DownloadMissing(biosDir, "http://unused", nil)
+	assert.Equal(t, 1, result.Failed)
+	assert.Equal(t, 0, result.Downloaded)
+	require.NotEmpty(t, result.Errors)
+	assert.Contains(t, result.Errors[0], "unsafe path")
 }

--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -11,6 +11,23 @@ type Entry struct {
 	Required    bool   // true if the console cannot function without it
 	OverrideURL string // if set, download from this URL instead of the default repo
 	SubDir      string // subdirectory within system_dir, e.g. "same_cdi/bios" (empty = flat)
+
+	// Bundle indicates that OverrideURL points at a .zip archive
+	// containing a directory tree rather than a single file. When
+	// true, the downloader fetches the archive, extracts every file
+	// into <biosDir>/<SubDir>/, then deletes the archive. FileName is
+	// interpreted as a *sentinel path* (relative to SubDir) used to
+	// detect whether the bundle has been installed — pick a file
+	// that's guaranteed to exist after extraction (e.g. for PPSSPP,
+	// "flash0/font/jpn0.pgf" or similar).
+	//
+	// Bundle entries skip MD5 validation on the archive bytes (the
+	// archive's own integrity is checked by the unzip step; the
+	// extracted files don't have individual MD5 checks). Set MD5 on
+	// a bundle entry only if you've pinned the archive's hash.
+	//
+	// See #911 for the PPSSPP flash0/lang/assets driver.
+	Bundle bool
 }
 
 // FilePath returns the path of this entry relative to the BIOS directory,


### PR DESCRIPTION
## Summary
- New \`Bundle bool\` on \`bios.Entry\`. When true, the downloader fetches the \`OverrideURL\` as a .zip, extracts every file into \`<biosDir>/<SubDir>/\`, and deletes the archive.
- The sentinel path at \`FilePath()\` is used for already-installed detection — same os.Stat code path as single-file entries.
- Three tests cover: extract happy path, already-installed skip, zip-slip refusal.

## Why
PPSSPP needs a directory tree (\`flash0/\`, \`lang/\`, asset files) under \`<system_dir>/PPSSPP/\` — that's 50+ files frequently churning, not a fixed list. Future cores in the same shape (DOSBox-Pure, ScummVM extras growing) reuse the same plumbing.

## Out of scope (intentional)
No registry entries land in this PR. The infrastructure is the deliverable; a follow-up will wire one PPSSPP entry once we pick a canonical archive URL (libretro's buildbot serves individual files, not a single .zip — sourcing decision).

## Test plan
- [x] \`go test ./internal/bios/...\` — all green including 3 new bundle tests
- [ ] CI green
- Once a PPSSPP archive URL is picked, the existing single-row registry add lights up the missing-BIOS UI for PSP fonts.

Refs #911. Closes #906 once the PPSSPP registry entry lands on top of this.