### PR TITLE
fix(server): wire PPSSPP system bundle into BIOS registry (#911)

### DIFF
--- a/server/internal/bios/downloader.go
+++ b/server/internal/bios/downloader.go
@@ -128,19 +128,22 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 			continue
 		}
 
-		// Ensure subdirectory exists for entries that need it
-		if entry.SubDir != "" {
-			if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
-				resp.Body.Close()
-				progress.Status = "failed"
-				progress.Error = fmt.Sprintf("creating subdirectory: %v", err)
-				result.Failed++
-				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
-				if onProgress != nil {
-					onProgress(progress)
-				}
-				continue
+		// Ensure the destination's parent directory exists. SubDir-style
+		// entries need this for `<biosDir>/<SubDir>/`; Bundle entries
+		// where FileName itself contains a relative path (e.g. the
+		// PPSSPP buildbot archive's `PPSSPP/ppge_atlas.zim` sentinel)
+		// also need it. Unconditional MkdirAll is harmless when the
+		// parent is already biosDir.
+		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+			resp.Body.Close()
+			progress.Status = "failed"
+			progress.Error = fmt.Sprintf("creating destination directory: %v", err)
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			if onProgress != nil {
+				onProgress(progress)
 			}
+			continue
 		}
 
 		// Write to .tmp file first

--- a/server/internal/bios/downloader_test.go
+++ b/server/internal/bios/downloader_test.go
@@ -331,6 +331,60 @@ func TestDownloadMissing_BundleSkipsWhenSentinelPresent(t *testing.T) {
 	assert.Equal(t, 0, calls, "should not hit the URL when sentinel is present")
 }
 
+// #911 — the real PPSSPP buildbot archive has every entry rooted under
+// `PPSSPP/`. The intended layout in biosDir is `<biosDir>/PPSSPP/...`,
+// so SubDir is left empty and FileName is the sentinel path relative
+// to biosDir (e.g. "PPSSPP/ppge_atlas.zim"). This exercise covers the
+// .tmp-parent mkdir for FileName-with-slashes + SubDir="".
+func TestDownloadMissing_BundleArchiveWithTopLevelDir(t *testing.T) {
+	biosDir := t.TempDir()
+	// Sentinel must be > 1KB to survive the downloader's
+	// partial-download heuristic on the second pass; pad it.
+	zipBytes := makeZipBytes(t, map[string][]byte{
+		"PPSSPP/ppge_atlas.zim":       bytes.Repeat([]byte{0xAB}, 2048),
+		"PPSSPP/flash0/font/ltn0.pgf": []byte("latin-bytes"),
+		"PPSSPP/lang/en_US.ini":       []byte("ui-strings"),
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(zipBytes)
+	}))
+	defer server.Close()
+
+	origRegistry := make([]Entry, len(registry))
+	copy(origRegistry, registry)
+	registry = []Entry{
+		{
+			ConsoleID:   "psp",
+			FileName:    "PPSSPP/ppge_atlas.zim",
+			Description: "PPSSPP bundle (top-level dir)",
+			Required:    true,
+			OverrideURL: server.URL,
+			Bundle:      true,
+		},
+	}
+	defer func() { registry = origRegistry }()
+
+	result := DownloadMissing(biosDir, "http://unused", nil)
+	assert.Equal(t, 1, result.Downloaded)
+	assert.Equal(t, 0, result.Failed, "errors: %v", result.Errors)
+
+	for _, rel := range []string{
+		"PPSSPP/ppge_atlas.zim",
+		"PPSSPP/flash0/font/ltn0.pgf",
+		"PPSSPP/lang/en_US.ini",
+	} {
+		path := filepath.Join(biosDir, filepath.FromSlash(rel))
+		_, err := os.Stat(path)
+		require.NoError(t, err, "expected extracted file at %s", path)
+	}
+
+	// Sentinel is one of the extracted files, so a second pass skips.
+	result2 := DownloadMissing(biosDir, "http://unused", nil)
+	assert.Equal(t, 1, result2.Skipped)
+	assert.Equal(t, 0, result2.Downloaded)
+}
+
 func TestDownloadMissing_BundleRefusesZipSlip(t *testing.T) {
 	biosDir := t.TempDir()
 	// Malicious archive — entry name escapes the dest dir.

--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -137,20 +137,29 @@ var registry = []Entry{
 
 	// PlayStation Portable (PSP) — ppsspp_libretro.info.
 	//
-	// PPSSPP needs `ppge_atlas.zim` under `<system_dir>/PPSSPP/` to
-	// render its own UI overlays; the canonical MD5 is published in
-	// the libretro core-info notes for this core. Without it games
-	// often launch but the in-engine UI / pause overlay shows
-	// missing glyphs.
+	// PPSSPP wants a directory tree under `<system_dir>/PPSSPP/`:
+	//   - `ppge_atlas.zim` — UI overlay atlas (without it, in-engine
+	//     pause / settings overlays render missing glyphs)
+	//   - `flash0/` — PSP system fonts (every game with text uses these)
+	//   - `lang/` — UI localisation strings
+	//   - `vfpu/`, `shaders/`, atlas .zim/.meta pairs, gamecontrollerdb,
+	//     compat.ini, etc. — runtime assets the core looks up
 	//
-	// PPSSPP also wants a `flash0/` directory of system fonts and a
-	// `lang/` directory of UI localisation files under the same
-	// `PPSSPP/` parent. Those are directory trees rather than single
-	// files, so they don't fit the current per-file registry shape;
-	// tracked separately in #906 follow-up so a future
-	// "bundle / extract" path can drop them in cleanly without
-	// turning every font into its own row.
-	{ConsoleID: "psp", FileName: "ppge_atlas.zim", Description: "PPSSPP Data ROM (UI atlas)", MD5: "866855cc330b9b95cc69135fb7b41d38", Required: true, SubDir: "PPSSPP"},
+	// Source: libretro's buildbot publishes a single canonical zip at
+	// `https://buildbot.libretro.com/assets/system/PPSSPP.zip` (this is
+	// what RetroArch's "Core System Files Downloader" pulls). Archive
+	// is rooted at `PPSSPP/`, so SubDir is left empty and FileName
+	// names the sentinel path relative to biosDir — extraction lays
+	// the tree at `<biosDir>/PPSSPP/...` directly.
+	//
+	// MD5 is intentionally unset on bundle entries: the archive's
+	// contents shift between PPSSPP releases (font tweaks, new
+	// languages); pinning the hash would lock us to one buildbot
+	// snapshot. The archive's own integrity is implicitly checked by
+	// the unzip step.
+	//
+	// Closes #911.
+	{ConsoleID: "psp", FileName: "PPSSPP/ppge_atlas.zim", Description: "PPSSPP system assets (atlas, fonts, lang)", Required: true, OverrideURL: "https://buildbot.libretro.com/assets/system/PPSSPP.zip", Bundle: true},
 
 	// Magnavox Odyssey 2 / Philips Videopac (O2) — o2em_libretro.info.
 	// o2rom.bin is required by the core to boot any cartridge; the

--- a/server/internal/bios/registry_test.go
+++ b/server/internal/bios/registry_test.go
@@ -133,19 +133,23 @@ func TestFds_DisksysMD5(t *testing.T) {
 	t.Fatal("fds/disksys.rom not found")
 }
 
-// PSP — ppge_atlas.zim is required and must land in the PPSSPP/
-// subdir for the libretro core to find it. Lock the published MD5.
-// See #906.
-func TestPsp_PpgeAtlasZim(t *testing.T) {
+// PSP — system assets are delivered as a single libretro buildbot
+// archive that extracts a `PPSSPP/` tree (atlas + flash0/font + lang/
+// + vfpu/ + fonts + ini) into biosDir. The sentinel is the atlas
+// file inside the bundle. See #911.
+func TestPsp_AssetsBundle(t *testing.T) {
 	for _, e := range ByConsole("psp") {
-		if e.FileName == "ppge_atlas.zim" {
-			assert.True(t, e.Required, "ppge_atlas.zim must be required")
-			assert.Equal(t, "866855cc330b9b95cc69135fb7b41d38", e.MD5)
-			assert.Equal(t, "PPSSPP", e.SubDir)
+		if e.FileName == "PPSSPP/ppge_atlas.zim" {
+			assert.True(t, e.Required, "PSP assets bundle must be required")
+			assert.True(t, e.Bundle, "PSP entry must be a Bundle")
+			assert.Equal(t, "https://buildbot.libretro.com/assets/system/PPSSPP.zip", e.OverrideURL)
+			// SubDir intentionally empty — archive's own top-level
+			// `PPSSPP/` matches the desired layout in biosDir.
+			assert.Equal(t, "", e.SubDir)
 			return
 		}
 	}
-	t.Fatal("psp/ppge_atlas.zim not found")
+	t.Fatal("psp assets bundle not found")
 }
 
 func TestRepoFolder(t *testing.T) {


### PR DESCRIPTION
Closes #911.

## What

Replaces the registry's single-file `ppge_atlas.zim` entry with a Bundle entry pointing at libretro's canonical PPSSPP system archive:

- **Source**: `https://buildbot.libretro.com/assets/system/PPSSPP.zip` — 10.8MB, 193 files. Same archive RetroArch's "Core System Files Downloader" pulls.
- **Sentinel**: `<biosDir>/PPSSPP/ppge_atlas.zim` (one of the extracted files; survives the existing "is installed?" check).
- **Layout**: archive is rooted at `PPSSPP/`, which matches the desired tree in `<biosDir>/PPSSPP/...`, so `SubDir` is empty and `FileName` is the sentinel path relative to biosDir.

After install, `<biosDir>/PPSSPP/` contains:
- `ppge_atlas.zim` + `font_atlas.zim` + `asciifont_atlas.zim` (UI atlases)
- `Roboto_Condensed-*.ttf` + `Inconsolata-Regular.ttf` (PPSSPP's replacement fonts for memory-card / save-dialog overlays)
- `flash0/font/*.pgf` (PSP system fonts — full Latin/JP/KR set)
- `lang/*.ini` (UI localisation, ~50 languages)
- `vfpu/*.dat` (VFPU math LUTs)
- `compat.ini`, `gamecontrollerdb.txt`, `themes/`, `shaders/`, etc.

## Why

Tested on AYN Thor with Metal Gear Solid: in-engine save creation rendered missing glyphs in the PSP OS overlay because PPSSPP's runtime fonts (Roboto_Condensed family + Inconsolata) weren't on disk. The single-file `ppge_atlas.zim` entry only covered the UI atlas; everything else PPSSPP needs at runtime — including its built-in font replacements — was missing.

Per [libretro PPSSPP docs](https://docs.libretro.com/library/ppsspp/#bios), this archive is the canonical install for system files.

## Infrastructure tweak

Bundle entries with `SubDir=""` need parent-mkdir for FileName-with-slashes (e.g. `PPSSPP/ppge_atlas.zim`). Removed the `if entry.SubDir != ""` gate on the .tmp parent mkdir — `os.MkdirAll(filepath.Dir(destPath), 0755)` is harmless when the parent is already biosDir.

## Tests

- `TestDownloadMissing_BundleArchiveWithTopLevelDir` — new test mirroring the real archive shape (entries rooted at `PPSSPP/`, SubDir empty), verifies the mkdir path and sentinel-skip on the second pass.
- `TestPsp_PpgeAtlasZim` → renamed to `TestPsp_AssetsBundle`, asserts the new entry shape.
- All other bios tests still green.

Refs #906 (single-file slice — superseded by this).