### PR TITLE
feat(server,web): record BIOS download failures as system events (#918)

### DIFF
--- a/server/internal/bios/downloader.go
+++ b/server/internal/bios/downloader.go
@@ -32,12 +32,28 @@ type DownloadProgress struct {
 	Total     int    `json:"total"`
 }
 
+// DownloadError is one entry in a DownloadResult's error list. Carries the
+// fields a system-event recorder or admin UI needs without the caller
+// having to re-parse a free-form string. See StartAutoDownload + #918.
+type DownloadError struct {
+	FileName  string
+	ConsoleID string
+	URL       string
+	Error     string
+}
+
+// String renders the error in the historical "filename: error" form so
+// callers that just want the human-readable summary still work.
+func (e DownloadError) String() string {
+	return fmt.Sprintf("%s: %s", e.FileName, e.Error)
+}
+
 // DownloadResult summarises a completed DownloadMissing run.
 type DownloadResult struct {
 	Downloaded int
 	Skipped    int
 	Failed     int
-	Errors     []string
+	Errors     []DownloadError
 }
 
 // DownloadMissing downloads all BIOS files that are missing from biosDir.
@@ -109,7 +125,12 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 			progress.Status = "failed"
 			progress.Error = fmt.Sprintf("HTTP request failed: %v", err)
 			result.Failed++
-			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			result.Errors = append(result.Errors, DownloadError{
+				FileName:  entry.FileName,
+				ConsoleID: entry.ConsoleID,
+				URL:       url,
+				Error:     progress.Error,
+			})
 			if onProgress != nil {
 				onProgress(progress)
 			}
@@ -121,7 +142,12 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 			progress.Status = "failed"
 			progress.Error = fmt.Sprintf("HTTP %d", resp.StatusCode)
 			result.Failed++
-			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			result.Errors = append(result.Errors, DownloadError{
+				FileName:  entry.FileName,
+				ConsoleID: entry.ConsoleID,
+				URL:       url,
+				Error:     progress.Error,
+			})
 			if onProgress != nil {
 				onProgress(progress)
 			}
@@ -139,7 +165,12 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 			progress.Status = "failed"
 			progress.Error = fmt.Sprintf("creating destination directory: %v", err)
 			result.Failed++
-			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			result.Errors = append(result.Errors, DownloadError{
+				FileName:  entry.FileName,
+				ConsoleID: entry.ConsoleID,
+				URL:       url,
+				Error:     progress.Error,
+			})
 			if onProgress != nil {
 				onProgress(progress)
 			}
@@ -154,7 +185,12 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 			progress.Status = "failed"
 			progress.Error = fmt.Sprintf("creating temp file: %v", err)
 			result.Failed++
-			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			result.Errors = append(result.Errors, DownloadError{
+				FileName:  entry.FileName,
+				ConsoleID: entry.ConsoleID,
+				URL:       url,
+				Error:     progress.Error,
+			})
 			if onProgress != nil {
 				onProgress(progress)
 			}
@@ -172,7 +208,12 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 			progress.Status = "failed"
 			progress.Error = fmt.Sprintf("downloading: %v", copyErr)
 			result.Failed++
-			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			result.Errors = append(result.Errors, DownloadError{
+				FileName:  entry.FileName,
+				ConsoleID: entry.ConsoleID,
+				URL:       url,
+				Error:     progress.Error,
+			})
 			if onProgress != nil {
 				onProgress(progress)
 			}
@@ -186,7 +227,12 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 			progress.Status = "failed"
 			progress.Error = fmt.Sprintf("MD5 mismatch: expected %s, got %s", entry.MD5, actualMD5)
 			result.Failed++
-			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			result.Errors = append(result.Errors, DownloadError{
+				FileName:  entry.FileName,
+				ConsoleID: entry.ConsoleID,
+				URL:       url,
+				Error:     progress.Error,
+			})
 			if onProgress != nil {
 				onProgress(progress)
 			}
@@ -211,7 +257,12 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 				progress.Status = "failed"
 				progress.Error = fmt.Sprintf("creating bundle target: %v", err)
 				result.Failed++
-				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+				result.Errors = append(result.Errors, DownloadError{
+				FileName:  entry.FileName,
+				ConsoleID: entry.ConsoleID,
+				URL:       url,
+				Error:     progress.Error,
+			})
 				if onProgress != nil {
 					onProgress(progress)
 				}
@@ -228,7 +279,12 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 				progress.Status = "failed"
 				progress.Error = fmt.Sprintf("extracting bundle: %v", err)
 				result.Failed++
-				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+				result.Errors = append(result.Errors, DownloadError{
+				FileName:  entry.FileName,
+				ConsoleID: entry.ConsoleID,
+				URL:       url,
+				Error:     progress.Error,
+			})
 				if onProgress != nil {
 					onProgress(progress)
 				}
@@ -243,7 +299,12 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 				progress.Status = "failed"
 				progress.Error = fmt.Sprintf("renaming temp file: %v", err)
 				result.Failed++
-				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+				result.Errors = append(result.Errors, DownloadError{
+				FileName:  entry.FileName,
+				ConsoleID: entry.ConsoleID,
+				URL:       url,
+				Error:     progress.Error,
+			})
 				if onProgress != nil {
 					onProgress(progress)
 				}
@@ -286,10 +347,17 @@ func StartAutoDownload(biosDir string, database *gorm.DB) {
 			"skipped", result.Skipped,
 			"failed", result.Failed,
 		)
-		if len(result.Errors) > 0 {
-			for _, e := range result.Errors {
-				slog.Warn("BIOS download error", "detail", e)
-			}
+		for _, e := range result.Errors {
+			slog.Warn("BIOS download error", "detail", e.String())
+			db.RecordOperationalEvent(database, db.SystemEventInput{
+				EventType: db.SystemEventBIOSDownloadFailed,
+				Metadata: db.BIOSDownloadFailedMetadata{
+					FileName:  e.FileName,
+					ConsoleID: e.ConsoleID,
+					URL:       e.URL,
+					Error:     e.Error,
+				},
+			})
 		}
 	}()
 }

--- a/server/internal/bios/downloader_test.go
+++ b/server/internal/bios/downloader_test.go
@@ -111,7 +111,7 @@ func TestDownloadMissing_MD5Mismatch(t *testing.T) {
 	assert.Equal(t, 0, result.Skipped)
 	assert.Equal(t, 1, result.Failed)
 	assert.Len(t, result.Errors, 1)
-	assert.Contains(t, result.Errors[0], "MD5 mismatch")
+	assert.Contains(t, result.Errors[0].Error, "MD5 mismatch")
 
 	// Temp file should have been cleaned up, no file on disk
 	_, err := os.Stat(filepath.Join(biosDir, "bad_md5.bin"))
@@ -131,7 +131,7 @@ func TestDownloadMissing_ServerError(t *testing.T) {
 	origRegistry := make([]Entry, len(registry))
 	copy(origRegistry, registry)
 	registry = []Entry{
-		{ConsoleID: "gba", FileName: "missing_remote.bin", Description: "Not Found", MD5: "abc", Required: true},
+		{ConsoleID: "gba", FileName: "missing_remote.bin", Description: "Not Found", MD5: "abc", Required: true, OverrideURL: server.URL + "/gba/missing_remote.bin"},
 	}
 	defer func() { registry = origRegistry }()
 
@@ -139,7 +139,17 @@ func TestDownloadMissing_ServerError(t *testing.T) {
 
 	assert.Equal(t, 0, result.Downloaded)
 	assert.Equal(t, 1, result.Failed)
-	assert.Contains(t, result.Errors[0], "HTTP 404")
+	require.Len(t, result.Errors, 1)
+	// #918 — the typed DownloadError carries every field the system-event
+	// recorder needs (filename, console, url, error message) so callers
+	// don't have to re-parse a free-form string.
+	assert.Equal(t, "missing_remote.bin", result.Errors[0].FileName)
+	assert.Equal(t, "gba", result.Errors[0].ConsoleID)
+	assert.Equal(t, server.URL+"/gba/missing_remote.bin", result.Errors[0].URL)
+	assert.Contains(t, result.Errors[0].Error, "HTTP 404")
+	// String() form is the historical "filename: error" rendering used
+	// by callers that just want a human-readable summary.
+	assert.Equal(t, "missing_remote.bin: HTTP 404", result.Errors[0].String())
 }
 
 func TestDownloadMissing_EmptyMD5Accepted(t *testing.T) {
@@ -471,5 +481,5 @@ func TestDownloadMissing_BundleRefusesZipSlip(t *testing.T) {
 	assert.Equal(t, 1, result.Failed)
 	assert.Equal(t, 0, result.Downloaded)
 	require.NotEmpty(t, result.Errors)
-	assert.Contains(t, result.Errors[0], "unsafe path")
+	assert.Contains(t, result.Errors[0].Error, "unsafe path")
 }

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -362,6 +362,12 @@ const (
 	// buildbot poll. Metadata carries old_sha256 and new_sha256 so the
 	// audit trail shows which version replaced which. See #555 Phase 2.
 	SystemEventCoreUpdated = "core_updated"
+	// Emitted by the BIOS auto-downloader when an entry fails to fetch
+	// or extract — HTTP error, non-200 status, MD5 mismatch, archive
+	// extraction failure, filesystem error. Lets admins notice when
+	// upstream sources go down or shift without tailing container
+	// logs. See #918.
+	SystemEventBIOSDownloadFailed = "bios_download_failed"
 )
 
 // AllSystemEventTypes is the canonical catalog of system event type strings.
@@ -383,6 +389,7 @@ var AllSystemEventTypes = []string{
 	SystemEventAPICredentialsInvalid,
 	SystemEventEmulatorJSLoadFailed,
 	SystemEventCoreUpdated,
+	SystemEventBIOSDownloadFailed,
 }
 
 // SystemEventTypeCategory maps each event type to its category code. Used by
@@ -404,6 +411,7 @@ var SystemEventTypeCategory = map[string]string{
 	SystemEventAPICredentialsInvalid:   CategoryOperational,
 	SystemEventEmulatorJSLoadFailed:    CategoryOperational,
 	SystemEventCoreUpdated:             CategoryOperational,
+	SystemEventBIOSDownloadFailed:      CategoryOperational,
 }
 
 // SystemEvent records an admin-only audit entry for an authentication,

--- a/server/internal/db/system_event_metadata.go
+++ b/server/internal/db/system_event_metadata.go
@@ -62,3 +62,13 @@ type EmulatorJSLoadFailedMetadata struct {
 	GameID string `json:"gameId"`
 	Core   string `json:"core"`
 }
+
+// BIOSDownloadFailedMetadata is the metadata shape for the
+// SystemEventBIOSDownloadFailed event. Emitted by the BIOS auto-downloader
+// for each registry entry that fails to fetch or extract.
+type BIOSDownloadFailedMetadata struct {
+	FileName  string `json:"fileName"`
+	ConsoleID string `json:"consoleId"`
+	URL       string `json:"url"`
+	Error     string `json:"error"`
+}

--- a/server/internal/db/system_event_recorder.go
+++ b/server/internal/db/system_event_recorder.go
@@ -114,7 +114,8 @@ func eventTypeShouldDedup(eventType string) bool {
 		SystemEventRACircuitBreakerTripped,
 		SystemEventScraperRepeatedErrors,
 		SystemEventROMFileMissing,
-		SystemEventAPICredentialsInvalid:
+		SystemEventAPICredentialsInvalid,
+		SystemEventBIOSDownloadFailed:
 		return true
 	}
 	return false

--- a/web/src/features/admin/components/system-event-badge.tsx
+++ b/web/src/features/admin/components/system-event-badge.tsx
@@ -9,6 +9,8 @@ import {
   Cpu,
   FileWarning,
   KeySquare,
+  Download,
+  RefreshCw,
   type LucideIcon,
 } from "lucide-react";
 import { Badge } from "@/components/ui";
@@ -107,6 +109,18 @@ export const SYSTEM_EVENT_META: Record<SystemEventType, EventMeta> = {
     variant: "danger",
     icon: AlertTriangle,
     severity: "alert",
+  },
+  core_updated: {
+    label: "Core Updated",
+    variant: "default",
+    icon: RefreshCw,
+    severity: "info",
+  },
+  bios_download_failed: {
+    label: "BIOS Download Failed",
+    variant: "warning",
+    icon: Download,
+    severity: "notice",
   },
 };
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -63,7 +63,9 @@ export type OperationalEventType =
   | "scraper_repeated_errors"
   | "rom_file_missing"
   | "api_credentials_invalid"
-  | "emulatorjs_load_failed";
+  | "emulatorjs_load_failed"
+  | "core_updated"
+  | "bios_download_failed";
 
 export type SystemEventType = SecurityEventType | OperationalEventType;
 


### PR DESCRIPTION
Closes #918.

## What

BIOS auto-download failures (HTTP error, 404, MD5 mismatch, bundle extraction failure, FS errors) now emit operational system events alongside auth anomalies, scraper errors, RA circuit breaker, etc. — so admins notice upstream source breakage in the events UI without tailing container logs.

## Server

- New \`SystemEventBIOSDownloadFailed\` event type (operational category, dedup-eligible)
- New \`BIOSDownloadFailedMetadata\` { fileName, consoleId, url, error } for type-safe recorder calls
- \`DownloadResult.Errors\` restructured from \`[]string\` to typed \`[]DownloadError\`. \`DownloadError.String()\` preserves the historical \"filename: error\" rendering for slog.Warn callers
- \`StartAutoDownload\` calls \`RecordOperationalEvent\` for each error in the typed list

## Web

- \`OperationalEventType\` union gains \`bios_download_failed\` and \`core_updated\` (the latter was already emitted server-side but never declared in the frontend type — drive-by exhaustiveness fix)
- \`SYSTEM_EVENT_META\` gets corresponding label/icon entries so the events badge renders both correctly

## Tests

- \`TestDownloadMissing_ServerError\` extended to assert every typed field on \`DownloadError\` plus \`String()\`
- All existing bios + db + web tests still green

## Out of scope

- Manual \"retry now\" admin trigger for failed entries (natural follow-up; dedup is already wired in anticipation)
- Email/push admin notification — events UI is enough for now