### PR TITLE
fix(player): drop 2-button-console face button rotation (#938)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/KeyMappingRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/KeyMappingRepositoryImpl.kt
@@ -8,7 +8,6 @@ import com.spela.player.domain.model.KeyMappingProfile
 import com.spela.player.domain.model.detectDevicePreset
 import com.spela.player.domain.model.getPlatformPresets
 import com.spela.player.domain.repository.KeyMappingRepository
-import com.spela.player.presentation.viewmodel.LibretroButtons
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -71,56 +70,27 @@ class KeyMappingRepositoryImpl(
     }
 
     /**
-     * Returns the platform default mapping, adjusted for the console type.
+     * Returns the platform default mapping, filtered to the libretro
+     * buttons the console's layout actually exposes. Anything outside
+     * the layout stays unbound — pressing a physical button mapped to
+     * an off-layout libretro id does nothing, instead of silently
+     * triggering a system switch the core wires onto an unused slot
+     * (e.g. prosystem mapping JOYPAD_Y to RESET on the Atari 7800,
+     * #936).
      *
-     * For 2-button systems (NES, Game Boy, Game Gear, Master System), the face
-     * buttons are shifted so the bottom-left pair (Y + B on Nintendo controllers,
-     * X + A on Xbox controllers) maps to the system's two action buttons. This
-     * feels more natural than using the bottom-right pair.
+     * No 2-button-console rotation: the previous logic (#938 root
+     * cause) tried to swap GB B / A onto the "bottom-left pair" but
+     * worked in libretro-id space, which on Xbox-style pads put GB B
+     * across the diamond from GB A — the opposite of ergonomic. The
+     * unrotated platform mapping puts GB B on the physical bottom and
+     * GB A on the physical right (Xbox A / B; SNES B / A on Switch),
+     * matching RetroArch defaults and user muscle memory. See #938.
      */
     private fun getDefaultsForConsole(consoleId: String): Map<Int, Int> {
-        // Filter the platform mapping down to the console's layout — any
-        // libretro button the layout doesn't expose stays unbound. This
-        // matters for consoles whose libretro core wires unsafe system
-        // switches (reset, difficulty, ...) onto unused JOYPAD slots:
-        // without filtering, the user's physical Y / X / L / R / etc.
-        // would silently fire those switches mid-game. See #936 for the
-        // Atari 7800 (prosystem) case.
         val layout = DefaultKeyMappings.allLayouts[consoleId.lowercase()]
-        val mapping = if (layout != null) {
-            val allowed = layout.buttons.map { it.retroButtonId }.toSet()
-            platformDefaultMapping.filterKeys { it in allowed }
-        } else {
-            platformDefaultMapping
-        }
-
-        if (consoleId.lowercase() !in twoButtonConsoles) return mapping
-
-        // Rotate face buttons so the left+bottom pair maps to B+A:
-        //   B → left button (was Y's key)
-        //   A → bottom button (was B's key)
-        //   Y → top button (was X's key, unused by core)
-        //   X → right button (was A's key, unused by core)
-        val bKey = platformDefaultMapping[LibretroButtons.B]    // bottom
-        val yKey = platformDefaultMapping[LibretroButtons.Y]    // left
-        val aKey = platformDefaultMapping[LibretroButtons.A]    // right
-        val xKey = platformDefaultMapping[LibretroButtons.X]    // top
-        if (bKey == null || yKey == null || aKey == null || xKey == null) {
-            return platformDefaultMapping
-        }
-
-        return buildMap {
-            putAll(platformDefaultMapping)
-            put(LibretroButtons.B, yKey)   // B → left
-            put(LibretroButtons.A, bKey)   // A → bottom
-            put(LibretroButtons.Y, xKey)   // Y → top (unused)
-            put(LibretroButtons.X, aKey)   // X → right (unused)
-        }
-    }
-
-    companion object {
-        /** Console IDs for systems with only 2 action buttons (B + A). */
-        private val twoButtonConsoles = setOf("nes", "gb", "gbc", "gg", "sms")
+            ?: return platformDefaultMapping
+        val allowed = layout.buttons.map { it.retroButtonId }.toSet()
+        return platformDefaultMapping.filterKeys { it in allowed }
     }
 
     override fun getDefaultMapping(): Map<Int, Int> = platformDefaultMapping

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/KeyMappingRepositoryImplTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/KeyMappingRepositoryImplTest.kt
@@ -287,6 +287,43 @@ class KeyMappingRepositoryImplTest {
     }
 
     @Test
+    fun gameBoyDefaultsAreUnrotated() = runTest {
+        // #938 — pre-fix, GB / GBC / NES / GG / SMS rotated face buttons
+        // so GB B mapped to libretro_Y's platform key (the "left"
+        // diamond position) and GB A mapped to libretro_B's key. On
+        // Xbox-style pads that pushed GB B to the physical left,
+        // diagonally across the diamond from GB A — the opposite of
+        // ergonomic. The unrotated mapping puts GB B at the physical
+        // bottom and GB A at the physical right, matching RetroArch's
+        // 2-button-console default.
+        val platformWithFaceButtons = mapOf(
+            LibretroButtons.UP to 100,
+            LibretroButtons.DOWN to 101,
+            LibretroButtons.LEFT to 102,
+            LibretroButtons.RIGHT to 103,
+            LibretroButtons.A to 200,         // physical right
+            LibretroButtons.B to 201,         // physical bottom
+            LibretroButtons.X to 202,
+            LibretroButtons.Y to 203,
+            LibretroButtons.START to 210,
+            LibretroButtons.SELECT to 211,
+        )
+        val repo = KeyMappingRepositoryImpl(database, platformWithFaceButtons)
+
+        for (consoleId in listOf("gb", "gbc", "nes", "gg", "sms")) {
+            val effective = repo.getEffectiveMapping(consoleId)
+            assertEquals(
+                201, effective[LibretroButtons.B],
+                "[$consoleId] B must keep the platform's bottom-position key (no rotation)",
+            )
+            assertEquals(
+                200, effective[LibretroButtons.A],
+                "[$consoleId] A must keep the platform's right-position key (no rotation)",
+            )
+        }
+    }
+
+    @Test
     fun atari7800DefaultsExcludeUnsafeButtons() = runTest {
         // #936 — the prosystem core wires the Atari 7800's hardware
         // switches (Reset, Pause, Difficulty, ...) onto JOYPAD_Y / X /


### PR DESCRIPTION
## Summary

Closes #938. Stacked on top of #945 (#936) since both touch \`getDefaultsForConsole\`.

GB / GBC / NES / GG / SMS had a face-button "rotation" intended to put the action buttons on the bottom-left pair (Y + B in libretro-id space) instead of the bottom-right (A + B). The implementation worked in libretro-id space, which on Xbox-style pads put GB B at the physical *left* of the diamond — the opposite of what the comment promised.

User-visible symptom: on AYN Thor, the right physical button (Xbox B) does nothing in Game Boy games; to press GB B the thumb has to slide across the entire button diamond. Less ergonomic than just leaving the platform default alone, which RetroArch and almost every other libretro frontend uses.

## Fix

Drop the rotation. \`getDefaultsForConsole\` now just returns \`platformDefaultMapping\` filtered by the console's layout (the protection added for #936). Same code path for every console.

Result on Android / Xbox-style: GB B → physical bottom (Xbox A), GB A → physical right (Xbox B). Both under the resting thumb.

## Test plan

- [x] \`gameBoyDefaultsAreUnrotated\` desktop test asserts B / A keep their platform-default keys for gb / gbc / nes / gg / sms.
- [x] Existing keymapping tests still pass.
- [ ] Post-merge: launch a Game Boy game on Thor, confirm Xbox A fires GB B and Xbox B fires GB A.

## Note on existing users

Per-console saved mappings in the DB are unchanged. The new default only applies on first launch or after \"Reset to default\". Acceptable per the issue's discussion of migration.