### PR TITLE
fix(player): Atari 7800 face buttons no longer reset the system (#936)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/KeyMappingRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/KeyMappingRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.spela.player.data.repository
 
 import com.spela.player.data.local.SpelaDatabase
 import com.spela.player.domain.model.DEFAULT_CONSOLE_ID
+import com.spela.player.domain.model.DefaultKeyMappings
 import com.spela.player.domain.model.KeyMappingPreset
 import com.spela.player.domain.model.KeyMappingProfile
 import com.spela.player.domain.model.detectDevicePreset
@@ -78,7 +79,22 @@ class KeyMappingRepositoryImpl(
      * feels more natural than using the bottom-right pair.
      */
     private fun getDefaultsForConsole(consoleId: String): Map<Int, Int> {
-        if (consoleId.lowercase() !in twoButtonConsoles) return platformDefaultMapping
+        // Filter the platform mapping down to the console's layout — any
+        // libretro button the layout doesn't expose stays unbound. This
+        // matters for consoles whose libretro core wires unsafe system
+        // switches (reset, difficulty, ...) onto unused JOYPAD slots:
+        // without filtering, the user's physical Y / X / L / R / etc.
+        // would silently fire those switches mid-game. See #936 for the
+        // Atari 7800 (prosystem) case.
+        val layout = DefaultKeyMappings.allLayouts[consoleId.lowercase()]
+        val mapping = if (layout != null) {
+            val allowed = layout.buttons.map { it.retroButtonId }.toSet()
+            platformDefaultMapping.filterKeys { it in allowed }
+        } else {
+            platformDefaultMapping
+        }
+
+        if (consoleId.lowercase() !in twoButtonConsoles) return mapping
 
         // Rotate face buttons so the left+bottom pair maps to B+A:
         //   B → left button (was Y's key)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/KeyMapping.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/KeyMapping.kt
@@ -260,10 +260,28 @@ object DefaultKeyMappings {
         ) + leftStickButtons,
     )
 
+    // Atari 7800 — prosystem_libretro. The 7800 controller has only
+    // Fire 1 (B) and Fire 2 (A); Reset / Pause / Select / Difficulty
+    // are hardware switches on the console itself. The prosystem core
+    // wires those switches to JOYPAD_Y / JOYPAD_X / JOYPAD_L / JOYPAD_R
+    // when the layout exposes them, so the user can accidentally reset
+    // the system mid-game by pressing Y. Keeping the layout limited to
+    // dpad + B + A means the keymap UI hides those buttons and the
+    // default profile leaves them unbound. See #936.
+    val ATARI7800 = ConsoleButtonLayout(
+        consoleId = "a78",
+        displayName = "Atari 7800",
+        buttons = dpadButtons + listOf(
+            ButtonInfo(LibretroButtons.B, "Fire 1"),
+            ButtonInfo(LibretroButtons.A, "Fire 2"),
+            ButtonInfo(LibretroButtons.START, "Pause"),
+        ),
+    )
+
     /** All known console layouts, indexed by console ID. */
     val allLayouts: Map<String, ConsoleButtonLayout> = listOf(
         NES, SNES, N64, GENESIS, GAMEBOY, GBA, PSX, PSP, NDS,
-        THREEDS, DREAMCAST, SATURN, GC,
+        THREEDS, DREAMCAST, SATURN, GC, ATARI7800,
     ).associateBy { it.consoleId }
 
     /**

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/KeyMappingRepositoryImplTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/KeyMappingRepositoryImplTest.kt
@@ -287,6 +287,46 @@ class KeyMappingRepositoryImplTest {
     }
 
     @Test
+    fun atari7800DefaultsExcludeUnsafeButtons() = runTest {
+        // #936 — the prosystem core wires the Atari 7800's hardware
+        // switches (Reset, Pause, Difficulty, ...) onto JOYPAD_Y / X /
+        // L / R / etc. when those slots are bound. The default profile
+        // for "a78" must leave those slots unbound so that pressing
+        // Y / X / L / R during gameplay does nothing.
+        val platformWithFullFaceButtons = mapOf(
+            LibretroButtons.UP to 100,
+            LibretroButtons.DOWN to 101,
+            LibretroButtons.LEFT to 102,
+            LibretroButtons.RIGHT to 103,
+            LibretroButtons.A to 200,
+            LibretroButtons.B to 201,
+            LibretroButtons.X to 202,
+            LibretroButtons.Y to 203,
+            LibretroButtons.L to 204,
+            LibretroButtons.R to 205,
+            LibretroButtons.START to 210,
+            LibretroButtons.SELECT to 211,
+        )
+        val repo = KeyMappingRepositoryImpl(database, platformWithFullFaceButtons)
+
+        val effective = repo.getEffectiveMapping("a78")
+
+        // Allowed: dpad + B + A + Start (per ATARI7800 layout)
+        assertEquals(100, effective[LibretroButtons.UP])
+        assertEquals(200, effective[LibretroButtons.A])
+        assertEquals(201, effective[LibretroButtons.B])
+        assertEquals(210, effective[LibretroButtons.START])
+
+        // Forbidden: every libretro id the prosystem core uses for
+        // system switches must be unmapped.
+        assertNull(effective[LibretroButtons.Y], "Y must be unbound — prosystem maps it to RESET")
+        assertNull(effective[LibretroButtons.X], "X must be unbound on a78")
+        assertNull(effective[LibretroButtons.L], "L must be unbound on a78")
+        assertNull(effective[LibretroButtons.R], "R must be unbound on a78")
+        assertNull(effective[LibretroButtons.SELECT], "SELECT must be unbound on a78")
+    }
+
+    @Test
     fun applyPresetWritesToGlobalDefault() = runTest {
         val repo = createRepo()
         val presets = repo.getAvailablePresets()


### PR DESCRIPTION
## Summary

Closes #936. Pressing Y on the Atari 7800 currently resets the game because the prosystem libretro core wires the 7800's hardware switches (Reset, Pause, Difficulty, Select) onto unused JOYPAD_Y / X / L / R / SELECT slots. Without an a78 layout entry, the player fell back to the FULL 16-button layout and bound every physical button to a libretro id, so the core saw user input on those slots and toggled the switches.

## Fix

Two parts:

1. **\`ATARI7800\` layout** — a78 is now in \`DefaultKeyMappings.allLayouts\`, exposing only dpad + B (Fire 1) + A (Fire 2) + Start (Pause). The keymap UI hides the unsafe buttons.
2. **Layout-aware defaults** — \`getDefaultsForConsole\` now filters \`platformDefaultMapping\` down to the libretro ids the console's layout actually exposes. Anything outside that set stays unbound, so pressing the physical button does nothing instead of triggering a system switch. This is generic: any console with a custom layout gets the same protection.

## Test plan

- [x] \`atari7800DefaultsExcludeUnsafeButtons\` desktop test asserts dpad/B/A/Start are bound and Y/X/L/R/SELECT are not.
- [x] Existing keymapping tests still pass.
- [ ] Post-merge: launch an Atari 7800 game on the Thor, press Y mid-game, confirm no reset; press Fire 1 (B), confirm action works.

## Out of scope

- Atari 2600 / 5200 may have similar core-level switch mappings — separate issue if the user reports it.
- A "Reset console" entry in the in-game overlay menu (mentioned as a follow-up in the issue) is not part of this PR; users can still reset via the existing emulation-control flow.