### PR TITLE
fix(web): show BIOS-missing warning triangle on console card (#933)

### DIFF
--- a/web/src/components/__tests__/console-card.test.tsx
+++ b/web/src/components/__tests__/console-card.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import { ConsoleCard } from "../console-card";
+import type { Console } from "@/types/api";
+
+function makeConsole(overrides: Partial<Console> = {}): Console {
+  return {
+    id: "nes",
+    name: "Nintendo Entertainment System",
+    abbreviation: "NES",
+    extensions: [],
+    defaultCore: "",
+    coverAspectRatio: 0.75,
+    colorTheme: "",
+    generation: 3,
+    iconUrl: "/api/consoles/nes/icon",
+    logoUrl: "/api/consoles/nes/logo",
+    gameCount: 10,
+    saveStateSupport: true,
+    saveStatePolicy: "small",
+    browserPlayable: false,
+    playable: true,
+    code: "nes",
+    emulatorJsCore: "",
+    logoPngUrl: "",
+    maker: { code: "", name: "" },
+    mediaType: { code: "", name: "", category: { code: "", name: "" } },
+    releaseYear: null,
+    unitsSold: null,
+    summary: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderCard(props: Parameters<typeof ConsoleCard>[0]) {
+  return render(
+    <MemoryRouter>
+      <ConsoleCard {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ConsoleCard", () => {
+  it("renders the console name and game count", () => {
+    renderCard({ console: makeConsole() });
+    expect(
+      screen.getByText("Nintendo Entertainment System"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("10 games")).toBeInTheDocument();
+  });
+
+  // #933: amber ⚠ badge in the top-right indicator group when the
+  // console has missing required BIOS files. Mirrors the player app.
+  it("shows the BIOS-missing warning when hasMissingBios is true", () => {
+    renderCard({
+      console: makeConsole({ name: "Fairchild Channel F" }),
+      hasMissingBios: true,
+    });
+    const warning = screen.getByTestId("console-card-bios-warning");
+    expect(warning).toBeInTheDocument();
+    expect(warning).toHaveAttribute(
+      "aria-label",
+      "BIOS missing for Fairchild Channel F",
+    );
+  });
+
+  it("does not show the BIOS-missing warning by default", () => {
+    renderCard({ console: makeConsole() });
+    expect(
+      screen.queryByTestId("console-card-bios-warning"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show the BIOS-missing warning when hasMissingBios is false", () => {
+    renderCard({ console: makeConsole(), hasMissingBios: false });
+    expect(
+      screen.queryByTestId("console-card-bios-warning"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/console-card.tsx
+++ b/web/src/components/console-card.tsx
@@ -1,14 +1,22 @@
 import { Link } from "react-router-dom";
-import { Check, Globe } from "lucide-react";
+import { AlertTriangle, Check, Globe } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { getConsoleStyle } from "@/lib/console-metadata";
 import type { Console } from "@/types/api";
 
 interface ConsoleCardProps {
   console: Console;
+  /**
+   * Render an amber ⚠ in the top-right indicator group when the
+   * console has missing required BIOS files. Mirrors the player app's
+   * `ConsoleComponents.kt` behaviour so both clients show the same
+   * "this console can't play games yet" cue at-a-glance, before the
+   * detail-page banner. See #933.
+   */
+  hasMissingBios?: boolean;
 }
 
-export function ConsoleCard({ console: c }: ConsoleCardProps) {
+export function ConsoleCard({ console: c, hasMissingBios = false }: ConsoleCardProps) {
   const style = getConsoleStyle(c.abbreviation);
 
   return (
@@ -40,8 +48,18 @@ export function ConsoleCard({ console: c }: ConsoleCardProps) {
         </div>
 
         {/* Feature indicators */}
-        {(c.saveStateSupport || c.browserPlayable) && (
+        {(hasMissingBios || c.saveStateSupport || c.browserPlayable) && (
           <div className="absolute top-2 right-2 flex gap-1">
+            {hasMissingBios && (
+              <div
+                data-testid="console-card-bios-warning"
+                className="flex h-6 w-6 items-center justify-center rounded-full bg-black/40 backdrop-blur-sm"
+                title={`BIOS missing for ${c.name}`}
+                aria-label={`BIOS missing for ${c.name}`}
+              >
+                <AlertTriangle className="h-3.5 w-3.5 text-amber-400" />
+              </div>
+            )}
             {c.saveStateSupport && (
               <div className="flex h-6 w-6 items-center justify-center rounded-full bg-black/40 backdrop-blur-sm" title="Save states supported">
                 <Check className="h-3.5 w-3.5 text-emerald-400" />

--- a/web/src/pages/consoles-page.tsx
+++ b/web/src/pages/consoles-page.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Gamepad2 } from "lucide-react";
 import { ConsoleCard } from "@/components/console-card";
 import { ConsoleCardSkeleton, EmptyState } from "@/components/ui";
+import { useBiosStatus } from "@/hooks/use-bios";
 import { useConsoles } from "@/hooks/use-consoles";
 import type { Console } from "@/types/api";
 import { PageLayout, SectionList } from "@/components/layout";
@@ -58,10 +59,24 @@ function groupByGeneration(
 
 export function ConsolesPage() {
   const { data: consoles, isLoading } = useConsoles();
+  const { data: biosData } = useBiosStatus();
   const groups = useMemo(
     () => (consoles ? groupByGeneration(consoles) : []),
     [consoles],
   );
+
+  // Set of consoleIds for which a required BIOS file is missing on disk.
+  // Mirrors the player app's `state.consolesWithMissingBios` so both
+  // clients flag the same consoles. See #933.
+  const consolesWithMissingBios = useMemo(() => {
+    const set = new Set<string>();
+    for (const bc of biosData?.consoles ?? []) {
+      if (bc.status === "missing" && bc.biosRequired) {
+        set.add(bc.consoleId);
+      }
+    }
+    return set;
+  }, [biosData]);
 
   return (
     <PageLayout title="Consoles" subtitle="Browse your game library by platform.">
@@ -94,7 +109,11 @@ export function ConsolesPage() {
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
                 {group.consoles.map((c) => (
-                  <ConsoleCard key={c.id} console={c} />
+                  <ConsoleCard
+                    key={c.id}
+                    console={c}
+                    hasMissingBios={consolesWithMissingBios.has(c.id)}
+                  />
                 ))}
               </div>
             </section>


### PR DESCRIPTION
## Summary

The player app already shows a yellow ⚠ in the top-right of console cards with missing required BIOS (\`ConsoleComponents.kt:278\`). The web only had the in-screen banner on the console detail page. Adding the same triangle to the web's console card so both clients flag affected consoles at-a-glance, before the user clicks in.

| | Card-corner triangle | In-screen banner |
|---|---|---|
| **Player app** | ✅ existing | ✅ existing |
| **Web (before)** | ❌ | ✅ existing |
| **Web (this PR)** | ✅ added | ✅ unchanged |

## Changes

- \`ConsoleCard.tsx\` — new \`hasMissingBios?: boolean\` prop. When true, renders an amber \`AlertTriangle\` (lucide-react) in the existing top-right indicator group alongside save-state / browser-playable badges. Has \`title\` + \`aria-label\` for hover/screen readers.
- \`ConsolesPage\` — calls \`useBiosStatus()\`, builds a \`Set<consoleId>\` of consoles where \`status === "missing" && biosRequired\`, passes \`hasMissingBios\` to each card. Mirrors the player's \`state.consolesWithMissingBios\`.

## Test plan

- [x] New \`console-card.test.tsx\`: warning renders when prop true, absent when false / unset, carries proper aria-label.
- [x] \`npm test\` — all 1600 web tests green.
- [x] \`npm run build\` clean.
- [ ] Post-merge: visual check — Channel F / FDS / Intellivision / Odyssey 2 cards on \`/consoles\` show the amber triangle alongside save-state / browser indicators.

## Related

Same UX-alignment conversation as the discussion under #933. The card icon in the player app was originally mistaken for a missing-image error fallback; once we recognised it as the warning triangle (and the underlying BIOSes as genuinely required), the natural follow-up was making the web do the same. BIOS auto-download for the four affected consoles ships separately via #944 (already merged).