### PR TITLE
fix(web): WCAG AA contrast on light + colored themes (#919 phase 1)

### DIFF
--- a/web/src/features/game-detail/components/scrape-match-modal.tsx
+++ b/web/src/features/game-detail/components/scrape-match-modal.tsx
@@ -96,7 +96,7 @@ function ScrapeMatchContent({
   return (
     <div data-comp="ScrapeMatchContent" className="space-y-4">
       {fileName && (
-        <p className="text-sm text-surface-400 truncate" title={fileName}>
+        <p className="text-sm text-tertiary truncate" title={fileName}>
           ROM: <span className="text-surface-200 font-mono">{fileName}</span>
         </p>
       )}
@@ -133,8 +133,8 @@ function ScrapeMatchContent({
 
           {!isLoading && !isError && results && results.length === 0 && (
             <div className="flex flex-col items-center py-8">
-              <Search className="h-8 w-8 text-surface-600 mb-2" />
-              <p className="text-sm text-surface-400">
+              <Search className="h-8 w-8 text-disabled mb-2" />
+              <p className="text-sm text-tertiary">
                 No results found on IGDB
               </p>
             </div>
@@ -156,7 +156,7 @@ function ScrapeMatchContent({
             ))}
 
           {debouncedQuery.length < 2 && !isLoading && (
-            <p className="py-8 text-sm text-surface-500 text-center">
+            <p className="py-8 text-sm text-tertiary text-center">
               Type at least 2 characters to search
             </p>
           )}
@@ -215,19 +215,19 @@ function IgdbResultItem({
             <Loader2 className="h-4 w-4 text-brand-400 animate-spin flex-shrink-0" />
           )}
         </div>
-        <div className="flex items-center gap-2 text-xs text-surface-400">
+        <div className="flex items-center gap-2 text-xs text-tertiary">
           {result.releaseYear && <span>{result.releaseYear}</span>}
           {result.developer && (
             <>
               {result.releaseYear && (
-                <span className="text-surface-600">&middot;</span>
+                <span className="text-disabled">&middot;</span>
               )}
               <span className="truncate">{result.developer}</span>
             </>
           )}
         </div>
         {result.summary && (
-          <p className="text-xs text-surface-500 line-clamp-2">
+          <p className="text-xs text-tertiary line-clamp-2">
             {result.summary}
           </p>
         )}

--- a/web/src/features/preferences/components/controller-visual.tsx
+++ b/web/src/features/preferences/components/controller-visual.tsx
@@ -7,7 +7,7 @@ interface ControllerVisualProps {
 function KeyBadge({ label, keyName }: { label: string; keyName: string }) {
   return (
     <div data-comp="KeyBadge" className="flex items-center gap-2">
-      <span className="text-xs text-surface-400 w-20 text-right">{label}</span>
+      <span className="text-xs text-tertiary w-20 text-right">{label}</span>
       <span className="inline-flex items-center justify-center min-w-[2rem] px-1.5 py-0.5 rounded bg-surface-800 border border-surface-700 text-xs font-mono text-surface-200">
         {formatKeyName(keyName)}
       </span>
@@ -37,7 +37,7 @@ export function ControllerVisual({ mapping }: ControllerVisualProps) {
       <div className="flex justify-between items-center px-4">
         {/* D-pad */}
         <div className="flex flex-col items-center gap-0.5">
-          <span className="text-[10px] uppercase tracking-wider text-surface-500 mb-1">
+          <span className="text-[10px] uppercase tracking-wider text-secondary mb-1">
             D-Pad
           </span>
           <div className="grid grid-cols-3 gap-0.5 w-24">
@@ -65,7 +65,7 @@ export function ControllerVisual({ mapping }: ControllerVisualProps) {
         <div className="flex flex-col items-center gap-2">
           <div className="flex gap-3">
             <div className="text-center">
-              <span className="text-[10px] uppercase tracking-wider text-surface-500 block mb-1">
+              <span className="text-[10px] uppercase tracking-wider text-secondary block mb-1">
                 Select
               </span>
               <span className="inline-flex items-center justify-center min-w-[2.5rem] px-1.5 py-1 rounded bg-surface-800 border border-surface-700 text-xs font-mono text-surface-200">
@@ -73,7 +73,7 @@ export function ControllerVisual({ mapping }: ControllerVisualProps) {
               </span>
             </div>
             <div className="text-center">
-              <span className="text-[10px] uppercase tracking-wider text-surface-500 block mb-1">
+              <span className="text-[10px] uppercase tracking-wider text-secondary block mb-1">
                 Start
               </span>
               <span className="inline-flex items-center justify-center min-w-[2.5rem] px-1.5 py-1 rounded bg-surface-800 border border-surface-700 text-xs font-mono text-surface-200">
@@ -85,7 +85,7 @@ export function ControllerVisual({ mapping }: ControllerVisualProps) {
 
         {/* Face buttons */}
         <div className="flex flex-col items-center gap-0.5">
-          <span className="text-[10px] uppercase tracking-wider text-surface-500 mb-1">
+          <span className="text-[10px] uppercase tracking-wider text-secondary mb-1">
             Face
           </span>
           <div className="grid grid-cols-3 gap-0.5 w-24">

--- a/web/src/features/preferences/components/custom-key-mapping-editor.tsx
+++ b/web/src/features/preferences/components/custom-key-mapping-editor.tsx
@@ -32,7 +32,7 @@ export function CustomKeyMappingEditor({
     <div data-comp="CustomKeyMappingEditor" className="space-y-4">
       {groups.map((group) => (
         <div key={group.label}>
-          <p className="text-xs font-semibold uppercase tracking-wider text-surface-400 mb-2">
+          <p className="text-xs font-semibold uppercase tracking-wider text-secondary mb-2">
             {group.label}
           </p>
           <div className="grid grid-cols-2 gap-x-6 gap-y-1.5">

--- a/web/src/features/preferences/components/devices-card.tsx
+++ b/web/src/features/preferences/components/devices-card.tsx
@@ -88,7 +88,7 @@ export function DevicesCard({
                 >
                   <div className="flex items-center gap-3 px-4 py-3">
                     <div className="h-9 w-9 rounded-lg bg-surface-800 flex items-center justify-center">
-                      <PlatformIcon className="h-4 w-4 text-surface-400" />
+                      <PlatformIcon className="h-4 w-4 text-tertiary" />
                     </div>
                     <div className="flex-1 min-w-0">
                       {isEditing ? (
@@ -125,7 +125,7 @@ export function DevicesCard({
                           </p>
                           <div className="flex items-center gap-2">
                             <Badge variant="default">{device.platform}</Badge>
-                            <span className="text-xs text-surface-500">
+                            <span className="text-xs text-tertiary">
                               Last seen {formatRelativeTime(device.lastSeenAt)}
                             </span>
                           </div>
@@ -172,7 +172,7 @@ export function DevicesCard({
 
                   {isExpanded && consoles && consoles.length > 0 && (
                     <div className="border-t border-surface-800 px-4 py-3">
-                      <p className="text-xs font-semibold uppercase tracking-wider text-surface-400 mb-2">
+                      <p className="text-xs font-semibold uppercase tracking-wider text-secondary mb-2">
                         Device Shader Overrides
                       </p>
                       <div className="space-y-2">

--- a/web/src/features/preferences/components/emulation-settings-card.tsx
+++ b/web/src/features/preferences/components/emulation-settings-card.tsx
@@ -82,7 +82,7 @@ export function EmulationSettingsCard({
                   <p className="text-sm font-medium text-surface-200 group-hover:text-surface-100 transition-colors">
                     {label}
                   </p>
-                  <p className="text-xs text-surface-500">{description}</p>
+                  <p className="text-xs text-tertiary">{description}</p>
                 </div>
                 <Switch
                   checked={preferences?.[key] ?? false}

--- a/web/src/features/preferences/components/key-mapping-card.tsx
+++ b/web/src/features/preferences/components/key-mapping-card.tsx
@@ -94,10 +94,10 @@ export function KeyMappingCard({
                   <table className="w-full">
                     <thead>
                       <tr className="border-b border-surface-800">
-                        <th className="text-left px-3 py-2 text-xs font-semibold uppercase tracking-wider text-surface-400">
+                        <th className="text-left px-3 py-2 text-xs font-semibold uppercase tracking-wider text-secondary">
                           Console
                         </th>
-                        <th className="text-left px-3 py-2 text-xs font-semibold uppercase tracking-wider text-surface-400">
+                        <th className="text-left px-3 py-2 text-xs font-semibold uppercase tracking-wider text-secondary">
                           Key Mapping
                         </th>
                       </tr>

--- a/web/src/features/preferences/components/retroachievements-card.tsx
+++ b/web/src/features/preferences/components/retroachievements-card.tsx
@@ -77,7 +77,7 @@ export function RetroAchievementsCard() {
                 <p className="text-sm font-medium text-surface-200">
                   Linked Account
                 </p>
-                <p className="text-xs text-surface-400">{status.username}</p>
+                <p className="text-xs text-tertiary">{status.username}</p>
               </div>
               <Button
                 variant="danger"
@@ -94,7 +94,7 @@ export function RetroAchievementsCard() {
                 <p className="text-sm font-medium text-surface-200 group-hover:text-surface-100 transition-colors">
                   Hardcore Mode
                 </p>
-                <p className="text-xs text-surface-500">
+                <p className="text-xs text-tertiary">
                   Disable save states and cheats for official leaderboard
                   eligibility
                 </p>
@@ -124,7 +124,7 @@ export function RetroAchievementsCard() {
               />
             </div>
             {linkError && <p className="text-sm text-danger-500">{linkError}</p>}
-            <p className="text-xs text-surface-500">
+            <p className="text-xs text-tertiary">
               Your password is only used to obtain a token and is never stored.
             </p>
             <Button

--- a/web/src/features/preferences/components/theme-card.tsx
+++ b/web/src/features/preferences/components/theme-card.tsx
@@ -57,7 +57,7 @@ export function ThemeCard({
                   <p className="text-sm font-medium text-surface-100">
                     {option.label}
                   </p>
-                  <p className="text-xs text-surface-500">
+                  <p className="text-xs text-tertiary">
                     {option.description}
                   </p>
                 </button>

--- a/web/src/features/preferences/components/video-filters-card.tsx
+++ b/web/src/features/preferences/components/video-filters-card.tsx
@@ -73,13 +73,13 @@ export function VideoFiltersCard({
                   <table className="w-full">
                     <thead>
                       <tr className="border-b border-surface-800">
-                        <th className="text-left px-3 py-2 text-xs font-semibold uppercase tracking-wider text-surface-400">
+                        <th className="text-left px-3 py-2 text-xs font-semibold uppercase tracking-wider text-secondary">
                           Console
                         </th>
-                        <th className="text-left px-3 py-2 text-xs font-semibold uppercase tracking-wider text-surface-400">
+                        <th className="text-left px-3 py-2 text-xs font-semibold uppercase tracking-wider text-secondary">
                           Shader
                         </th>
-                        <th className="text-left px-3 py-2 text-xs font-semibold uppercase tracking-wider text-surface-400">
+                        <th className="text-left px-3 py-2 text-xs font-semibold uppercase tracking-wider text-secondary">
                           Preview
                         </th>
                       </tr>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -53,6 +53,27 @@
   --color-body-text: #f1f3f5;
   --color-muted: #868e96;
 
+  /* Semantic text-emphasis tokens. Use these (Tailwind: text-primary,
+   * text-secondary, text-tertiary, text-disabled) for muted/secondary
+   * text rather than `text-surface-{400,500}` — surface-N values are a
+   * position on the neutral ramp, and reverse on light themes such
+   * that a class authored for "muted on dark" reads as washed-out
+   * mid-grey on white. The semantic tokens are overridden per theme
+   * to keep WCAG AA on each palette. See #919.
+   *
+   * Defaults are dark-theme values; light themes override in their
+   * own theme files.
+   *
+   *   primary:    high-emphasis body / headings (AAA)
+   *   secondary:  labels, descriptions (AAA / AA body)
+   *   tertiary:   dim metadata (AA body)
+   *   disabled:   intentionally below AA — large-only target
+   */
+  --color-text-primary: #f1f3f5;
+  --color-text-secondary: #cbd5e1;
+  --color-text-tertiary: #94a3b8;
+  --color-text-disabled: #64748b;
+
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
 }
 
@@ -97,4 +118,19 @@
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-surface-600);
+}
+
+/* Light themes need a darker scrollbar thumb — surface-700 reverses to
+ * `#dee2e6` on white, which is invisible. Use a slate-derived value
+ * tuned to ~3:1 against the page background. See #919. */
+[data-theme="default-light"] ::-webkit-scrollbar-thumb,
+[data-theme="nintendo-colorful"] ::-webkit-scrollbar-thumb,
+[data-theme="sunset-warm"] ::-webkit-scrollbar-thumb {
+  background: var(--color-surface-400);
+}
+
+[data-theme="default-light"] ::-webkit-scrollbar-thumb:hover,
+[data-theme="nintendo-colorful"] ::-webkit-scrollbar-thumb:hover,
+[data-theme="sunset-warm"] ::-webkit-scrollbar-thumb:hover {
+  background: var(--color-surface-500);
 }

--- a/web/src/lib/themes/default-light.css
+++ b/web/src/lib/themes/default-light.css
@@ -4,8 +4,14 @@
   --color-surface-100: #212529;
   --color-surface-200: #343a40;
   --color-surface-300: #495057;
-  --color-surface-400: #868e96;
-  --color-surface-500: #adb5bd;
+  /* surface-400 / surface-500 are widely abused as "muted helper text"
+   * across ~1000 call sites authored for dark mode (where these are
+   * light-grey on dark bg). Retuned for default-light to slate-600 /
+   * slate-700 so they pass WCAG AA on white as a safety net for
+   * unmigrated sites. New code should prefer the semantic
+   * text-secondary / text-tertiary tokens. See #919. */
+  --color-surface-400: #64748b;
+  --color-surface-500: #475569;
   --color-surface-600: #ced4da;
   --color-surface-700: #dee2e6;
   --color-surface-800: #f1f3f5;
@@ -17,15 +23,24 @@
   --color-accent-500: #006080;
   --color-accent-600: #004060;
   --color-card-bg: #ffffff;
-  --color-card-border: #e9ecef;
+  /* slate-300 — visible card edge on white (was #e9ecef, 1.18:1) */
+  --color-card-border: #cbd5e1;
   --color-nav-bg: #f1f3f5;
   --color-nav-text: #495057;
   --color-nav-active: #0081b3;
   --color-heading: #212529;
   --color-body: #f8f9fa;
   --color-body-text: #212529;
-  --color-muted: #868e96;
+  /* was #868e96 (3.36:1, fails AA body); now slate-600 (7.55:1, AAA) */
+  --color-muted: #475569;
   --color-success-500: #16a34a;
   --color-warning-500: #d97706;
   --color-danger-500: #dc2626;
+
+  /* Semantic text-emphasis tokens — see comment in index.css. UX-tuned
+   * for white background. */
+  --color-text-primary: #212529; /* 16.1:1 — AAA */
+  --color-text-secondary: #475569; /* slate-600, 7.55:1 — AAA */
+  --color-text-tertiary: #64748b; /* slate-500, 4.85:1 — AA body */
+  --color-text-disabled: #94a3b8; /* slate-400, 2.95:1 — large-only */
 }

--- a/web/src/lib/themes/nintendo-colorful.css
+++ b/web/src/lib/themes/nintendo-colorful.css
@@ -4,8 +4,11 @@
   --color-surface-100: #2d2d44;
   --color-surface-200: #3d3d5c;
   --color-surface-300: #6b6b8a;
-  --color-surface-400: #9090a8;
-  --color-surface-500: #b0b0c4;
+  /* Retuned for unmigrated text-surface-400/500 call sites — see
+   * default-light.css and #919. Original values were 3.2:1 / 2.4:1
+   * on the cream body bg and failed WCAG AA. */
+  --color-surface-400: #5a5a72; /* was #9090a8 */
+  --color-surface-500: #3d3d5c; /* was #b0b0c4 */
   --color-surface-600: #d4d4e0;
   --color-surface-700: #e8e8f0;
   --color-surface-800: #f2f0eb;
@@ -37,4 +40,11 @@
   --color-success-500: #43b047;
   --color-warning-500: #f5c722;
   --color-danger-500: #e52521;
+
+  /* Semantic text-emphasis tokens — see comment in index.css. Tuned
+   * for the cream body bg (#faf8f4). */
+  --color-text-primary: #2d2d44;
+  --color-text-secondary: #3d3d5c;
+  --color-text-tertiary: #5a5a72;
+  --color-text-disabled: #9090a8;
 }

--- a/web/src/lib/themes/ocean-dark.css
+++ b/web/src/lib/themes/ocean-dark.css
@@ -37,4 +37,11 @@
   --color-success-500: #00c896;
   --color-warning-500: #f5b742;
   --color-danger-500: #ff6b6b;
+
+  /* Semantic text-emphasis tokens — see comment in index.css. Tuned
+   * for the dark navy body bg (#04111f). */
+  --color-text-primary: #b3d9f2;
+  --color-text-secondary: #80bfe0;
+  --color-text-tertiary: #5599c4;
+  --color-text-disabled: #3a7da8;
 }

--- a/web/src/lib/themes/sunset-warm.css
+++ b/web/src/lib/themes/sunset-warm.css
@@ -4,8 +4,10 @@
   --color-surface-100: #3d2218;
   --color-surface-200: #5c3525;
   --color-surface-300: #7a5040;
-  --color-surface-400: #a07a68;
-  --color-surface-500: #c4a090;
+  /* Retuned — original values 3.3:1 / 2.1:1 on the cream body bg
+   * failed WCAG AA. See default-light.css and #919. */
+  --color-surface-400: #6e4538; /* was #a07a68 */
+  --color-surface-500: #5c3525; /* was #c4a090 */
   --color-surface-600: #dcc4b4;
   --color-surface-700: #eeddd0;
   --color-surface-800: #f8f0e8;
@@ -37,4 +39,11 @@
   --color-success-500: #4a9e3d;
   --color-warning-500: #d4902e;
   --color-danger-500: #c44e1e;
+
+  /* Semantic text-emphasis tokens — see comment in index.css. Tuned
+   * for the warm cream body bg (#fdf8f4). */
+  --color-text-primary: #3d2218;
+  --color-text-secondary: #5c3525;
+  --color-text-tertiary: #7a5040;
+  --color-text-disabled: #a07a68;
 }

--- a/web/src/lib/themes/theme-contrast.test.ts
+++ b/web/src/lib/themes/theme-contrast.test.ts
@@ -1,0 +1,136 @@
+// Locks in WCAG contrast ratios for the semantic text-emphasis tokens
+// across each theme. If a future palette change accidentally pushes a
+// token below its target ratio, this test fails before the regression
+// ships. See #919.
+//
+// We hard-code the token values rather than parsing CSS (vitest doesn't
+// have a real DOM with `:root` :where()-style cascade resolution that
+// matches Tailwind 4's @theme block). The values must stay in sync with
+// the corresponding CSS files under web/src/lib/themes/.
+
+import { describe, expect, it } from "vitest";
+
+// --- WCAG contrast helpers --------------------------------------------------
+
+function relativeLuminance(hex: string): number {
+  const m = hex.replace("#", "").match(/.{2}/g);
+  if (!m || m.length !== 3) throw new Error(`bad hex: ${hex}`);
+  const [r, g, b] = m.map((p) => {
+    const v = parseInt(p, 16) / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  }) as [number, number, number];
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(fg: string, bg: string): number {
+  const lf = relativeLuminance(fg);
+  const lb = relativeLuminance(bg);
+  const [light, dark] = lf > lb ? [lf, lb] : [lb, lf];
+  return (light + 0.05) / (dark + 0.05);
+}
+
+const AA_BODY = 4.5;
+
+// --- Token values per theme -------------------------------------------------
+//
+// Mirrors the CSS in web/src/lib/themes/. Update both sides together.
+
+const TOKENS = {
+  "default-dark": {
+    bg: "#16191d", // --color-body
+    primary: "#f1f3f5", // --color-text-primary
+    secondary: "#cbd5e1", // --color-text-secondary
+    tertiary: "#94a3b8", // --color-text-tertiary
+    disabled: "#64748b", // --color-text-disabled
+  },
+  "default-light": {
+    bg: "#ffffff",
+    primary: "#212529",
+    secondary: "#475569",
+    tertiary: "#64748b",
+    disabled: "#94a3b8",
+  },
+  "nintendo-colorful": {
+    bg: "#faf8f4", // --color-body
+    primary: "#2d2d44",
+    secondary: "#3d3d5c",
+    tertiary: "#5a5a72",
+    disabled: "#9090a8",
+  },
+  "sunset-warm": {
+    bg: "#fdf8f4",
+    primary: "#3d2218",
+    secondary: "#5c3525",
+    tertiary: "#7a5040",
+    disabled: "#a07a68",
+  },
+  "ocean-dark": {
+    bg: "#04111f",
+    primary: "#b3d9f2",
+    secondary: "#80bfe0",
+    tertiary: "#5599c4",
+    disabled: "#3a7da8",
+  },
+} as const;
+
+describe("theme contrast — semantic text tokens (#919)", () => {
+  for (const [theme, t] of Object.entries(TOKENS)) {
+    describe(theme, () => {
+      it("text-primary clears AA body on its own bg", () => {
+        expect(contrastRatio(t.primary, t.bg)).toBeGreaterThanOrEqual(AA_BODY);
+      });
+
+      it("text-secondary clears AA body on its own bg", () => {
+        expect(contrastRatio(t.secondary, t.bg)).toBeGreaterThanOrEqual(
+          AA_BODY,
+        );
+      });
+
+      it("text-tertiary clears AA body on its own bg", () => {
+        expect(contrastRatio(t.tertiary, t.bg)).toBeGreaterThanOrEqual(
+          AA_BODY,
+        );
+      });
+
+      // text-disabled is intentionally below AA body — that's the
+      // semantic of disabled. We just verify it's perceptibly distinct
+      // from the background, not bumping into "almost invisible".
+      // Issue #919 documents 2.95:1 on white for default-light.
+      it("text-disabled is perceptibly distinct from its bg (>= 2.5:1)", () => {
+        expect(contrastRatio(t.disabled, t.bg)).toBeGreaterThanOrEqual(2.5);
+      });
+    });
+  }
+});
+
+// --- Spot checks for the surface-N retunes mentioned in the issue ----------
+//
+// These are the safety-net values: surface-400 / surface-500 / muted on the
+// light-theme body bgs that ~1000 unmigrated call sites still use as
+// "muted text" classes.
+
+describe("light-theme surface-N retune locks (#919)", () => {
+  it("default-light text-surface-400 (#64748b) on white passes AA body", () => {
+    expect(contrastRatio("#64748b", "#ffffff")).toBeGreaterThanOrEqual(
+      AA_BODY,
+    );
+  });
+
+  it("default-light text-surface-500 (#475569) on white passes AA body", () => {
+    expect(contrastRatio("#475569", "#ffffff")).toBeGreaterThanOrEqual(
+      AA_BODY,
+    );
+  });
+
+  it("default-light text-muted (#475569) on white passes AA body", () => {
+    expect(contrastRatio("#475569", "#ffffff")).toBeGreaterThanOrEqual(
+      AA_BODY,
+    );
+  });
+
+  it("default-light card-border (#cbd5e1) is visible on white (>= 1.4:1)", () => {
+    // Borders don't need AA — they need to be perceptible. The original
+    // #e9ecef was 1.18:1 (basically invisible). 1.4 is a soft floor.
+    expect(contrastRatio("#cbd5e1", "#ffffff")).toBeGreaterThanOrEqual(1.4);
+  });
+});


### PR DESCRIPTION
Closes #919.

## What

Light/colored themes rendered helper text, column headers, descriptions in mid-grey on white/cream — well below WCAG AA. Root cause is structural: the surface-N ramp is being abused as a semantic role ("muted helper text") when it's actually a position on the neutral scale. Reversing the ramp for light themes leaves mid-greys still mid-grey, so anything authored with `text-surface-{400,500}` for dark mode breaks on light themes.

## Phase 1 changes

1. **Semantic text-emphasis tokens** in `@theme` + per-theme overrides: `text-primary`, `text-secondary`, `text-tertiary`, `text-disabled`. Each theme tunes values to clear AA on its own background.
2. **Safety-net retune** of the abused `surface-{400,500}` + `muted` tokens in default-light / nintendo-colorful / sunset-warm so unmigrated call sites still pass AA.
3. **Migrate 10 highest-traffic components** (preferences/* + scrape-match-modal) from `text-surface-{400,500}` to semantic tokens.
4. **Incidental fixes**: card-border `#e9ecef` (1.18:1) → `#cbd5e1` (perceptible); scrollbar thumb override for light themes (was `surface-700` = invisible on white).
5. **Lock contrast with a unit test** — 24 tests assert every theme's semantic tokens hit their target ratios.

## Verification

- 1596 web tests pass (24 new + all existing)
- TypeScript clean
- `npm run build` green
- Computed ratios for default-light:
  - text-primary `#212529` on white: 16.1:1 (AAA)
  - text-secondary `#475569` on white: 7.6:1 (AAA)
  - text-tertiary `#64748b` on white: 4.9:1 (AA body)
  - text-disabled `#94a3b8` on white: 3.0:1 (large-only — intentional)

## Phase 2 (separate follow-up)

Codemod the remaining ~1000 `text-surface-{400,500,600}` usages to semantic tokens. Lower urgency now that the retune safety net is in place.

## Not in scope

- Focus rings (already handled by per-theme brand-500 override)
- `.glass` component (intentional translucent design)
- Disabled-state contrast (intentionally lower)