### PR TITLE
feat(player): per-console Favorites section on console screen (#942)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Settings
@@ -99,6 +100,13 @@ fun ConsoleScreen(
             .take(5)
     }
 
+    // Per-console favorites — state.favoriteGames is global across the
+    // user; filter to this console here so the section only shows games
+    // for the platform the user is browsing. See #942.
+    val consoleFavorites = remember(state.favoriteGames, consoleId) {
+        state.favoriteGames.filter { it.consoleId == consoleId }
+    }
+
     // Darkened version of the console's brand gradient for the full-screen background
     val screenGradientColors = if (console != null) {
         val (from, to) = getConsoleGradient(console.abbreviation, console.colorTheme)
@@ -146,6 +154,23 @@ fun ConsoleScreen(
                         ) {
                             ContinuePlayingRow(
                                 games = continuePlayingGames,
+                                onGameSelected = onGameSelected,
+                            )
+                        }
+                    }
+
+                    // Favorites for this console (#942) — sits with the
+                    // "what the user has touched" cluster, above the
+                    // BIOS warning and the discovery sections below.
+                    if (consoleFavorites.isNotEmpty()) {
+                        SpTitledSection(
+                            title = "Favorites",
+                            icon = Icons.Filled.Favorite,
+                            edgeToEdgeContent = true,
+                            modifier = Modifier.rememberFocus("section_favorites"),
+                        ) {
+                            ContinuePlayingRow(
+                                games = consoleFavorites,
                                 onGameSelected = onGameSelected,
                             )
                         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -272,6 +272,14 @@ class GameListViewModel(
                 )
             }
         }
+        // Load favorites in parallel — needed for the per-console
+        // Favorites section. The list is global; ConsoleScreen filters
+        // by consoleId. Best-effort: failures don't surface so the
+        // section just stays hidden. See #942.
+        scope.launch(dispatchers.io) {
+            val favorites = getFavoriteGamesUseCase().getOrDefault(emptyList())
+            _state.update { it.copy(favoriteGames = favorites) }
+        }
     }
 
     private fun searchGames(query: String) {

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/GameListViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/GameListViewModelTest.kt
@@ -139,6 +139,23 @@ class GameListViewModelTest {
     // `selectedConsoleId` (set by SelectConsole), so the API was
     // queried with consoleId=null and returned matches from every
     // console. Now both fields collapse to `effectiveConsoleId`.
+    // #942 — landing on a console screen via SelectConsole (e.g. via a
+    // deep link or from the main shelf) must populate state.favoriteGames
+    // so the per-console Favorites section can render. Pre-fix, favorites
+    // were only loaded by LoadDashboard, so the section was always empty
+    // unless the user came through the dashboard first.
+    @Test
+    fun selectConsoleLoadsFavorites() = runTest(testDispatcher) {
+        fakeGameRepo.favorites = fakeGameRepo.allGames.filter { it.consoleId == "nes" }
+        val vm = createViewModel()
+        vm.onIntent(GameListIntent.SelectConsole("nes"))
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertTrue(state.favoriteGames.isNotEmpty(), "favorites should populate after SelectConsole")
+        assertEquals(2, state.favoriteGames.size, "fake repo has 2 NES favorites")
+    }
+
     @Test
     fun searchScopesToActiveConsoleAfterSelect() = runTest(testDispatcher) {
         val vm = createViewModel()
@@ -194,6 +211,9 @@ class FakeGameRepository : GameRepository {
         Console("nes", "NES", "NES", 10),
         Console("snes", "SNES", "SNES", 5),
     )
+
+    val allGames: List<Game>
+        get() = games
 
     private val games = listOf(
         Game("1", "Super Mario Bros.", "nes", "NES", fileSize = 40960, fileName = "smb.nes"),
@@ -269,8 +289,11 @@ class FakeGameRepository : GameRepository {
         return Result.success(games.take(1))
     }
 
+    var favorites: List<Game> = emptyList()
+
     override suspend fun getFavoriteGames(): Result<List<Game>> {
-        return Result.success(emptyList())
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(favorites)
     }
 
     override suspend fun addFavorite(gameId: String): Result<Unit> = Result.success(Unit)


### PR DESCRIPTION
## Summary

Closes #942. New "Favorites" section on the console detail screen, directly under "Continue Playing" and above the BIOS warning. Lists the user's favorited games for that console only. Hidden when there are no favorites for the console — same self-hide pattern as Continue Playing / Top Rated / etc.

## Changes

- **\`ConsoleScreen.kt\`** — new section bound to a derived list filtered from \`state.favoriteGames\` by \`consoleId\`. Reuses the \`ContinuePlayingRow\` horizontal-row layout (generic — just takes \`games\` + \`onGameSelected\`).
- **\`GameListViewModel.loadGamesForConsole\`** — also loads favorites in parallel. Pre-fix, favorites were only loaded by \`loadDashboard\`, so the section was always empty when the user landed on a console screen directly (deep link / shelf).
- **\`GameListViewModelTest\`** — new \`selectConsoleLoadsFavorites\` test asserts \`state.favoriteGames\` populates after \`SelectConsole\`.

## Test plan

- [x] \`./gradlew :shared:desktopTest\` passes (full suite + new test).
- [ ] Post-merge: favorite a game on NES, navigate to NES console screen, confirm the Favorites section appears with that game. Unfavorite it and confirm the section hides.

## Out of scope

- Web app — separate code path; can be a follow-up if the same UX is wanted there.
- Server-side console-scoped \`/favorites?consoleId=\` endpoint (Option B from the issue) — client-side filter is fine for typical favorite list sizes; can revisit if performance becomes a concern.