### PR TITLE
feat(server,player): sync BIOS bundles end-to-end (#911)

### DIFF
--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/BiosApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/BiosApi.kt
@@ -111,6 +111,38 @@ open class BiosApi : ApiClient {
 
 
     /**
+     * Download a BIOS bundle archive
+     * Streams a zip of `&lt;biosDir&gt;/&lt;SubDir&gt;/` for a Bundle registry entry. Clients unzip on the device. 404 when the entry isn&#39;t a Bundle or the SubDir hasn&#39;t been populated yet on the server. See #911.
+     * @param filename Sentinel filename of the bundle entry (matches registry FileName).
+     * @return void
+     */
+    open suspend fun downloadBiosArchive(filename: kotlin.String): HttpResponse<Unit> {
+
+        val localVariableAuthNames = listOf<String>()
+
+        val localVariableBody = 
+            io.ktor.client.utils.EmptyContent
+
+        val localVariableQuery = mutableMapOf<String, List<String>>()
+        val localVariableHeaders = mutableMapOf<String, String>()
+
+        val localVariableConfig = RequestConfig<kotlin.Any?>(
+            RequestMethod.GET,
+            "/api/bios/archive/{filename}".replace("{" + "filename" + "}", "$filename"),
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false,
+        )
+
+        return request(
+            localVariableConfig,
+            localVariableBody,
+            localVariableAuthNames
+        ).wrap()
+    }
+
+
+    /**
      * List BIOS files
      * Returns registry-driven BIOS file status plus per-console summaries.
      * @return BiosListResponse

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BiosFileResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BiosFileResponse.kt
@@ -23,6 +23,7 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param bundle 
  * @param consoleId 
  * @param consoleName 
  * @param description 
@@ -38,6 +39,8 @@ import kotlinx.serialization.encoding.*
 @Serializable
 
 data class BiosFileResponse (
+
+    @SerialName(value = "bundle") @Required val bundle: kotlin.Boolean,
 
     @SerialName(value = "consoleId") @Required val consoleId: kotlin.String?,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleFileStatus.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleFileStatus.kt
@@ -23,6 +23,7 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param bundle 
  * @param description 
  * @param fileName 
  * @param md5 
@@ -33,6 +34,8 @@ import kotlinx.serialization.encoding.*
 @Serializable
 
 data class ConsoleFileStatus (
+
+    @SerialName(value = "bundle") @Required val bundle: kotlin.Boolean,
 
     @SerialName(value = "description") @Required val description: kotlin.String,
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -824,6 +824,18 @@ class SpelaApiClient(
         return biosApi.downloadBios(filename).response.body<ByteArray>()
     }
 
+    /**
+     * Fetches a Bundle BIOS entry's archive — a zip of the
+     * `<biosDir>/<SubDir>/` tree on the server. Used by
+     * BiosRepository when a registry entry is flagged
+     * `bundle = true` (e.g. PPSSPP system assets — flash0 + lang +
+     * fonts + atlases). Caller unzips the bytes into the local
+     * `<biosDir>/<SubDir>/` to mirror the server's layout. See #911.
+     */
+    suspend fun downloadBiosArchive(filename: String): ByteArray {
+        return biosApi.downloadBiosArchive(filename).response.body<ByteArray>()
+    }
+
     // Cores
 
     suspend fun getAvailableCores(): List<com.spela.client.models.Core> {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/BiosRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/BiosRepository.kt
@@ -22,14 +22,25 @@ open class BiosRepository(
         for (file in serverFiles) {
             val localDir = if (!file.subDir.isNullOrEmpty()) "$biosDir/${file.subDir}" else biosDir
             val localPath = "$localDir/${file.name}"
-            if (!fileStorage.fileExists(localPath)) {
-                try {
-                    if (!file.subDir.isNullOrEmpty()) fileStorage.createDirectory(localDir)
+            if (fileStorage.fileExists(localPath)) continue
+            try {
+                if (!file.subDir.isNullOrEmpty()) fileStorage.createDirectory(localDir)
+                if (file.bundle) {
+                    // Bundle entries are a directory tree on the
+                    // server (PPSSPP system assets, etc.). Fetch
+                    // the whole tree as a zip and extract into
+                    // `<biosDir>/<SubDir>/`. The sentinel at
+                    // `localPath` lives somewhere inside the zip,
+                    // so this also satisfies the next pass's
+                    // fileExists check. See #911.
+                    val archive = apiClient.downloadBiosArchive(file.name)
+                    fileStorage.unzipBytesToDirectory(archive, localDir)
+                } else {
                     val data = apiClient.downloadBiosFile(file.name)
                     fileStorage.writeFile(localPath, data)
-                } catch (e: Exception) {
-                    println("[Bios] Failed to download ${file.name}: ${e.message}")
                 }
+            } catch (e: Exception) {
+                println("[Bios] Failed to download ${file.name}: ${e.message}")
             }
         }
     }
@@ -66,7 +77,7 @@ open class BiosRepository(
 
         val missingFiles = console.files
             .filter { it.required && it.status == "missing" }
-            .map { BiosMissingFile(it.fileName, it.description, it.required, it.subDir) }
+            .map { BiosMissingFile(it.fileName, it.description, it.required, it.subDir, it.bundle) }
 
         // Also check local files - some may have been synced already
         val localFiles = getLocalBiosFiles()
@@ -106,14 +117,18 @@ open class BiosRepository(
         for (missing in consoleStatus.missingFiles) {
             val localDir = if (!missing.subDir.isNullOrEmpty()) "$biosDir/${missing.subDir}" else biosDir
             val localPath = "$localDir/${missing.fileName}"
-            if (!fileStorage.fileExists(localPath)) {
-                try {
-                    if (!missing.subDir.isNullOrEmpty()) fileStorage.createDirectory(localDir)
+            if (fileStorage.fileExists(localPath)) continue
+            try {
+                if (!missing.subDir.isNullOrEmpty()) fileStorage.createDirectory(localDir)
+                if (missing.bundle) {
+                    val archive = apiClient.downloadBiosArchive(missing.fileName)
+                    fileStorage.unzipBytesToDirectory(archive, localDir)
+                } else {
                     val data = apiClient.downloadBiosFile(missing.fileName)
                     fileStorage.writeFile(localPath, data)
-                } catch (e: Exception) {
-                    stillMissing.add(missing)
                 }
+            } catch (e: Exception) {
+                stillMissing.add(missing)
             }
         }
 
@@ -142,7 +157,7 @@ open class BiosRepository(
                         }
                         file.fileName !in localFiles && !fileStorage.fileExists(localPath)
                     }
-                    .map { BiosMissingFile(it.fileName, it.description, it.required, it.subDir) }
+                    .map { BiosMissingFile(it.fileName, it.description, it.required, it.subDir, it.bundle) }
 
                 if (missingFiles.isNotEmpty()) {
                     console.consoleId to BiosConsoleStatus(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -908,4 +908,5 @@ data class BiosMissingFile(
     val description: String,
     val required: Boolean,
     val subDir: String? = null,
+    val bundle: Boolean = false,
 )

--- a/server/internal/api/bios_handler_test.go
+++ b/server/internal/api/bios_handler_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"archive/zip"
 	"bytes"
 	"crypto/md5"
 	"encoding/hex"
@@ -261,6 +262,67 @@ func TestListBiosFiles_BundleEntry_PresentUnderSubDir(t *testing.T) {
 	require.NotNil(t, pspConsole)
 	assert.Equal(t, 1, pspConsole.RequiredPresent, "PSP required count should report 1/1 with sentinel on disk")
 	assert.Equal(t, 1, pspConsole.RequiredTotal)
+}
+
+// #911 — clients downloading a Bundle entry fetch a zip of the
+// SubDir tree rather than a single file. Build the SubDir on disk,
+// hit the archive endpoint, assert the response is a valid zip
+// containing the files we placed.
+func TestDownloadBiosArchive_StreamsZipOfSubDir(t *testing.T) {
+	store, database, router := setupBiosTestEnv(t)
+	token := createBiosTestUser(t, database, "user")
+
+	pspDir := filepath.Join(store.BiosDir, "PPSSPP")
+	require.NoError(t, os.MkdirAll(filepath.Join(pspDir, "flash0", "font"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pspDir, "ppge_atlas.zim"), bytes.Repeat([]byte{0xAB}, 2048), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(pspDir, "flash0", "font", "ltn0.pgf"), []byte("font-data"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(pspDir, "Roboto_Condensed-Regular.ttf"), bytes.Repeat([]byte{0xCD}, 1024), 0644))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/bios/archive/ppge_atlas.zim", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	assert.Equal(t, "application/zip", w.Header().Get("Content-Type"))
+
+	zr, err := zip.NewReader(bytes.NewReader(w.Body.Bytes()), int64(w.Body.Len()))
+	require.NoError(t, err)
+
+	got := make(map[string]int)
+	for _, f := range zr.File {
+		got[f.Name] = int(f.UncompressedSize64)
+	}
+	assert.Equal(t, 2048, got["ppge_atlas.zim"])
+	assert.Equal(t, len("font-data"), got["flash0/font/ltn0.pgf"])
+	assert.Equal(t, 1024, got["Roboto_Condensed-Regular.ttf"])
+}
+
+func TestDownloadBiosArchive_404WhenNotBundle(t *testing.T) {
+	_, database, router := setupBiosTestEnv(t)
+	token := createBiosTestUser(t, database, "user")
+
+	w := httptest.NewRecorder()
+	// scph5501 is a single-file PSX BIOS, not a bundle.
+	req := httptest.NewRequest("GET", "/api/bios/archive/scph5501.bin", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestDownloadBiosArchive_404WhenSubDirMissing(t *testing.T) {
+	_, database, router := setupBiosTestEnv(t)
+	token := createBiosTestUser(t, database, "user")
+
+	// PSP entry is a bundle but the SubDir hasn't been populated on this
+	// fresh test env — the endpoint should 404, not 500 or empty zip.
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/bios/archive/ppge_atlas.zim", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestListBiosFiles_RequiresAuth(t *testing.T) {

--- a/server/internal/api/huma_bios.go
+++ b/server/internal/api/huma_bios.go
@@ -144,6 +144,7 @@ func (h *BiosHandler) HumaListBiosFiles(_ context.Context, _ *ListBiosFilesInput
 				Description: &desc,
 				Required:    e.Required,
 				Status:      "missing",
+				Bundle:      e.Bundle,
 			})
 			continue
 		}
@@ -172,6 +173,7 @@ func (h *BiosHandler) HumaListBiosFiles(_ context.Context, _ *ListBiosFilesInput
 			Description: &desc,
 			Required:    e.Required,
 			Status:      status,
+			Bundle:      e.Bundle,
 		})
 	}
 
@@ -256,6 +258,7 @@ func (h *BiosHandler) HumaListBiosFiles(_ context.Context, _ *ListBiosFilesInput
 				MD5:         e.MD5,
 				Status:      status,
 				SubDir:      e.SubDir,
+				Bundle:      e.Bundle,
 			})
 		}
 

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"archive/zip"
 	"context"
 	"fmt"
 	"io"
@@ -63,6 +64,60 @@ func streamSaveFromDisk(absPath, downloadName, compression string) *huma.StreamR
 	}
 }
 
+// streamBundleAsZip walks rootDir and streams a zip of every regular
+// file under it (paths inside the zip are relative to rootDir, with
+// forward slashes). Used by the BIOS bundle download endpoint (#911)
+// to ship a Bundle entry's extracted directory tree as a single
+// archive the client can unzip on its end.
+//
+// We re-zip on every request rather than caching: the bundle is small
+// (PPSSPP is ~10MB raw, ~zip), single-digit clients per server, and
+// the alternative (keep the originally-fetched archive on disk
+// alongside the extracted tree) doubles disk usage and adds a
+// staleness window when the bundle is re-downloaded.
+func streamBundleAsZip(rootDir, downloadFileName string) *huma.StreamResponse {
+	return &huma.StreamResponse{
+		Body: func(hctx huma.Context) {
+			hctx.SetHeader("Content-Type", "application/zip")
+			hctx.SetHeader("Content-Disposition", fmt.Sprintf("attachment; filename=%q", downloadFileName+".zip"))
+
+			zw := zip.NewWriter(hctx.BodyWriter())
+			defer zw.Close()
+
+			err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, walkErr error) error {
+				if walkErr != nil {
+					return walkErr
+				}
+				if d.IsDir() {
+					return nil
+				}
+				if !d.Type().IsRegular() {
+					return nil
+				}
+				rel, err := filepath.Rel(rootDir, path)
+				if err != nil {
+					return err
+				}
+				zipName := filepath.ToSlash(rel)
+				zfw, err := zw.Create(zipName)
+				if err != nil {
+					return err
+				}
+				f, err := os.Open(path)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				_, err = io.Copy(zfw, f)
+				return err
+			})
+			if err != nil {
+				slog.Warn("bundle stream walk failed", "root", rootDir, "err", err)
+			}
+		},
+	}
+}
+
 // streamBytesInline returns a huma.StreamResponse that writes the given bytes
 // inline (no Content-Disposition — the browser renders them directly,
 // typical for console icons / logos). Used by endpoints that serve embedded
@@ -89,6 +144,14 @@ type CoreDownloadInput struct {
 // BiosDownloadInput is the input for GET /api/bios/{filename}.
 type BiosDownloadInput struct {
 	Filename string `path:"filename" doc:"BIOS file name."`
+}
+
+// BiosArchiveDownloadInput is the input for GET /api/bios/archive/{filename}.
+// Filename matches the registry entry's FileName for a Bundle entry; the
+// server returns a zip of `<biosDir>/<SubDir>/` so the client can extract
+// the directory tree on the device.
+type BiosArchiveDownloadInput struct {
+	Filename string `path:"filename" doc:"Sentinel filename of the bundle entry (matches registry FileName)."`
 }
 
 // SessionSaveDownloadInput is the input for GET /api/sessions/{id}/saves/{saveId}.
@@ -226,6 +289,17 @@ func RegisterDownloadRoutes(
 		Middlewares: authedMW,
 		Security:    sec,
 	}, biosH.HumaDownloadBios)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "downloadBiosArchive",
+		Method:      http.MethodGet,
+		Path:        "/api/bios/archive/{filename}",
+		Summary:     "Download a BIOS bundle archive",
+		Description: "Streams a zip of `<biosDir>/<SubDir>/` for a Bundle registry entry. Clients unzip on the device. 404 when the entry isn't a Bundle or the SubDir hasn't been populated yet on the server. See #911.",
+		Tags:        []string{"bios"},
+		Middlewares: authedMW,
+		Security:    sec,
+	}, biosH.HumaDownloadBiosArchive)
 
 	huma.Register(api, huma.Operation{
 		OperationID: "downloadSessionSave",
@@ -478,6 +552,56 @@ func (h *CoreHandler) HumaDownloadCore(_ context.Context, in *CoreDownloadInput)
 	h.ensureCoreMetadata(&core, corePath)
 
 	return streamFileFromDisk(corePath, core.Name+"_libretro"+ext, "application/octet-stream"), nil
+}
+
+// HumaDownloadBiosArchive is the huma implementation of
+// GET /api/bios/archive/{filename}. For a Bundle registry entry whose
+// FileName matches the path parameter, it streams a zip of the
+// `<biosDir>/<SubDir>/` tree so the client can extract on the device.
+// 404 when the entry isn't a Bundle, the registry doesn't know it, or
+// the SubDir on disk is empty (i.e. the bundle hasn't been
+// downloaded/extracted yet on the server).
+func (h *BiosHandler) HumaDownloadBiosArchive(_ context.Context, in *BiosArchiveDownloadInput) (*huma.StreamResponse, error) {
+	matches := bios.ByFileName(in.Filename)
+	var entry *bios.Entry
+	for i := range matches {
+		if matches[i].Bundle {
+			cp := matches[i]
+			entry = &cp
+			break
+		}
+	}
+	if entry == nil {
+		return nil, huma.Error404NotFound("no bundle entry registered for this filename")
+	}
+
+	subDir := entry.SubDir
+	if subDir == "" {
+		// Defensive — every current Bundle entry sets SubDir, but if
+		// one didn't we'd be exposing the entire BIOS dir which we
+		// never want to do.
+		return nil, huma.Error404NotFound("bundle entry has no SubDir")
+	}
+
+	rootDir := filepath.Join(h.Storage.BiosDir, filepath.FromSlash(subDir))
+	info, err := os.Stat(rootDir)
+	if err != nil || !info.IsDir() {
+		return nil, huma.Error404NotFound("bundle not extracted on server")
+	}
+
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("internal error")
+	}
+	absBios, err := filepath.Abs(h.Storage.BiosDir)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("internal error")
+	}
+	if !strings.HasPrefix(absRoot, absBios+string(filepath.Separator)) {
+		return nil, huma.Error403Forbidden("access denied")
+	}
+
+	return streamBundleAsZip(absRoot, in.Filename), nil
 }
 
 // HumaDownloadBios is the huma implementation of GET /api/bios/{filename}.

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -1367,6 +1367,15 @@ type BiosFileResponse struct {
 	Description *string `json:"description"`
 	Required    bool    `json:"required"`
 	Status      string  `json:"status"` // "valid", "present", "invalid", "missing"
+
+	// Bundle marks an entry whose payload on the server is a directory
+	// tree (e.g. PPSSPP system assets — flash0/lang/atlases/fonts).
+	// Clients can't fetch this with the per-file
+	// `GET /api/bios/{filename}` endpoint; they call
+	// `GET /api/bios/archive/{filename}` instead, which returns a zip
+	// of `<biosDir>/<SubDir>/` for the entry to be extracted on the
+	// device. See #911.
+	Bundle bool `json:"bundle"`
 }
 
 // ConsoleFileStatus represents a single BIOS file within a console summary.
@@ -1375,8 +1384,9 @@ type ConsoleFileStatus struct {
 	Description string `json:"description"`
 	Required    bool   `json:"required"`
 	MD5         string `json:"md5"`
-	Status      string `json:"status"`           // "valid", "present", "invalid", "missing"
+	Status      string `json:"status"` // "valid", "present", "invalid", "missing"
 	SubDir      string `json:"subDir"` // subdirectory within system_dir
+	Bundle      bool   `json:"bundle"` // payload is an extracted directory tree, not a single file (#911)
 }
 
 // ConsoleBiosStatus represents the BIOS status summary for one console.

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -1033,6 +1033,9 @@
             "readOnly": true,
             "type": "string"
           },
+          "bundle": {
+            "type": "boolean"
+          },
           "consoleId": {
             "type": [
               "string",
@@ -1084,7 +1087,8 @@
           "consoleName",
           "description",
           "required",
-          "status"
+          "status",
+          "bundle"
         ],
         "type": "object"
       },
@@ -1814,6 +1818,9 @@
       "ConsoleFileStatus": {
         "additionalProperties": false,
         "properties": {
+          "bundle": {
+            "type": "boolean"
+          },
           "description": {
             "type": "string"
           },
@@ -1839,7 +1846,8 @@
           "required",
           "md5",
           "status",
-          "subDir"
+          "subDir",
+          "bundle"
         ],
         "type": "object"
       },
@@ -13819,6 +13827,48 @@
           }
         ],
         "summary": "List BIOS files",
+        "tags": [
+          "bios"
+        ]
+      }
+    },
+    "/api/bios/archive/{filename}": {
+      "get": {
+        "description": "Streams a zip of `\u003cbiosDir\u003e/\u003cSubDir\u003e/` for a Bundle registry entry. Clients unzip on the device. 404 when the entry isn't a Bundle or the SubDir hasn't been populated yet on the server. See #911.",
+        "operationId": "downloadBiosArchive",
+        "parameters": [
+          {
+            "description": "Sentinel filename of the bundle entry (matches registry FileName).",
+            "in": "path",
+            "name": "filename",
+            "required": true,
+            "schema": {
+              "description": "Sentinel filename of the bundle entry (matches registry FileName).",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Download a BIOS bundle archive",
         "tags": [
           "bios"
         ]


### PR DESCRIPTION
Closes the missing-glyphs symptom in PSP games — third and final slice of #911.

## Background

PR #917 added the PPSSPP system bundle on the server, and PR #920 fixed the admin "missing BIOS" UI. But the player's `BiosRepository.syncBiosFiles()` only fetches one file per registry entry — for PPSSPP that's just `ppge_atlas.zim`. The other 192 files in the bundle (flash0 fonts, lang/, Roboto fallback fonts, atlases, vfpu LUTs) never reached the device, so PPSSPP rendered the in-game OS save dialogs without any glyphs. In some games (MGS Portable Ops) the dialog body itself didn't appear because the UI atlases were missing.

Verified the diagnosis on AYN Thor by manually `adb push`-ing the bundle into `/data/data/com.spela.player/files/bios/PPSSPP/` and watching MGS save dialogs render correctly.

## Server changes

- `BiosFileResponse` + `ConsoleFileStatus` JSON gain a `bundle` bool so clients can tell which entries need archive download
- New `GET /api/bios/archive/{filename}` endpoint streams a zip of `<biosDir>/<SubDir>/` for a Bundle entry. Re-zips on each request — single-digit clients per server, ~10MB archive, simpler than tracking a parallel cache against a tree the bundle downloader can rewrite

## Player changes

- `BiosRepository.syncBiosFiles` (and the `preLaunchBiosCheck` path): when `file.bundle == true`, call `apiClient.downloadBiosArchive` and `unzipBytesToDirectory` into the entry's local SubDir. Sentinel ends up extracted as part of the tree, so the next sync pass sees it on disk and skips
- `BiosMissingFile` carries the `bundle` flag through `getConsoleStatus` so the pre-launch sync also takes the right path
- Regenerated the kotlin OpenAPI client (BiosApi gets `downloadBiosArchive`, BiosFileResponse + ConsoleFileStatus get `bundle`)

## Tests

- `TestDownloadBiosArchive_StreamsZipOfSubDir` — happy path; build flash0/font + Roboto on disk, fetch archive, parse zip, assert each entry round-trips with right size
- `TestDownloadBiosArchive_404WhenNotBundle` — single-file entries don't expose the archive endpoint
- `TestDownloadBiosArchive_404WhenSubDirMissing` — endpoint reports not-found rather than streaming an empty zip when the bundle hasn't been extracted yet on the server

Existing bios + bios-listing api tests still pass.

## Manual verification path

1. Server has bundle extracted (auto-download from libretro buildbot — already deployed in v0.0.225/226)
2. Player launches → sync runs → fetches `/api/bios/archive/ppge_atlas.zim` → gets ~10MB zip → unzips into `<files>/bios/PPSSPP/`
3. PSP game launches with full asset tree → OS save dialogs render correctly

Refs #911.