### PR TITLE
fix(server): use StripPrefix for PPSSPP bundle, fix missing-BIOS UI (#911)

### DIFF
--- a/server/internal/api/bios_handler_test.go
+++ b/server/internal/api/bios_handler_test.go
@@ -213,6 +213,56 @@ func TestListBiosFiles_ConsoleSummary_NotRequired(t *testing.T) {
 	assert.False(t, gbaConsole.BiosRequired)
 }
 
+// #911 regression — PSP entry is a Bundle with SubDir="PPSSPP" and
+// StripPrefix; the sentinel lands at <biosDir>/PPSSPP/ppge_atlas.zim
+// after the buildbot archive is extracted. Earlier shapes that put
+// the path inside FileName ("PPSSPP/ppge_atlas.zim" with empty
+// SubDir) tripped the listing endpoint into reporting "missing" even
+// when the file was on disk — the flat-dir lookup missed it and the
+// Stat fallback was gated on SubDir!="". Lock the present-status
+// behaviour for the canonical PSP entry shape.
+func TestListBiosFiles_BundleEntry_PresentUnderSubDir(t *testing.T) {
+	store, database, router := setupBiosTestEnv(t)
+	token := createBiosTestUser(t, database, "user")
+
+	pspDir := filepath.Join(store.BiosDir, "PPSSPP")
+	require.NoError(t, os.MkdirAll(pspDir, 0755))
+	// Sentinel must be > 1KB so the size heuristic doesn't flag it.
+	require.NoError(t, os.WriteFile(filepath.Join(pspDir, "ppge_atlas.zim"), bytes.Repeat([]byte{0xAB}, 2048), 0644))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/bios", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp BiosListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var psp *BiosFileResponse
+	for i, f := range resp.Files {
+		if f.Name == "ppge_atlas.zim" && f.ConsoleID != nil && *f.ConsoleID == "psp" {
+			psp = &resp.Files[i]
+			break
+		}
+	}
+	require.NotNil(t, psp, "PSP bundle entry should appear in /api/bios with FileName=ppge_atlas.zim")
+	assert.NotEqual(t, "missing", psp.Status, "sentinel under SubDir must not be reported as missing")
+	assert.Equal(t, "PPSSPP", psp.SubDir)
+
+	var pspConsole *ConsoleBiosStatus
+	for i, cs := range resp.Consoles {
+		if cs.ConsoleID == "psp" {
+			pspConsole = &resp.Consoles[i]
+			break
+		}
+	}
+	require.NotNil(t, pspConsole)
+	assert.Equal(t, 1, pspConsole.RequiredPresent, "PSP required count should report 1/1 with sentinel on disk")
+	assert.Equal(t, 1, pspConsole.RequiredTotal)
+}
+
 func TestListBiosFiles_RequiresAuth(t *testing.T) {
 	_, _, router := setupBiosTestEnv(t)
 

--- a/server/internal/bios/downloader.go
+++ b/server/internal/bios/downloader.go
@@ -217,7 +217,7 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 				}
 				continue
 			}
-			if err := extractZipBundle(tmpPath, extractRoot); err != nil {
+			if err := extractZipBundle(tmpPath, extractRoot, entry.StripPrefix); err != nil {
 				// Best-effort cleanup of any partial files written
 				// before the failure so the bundle isn't half-
 				// installed. We don't try to undo every extracted
@@ -298,11 +298,18 @@ func StartAutoDownload(biosDir string, database *gorm.DB) {
 // preserving the archive's relative directory structure. Used by the
 // Bundle path in [DownloadMissing] (#911).
 //
+// When stripPrefix is non-empty, archive entries that start with that
+// prefix have it removed before being joined onto destDir; entries
+// that don't start with the prefix are skipped. Used to drop a
+// wrapper directory baked into archives like the libretro PPSSPP
+// buildbot zip (rooted at `PPSSPP/`) so its contents land at
+// `<destDir>/...` rather than `<destDir>/PPSSPP/...`.
+//
 // Refuses to write outside destDir (defends against zip-slip — an
 // archive entry whose name resolves to "../etc/passwd" can't escape
 // the BIOS dir). Symlinks inside the archive are skipped, not
 // followed, for the same reason.
-func extractZipBundle(archivePath, destDir string) error {
+func extractZipBundle(archivePath, destDir, stripPrefix string) error {
 	r, err := zip.OpenReader(archivePath)
 	if err != nil {
 		return fmt.Errorf("opening archive: %w", err)
@@ -320,7 +327,22 @@ func extractZipBundle(archivePath, destDir string) error {
 			return fmt.Errorf("archive entry has unsafe path: %q", zf.Name)
 		}
 
-		target := filepath.Join(destDir, filepath.FromSlash(zf.Name))
+		name := zf.Name
+		if stripPrefix != "" {
+			if !strings.HasPrefix(name, stripPrefix) {
+				// Archive contains files outside the wrapper we
+				// expect — skip rather than spilling them next to
+				// SubDir.
+				continue
+			}
+			name = strings.TrimPrefix(name, stripPrefix)
+			if name == "" {
+				// The prefix directory entry itself.
+				continue
+			}
+		}
+
+		target := filepath.Join(destDir, filepath.FromSlash(name))
 		absTarget, err := filepath.Abs(target)
 		if err != nil {
 			return fmt.Errorf("resolving target: %w", err)

--- a/server/internal/bios/downloader_test.go
+++ b/server/internal/bios/downloader_test.go
@@ -336,7 +336,7 @@ func TestDownloadMissing_BundleSkipsWhenSentinelPresent(t *testing.T) {
 // so SubDir is left empty and FileName is the sentinel path relative
 // to biosDir (e.g. "PPSSPP/ppge_atlas.zim"). This exercise covers the
 // .tmp-parent mkdir for FileName-with-slashes + SubDir="".
-func TestDownloadMissing_BundleArchiveWithTopLevelDir(t *testing.T) {
+func TestDownloadMissing_BundleStripsArchivePrefix(t *testing.T) {
 	biosDir := t.TempDir()
 	// Sentinel must be > 1KB to survive the downloader's
 	// partial-download heuristic on the second pass; pad it.
@@ -356,11 +356,13 @@ func TestDownloadMissing_BundleArchiveWithTopLevelDir(t *testing.T) {
 	registry = []Entry{
 		{
 			ConsoleID:   "psp",
-			FileName:    "PPSSPP/ppge_atlas.zim",
-			Description: "PPSSPP bundle (top-level dir)",
+			FileName:    "ppge_atlas.zim",
+			Description: "PPSSPP bundle (StripPrefix)",
 			Required:    true,
+			SubDir:      "PPSSPP",
 			OverrideURL: server.URL,
 			Bundle:      true,
+			StripPrefix: "PPSSPP/",
 		},
 	}
 	defer func() { registry = origRegistry }()
@@ -369,6 +371,9 @@ func TestDownloadMissing_BundleArchiveWithTopLevelDir(t *testing.T) {
 	assert.Equal(t, 1, result.Downloaded)
 	assert.Equal(t, 0, result.Failed, "errors: %v", result.Errors)
 
+	// Each archive entry's PPSSPP/ wrapper is stripped, then placed
+	// under SubDir — net result is the same `<biosDir>/PPSSPP/...`
+	// layout, but FileName stays clean and the Stat path matches.
 	for _, rel := range []string{
 		"PPSSPP/ppge_atlas.zim",
 		"PPSSPP/flash0/font/ltn0.pgf",
@@ -379,10 +384,60 @@ func TestDownloadMissing_BundleArchiveWithTopLevelDir(t *testing.T) {
 		require.NoError(t, err, "expected extracted file at %s", path)
 	}
 
+	// No PPSSPP/PPSSPP doubled directory.
+	_, err := os.Stat(filepath.Join(biosDir, "PPSSPP", "PPSSPP"))
+	assert.True(t, os.IsNotExist(err), "stripPrefix must not leave a doubled wrapper")
+
 	// Sentinel is one of the extracted files, so a second pass skips.
 	result2 := DownloadMissing(biosDir, "http://unused", nil)
 	assert.Equal(t, 1, result2.Skipped)
 	assert.Equal(t, 0, result2.Downloaded)
+}
+
+// Archive entries that don't start with StripPrefix are skipped — a
+// defensive choice so a mis-sourced archive can't spill files
+// outside SubDir.
+func TestDownloadMissing_BundleStripPrefixSkipsNonMatching(t *testing.T) {
+	biosDir := t.TempDir()
+	zipBytes := makeZipBytes(t, map[string][]byte{
+		"PPSSPP/ppge_atlas.zim": bytes.Repeat([]byte{0xAB}, 2048),
+		"unrelated/secret.txt":  []byte("should not land"),
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(zipBytes)
+	}))
+	defer server.Close()
+
+	origRegistry := make([]Entry, len(registry))
+	copy(origRegistry, registry)
+	registry = []Entry{
+		{
+			ConsoleID:   "psp",
+			FileName:    "ppge_atlas.zim",
+			Description: "PPSSPP bundle",
+			Required:    true,
+			SubDir:      "PPSSPP",
+			OverrideURL: server.URL,
+			Bundle:      true,
+			StripPrefix: "PPSSPP/",
+		},
+	}
+	defer func() { registry = origRegistry }()
+
+	result := DownloadMissing(biosDir, "http://unused", nil)
+	assert.Equal(t, 1, result.Downloaded)
+	assert.Equal(t, 0, result.Failed, "errors: %v", result.Errors)
+
+	_, err := os.Stat(filepath.Join(biosDir, "PPSSPP", "ppge_atlas.zim"))
+	require.NoError(t, err)
+
+	// The non-prefixed entry is dropped on the floor — never written
+	// anywhere on disk.
+	_, err = os.Stat(filepath.Join(biosDir, "unrelated", "secret.txt"))
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(biosDir, "PPSSPP", "unrelated", "secret.txt"))
+	assert.True(t, os.IsNotExist(err))
 }
 
 func TestDownloadMissing_BundleRefusesZipSlip(t *testing.T) {

--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -28,6 +28,18 @@ type Entry struct {
 	//
 	// See #911 for the PPSSPP flash0/lang/assets driver.
 	Bundle bool
+
+	// StripPrefix, when non-empty on a Bundle entry, drops that
+	// leading path prefix from each archive entry before joining
+	// it onto the extract root. Used for archives whose contents
+	// already sit under a wrapper directory matching SubDir — the
+	// libretro PPSSPP buildbot zip is rooted at `PPSSPP/`, and
+	// our SubDir is also `PPSSPP`, so without stripping we'd get
+	// `<biosDir>/PPSSPP/PPSSPP/...`. Archive entries that don't
+	// start with the prefix are skipped (a defensive choice — an
+	// archive with mixed contents would otherwise leak files
+	// outside SubDir).
+	StripPrefix string
 }
 
 // FilePath returns the path of this entry relative to the BIOS directory,
@@ -146,11 +158,13 @@ var registry = []Entry{
 	//     compat.ini, etc. — runtime assets the core looks up
 	//
 	// Source: libretro's buildbot publishes a single canonical zip at
-	// `https://buildbot.libretro.com/assets/system/PPSSPP.zip` (this is
-	// what RetroArch's "Core System Files Downloader" pulls). Archive
-	// is rooted at `PPSSPP/`, so SubDir is left empty and FileName
-	// names the sentinel path relative to biosDir — extraction lays
-	// the tree at `<biosDir>/PPSSPP/...` directly.
+	// `https://buildbot.libretro.com/assets/system/PPSSPP.zip` (this
+	// is what RetroArch's "Core System Files Downloader" pulls).
+	// Archive contents are rooted at `PPSSPP/`, which already matches
+	// the SubDir we want to extract into; StripPrefix drops the
+	// wrapper so we don't end up at `<biosDir>/PPSSPP/PPSSPP/...`.
+	// Sentinel is the atlas file, which lands at
+	// `<biosDir>/PPSSPP/ppge_atlas.zim` after extraction.
 	//
 	// MD5 is intentionally unset on bundle entries: the archive's
 	// contents shift between PPSSPP releases (font tweaks, new
@@ -159,7 +173,7 @@ var registry = []Entry{
 	// the unzip step.
 	//
 	// Closes #911.
-	{ConsoleID: "psp", FileName: "PPSSPP/ppge_atlas.zim", Description: "PPSSPP system assets (atlas, fonts, lang)", Required: true, OverrideURL: "https://buildbot.libretro.com/assets/system/PPSSPP.zip", Bundle: true},
+	{ConsoleID: "psp", FileName: "ppge_atlas.zim", Description: "PPSSPP system assets (atlas, fonts, lang)", Required: true, SubDir: "PPSSPP", OverrideURL: "https://buildbot.libretro.com/assets/system/PPSSPP.zip", Bundle: true, StripPrefix: "PPSSPP/"},
 
 	// Magnavox Odyssey 2 / Philips Videopac (O2) — o2em_libretro.info.
 	// o2rom.bin is required by the core to boot any cartridge; the

--- a/server/internal/bios/registry_test.go
+++ b/server/internal/bios/registry_test.go
@@ -134,18 +134,19 @@ func TestFds_DisksysMD5(t *testing.T) {
 }
 
 // PSP — system assets are delivered as a single libretro buildbot
-// archive that extracts a `PPSSPP/` tree (atlas + flash0/font + lang/
-// + vfpu/ + fonts + ini) into biosDir. The sentinel is the atlas
-// file inside the bundle. See #911.
+// archive (`PPSSPP/` wrapper containing atlas + flash0/font + lang/
+// + vfpu/ + fonts + ini). The wrapper matches our SubDir, so
+// StripPrefix drops it during extraction; FileName names a clean
+// sentinel that bios.ByFileName() can match for upload routing.
+// See #911.
 func TestPsp_AssetsBundle(t *testing.T) {
 	for _, e := range ByConsole("psp") {
-		if e.FileName == "PPSSPP/ppge_atlas.zim" {
+		if e.FileName == "ppge_atlas.zim" {
 			assert.True(t, e.Required, "PSP assets bundle must be required")
 			assert.True(t, e.Bundle, "PSP entry must be a Bundle")
 			assert.Equal(t, "https://buildbot.libretro.com/assets/system/PPSSPP.zip", e.OverrideURL)
-			// SubDir intentionally empty — archive's own top-level
-			// `PPSSPP/` matches the desired layout in biosDir.
-			assert.Equal(t, "", e.SubDir)
+			assert.Equal(t, "PPSSPP", e.SubDir)
+			assert.Equal(t, "PPSSPP/", e.StripPrefix)
 			return
 		}
 	}


### PR DESCRIPTION
Follow-up to PR #917 — the bundle entry shape baked the path into FileName, which broke the admin BIOS listing UI and upload routing.

## Symptoms (v0.0.225)

- Admin → BIOS Files screen: PSP "0/1 files present", `ppge_atlas.zim` shown as **missing** despite the file being on disk after auto-download
- Player app shows "BIOS required" warning when launching a PSP game
- UI label rendered as `PPSSPP/ppge_atlas.zim` (with slashes) instead of just the filename

## Root cause

`huma_bios.go` does a flat-dir lookup via `diskFiles[e.FileName]` first, then falls back to `os.Stat(fullPath)` only when `e.SubDir != ""`. The previous shape (`SubDir=""`, `FileName="PPSSPP/ppge_atlas.zim"`) hit neither path: not in the flat map, fallback gated off.

The path-in-FileName shape also breaks `bios.ByFileName("ppge_atlas.zim")` used for upload routing.

## Fix

New `StripPrefix string` field on `bios.Entry`. PPSSPP entry now matches every other registry row's shape:

```go
{ConsoleID: "psp", FileName: "ppge_atlas.zim", SubDir: "PPSSPP",
 OverrideURL: "https://buildbot.libretro.com/assets/system/PPSSPP.zip",
 Bundle: true, StripPrefix: "PPSSPP/", Required: true}
```

`extractZipBundle` drops the wrapper from each archive entry before joining onto the extract root, so the buildbot zip's `PPSSPP/` prefix doesn't double up. Archive entries that don't match the prefix are skipped — defence against a mis-sourced archive leaking files outside SubDir.

## Tests

- `TestDownloadMissing_BundleStripsArchivePrefix` — mirrors the real archive (entries rooted at `PPSSPP/`), asserts the layout + no doubled wrapper
- `TestDownloadMissing_BundleStripPrefixSkipsNonMatching` — non-prefixed entries are dropped
- `TestListBiosFiles_BundleEntry_PresentUnderSubDir` — **api-level regression** that would have caught the "0/1 missing despite file on disk" symptom
- `TestPsp_AssetsBundle` updated for the new shape

## Upgrade note

Users on v0.0.225 with the bundle already extracted will keep working — the file is at the same location on disk (`<biosDir>/PPSSPP/ppge_atlas.zim`); only the registry's view of it changes. No file deletion or re-download required.

Refs #911.