### PR TITLE
fix(player): tinted-on-gradient buttons for console banner (#930)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpButton.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpButton.kt
@@ -37,7 +37,7 @@ import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.ui.theme.spelaBrandGradient
 
-enum class SpButtonStyle { Primary, Secondary, Outlined, Ghost }
+enum class SpButtonStyle { Primary, Secondary, Outlined, Ghost, Tinted }
 
 @Composable
 fun SpButton(
@@ -148,6 +148,38 @@ fun SpButton(
                     contentColor = Color.White,
                     disabledContentColor = SpColor.OnBackgroundTertiary,
                 ),
+                contentPadding = if (isIconOnly) iconOnlyPadding else defaultPadding,
+            ) {
+                ButtonContent(text, isLoading, leadingIcon, Color.White)
+            }
+        }
+
+        SpButtonStyle.Tinted -> {
+            // Tinted-on-gradient — for buttons sitting on top of the
+            // colorful console banner gradient. Uses the same white-
+            // tint + thin-white-border treatment as the hero badges
+            // so the buttons read as related controls instead of
+            // competing with the gradient via neon glow. See #930.
+            Button(
+                onClick = { if (!isLoading) onClick() },
+                modifier = modifier
+                    .heightIn(min = 48.dp)
+                    .border(
+                        1.dp,
+                        if (enabled) SpColor.OnGradientBorder else SpColor.Divider,
+                        shape,
+                    )
+                    .then(focusMods),
+                enabled = enabled,
+                shape = shape,
+                interactionSource = interactionSource,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = SpColor.OnGradientFill,
+                    contentColor = Color.White,
+                    disabledContainerColor = SpColor.OnGradientFill,
+                    disabledContentColor = SpColor.OnBackgroundTertiary,
+                ),
+                elevation = ButtonDefaults.buttonElevation(0.dp, 0.dp, 0.dp, 0.dp, 0.dp),
                 contentPadding = if (isIconOnly) iconOnlyPadding else defaultPadding,
             ) {
                 ButtonContent(text, isLoading, leadingIcon, Color.White)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -623,12 +623,16 @@ private fun ConsoleHeroBannerContent(
                         verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
                         horizontalAlignment = Alignment.End,
                     ) {
+                        // Both banner action buttons use the tinted-on-
+                        // gradient treatment so they read as siblings of
+                        // the hero badges (white tint + thin white border)
+                        // instead of competing with the gradient via the
+                        // brand-gradient + neon glow. See #930.
                         if (onConsoleSettings != null) {
                             SpButton(
                                 text = "Console settings",
                                 onClick = onConsoleSettings,
-                                style = SpButtonStyle.Outlined,
-                                onGradient = true,
+                                style = SpButtonStyle.Tinted,
                                 modifier = Modifier.autoFocus(),
                                 leadingIcon = {
                                     Icon(
@@ -643,8 +647,7 @@ private fun ConsoleHeroBannerContent(
                             SpButton(
                                 text = "Browse games",
                                 onClick = onBrowseGames,
-                                style = SpButtonStyle.Secondary,
-                                onGradient = true,
+                                style = SpButtonStyle.Tinted,
                                 modifier = Modifier.testTag(
                                     com.spela.player.presentation.ui.TestTags
                                         .consoleBrowseGames(console.id),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
@@ -84,6 +84,16 @@ object SpColor {
     val DownloadComplete = Success
     val DownloadFailed = Error
 
+    // On-gradient surface tokens — for badges, buttons, and other
+    // controls that sit on top of the colorful console banner gradient.
+    // Centralised so the badges in ConsoleComponents.kt, the Tinted
+    // SpButton style, and any future controls (SpSplitButton on
+    // gradient, ScreenshotLightbox nav, ...) reference one source of
+    // truth. See #930.
+    val OnGradientFill = Color.White.copy(alpha = 0.10f)
+    val OnGradientFillHover = Color.White.copy(alpha = 0.16f)
+    val OnGradientBorder = Color.White.copy(alpha = 0.20f)
+
     // Console brand colors
     val ConsoleNes = Color(0xFFE60012)
     val ConsoleSnes = Color(0xFF7B7BB0)


### PR DESCRIPTION
## Summary

Closes #930. The "Console settings" and "Browse games" buttons sit on top of the colorful console hero gradient. Their previous \`Outlined\` / \`Secondary\` styles applied a brand-gradient border + neon-glow underlay that competed with the gradient backdrop. Switching them to a new \`Tinted\` style (matching the hero badges' white-tint + thin-white-border treatment) reads cleaner against the gradient.

## Changes

- New \`SpButtonStyle.Tinted\` — solid \`OnGradientFill\` background, thin \`OnGradientBorder\` border, white text, no neon glow.
- New \`SpColor\` tokens: \`OnGradientFill\`, \`OnGradientFillHover\`, \`OnGradientBorder\` — single source of truth for badges, the new button variant, and any future on-gradient controls (SpSplitButton, ScreenshotLightbox nav, etc.).
- \`ConsoleComponents.kt\` — both action buttons switched to \`SpButtonStyle.Tinted\`. \`onGradient = true\` flag dropped (no longer needed).

## Test plan

- [x] \`./gradlew :shared:desktopTest\` passes (no existing tests asserted on the old neon-glow rendering).
- [ ] Post-merge: visual check on the console hero — both buttons should look like white pill badges with a thin white border, matching the metadata badges to their left.

## Out of scope

- Migrating the other inline copies of the white-tint pattern (\`SpSplitButton:97\`, \`ScreenshotLightbox:59-62\`, \`SpControllerStatusCard\`, etc.) to the new tokens — leaving as a follow-up.