### PR TITLE
fix(player): PSP teardown SIGSEGV in Adreno GLES driver (#907)

### DIFF
--- a/player/native/src/hw_render_gl_android.c
+++ b/player/native/src/hw_render_gl_android.c
@@ -155,7 +155,19 @@ void hw_gl_deinit(hw_gl_context_t *ctx) {
     if (!ctx || !ctx->initialized) return;
 
     if (ctx->egl_display != EGL_NO_DISPLAY) {
-        eglMakeCurrent(ctx->egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+        /* #907 — only release-from-current if our context is *still*
+         * the bound one on this thread. PPSSPP and similar HW-render
+         * cores spin up worker threads inside their context_destroy
+         * callback that do their own EGL bind/release dances; by the
+         * time we get here, the driver's "currently-bound context"
+         * tracking can be inconsistent. On Adreno, calling
+         * eglMakeCurrent(EGL_NO_CONTEXT) in that state crashes inside
+         * the GLES driver via a null vtable dispatch (pc=0 in the
+         * tombstone). When the context isn't bound to us, the call
+         * is also unnecessary — skip it. */
+        if (eglGetCurrentContext() == ctx->egl_context && ctx->egl_context != EGL_NO_CONTEXT) {
+            eglMakeCurrent(ctx->egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+        }
         if (ctx->egl_surface != EGL_NO_SURFACE) {
             eglDestroySurface(ctx->egl_display, ctx->egl_surface);
             ctx->egl_surface = EGL_NO_SURFACE;

--- a/player/native/src/hw_render_gl_android.c
+++ b/player/native/src/hw_render_gl_android.c
@@ -155,19 +155,20 @@ void hw_gl_deinit(hw_gl_context_t *ctx) {
     if (!ctx || !ctx->initialized) return;
 
     if (ctx->egl_display != EGL_NO_DISPLAY) {
-        /* #907 — only release-from-current if our context is *still*
-         * the bound one on this thread. PPSSPP and similar HW-render
-         * cores spin up worker threads inside their context_destroy
-         * callback that do their own EGL bind/release dances; by the
-         * time we get here, the driver's "currently-bound context"
-         * tracking can be inconsistent. On Adreno, calling
-         * eglMakeCurrent(EGL_NO_CONTEXT) in that state crashes inside
-         * the GLES driver via a null vtable dispatch (pc=0 in the
-         * tombstone). When the context isn't bound to us, the call
-         * is also unnecessary — skip it. */
-        if (eglGetCurrentContext() == ctx->egl_context && ctx->egl_context != EGL_NO_CONTEXT) {
-            eglMakeCurrent(ctx->egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-        }
+        /* #907 — DO NOT call eglMakeCurrent(EGL_NO_CONTEXT). After a
+         * core's context_destroy callback runs (PPSSPP and other GLES
+         * HW-render cores spin up worker threads that bind/release
+         * EGL on their own), Adreno's driver-side "currently-bound
+         * context" cache is inconsistent. Calling release crashes
+         * inside libGLESv2_adreno via a null vtable dispatch — the
+         * exact tombstone pattern we hit twice while iterating on
+         * this fix. eglDestroyContext on a still-current context is
+         * well-defined per EGL spec (mark for deletion, free on
+         * release or thread exit); the emulation thread exits within
+         * seconds, so we're not leaking persistently.
+         *
+         * Surface destroy is independent and stays. Context destroy
+         * relies on the spec's mark-for-deletion semantics. */
         if (ctx->egl_surface != EGL_NO_SURFACE) {
             eglDestroySurface(ctx->egl_display, ctx->egl_surface);
             ctx->egl_surface = EGL_NO_SURFACE;

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -1069,17 +1069,23 @@ JNI_FUNC(void, nativeUnloadGame)(JNIEnv *env, jobject thiz) {
     /* Tear down OpenGL/GLES HW render context before unloading game */
     if (g_core.hw_render_enabled && g_core.hw_gl_ctx) {
         if (g_core.hw_render_callback.context_destroy) {
+            /* #907 — bind the context to SpelaEmulation so PPSSPP's
+             * GLRenderManager has a current context to do its
+             * teardown work against. Without this, PPSSPP's render
+             * thread blocks indefinitely waiting for a binding it
+             * can't acquire, and the whole teardown hangs.
+             *
+             * After context_destroy returns, Adreno's driver state
+             * for our binding is corrupted (PPSSPP's render thread
+             * released its own binding in a way that confuses the
+             * driver). We DON'T attempt to release SpelaEmulation's
+             * binding here — see hw_gl_deinit and the Kotlin-side
+             * thread-parking trick: the thread is parked forever
+             * after this, never exits, so pthread_exit's automatic
+             * eglReleaseThread (which would crash trying to clean
+             * up the corrupted binding) never runs. */
             hw_gl_make_current(g_core.hw_gl_ctx);
             g_core.hw_render_callback.context_destroy();
-            /* #907 — release the context immediately while EGL is in a
-             * known-clean state. PPSSPP's context_destroy spins up
-             * worker threads that do their own EGL bind/release
-             * dances; releasing here, on the emulation thread, before
-             * we hand off to hw_gl_destroy avoids a stage where the
-             * driver's "currently-bound context" pointer references a
-             * partially-released context (the trigger for the Adreno
-             * SIGSEGV at hw_gl_deinit's eglMakeCurrent). */
-            hw_gl_release_current(g_core.hw_gl_ctx);
         }
         hw_gl_destroy(g_core.hw_gl_ctx);
         g_core.hw_gl_ctx = NULL;
@@ -1133,15 +1139,14 @@ JNI_FUNC(void, nativeDeinit)(JNIEnv *env, jobject thiz) {
         gpu_renderer_hw_vulkan_deinit(g_gpu_renderer);
         g_core.hw_render_enabled = false;
     } else if (g_core.hw_gl_ctx) {
+        /* #907 — bind so PPSSPP's GLRenderManager has a current
+         * context for cleanup. We rely on Kotlin-side thread-parking
+         * to avoid the post-corruption pthread_exit crash; see the
+         * comment in nativeUnloadGame. */
         hw_gl_make_current(g_core.hw_gl_ctx);
         if (g_core.hw_render_callback.context_destroy) {
             g_core.hw_render_callback.context_destroy();
         }
-        /* #907 — same release-while-clean pattern as nativeUnloadGame's
-         * GL teardown path. Adreno's GLES driver crashes if we let
-         * hw_gl_deinit's eglMakeCurrent see a context whose state was
-         * partially torn down by the core's worker threads. */
-        hw_gl_release_current(g_core.hw_gl_ctx);
     }
 
     /* Step 2: retro_unload_game */

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -1071,6 +1071,15 @@ JNI_FUNC(void, nativeUnloadGame)(JNIEnv *env, jobject thiz) {
         if (g_core.hw_render_callback.context_destroy) {
             hw_gl_make_current(g_core.hw_gl_ctx);
             g_core.hw_render_callback.context_destroy();
+            /* #907 — release the context immediately while EGL is in a
+             * known-clean state. PPSSPP's context_destroy spins up
+             * worker threads that do their own EGL bind/release
+             * dances; releasing here, on the emulation thread, before
+             * we hand off to hw_gl_destroy avoids a stage where the
+             * driver's "currently-bound context" pointer references a
+             * partially-released context (the trigger for the Adreno
+             * SIGSEGV at hw_gl_deinit's eglMakeCurrent). */
+            hw_gl_release_current(g_core.hw_gl_ctx);
         }
         hw_gl_destroy(g_core.hw_gl_ctx);
         g_core.hw_gl_ctx = NULL;
@@ -1128,6 +1137,11 @@ JNI_FUNC(void, nativeDeinit)(JNIEnv *env, jobject thiz) {
         if (g_core.hw_render_callback.context_destroy) {
             g_core.hw_render_callback.context_destroy();
         }
+        /* #907 — same release-while-clean pattern as nativeUnloadGame's
+         * GL teardown path. Adreno's GLES driver crashes if we let
+         * hw_gl_deinit's eglMakeCurrent see a context whose state was
+         * partially torn down by the core's worker threads. */
+        hw_gl_release_current(g_core.hw_gl_ctx);
     }
 
     /* Step 2: retro_unload_game */

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
@@ -10,6 +10,7 @@ import com.spela.player.netplay.NetplayInputBuffer
 import com.spela.player.netplay.NetplayTransport
 import com.spela.player.presentation.viewmodel.LibretroController
 import com.spela.player.util.FileStorage
+import java.util.concurrent.CountDownLatch
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -67,6 +68,13 @@ class AndroidLibretroController(
     var vulkanSurfaceView: SurfaceView? = null
 
     private var emulationThread: Thread? = null
+    /**
+     * Latch the emulation thread counts down once
+     * nativeUnloadGame + nativeDeinit have completed. stop() waits on
+     * this instead of joining the thread, because the thread itself
+     * never exits — see #907.
+     */
+    private var teardownDoneLatch: CountDownLatch? = null
     private var targetFps = 60.0
 
     /* Frame timing for performance stats */
@@ -141,6 +149,8 @@ class AndroidLibretroController(
         lastPhysicalInputNanos = 0L
 
         val isNetplay = netplayTransport != null
+        val latch = CountDownLatch(1)
+        teardownDoneLatch = latch
         emulationThread = Thread({
             startAudio()
             if (isNetplay) {
@@ -151,13 +161,11 @@ class AndroidLibretroController(
             // Libretro contract (RetroArch's runloop_event_deinit_core,
             // see #724 research): retro_unload_game and retro_deinit must
             // run on the same thread that called retro_run. Calling them
-            // from stop()'s caller thread after thread.join() leaves
-            // cores like Play! PS2 and mupen64plus_next confused — the
-            // EGL "current context" is wrong, and worker threads inside
-            // the core look for synchronization with a thread that's
-            // gone. Run them here, as the emulation thread's last act
-            // before exiting; stop() picks up the join and finishes the
-            // GPU teardown afterwards.
+            // from stop()'s caller thread leaves cores like Play! PS2
+            // and mupen64plus_next confused — the EGL "current context"
+            // is wrong, and worker threads inside the core look for
+            // synchronization with a thread that's gone. Run them here,
+            // as the emulation thread's last act.
             try {
                 jni.nativeUnloadGame()
                 Log.i(TAG, "emulation thread: nativeUnloadGame complete")
@@ -169,6 +177,28 @@ class AndroidLibretroController(
                 Log.i(TAG, "emulation thread: nativeDeinit complete")
             } catch (t: Throwable) {
                 Log.e(TAG, "nativeDeinit on emulation thread failed", t)
+            }
+            // Signal stop() that teardown is done — it can proceed
+            // with frontend-side cleanup (audio, GPU, bitmaps).
+            latch.countDown()
+
+            // #907 — DO NOT exit this thread. PPSSPP's context_destroy
+            // poisons Adreno's per-thread EGL binding; pthread_exit's
+            // automatic eglReleaseThread (run by the EGL TLS
+            // destructor) tries to clean up that binding and crashes
+            // inside libGLESv2_adreno via a null vtable dispatch.
+            // Park the thread forever — no exit means no
+            // eglReleaseThread, no crash. The OS reclaims the stack
+            // when the process exits. Each game launch creates a
+            // new SpelaEmulation thread; old ones accumulate parked
+            // (one EGL binding + ~1MB stack each) but the trade-off
+            // is tolerable vs. a guaranteed crash on every exit.
+            try {
+                while (true) {
+                    Thread.sleep(Long.MAX_VALUE)
+                }
+            } catch (_: InterruptedException) {
+                // Allow process-shutdown signals to break the park.
             }
         }, "SpelaEmulation").apply {
             priority = Thread.MAX_PRIORITY
@@ -195,14 +225,18 @@ class AndroidLibretroController(
             req.latch.countDown()
         }
         netplayTransport?.disconnect()
-        // The emulation thread runs nativeUnloadGame + nativeDeinit as
-        // its final acts before exiting (see start()'s thread body). We
-        // wait for it to finish, then take down our frontend-side GPU
-        // resources. No timeout — heavy cores can spend tens of seconds
-        // in retro_unload_game / retro_deinit on slow devices.
-        emulationThread?.join()
-        Log.i(TAG, "emulation thread joined (libretro teardown complete)")
+        // The emulation thread runs nativeUnloadGame + nativeDeinit and
+        // signals teardownDoneLatch. We wait on the LATCH (not on the
+        // thread itself) — the thread parks forever after teardown to
+        // avoid the Adreno crash described in #907. No timeout — heavy
+        // cores can spend tens of seconds in retro_unload_game /
+        // retro_deinit on slow devices.
+        teardownDoneLatch?.await()
+        Log.i(TAG, "libretro teardown complete (thread parked)")
+        // Drop our reference; the thread is parked but still alive.
+        // The OS reclaims its stack when the process exits.
         emulationThread = null
+        teardownDoneLatch = null
         audioPlayer?.stop()
         audioPlayer = null
         clearNetplayMode()


### PR DESCRIPTION
Closes #907.

## What

Stops the PSP teardown SIGSEGV in libGLESv2_adreno by **never releasing the EGL context** on the emulation thread. After PPSSPP's `context_destroy` runs, the SpelaEmulation thread parks forever on `Thread.sleep(Long.MAX_VALUE)`; `stop()` waits on a CountDownLatch the thread signals once `retro_unload_game` + `retro_deinit` return.

## Why this approach

Earlier attempts (eglMakeCurrent guard, explicit release-from-current right after context_destroy) all hit the same Adreno bug: once PPSSPP's worker threads have run their internal EGL bind/release dance during `context_destroy`, the driver's per-thread "currently-bound context" cache is poisoned. **Any** release path on that thread crashes:

- explicit `eglMakeCurrent(EGL_NO_CONTEXT)` → SIGSEGV
- explicit `eglReleaseThread()` → SIGSEGV
- `pthread_exit` (auto-runs eglReleaseThread via the EGL TLS destructor) → SIGSEGV

Tombstones consistently showed `pc=0` inside libGLESv2_adreno during those release paths — a null-vtable dispatch in the driver's per-context cleanup. Removing all eglMakeCurrent release calls and parking the thread forever sidesteps the bug entirely: no release, no crash.

## Trade-off

Each PSP launch creates a fresh parked SpelaEmulation thread. PPSSPP's `context_destroy` does free the GPU resources it owns (textures/FBOs/programs), so the per-launch leak is bounded to ~1MB stack + the EGL context object. Multi-game PSP sessions still degrade — tracked as #916 (single persistent thread, Vulkan HW render, or dedicated emulation process are the candidate long-term fixes).

User-visible behaviour:

- One PSP game per session: works, no crash
- Multi-game PSP sessions: works for a few launches, then can stall on game load. Workaround: force-stop and relaunch the app.

## Files

- `player/native/src/libretro_bridge.c` — bind context before PPSSPP's `context_destroy`, no explicit release after
- `player/native/src/hw_render_gl_android.c` — `hw_gl_deinit` no longer calls `eglMakeCurrent(EGL_NO_CONTEXT)`; relies on EGL spec's mark-for-deletion semantics for the destroyed context
- `player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt` — emulation thread parks after teardown; `stop()` waits on CountDownLatch instead of `Thread.join()`

## Verification

- MGS Portable Ops: launch → play → exit → relaunch → resume save state works
- Tombstones: clean, no SIGSEGV in libGLESv2_adreno on PSP exit
