### PR TITLE
fix(player): console All-Games search scoping + UX (#941)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameListState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameListState.kt
@@ -42,4 +42,17 @@ data class GameListState(
     val hasMorePages: Boolean = false,
     val isLoadingMore: Boolean = false,
     val hideBetas: Boolean = true,
-)
+) {
+    /**
+     * Resolves the two console-id fields into the one queries should
+     * scope to. Prefers `selectedConsoleId` (set when the user lands
+     * on a per-console screen) over `selectedConsoleFilter` (set by
+     * an explicit FilterByConsole intent in cross-console list views).
+     *
+     * Why: pre-#941, search/reload/pagination always used
+     * selectedConsoleFilter, which was null in console-scoped flows,
+     * so the API returned cross-console matches.
+     */
+    val effectiveConsoleId: String?
+        get() = selectedConsoleId ?: selectedConsoleFilter
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleGamesScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -30,12 +29,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.intent.GameListIntent
@@ -88,25 +86,14 @@ fun ConsoleGamesScreen(
     val console = state.consoles.firstOrNull { it.id == consoleId }
     val consoleName = console?.name ?: "Games"
 
-    var isSearchVisible by rememberSaveable { mutableStateOf(false) }
     var showSortMenu by remember { mutableStateOf(false) }
-    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
 
-    PlatformBackHandler {
-        if (isSearchVisible) {
-            viewModel.onIntent(GameListIntent.Search(""))
-            isSearchVisible = false
-        } else {
-            onBack()
-        }
-    }
+    PlatformBackHandler { onBack() }
 
     LaunchedEffect(consoleId) {
         viewModel.onIntent(GameListIntent.SelectConsole(consoleId))
-    }
-
-    LaunchedEffect(isSearchVisible) {
-        if (isSearchVisible) focusRequester.requestFocus()
     }
 
     // Client-side sort
@@ -151,29 +138,33 @@ fun ConsoleGamesScreen(
                 horizontalArrangement = Arrangement.spacedBy(SpSpacing.Default),
                 verticalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
             ) {
-                // Search field
+                // Search field — always visible. The IME Search action
+                // dismisses the keyboard (#941); the trailing X button
+                // clears the query.
                 item(span = { GridItemSpan(maxLineSpan) }) {
-                    if (isSearchVisible) {
-                        SpSearchField(
-                            value = state.searchQuery,
-                            onValueChange = { viewModel.onIntent(GameListIntent.Search(it)) },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = SpSpacing.Small)
-                                .focusRequester(focusRequester),
-                            placeholder = "Search $consoleName games...",
-                            trailingIcon = {
+                    SpSearchField(
+                        value = state.searchQuery,
+                        onValueChange = { viewModel.onIntent(GameListIntent.Search(it)) },
+                        onSearch = {
+                            keyboardController?.hide()
+                            focusManager.clearFocus()
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = SpSpacing.Small),
+                        placeholder = "Search $consoleName games...",
+                        trailingIcon = if (state.searchQuery.isNotEmpty()) {
+                            {
                                 SpIconButton(
                                     icon = Icons.Filled.Close,
-                                    contentDescription = "Close search",
+                                    contentDescription = "Clear search",
                                     onClick = {
                                         viewModel.onIntent(GameListIntent.Search(""))
-                                        isSearchVisible = false
                                     },
                                 )
-                            },
-                        )
-                    }
+                            }
+                        } else null,
+                    )
                 }
 
                 // Games heading + sort
@@ -262,21 +253,7 @@ fun ConsoleGamesScreen(
             SpTopBar(
                 title = "$consoleName Games",
                 showBack = true,
-                onBack = {
-                    if (isSearchVisible) {
-                        viewModel.onIntent(GameListIntent.Search(""))
-                        isSearchVisible = false
-                    } else {
-                        onBack()
-                    }
-                },
-                actions = {
-                    SpIconButton(
-                        icon = Icons.Filled.Search,
-                        contentDescription = "Search games",
-                        onClick = { isSearchVisible = !isSearchVisible },
-                    )
-                },
+                onBack = onBack,
             )
         }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -283,7 +283,7 @@ class GameListViewModel(
             val current = _state.value
             searchGamesUseCase(
                 query = current.searchQuery,
-                consoleId = current.selectedConsoleFilter,
+                consoleId = current.effectiveConsoleId,
                 sortBy = current.sortBy,
                 sortOrder = current.sortOrder,
             ).fold(
@@ -328,7 +328,7 @@ class GameListViewModel(
             if (repo != null) {
                 repo.searchGamesPaginated(
                     query = current.searchQuery,
-                    consoleId = current.selectedConsoleFilter,
+                    consoleId = current.effectiveConsoleId,
                     sortBy = current.sortBy,
                     sortOrder = current.sortOrder,
                     page = 1,
@@ -353,7 +353,7 @@ class GameListViewModel(
             } else {
                 searchGamesUseCase(
                     query = current.searchQuery,
-                    consoleId = current.selectedConsoleFilter,
+                    consoleId = current.effectiveConsoleId,
                     sortBy = current.sortBy,
                     sortOrder = current.sortOrder,
                 ).fold(
@@ -384,7 +384,7 @@ class GameListViewModel(
         scope.launch(dispatchers.io) {
             repo.searchGamesPaginated(
                 query = current.searchQuery,
-                consoleId = current.selectedConsoleFilter,
+                consoleId = current.effectiveConsoleId,
                 sortBy = current.sortBy,
                 sortOrder = current.sortOrder,
                 page = current.currentPage + 1,

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/GameListViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/GameListViewModelTest.kt
@@ -133,6 +133,35 @@ class GameListViewModelTest {
         assertEquals("Super Mario Bros.", state.games[0].title)
     }
 
+    // #941 — searching from a console-scoped flow must only return
+    // games for that console. Pre-fix, the search call site used
+    // `selectedConsoleFilter` (set only by FilterByConsole) instead of
+    // `selectedConsoleId` (set by SelectConsole), so the API was
+    // queried with consoleId=null and returned matches from every
+    // console. Now both fields collapse to `effectiveConsoleId`.
+    @Test
+    fun searchScopesToActiveConsoleAfterSelect() = runTest(testDispatcher) {
+        val vm = createViewModel()
+        // Land on the NES per-console screen (sets selectedConsoleId=nes)
+        vm.onIntent(GameListIntent.SelectConsole("nes"))
+        advanceUntilIdle()
+        // Search for a substring that matches games on multiple consoles.
+        // The fake repo has SNES "Chrono Trigger"; "o" matches both
+        // "The Legend of Zelda" (nes) and "Chrono Trigger" (snes).
+        vm.onIntent(GameListIntent.Search("o"))
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertEquals("o", state.searchQuery)
+        assertTrue(state.games.isNotEmpty(), "search should return some matches")
+        for (g in state.games) {
+            assertEquals(
+                "nes", g.consoleId,
+                "search from NES screen returned a game from console=${g.consoleId} (${g.title})",
+            )
+        }
+    }
+
     @Test
     fun errorStateOnFailure() = runTest(testDispatcher) {
         fakeGameRepo.shouldFail = true
@@ -209,7 +238,10 @@ class FakeGameRepository : GameRepository {
 
     override suspend fun searchGames(query: String, consoleId: String?, sortBy: String?, sortOrder: String?): Result<List<Game>> {
         return if (shouldFail) Result.failure(Exception("Network error"))
-        else Result.success(games.filter { it.title.contains(query, ignoreCase = true) })
+        else Result.success(
+            games.filter { it.title.contains(query, ignoreCase = true) }
+                .filter { consoleId == null || it.consoleId == consoleId },
+        )
     }
 
     override suspend fun searchGamesPaginated(


### PR DESCRIPTION
## Summary

Closes #941. Three bugs on the per-console All-Games screen:

1. **Search returned cross-console results.** ViewModel queries used \`selectedConsoleFilter\` (set only by the cross-console FilterByConsole intent) instead of \`selectedConsoleId\` (set by the per-console SelectConsole intent). API always saw \`consoleId=null\`.
2. **Search field hidden** behind a magnifying-glass toggle. Now always visible at the top of the grid.
3. **IME Search action** didn't dismiss the keyboard. Now wired via \`keyboardController.hide()\` + \`focusManager.clearFocus()\`.

## Fix

- New derived property \`GameListState.effectiveConsoleId = selectedConsoleId ?: selectedConsoleFilter\`. All four query call sites in \`GameListViewModel\` (search, reload, paginated, fallback) now use it. Both underlying fields stay so the cross-console FilterByConsole flow still works.
- \`ConsoleGamesScreen\`: drop \`isSearchVisible\` toggle + magnifying-glass action button + the back-handler branch that ate system back to clear search. Render \`SpSearchField\` unconditionally with an \`onSearch\` handler that hides keyboard / clears focus. Trailing X button only renders when the query is non-empty.

## Test plan

- [x] \`searchScopesToActiveConsoleAfterSelect\` test asserts SelectConsole("nes") + Search("o") returns only NES games (the fake repo has matching SNES games).
- [x] \`./gradlew :shared:desktopTest\` passes.
- [ ] Post-merge: navigate to Sega Genesis → All Games, type "sonic", confirm only Genesis Sonic results show. Confirm search field is visible without tapping anything. Confirm tapping the keyboard's Search button dismisses the keyboard.

## Out of scope

- Global search and ExploreSearchScreen (intentionally cross-console).
- Web app (separate code path).