### PR TITLE
fix(scraper): box art region preference beats priority in tiebreak (#937)

### DIFF
--- a/server/internal/scraper/namematch.go
+++ b/server/internal/scraper/namematch.go
@@ -320,10 +320,25 @@ func findBestMatch(normalizedQuery string, entries []nameEntry, threshold float6
 			continue
 		}
 
-		// Tie-breaking: higher score > lower priority > preferred region
-		if score > bestScore ||
-			(score == bestScore && e.Priority < bestEntry.Priority) ||
-			(score == bestScore && e.Priority == bestEntry.Priority && hasPreferredRegion(e.Raw) && !hasPreferredRegion(bestEntry.Raw)) {
+		// Tie-breaking, in order of decreasing weight:
+		//   1. Higher score wins.
+		//   2. Same score: preferred region (USA/World) wins.
+		//   3. Same score AND same region preference: lower priority
+		//      (cleaner filename) wins.
+		//
+		// Region trumps priority because for box art, getting the right
+		// region matters more than filename "cleanliness". Without this,
+		// a Japan-only entry like `Ice Climber (Japan).png` (priority 0
+		// — single paren group, no date, no tags) beats a USA-region
+		// entry like `Ice Climber (USA, Europe, Korea) (En).png`
+		// (priority 2 — two paren groups), and the user gets a Japanese
+		// cover for a USA game. See #937.
+		ePref := hasPreferredRegion(e.Raw)
+		bestPref := hasPreferredRegion(bestEntry.Raw)
+		shouldReplace := score > bestScore ||
+			(score == bestScore && ePref && !bestPref) ||
+			(score == bestScore && ePref == bestPref && e.Priority < bestEntry.Priority)
+		if shouldReplace {
 			bestEntry = e
 			bestScore = score
 			found = true

--- a/server/internal/scraper/namematch_test.go
+++ b/server/internal/scraper/namematch_test.go
@@ -484,6 +484,67 @@ func TestFindBestMatch_PrefersUSAOverJapan(t *testing.T) {
 	}
 }
 
+// TestFindBestMatch_RegionBeatsPriority pins the #937 fix. Pre-fix,
+// findBestMatch ranked entries by priority before consulting region
+// preference, so a Japan-only entry with the cleanest filename
+// (priority 0 — single paren group, no date, no tags) beat any
+// USA/World entry that happened to have a more elaborate filename
+// (priority 2 — multi-region tag like "(USA, Europe, Korea)").
+//
+// The actual libretro thumbnails repo for Ice Climber on NES contains
+// exactly this shape — a clean "Ice Climber (Japan).png" sitting next
+// to a multi-region "Ice Climber (USA, Europe, Korea) (En).png". The
+// user reported seeing Japanese box art for the USA primary game; this
+// test reproduces it on the entries actually present upstream and
+// asserts the fix picks the USA entry.
+func TestFindBestMatch_RegionBeatsPriority(t *testing.T) {
+	entry := func(raw string) nameEntry {
+		return nameEntry{
+			Raw:        raw,
+			Normalized: normalizeName(raw),
+			Priority:   computePriority(raw),
+		}
+	}
+	// A representative slice of the actual Ice Climber libretro entries
+	// (verified via the libretro-thumbnails NES repo). Includes the
+	// problematic mix: Japan-only at clean priority 0, USA at priority
+	// 2, and TOSEC-style dated entries at priority 3.
+	entries := []nameEntry{
+		entry("Ice Climber (Japan)"),
+		entry("Ice Climber (Japan) (En)"),
+		entry("Ice Climber (USA) (e-Reader Edition)"),
+		entry("Ice Climber (USA, Europe, Korea) (En)"),
+		entry("Ice Climber (1985-01-30)(Nintendo)(EU-JP)"),
+		entry("Ice Climber (1985-10)(Nintendo)(US)"),
+		entry("Ice Climber (1988-11-18)(Nintendo)(JP)[h][FDS to NES]"),
+	}
+
+	// Sanity check the priorities so this test still asserts what we
+	// think it asserts if computePriority changes.
+	if got := entries[0].Priority; got != 0 {
+		t.Fatalf("Ice Climber (Japan) should be priority 0, got %d", got)
+	}
+	if got := entries[3].Priority; got != 2 {
+		t.Fatalf("Ice Climber (USA, Europe, Korea) (En) should be priority 2, got %d", got)
+	}
+
+	normalized := normalizeName("Ice Climber")
+	match, _, found := findBestMatch(normalized, entries, 0.88)
+	if !found {
+		t.Fatalf("expected a match for Ice Climber, got none")
+	}
+	// Any USA/World-tagged entry is acceptable. The bug was picking a
+	// Japan-only entry; we just don't want that.
+	if hasPreferredRegion(match.Raw) {
+		return
+	}
+	t.Errorf(
+		"findBestMatch picked %q (priority %d) — expected a USA/World "+
+			"entry; preferred-region tie-break must beat priority",
+		match.Raw, match.Priority,
+	)
+}
+
 func TestFindBestMatch_EmptyInputs(t *testing.T) {
 	_, _, found := findBestMatch("", []nameEntry{{Raw: "test", Normalized: "test"}}, 0.88)
 	if found {


### PR DESCRIPTION
## Summary

Closes #937. Re-orders the libretro-name match tiebreak so region preference (USA/World) beats priority (filename "cleanliness") when scores tie.

## Root cause

For Ice Climber on NES, the libretro thumbnails repo has many entries that all normalize to "ice climber" and score 1.0:

| Entry | \`computePriority\` | Has preferred region |
|---|---|---|
| \`Ice Climber (Japan).png\` | **0** (clean — single paren group) | no |
| \`Ice Climber (USA, Europe, Korea) (En).png\` | 2 (two paren groups) | yes |
| \`Ice Climber (1985-10)(Nintendo)(US).png\` | 3 (date pattern) | yes |

Pre-fix tiebreak: score → priority → preferred region. Step 2 picks Japan (priority 0 < 2). Step 3 never fires. User gets Japanese box art on a USA primary game.

I verified by downloading the actual files: \`Ice Climber (Japan).png\` is the Japanese カバー (アイスクライマー katakana title); \`Ice Climber (USA, Europe, Korea) (En).png\` is the western black-box NES art.

## Fix

Re-order tiebreak so region beats priority:
1. Higher score wins
2. Same score AND \`e\` is preferred-region AND current best is not → \`e\` wins
3. Same score AND same region preference AND lower priority → \`e\` wins

For box art, getting the right region matters more than filename cleanliness; priority still serves as the within-region tiebreaker.

## Test plan

- [x] New \`TestFindBestMatch_RegionBeatsPriority\` reproduces the Ice Climber libretro entry list (priority 0 Japan-only, priority 2 USA-multi-region, priority 3 dated TOSEC-style) and asserts a USA/World entry wins.
- [x] Pre-existing \`TestFindBestMatch_PrefersUSAOverJapan\` still passes.
- [x] Full \`go test ./internal/scraper/...\` passes.
- [ ] Post-merge: trigger a re-scrape on Ice Climber via the admin UI; verify the new \`boxart-libretro.png\` is the western art.

## Caveat

Existing on-disk \`boxart-libretro.png\` files for already-scraped games still contain the old (wrong-region) art. They'll only refresh on a fresh scrape. Operators can force re-scrape from the admin UI to pick up the fix on existing games — separate from this PR's code change.