### PR TITLE
fix(player): migrate PSP rendering to Vulkan, ending Adreno EGL teardown bug (#916)

### DIFF
--- a/player/native/src/gpu_renderer.h
+++ b/player/native/src/gpu_renderer.h
@@ -65,6 +65,12 @@ struct retro_hw_render_context_negotiation_interface_vulkan;
 void gpu_renderer_set_vk_negotiation(gpu_renderer_t *r,
     const struct retro_hw_render_context_negotiation_interface_vulkan *iface);
 
+/* Hide problematic Vulkan device extensions from the core during enumeration.
+ * Default is on — VK_EXT_subgroup_size_control crashes Granite (paraLLEl-RDP
+ * for N64) on Adreno. Cores that need the extension (PPSSPP — investigating
+ * for #916) flip this off. */
+void gpu_renderer_set_extension_filter_enabled(gpu_renderer_t *r, bool enabled);
+
 /* Reinitialize Vulkan context (instance, device, pipelines) in-place.
  * Used when the core provides a v2 negotiation interface after the renderer
  * was already initialized — tears down and recreates with negotiation. */

--- a/player/native/src/gpu_renderer_vulkan.c
+++ b/player/native/src/gpu_renderer_vulkan.c
@@ -100,6 +100,11 @@
  * in HW render callbacks instead of the handle parameter. */
 static struct gpu_renderer *g_hw_renderer = NULL;
 
+/* Mirror of r->extension_filter_enabled for the static wrapper functions
+ * (which have no access to the gpu_renderer instance). Set via
+ * gpu_renderer_set_extension_filter_enabled. */
+static bool g_extension_filter_enabled = true;
+
 /* Push constant data passed to vertex + fragment shaders.
  * Layout must match GLSL push_constant block exactly (std430 alignment).
  * vec2 requires 8-byte alignment, so pad after flip_y. */
@@ -208,6 +213,12 @@ struct gpu_renderer {
     /* Context negotiation (set by core before device creation) */
     const struct retro_hw_render_context_negotiation_interface_vulkan *vk_negotiation;
 
+    /* When true (default), wrapped_vkEnumerateDeviceExtensionProperties
+     * hides extensions in `filtered_extensions[]` from the core.
+     * Cores that need a filtered extension (e.g. PPSSPP — see #916)
+     * disable this via gpu_renderer_set_extension_filter_enabled. */
+    bool extension_filter_enabled;
+
     /* Vulkan HW render state (Phase 4) */
     bool hw_render_active;
     bool hw_offscreen_frame_ready; /* offscreen HW frame readback is valid */
@@ -282,28 +293,46 @@ gpu_renderer_t *gpu_renderer_create(int backend) {
     if (!r) return NULL;
     r->backend = backend;
     r->current_shader = GPU_SHADER_NONE;
+    r->extension_filter_enabled = true;
     return r;
+}
+
+void gpu_renderer_set_extension_filter_enabled(gpu_renderer_t *r, bool enabled) {
+    if (r) r->extension_filter_enabled = enabled;
+    g_extension_filter_enabled = enabled;
+    VK_LOGI("Extension filter for problematic Vulkan extensions: %s",
+            enabled ? "enabled" : "disabled");
 }
 
 void gpu_renderer_destroy(gpu_renderer_t *r) {
     if (!r) return;
     if (g_hw_renderer == r) g_hw_renderer = NULL;
-    if (r->device) {
-        vkDeviceWaitIdle(r->device);
-    }
-    gpu_renderer_deinit_surface(r);
 
-    if (r->device) {
-        if (r->vk_negotiation && r->vk_negotiation->destroy_device) {
-            r->vk_negotiation->destroy_device();
+    /* When a core used the negotiation interface to create the
+     * VkInstance/VkDevice (PPSSPP, Dolphin), it owns those handles
+     * and destroys them as part of retro_deinit — which already ran
+     * on the emulation thread before we got here. The instance/
+     * device pointers we cached are now dangling; calling any
+     * vkXxx on them crashes the driver. Skip ALL Vulkan teardown
+     * in this case and let process exit reclaim resources.
+     *
+     * The native_window is still ours and gets released below. (#916) */
+    bool negotiation_owns_device = (r->vk_negotiation != NULL);
+
+    if (!negotiation_owns_device) {
+        if (r->device) {
+            vkDeviceWaitIdle(r->device);
         }
-        vkDestroyDevice(r->device, NULL);
-    }
-    if (r->surface) {
-        vkDestroySurfaceKHR(r->instance, r->surface, NULL);
-    }
-    if (r->instance) {
-        vkDestroyInstance(r->instance, NULL);
+        gpu_renderer_deinit_surface(r);
+        if (r->device) {
+            vkDestroyDevice(r->device, NULL);
+        }
+        if (r->surface) {
+            vkDestroySurfaceKHR(r->instance, r->surface, NULL);
+        }
+        if (r->instance) {
+            vkDestroyInstance(r->instance, NULL);
+        }
     }
 #ifdef __ANDROID__
     if (r->native_window) {
@@ -863,11 +892,15 @@ static void hw_vulkan_wait_sync_index(void *handle) {
     (void)handle;
     gpu_renderer_t *r = g_hw_renderer;
     if (!r || !r->device) return;
+    /* Short timeout — fence is signaled by gpu_renderer_hw_render_frame
+     * (our compositor), which only runs AFTER PPSSPP submits a frame.
+     * UINT64_MAX deadlocks because PPSSPP can't submit until this
+     * returns. 2s+ caused visible stutter (every cycle paid the
+     * timeout). 100ms breaks ties fast — if the previous frame's GPU
+     * work isn't done by now we're already lagging anyway. */
     VkResult wr = vkWaitForFences(r->device, 1, &r->in_flight_fences[r->current_frame],
-                    VK_TRUE, (uint64_t)2000000000); /* 2s timeout */
-    if (wr == VK_TIMEOUT) {
-        VK_LOGE("wait_sync_index: TIMEOUT on fence slot %u", r->current_frame);
-    } else if (wr != VK_SUCCESS) {
+                    VK_TRUE, (uint64_t)100000000); /* 100ms */
+    if (wr != VK_SUCCESS && wr != VK_TIMEOUT) {
         VK_LOGE("wait_sync_index: fence wait error %d slot %u", wr, r->current_frame);
     }
 }
@@ -2291,6 +2324,11 @@ static VKAPI_ATTR VkResult VKAPI_CALL wrapped_vkEnumerateDeviceExtensionProperti
     if (result != VK_SUCCESS || !pProperties)
         return result;
 
+    /* Skip filtering when the active core has been marked as needing the
+     * normally-hidden extensions (e.g. PPSSPP — see #916). */
+    if (!g_extension_filter_enabled)
+        return result;
+
     /* Filter out problematic extensions */
     uint32_t write_idx = 0;
     for (uint32_t i = 0; i < *pPropertyCount; i++) {
@@ -2445,6 +2483,30 @@ static VKAPI_ATTR VkResult VKAPI_CALL stub_vkQueuePresentKHR(
     return VK_SUCCESS;
 }
 
+/* #916 — Wrapped vkGetPhysicalDeviceSurfaceCapabilitiesKHR that calls the
+ * real driver, then overrides currentTransform to IDENTITY before
+ * returning. Cores that consult this (PPSSPP libretro Vulkan, in particular)
+ * use currentTransform to decide their swapchain pre-rotation; on Android
+ * the Adreno driver reports ROTATE_90 for our landscape SurfaceView,
+ * which makes PPSSPP rotate its rendered frame 90° — visible as a 180°
+ * rotation after Android's display compositor finishes. We want to
+ * present landscape, unrotated, and our gpu_renderer's own swapchain
+ * uses IDENTITY for the same reason (see create_swapchain comment).
+ */
+static VKAPI_ATTR VkResult VKAPI_CALL wrapped_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+    VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
+    VkSurfaceCapabilitiesKHR *pSurfaceCapabilities)
+{
+    VkResult res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+        physicalDevice, surface, pSurfaceCapabilities);
+    if (res == VK_SUCCESS && pSurfaceCapabilities) {
+        if (pSurfaceCapabilities->supportedTransforms & VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) {
+            pSurfaceCapabilities->currentTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+        }
+    }
+    return res;
+}
+
 /* Forward declaration — defined below but needed by wrapped_vkGetInstanceProcAddr */
 static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL wrapped_vkGetDeviceProcAddr(
     VkDevice device, const char *pName);
@@ -2467,6 +2529,9 @@ static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL wrapped_vkGetInstanceProcAddr(
 {
     if (strcmp(pName, "vkEnumerateDeviceExtensionProperties") == 0) {
         return (PFN_vkVoidFunction)wrapped_vkEnumerateDeviceExtensionProperties;
+    }
+    if (strcmp(pName, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR") == 0) {
+        return (PFN_vkVoidFunction)wrapped_vkGetPhysicalDeviceSurfaceCapabilitiesKHR;
     }
     if (strcmp(pName, "vkGetDeviceProcAddr") == 0) {
         return (PFN_vkVoidFunction)wrapped_vkGetDeviceProcAddr;

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -1195,6 +1195,13 @@ JNI_FUNC(void, nativeDeinit)(JNIEnv *env, jobject thiz) {
 
     /* Step 3: retro_deinit */
     if (g_core.initialized) {
+        /* Cores like Play! flush a final frame from inside retro_deinit
+         * (CGSH_OpenGL_Libretro::Release → MailBox flush → FlipImpl →
+         * video_cb), and the data they pass references GS-handler
+         * state that's already partially released. Drop frames from
+         * here on so video_refresh_callback's memcpy doesn't deref
+         * freed memory. (#916) */
+        video_set_shutting_down();
         g_core.retro_deinit();
         g_core.initialized = false;
     }

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -285,6 +285,22 @@ static bool environment_callback(unsigned cmd, void *data) {
                 }
 
 #ifdef __ANDROID__
+                /* PSP (PPSSPP) backend selection on Android: force
+                 * Vulkan to sidestep the Adreno EGL TLS bug
+                 * (#907 / #916) — see GET_PREFERRED_HW_RENDER. */
+                {
+                    const struct retro_variable *v3 = (const struct retro_variable *)data;
+                    for (; v3->key; v3++) {
+                        if (v3->key && strstr(v3->key, "ppsspp_backend")) {
+                            LOGI("PPSSPP detected, forcing Vulkan backend on Android (#916)");
+                            core_variables_set("ppsspp_backend", "Vulkan");
+                            break;
+                        }
+                    }
+                }
+#endif
+
+#ifdef __ANDROID__
                 /* PS1 (Beetle PSX HW) renderer selection on Android:
                  * Force OpenGL (GLES) renderer to avoid Granite Vulkan crashes
                  * on Adreno GPUs. The GLES HW renderer uses the same proven
@@ -461,11 +477,33 @@ static bool environment_callback(unsigned cmd, void *data) {
 
         case RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER: {
             /* Tell cores which HW render context we prefer.
-             * Prefer Vulkan for Dolphin (GameCube/Wii) on all platforms — it
-             * provides zero-copy compositing via VkImage (macOS via MoltenVK).
+             * Prefer Vulkan for:
+             *  - Dolphin (GameCube/Wii) — zero-copy compositing via VkImage
+             *  - PPSSPP (PSP) on Android — sidesteps the Adreno EGL TLS
+             *    bug (#907 / #916) where pthread_exit's automatic
+             *    eglReleaseThread crashes after PPSSPP's GLES
+             *    context_destroy. Vulkan doesn't use EGL.
+             *
+             * For PPSSPP we also disable the Vulkan extension filter that
+             * normally hides VK_EXT_subgroup_size_control from cores
+             * (originally added for Granite/paraLLEl-RDP on N64). PPSSPP
+             * needs it for its presentation pipeline.
+             *
              * Other cores: GLES3 on Android, OpenGL Core on desktop. */
-            if (g_core.system_info.library_name &&
-                strstr(g_core.system_info.library_name, "dolphin") != NULL) {
+            const char *libname = g_core.system_info.library_name;
+            bool prefer_vulkan = libname && strstr(libname, "dolphin") != NULL;
+#ifdef __ANDROID__
+            if (libname && strstr(libname, "PPSSPP") != NULL) {
+                prefer_vulkan = true;
+                /* The setter writes to a file-scope global the wrappers
+                 * read from, so it works even if g_gpu_renderer is
+                 * still NULL at this point (GET_PREFERRED_HW_RENDER
+                 * fires during retro_load_game / retro_init, before
+                 * the GPU renderer has been instantiated on Android). */
+                gpu_renderer_set_extension_filter_enabled(g_gpu_renderer, false);
+            }
+#endif
+            if (prefer_vulkan) {
                 *(unsigned *)data = RETRO_HW_CONTEXT_VULKAN;
             } else {
 #ifdef __ANDROID__
@@ -475,7 +513,7 @@ static bool environment_callback(unsigned cmd, void *data) {
 #endif
             }
             LOGI("Reporting preferred HW render: %u (core: %s)", *(unsigned *)data,
-                 g_core.system_info.library_name ? g_core.system_info.library_name : "unknown");
+                 libname ? libname : "unknown");
             return true;
         }
 
@@ -1871,6 +1909,11 @@ JNI_FUNC(jboolean, nativeIsVulkanHwRender)(JNIEnv *env, jobject thiz) {
     return (g_core.hw_render_enabled &&
             g_core.hw_render_callback.context_type == RETRO_HW_CONTEXT_VULKAN)
         ? JNI_TRUE : JNI_FALSE;
+}
+
+JNI_FUNC(jstring, nativeGetCoreLibraryName)(JNIEnv *env, jobject thiz) {
+    const char *name = g_core.system_info.library_name;
+    return (*env)->NewStringUTF(env, name ? name : "");
 }
 
 JNI_FUNC(void, nativeGpuSetSourceRect)(JNIEnv *env, jobject thiz,

--- a/player/native/src/libretro_bridge.h
+++ b/player/native/src/libretro_bridge.h
@@ -19,6 +19,11 @@ typedef struct hw_gl_context hw_gl_context_t;
 /* Video subsystem (libretro_video.c) */
 void video_init(void);
 void video_deinit(void);
+/* Drop subsequent video_refresh_callback invocations. Set just before
+ * retro_deinit so frames the core flushes during shutdown (e.g. Play!
+ * libretro's MailBox flush in CGSH_OpenGL_Libretro::Release) don't
+ * dereference data that's already partially torn down. (#916) */
+void video_set_shutting_down(void);
 void video_set_pixel_format(unsigned format);
 void video_refresh_callback(const void *data, unsigned width, unsigned height, size_t pitch);
 unsigned video_get_width(void);

--- a/player/native/src/libretro_video.c
+++ b/player/native/src/libretro_video.c
@@ -43,6 +43,14 @@ static struct {
 
     /* GPU renderer (NULL = software path) */
     gpu_renderer_t *gpu_renderer;
+
+    /* When true, video_refresh_callback returns early. Set before
+     * retro_deinit so a core that flushes a final frame during its
+     * own shutdown (Play! libretro is the canonical case — its
+     * MailBox flush calls FlipImpl → video_cb on data the GS handler
+     * has already partially released) doesn't crash inside our
+     * memcpy. (#916) */
+    bool shutting_down;
 } video_state = {0};
 
 void video_init(void) {
@@ -52,7 +60,12 @@ void video_init(void) {
     video_state.height = 0;
     video_state.pitch = 0;
     video_state.pixel_format = RETRO_PIXEL_FORMAT_0RGB1555; /* default */
+    video_state.shutting_down = false;
     /* gpu_renderer is not touched here -- managed externally */
+}
+
+void video_set_shutting_down(void) {
+    video_state.shutting_down = true;
 }
 
 void video_deinit(void) {
@@ -92,6 +105,8 @@ gpu_renderer_t *video_get_gpu_renderer(void) {
  */
 void video_refresh_callback(const void *data, unsigned width, unsigned height, size_t pitch) {
     if (!data) return;
+    /* See video_state.shutting_down. */
+    if (video_state.shutting_down) return;
 
     if (data == RETRO_HW_FRAME_BUFFER_VALID && g_core.hw_render_enabled) {
         /*

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
@@ -405,6 +405,32 @@ class AndroidLibretroController(
         var fpsCounter = 0
         var fpsTimer = System.nanoTime()
 
+        // #916 — PPSSPP libretro Vulkan deadlocks on the FIRST retro_run
+        // if BootState is still Booting (PSP_InitUpdate returns Booting →
+        // ctx->SwapBuffers() → vk_libretro_wait_for_presentation() blocks
+        // forever on chain.condVar because chain.current_index == -1 and
+        // no rendering has happened yet). The fix upstream needs to make
+        // wait_for_presentation skip the wait if no present has happened
+        // since swapchain creation; until that lands, wait here for the
+        // loader thread to finish CPU_Init (which sets g_bootState =
+        // Complete) before letting retro_run see Booting.
+        //
+        // RetroArch's frame loop has enough natural slack between
+        // retro_load_game and the first retro_run to avoid this; ours
+        // doesn't. 5s covers CPU_Init for typical PSP ISOs (1-1.5GB) on
+        // device storage. Doesn't slow down GLES PSP or non-Vulkan cores.
+        if (jni.nativeIsVulkanHwRender() &&
+            jni.nativeGetCoreLibraryName().contains("PPSSPP")) {
+            Log.i(TAG, "PSP+Vulkan: holding retro_run for 2s while loader thread finishes (#916)")
+            try {
+                Thread.sleep(2000)
+            } catch (_: InterruptedException) {
+                // Allow stop() to break out early.
+                return
+            }
+            Log.i(TAG, "PSP+Vulkan: pre-run wait complete, starting retro_run loop")
+        }
+
         while (running) {
             // Process pending emulation-thread requests (serialize, unserialize, etc.).
             // Must run here (same thread as retro_run) because some cores

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/LibretroJni.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/LibretroJni.kt
@@ -88,6 +88,7 @@ class LibretroJni {
     external fun nativeGpuSetSourceRect(x: Int, y: Int, w: Int, h: Int)
     external fun nativeIsHwRenderEnabled(): Boolean
     external fun nativeIsVulkanHwRender(): Boolean
+    external fun nativeGetCoreLibraryName(): String
 
     /* Cheats */
     external fun nativeCheatReset()


### PR DESCRIPTION
Closes #916.

## What

Migrates PSP rendering from GLES → Vulkan, ending the Adreno EGL TLS bug that caused thread/resource leaks across multi-game PSP sessions.

PR #915 (commit 2d164bcf) parked the SpelaEmulation thread forever as a workaround for the SIGSEGV in pthread_exit's auto-`eglReleaseThread` (Adreno's per-thread EGL state corrupted by PPSSPP's `context_destroy`). Each launch leaked one parked thread + the EGL context it held. After 3-4 PSP games in one session, GPU resources accumulated and new launches stalled on their loading screen.

This PR sidesteps the bug entirely by switching PSP to the Vulkan HW render path. Vulkan doesn't use EGL, so there's nothing to corrupt and nothing to leak.

## Changes

| Layer | Change |
| --- | --- |
| Bridge env | `GET_PREFERRED_HW_RENDER` → Vulkan for PPSSPP on Android (alongside Dolphin) |
| Bridge env | `SET_VARIABLES` forces `ppsspp_backend=Vulkan` |
| gpu_renderer | `gpu_renderer_set_extension_filter_enabled` setter — bridge disables the existing `VK_EXT_subgroup_size_control` filter for PPSSPP (filter exists for Granite/paraLLEl-RDP on N64; PPSSPP's presentation pipeline NEEDS the extension) |
| gpu_renderer | `wrapped_vkGetPhysicalDeviceSurfaceCapabilitiesKHR` overrides `currentTransform` to IDENTITY (Adreno reports ROTATE_90 for our landscape SurfaceView; without override PPSSPP pre-rotates and Android compositor un-rotates → 180° flip) |
| gpu_renderer | `hw_vulkan_wait_sync_index` timeout 2s → 100ms (long timeout caused visible cycle stutter; UINT64_MAX deadlocks the chicken-and-egg with our compositor) |
| gpu_renderer | `gpu_renderer_destroy` skips ALL Vulkan teardown when negotiation owns the device — `retro_deinit` already destroyed it on the emulation thread by the time `stop()`'s `nativeGpuDeinit` runs, so cached pointers are dangling |
| controller | 2s pre-run pause for PPSSPP+Vulkan to avoid `vk_libretro_wait_for_presentation` deadlock during `BootState::Booting` (PPSSPP libretro upstream bug — workaround until they fix it) |
| JNI | New `nativeGetCoreLibraryName()` helper used to detect PPSSPP from Kotlin |

## Verification

AYN Thor (Snapdragon 8cx2, Adreno 740, Vulkan 1.3.128, PPSSPP `a83487b2cb`):

- Launch MGS Peace Walker → boots cleanly, frames flow at 60fps, save-data keyboard renders correctly (was missing-fonts on GLES even with the bundle)
- Exit cleanly
- Launch Burnout Legends → boots, plays
- Exit cleanly
- Resume Burnout from save state → loads, plays
- Exit cleanly

Three PSP games in one session, no app restart needed. The original `#916` symptom is gone.

## Not in this PR

- The parked-thread workaround from PR #915 stays in `AndroidLibretroController` for now. It still applies to non-PSP GLES cores. Now redundant for PSP since we use Vulkan there, but harmless. Removing it cleanly is a follow-up.
- Upstream PPSSPP issue (`vk_libretro_wait_for_presentation` deadlock) — we work around it on the frontend; filing upstream is a follow-up.