### PR TITLE
fix(bios): repoint cdimono1.zip at complete 5-file set (#939)

### DIFF
--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -134,9 +134,19 @@ var registry = []Entry{
 	{ConsoleID: "cv", FileName: "colecovision.rom", Description: "ColecoVision BIOS", MD5: "2c66f5911e5b42b8ebe113403548eee7", Required: true, OverrideURL: "https://raw.githubusercontent.com/Abdess/retrobios/main/bios/Coleco/ColecoVision/BIOS.col"},
 
 	// Philips CD-i (CDI) — same_cdi_libretro.info (MAME-based, needs subdirectory)
-	// cdimono1 requires 5 files including servo/slave MCU ROMs (added in MAME 0.222).
-	// The MAME 0.208 archive only has 3 files — use retrobios which has the complete set.
-	{ConsoleID: "cdi", FileName: "cdimono1.zip", Description: "CD-i Mono-I BIOS", MD5: "", Required: true, OverrideURL: "https://github.com/Abdess/retrobios/raw/main/bios/Philips/CD-i/cdimono1.zip", SubDir: "same_cdi/bios"},
+	// cdimono1 must contain 5 files: 3 main BIOS .rom dumps plus the
+	// SERVO and SLAVE MC68HC705C8A microcontroller ROMs (added to MAME
+	// in 0.222). Without the 8KB chip ROMs SAME_CDI loads but stays on
+	// a black screen — the core can't initialise the disc-drive servo
+	// or the front-panel slave processor, so games like Myst never
+	// reach the title screen (#939).
+	//
+	// The Abdess/retrobios mirror only has the 3 main .rom files. The
+	// MAME 0.221 merged archive predates 0.222 so it's also incomplete.
+	// archive.org's user-uploaded `cdimono1` item has the full 5-file
+	// torrentzipped set; pinning the MD5 ensures any older 3-file zip
+	// already cached on a server gets re-downloaded.
+	{ConsoleID: "cdi", FileName: "cdimono1.zip", Description: "CD-i Mono-I BIOS", MD5: "cfca9b8a96ed810bb3cd5ac11d7d1dda", Required: true, OverrideURL: "https://archive.org/download/cdimono1/cdimono1.zip", SubDir: "same_cdi/bios"},
 	{ConsoleID: "cdi", FileName: "cdimono2.zip", Description: "CD-i Mono-II BIOS", MD5: "", Required: false, OverrideURL: "https://archive.org/download/MAME208RomsOnlyMerged/cdimono2.zip", SubDir: "same_cdi/bios"},
 	{ConsoleID: "cdi", FileName: "cdibios.zip", Description: "CD-i BIOS (generic)", MD5: "", Required: false, OverrideURL: "https://archive.org/download/MAME208RomsOnlyMerged/cdibios.zip", SubDir: "same_cdi/bios"},
 

--- a/server/internal/bios/registry_test.go
+++ b/server/internal/bios/registry_test.go
@@ -226,6 +226,26 @@ func TestDownloadable_IncludesOverrideURLEntries(t *testing.T) {
 	}
 }
 
+// TestCDIMono1_PointsAtCompleteSet locks in the MD5 of the cdimono1.zip
+// download. The Mono-I BIOS needs 5 files: 3 main BIOS dumps plus the
+// SERVO and SLAVE microcontroller ROMs. Earlier we shipped a 3-file zip
+// from Abdess/retrobios; SAME_CDI loaded it but couldn't initialise the
+// hardware so games like Myst showed only a black screen (#939). Pinning
+// the MD5 forces stale 3-file zips to be re-downloaded.
+func TestCDIMono1_PointsAtCompleteSet(t *testing.T) {
+	matches := ByFileName("cdimono1.zip")
+	if assert.Len(t, matches, 1) {
+		e := matches[0]
+		assert.Equal(t, "cdi", e.ConsoleID)
+		assert.True(t, e.Required, "cdimono1 is required for CD-i emulation")
+		assert.Equal(t, "cfca9b8a96ed810bb3cd5ac11d7d1dda", e.MD5,
+			"MD5 must match the 5-file (BIOS + SERVO + SLAVE) zip; if this trips, "+
+				"verify the new zip contains zx405037p_*.7201 and zx405042p_*.7206 chip ROMs")
+		assert.NotEmpty(t, e.OverrideURL, "must have a download URL")
+		assert.Equal(t, "same_cdi/bios", e.SubDir)
+	}
+}
+
 func TestRegistryEntries_HaveRequiredFields(t *testing.T) {
 	for _, e := range All() {
 		assert.NotEmpty(t, e.ConsoleID, "ConsoleID must not be empty")


### PR DESCRIPTION
## Summary

Closes #939 — Myst (and every other CD-i title) booted to a black screen because the cdimono1.zip we shipped only had 3 of the 5 ROMs SAME_CDI's Mono-I board needs.

## Root cause

The Abdess/retrobios mirror only contains `cdi200.rom`, `cdi220.rom`, `cdi220b.rom`. SAME_CDI also requires the SERVO (`zx405037p_*.7201`) and SLAVE (`zx405042p_*.7206`) MC68HC705C8A microcontroller ROMs, added to the MAME `cdimono1` set in 0.222. Without them the core loads but the disc-drive servo and front-panel slave processor never initialise → permanent black screen.

## Fix

- Repoint `OverrideURL` to `https://archive.org/download/cdimono1/cdimono1.zip` (5-file torrentzipped set)
- Pin `MD5: cfca9b8a96ed810bb3cd5ac11d7d1dda` so any 3-file zip already cached on a server re-downloads automatically (the downloader compares MD5 on existing files and re-fetches on mismatch)
- Add a registry test that locks in the new MD5

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/bios/...` passes (including new `TestCDIMono1_PointsAtCompleteSet`)
- [x] Manually downloaded the new zip; `unzip -l` reports 5 entries with the expected sizes (524288, 524288, 524288, 8192, 8192)
- [ ] Post-merge: redeploy server, clear cached `bios/same_cdi/bios/cdimono1.zip`, trigger BIOS auto-download from admin, launch Myst on Thor, confirm boot reaches title screen