### PR TITLE
fix(downloads): unify on logical bytes; remove progress-bar jumps (#931)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1458,6 +1458,24 @@ class SpelaApiClient(
 
     /**
      * Extracts files from a tar archive response, streaming directly to disk.
+     *
+     * Progress is reported in **logical bytes** — the running sum of
+     * `fileSize` from each tar entry, NOT the over-the-wire byte count.
+     * The wire stream includes 512-byte tar headers and per-file
+     * padding-to-512 that aren't useful to the user. Logical bytes
+     * match what `disc.fileSize` / `gameDetail.fileSize` represent on
+     * the server side, so the caller can compute progress fractions
+     * with both numerator and denominator in the same unit.
+     *
+     * Total: prefers the server's `X-Logical-Size` header (sum of
+     * post-extract file sizes — see `streamArchiveTar` in
+     * server/internal/api/huma_downloads.go) over `Content-Length`
+     * (which is the over-the-wire size and would make the bar overshoot
+     * 1.0 on the last frame). Falls back to `Content-Length` so older
+     * servers still produce a usable, if slightly off, progress bar.
+     *
+     * See #931 for the full root-cause analysis (mixed-units bar jumps
+     * for multi-disc games and 100%-on-frame-1 for ScummVM tars).
      */
     private suspend fun extractTarFromResponse(
         response: HttpResponse,
@@ -1465,17 +1483,17 @@ class SpelaApiClient(
         outputDir: String,
         onProgress: (Long, Long?) -> Unit,
     ) {
-        val totalBytes = response.contentLength()
+        val totalLogical = response.headers["X-Logical-Size"]?.toLongOrNull()
+            ?: response.contentLength()
         val channel = response.bodyAsChannel()
-        var downloaded = 0L
+        var logicalDownloaded = 0L
 
         // Tar format: 512-byte header, file data (padded to 512), repeat
         while (true) {
-            // Read 512-byte tar header
+            // Read 512-byte tar header. No progress emit — the header
+            // is wire overhead, not logical content.
             val header = ByteArray(512)
             channel.readFully(header, 0, 512)
-            downloaded += 512
-            onProgress(downloaded, totalBytes)
 
             // End-of-archive: all-zero block
             if (header.all { it == 0.toByte() }) break
@@ -1490,7 +1508,9 @@ class SpelaApiClient(
             val fileSize = sizeStr.toLongOrNull(8) ?: 0L
 
             if (fileSize > 0) {
-                // Stream file content directly to disk
+                // Stream file content directly to disk. Each chunk read
+                // contributes to logicalDownloaded — these are real
+                // user-visible bytes that end up on disk.
                 val filePath = "$outputDir/$name"
                 fileStorage.writeFileStreaming(filePath) { append ->
                     var remaining = fileSize
@@ -1501,16 +1521,16 @@ class SpelaApiClient(
                         if (bytesRead == -1) break
                         append(buffer, 0, bytesRead)
                         remaining -= bytesRead
-                        downloaded += bytesRead
-                        onProgress(downloaded, totalBytes)
+                        logicalDownloaded += bytesRead
+                        onProgress(logicalDownloaded, totalLogical)
                     }
                 }
-                // Skip padding to next 512-byte boundary
+                // Skip padding to next 512-byte boundary. Wire bytes
+                // again — silently consumed, no progress emit.
                 val padding = ((512 - (fileSize % 512)) % 512).toInt()
                 if (padding > 0) {
                     val skip = ByteArray(padding)
                     channel.readFully(skip, 0, padding)
-                    downloaded += padding
                 }
             }
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
@@ -45,6 +45,33 @@ class DownloadRepositoryImpl(
 
     private fun resetSpeed(gameId: String) {
         speedTrackers.remove(gameId)
+        // Reset the monotonic high-water mark together with the speed
+        // tracker — both have the same lifecycle (cleared whenever a
+        // download terminates: completed, failed, or cancelled).
+        resetMonotonic(gameId)
+    }
+
+    /*
+     * High-water mark per active download — defends against ANY future
+     * unit mismatch making the bar visibly retreat. The unit fix in
+     * #931 (logical-bytes tar parser + X-Logical-Size header) removes
+     * the known sources of backward jumps, but a monotonic clamp here
+     * is cheap insurance against regressions.
+     *
+     * Reset in cleanupPartialDownload() and on COMPLETED so the next
+     * download for the same game starts at 0.
+     */
+    private val lastEmittedBytes = mutableMapOf<String, Long>()
+
+    private fun monotonicBytes(gameId: String, candidate: Long): Long {
+        val prev = lastEmittedBytes[gameId] ?: 0L
+        val next = maxOf(prev, candidate)
+        lastEmittedBytes[gameId] = next
+        return next
+    }
+
+    private fun resetMonotonic(gameId: String) {
+        lastEmittedBytes.remove(gameId)
     }
 
     init {
@@ -207,9 +234,10 @@ class DownloadRepositoryImpl(
             // compressed size while downloaded bytes count decompressed data,
             // causing the progress bar to jump past 100%.
             val reportedTotal = if (expectedSize > 0) expectedSize else (total ?: -1)
-            val speed = recordSpeed(gameId, downloaded)
+            val monotonic = monotonicBytes(gameId, downloaded)
+            val speed = recordSpeed(gameId, monotonic)
             downloads.update {
-                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal, bytesPerSecond = speed))
+                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, monotonic, reportedTotal, bytesPerSecond = speed))
             }
         }
 
@@ -250,12 +278,16 @@ class DownloadRepositoryImpl(
 
         if (disc.fileName.endsWith(".cue", ignoreCase = true) ||
             disc.fileName.endsWith(".gdi", ignoreCase = true)) {
-            // Tar archive (cue+bin or gdi+tracks) — stream-extract directly to disk
+            // Tar archive (cue+bin or gdi+tracks) — stream-extract directly to disk.
+            // Prefer the server-supplied X-Logical-Size total over the DB
+            // disc.fileSize: same units (logical bytes) but the server
+            // measures the actual files in the archive. See #931.
             apiClient.downloadDiscAndExtract(gameId, disc.discNumber.toInt(), fileStorage, gameDir) { downloaded, total ->
-                val reportedTotal = if (disc.fileSize > 0) disc.fileSize else (total ?: -1)
-                val speed = recordSpeed(gameId, downloaded)
+                val reportedTotal = total ?: if (disc.fileSize > 0) disc.fileSize else -1L
+                val monotonic = monotonicBytes(gameId, downloaded)
+                val speed = recordSpeed(gameId, monotonic)
                 downloads.update {
-                    it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal, bytesPerSecond = speed))
+                    it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, monotonic, reportedTotal, bytesPerSecond = speed))
                 }
             }
         } else {
@@ -263,9 +295,10 @@ class DownloadRepositoryImpl(
             val discPath = "$gameDir/${disc.fileName}"
             apiClient.downloadDiscToFile(gameId, disc.discNumber.toInt(), fileStorage, discPath) { downloaded, total ->
                 val reportedTotal = if (disc.fileSize > 0) disc.fileSize else (total ?: -1)
-                val speed = recordSpeed(gameId, downloaded)
+                val monotonic = monotonicBytes(gameId, downloaded)
+                val speed = recordSpeed(gameId, monotonic)
                 downloads.update {
-                    it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal, bytesPerSecond = speed))
+                    it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, monotonic, reportedTotal, bytesPerSecond = speed))
                 }
             }
         }
@@ -286,10 +319,15 @@ class DownloadRepositoryImpl(
      *     `*.scummvm` marker.
      *
      * Streams the tar straight to disk via `downloadGameAndExtract` (extracts
-     * file-by-file as the response arrives), then reports COMPLETED. There is
-     * no `actualSize == expectedSize` check because the wire bytes are the
-     * uncompressed tar (with 512-byte headers and per-file padding), which
-     * never matches `game.fileSize` (the size of the entry file alone).
+     * file-by-file as the response arrives), then reports COMPLETED.
+     *
+     * Total source: prefer the server-supplied total (X-Logical-Size header,
+     * sum of post-extract file sizes — see #931 / streamArchiveTar). For
+     * ScummVM games game.fileSize is the size of the marker file alone
+     * (often a few hundred bytes), so falling back to it would peg the bar
+     * at 100% on the first emission. Falls back to game.fileSize only if
+     * the server didn't supply X-Logical-Size — keeps an old-server client
+     * functional.
      */
     private suspend fun downloadTarBundledGameFromGameEndpoint(
         gameId: String,
@@ -302,17 +340,24 @@ class DownloadRepositoryImpl(
         }
         fileStorage.createDirectory(gameDir)
 
+        var lastTotal = -1L
         apiClient.downloadGameAndExtract(gameId, fileStorage, gameDir) { downloaded, total ->
-            val reportedTotal = if (expectedSize > 0) expectedSize else (total ?: -1)
-            val speed = recordSpeed(gameId, downloaded)
+            val reportedTotal = total ?: if (expectedSize > 0) expectedSize else -1L
+            lastTotal = reportedTotal
+            val monotonic = monotonicBytes(gameId, downloaded)
+            val speed = recordSpeed(gameId, monotonic)
             downloads.update {
-                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal, bytesPerSecond = speed))
+                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, monotonic, reportedTotal, bytesPerSecond = speed))
             }
         }
 
+        // Use whichever total the bar saw last — that's what the user
+        // watched the progress fill toward, so completing to the same
+        // number is monotonic.
+        val finalTotal = if (lastTotal > 0) lastTotal else expectedSize
         resetSpeed(gameId)
         downloads.update {
-            it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.COMPLETED, expectedSize, expectedSize))
+            it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.COMPLETED, finalTotal, finalTotal))
         }
         return gameDir
     }
@@ -342,9 +387,13 @@ class DownloadRepositoryImpl(
 
             if (disc.fileName.endsWith(".cue", ignoreCase = true) ||
                 disc.fileName.endsWith(".gdi", ignoreCase = true)) {
-                // Tar archive (cue+bin or gdi+tracks) - stream-extract directly to disk
+                // Tar archive (cue+bin or gdi+tracks) - stream-extract directly to disk.
+                // Both discOffset (sum of disc.fileSize) and downloaded (from
+                // the tar parser, post-#931) are in logical bytes — same unit
+                // as totalSize, so the running sum no longer jumps backward
+                // at disc boundaries.
                 apiClient.downloadDiscAndExtract(gameId, disc.discNumber.toInt(), fileStorage, gameDir) { downloaded, total ->
-                    val totalDownloaded = discOffset + downloaded
+                    val totalDownloaded = monotonicBytes(gameId, discOffset + downloaded)
                     val speed = recordSpeed(gameId, totalDownloaded)
                     downloads.update {
                         it + (gameId to DownloadProgress(
@@ -359,7 +408,7 @@ class DownloadRepositoryImpl(
                 // Single file (ISO/CHD/CSO) - stream to disk
                 val discPath = "$gameDir/${disc.fileName}"
                 apiClient.downloadDiscToFile(gameId, disc.discNumber.toInt(), fileStorage, discPath) { downloaded, total ->
-                    val totalDownloaded = discOffset + downloaded
+                    val totalDownloaded = monotonicBytes(gameId, discOffset + downloaded)
                     val speed = recordSpeed(gameId, totalDownloaded)
                     downloads.update {
                         it + (gameId to DownloadProgress(

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -1065,11 +1065,26 @@ func (h *GameHandler) HumaDownloadDisc(_ context.Context, in *GameDiscDownloadIn
 // streamArchiveTar returns a StreamResponse that writes an uncompressed tar
 // of the given files. Errors during streaming are logged but not surfaced —
 // once headers are sent the response body is one-way.
+//
+// Sets X-Logical-Size to the sum of file sizes inside the tar (not the
+// over-the-wire byte count, which includes 512-byte tar headers and
+// per-file padding). The player app uses this value as the
+// authoritative download-progress total; without it, the client has to
+// fall back to game.fileSize, which for ScummVM and old .cue/.gdi
+// records is the marker file size — orders of magnitude smaller than
+// the real download. See #931.
 func streamArchiveTar(files []string, downloadName, contextName string) *huma.StreamResponse {
 	return &huma.StreamResponse{
 		Body: func(hctx huma.Context) {
+			var totalLogical int64
+			for _, f := range files {
+				if info, err := os.Stat(f); err == nil {
+					totalLogical += info.Size()
+				}
+			}
 			hctx.SetHeader("Content-Type", "application/x-tar")
 			hctx.SetHeader("Content-Disposition", fmt.Sprintf("attachment; filename=%q", downloadName))
+			hctx.SetHeader("X-Logical-Size", strconv.FormatInt(totalLogical, 10))
 			if err := serveTar(hctx.BodyWriter(), files); err != nil {
 				slog.Warn("error streaming tar", "context", contextName, "error", err)
 			}


### PR DESCRIPTION
## Summary

Closes #931. Two prior PRs (#797, #894) patched visual symptoms of this bug (visibility flicker, height latch) without addressing the root cause: the download-progress callback's \`(downloaded, total)\` tuple was carrying values in two different units.

## Root cause (recap)

| Path | \`downloaded\` was | \`total\` was | Symptom |
|---|---|---|---|
| Multi-disc | per-disc **wire bytes** + previous-discs' \`disc.fileSize\` (logical) | sum of \`disc.fileSize\` (logical) | **bar jumps backward at every disc boundary** |
| Single-disc with .cue/.gdi tar | wire | \`disc.fileSize\` (logical) | overshoots 1.0 slightly at end |
| ScummVM / old .cue/.gdi | wire | \`game.fileSize\` (the **marker file** alone) | **bar pegs at 100% on frame 1** |
| Plain ROM (path 4) | wire | \`gameDetail.fileSize\` (≈ wire) | fine |

## Fix

Three layers, one unit:

**1. Server (\`huma_downloads.go::streamArchiveTar\`)** — stat each file, set \`X-Logical-Size\` header to the sum. One stat per file; trivial cost.

**2. Client tar parser (\`SpelaApiClient::extractTarFromResponse\`)** — reports logical bytes (running sum of \`fileSize\` from each tar entry). Total: \`X-Logical-Size\` first, \`Content-Length\` second. Header reads and padding skips no longer emit progress.

**3. \`DownloadRepositoryImpl\`**
- \`downloadTarBundledGameFromGameEndpoint\`: prefers server total over the bogus \`game.fileSize\` for ScummVM.
- \`downloadSingleDiscWithDiscRecord\` (.cue/.gdi): prefers server total over \`disc.fileSize\`.
- \`downloadMultiDiscGame\`: \`discOffset\` (logical) and \`downloaded\` (logical, post-fix) are now in the same unit. Boundary jump disappears with no further change.
- All progress emits go through a new \`monotonicBytes()\` guard — defense in depth so the bar can never visibly retreat even if a future bug reintroduces a unit mismatch. Reset alongside \`speedTrackers\` on terminal states.

## Test plan

- [x] \`./gradlew :shared:desktopTest\` passes (no test broke).
- [x] \`go test ./internal/api/\` passes.
- [x] \`go build ./...\` and \`./gradlew :shared:compileKotlinDesktop\` clean.
- [ ] Post-merge verification on Thor:
  - PS1 multi-disc game (e.g. Final Fantasy VIII): bar moves monotonically from 0 → 100, no boundary jumps.
  - ScummVM game (e.g. Monkey Island): bar moves smoothly from 0 → total instead of pegging at 100%.
  - Plain ROM (NES, SNES): no regression.
  - Cancel and re-download: bar starts at 0.

## Out of scope

- Web app's EmulatorJS download UX (different code path).
- BIOS / core download progress (separate flows; same patterns may apply later).
- Pre-download size label semantics for ScummVM (the \`game.fileSize\` field still represents the marker file; fixing the *label* would mean changing the field's meaning across all consumers — separate refactor).