### PR TITLE
feat(player): instant-download UX for small games (#932)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/DownloadThresholds.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/DownloadThresholds.kt
@@ -1,0 +1,29 @@
+package com.spela.player.domain.model
+
+/**
+ * Size threshold under which a download is treated as instant — no
+ * separate "Download" button, no progress indicator. Below this size
+ * the download finishes faster than a progress bar can render
+ * usefully on any reasonable home connection (~25 MB/s ≈ 0.6 s for a
+ * 16 MB game), so flashing a "Downloading…" UI just adds visual noise
+ * for what feels like one click.
+ *
+ * The button-as-Play behaviour kicks in here: tapping the (Play /
+ * Resume / Continue) button on a sub-threshold game starts the
+ * download silently and launches the emulator on completion. If the
+ * download takes longer than [INSTANT_DOWNLOAD_FALLBACK_DELAY_MS]
+ * — slow network, server cold start, threshold tuned too aggressively
+ * — the regular progress indicator is surfaced so the user isn't left
+ * with a silent spinner.
+ *
+ * See #932.
+ */
+const val INSTANT_DOWNLOAD_THRESHOLD_BYTES: Long = 16L * 1024 * 1024
+
+/**
+ * After this delay, a still-in-flight instant-download falls back to
+ * the regular progress UI (download bar + status text). Sized so a
+ * fast connection completes silently and a slow one transitions
+ * before the user thinks the app has hung.
+ */
+const val INSTANT_DOWNLOAD_FALLBACK_DELAY_MS: Long = 750L

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
@@ -3,6 +3,19 @@ package com.spela.player.presentation.intent
 sealed interface GameDetailIntent {
     data class LoadGame(val gameId: String) : GameDetailIntent
     data object DownloadGame : GameDetailIntent
+    /**
+     * Silent download-then-launch path for sub-threshold games. The
+     * ViewModel kicks off the download, suppresses progress UI for
+     * the first 750 ms, and on success raises [pendingAutoLaunch] so
+     * the screen invokes its onPlay handler. See #932.
+     */
+    data object DownloadGameAndPlay : GameDetailIntent
+    /**
+     * Screen-side acknowledgement that the auto-launch signal was
+     * consumed. Clears [GameDetailState.pendingAutoLaunch] so the
+     * effect doesn't re-fire on recomposition.
+     */
+    data object ConsumeAutoLaunch : GameDetailIntent
     data object PlayGame : GameDetailIntent
     data object DeleteLocalGame : GameDetailIntent
     data object ShowDeleteDownloadDialog : GameDetailIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
@@ -35,6 +35,20 @@ data class GameDetailState(
     val isGameCached: Boolean = false,
     val isLoading: Boolean = false,
     val isDownloading: Boolean = false,
+    /**
+     * True while a sub-threshold download (kicked off by
+     * DownloadGameAndPlay) is still inside the silent window
+     * [INSTANT_DOWNLOAD_FALLBACK_DELAY_MS]. Suppresses the progress
+     * bar and "Downloading…" status so the click feels like an
+     * instant launch on fast connections. See #932.
+     */
+    val isInstantDownload: Boolean = false,
+    /**
+     * Set to true when DownloadGameAndPlay finishes successfully.
+     * The screen observes this and invokes its onPlay handler, then
+     * dispatches ConsumeAutoLaunch to clear the flag. See #932.
+     */
+    val pendingAutoLaunch: Boolean = false,
     val isScraping: Boolean = false,
     val isScrapeQueued: Boolean = false,
     val isSharing: Boolean = false,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.BiosMissingFile
 import com.spela.player.domain.model.DownloadState
 import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.INSTANT_DOWNLOAD_THRESHOLD_BYTES
 import com.spela.player.domain.model.NETPLAY_SUPPORTED_CONSOLES
 import com.spela.player.presentation.state.GameDetailState
 import com.spela.player.presentation.state.GameSyncState
@@ -77,6 +78,14 @@ fun GameHeroContent(
     onPlayFresh: ((String) -> Unit)?,
     onPlayFromTitleScreen: ((String) -> Unit)? = null,
     onDownloadGame: () -> Unit,
+    /**
+     * Sub-threshold instant-download flow (#932). Wired by the screen
+     * to dispatch GameDetailIntent.DownloadGameAndPlay. Tap on the
+     * Play/Resume/Continue button for a small uncached game routes
+     * here instead of onDownloadGame, so the user experiences a
+     * single-click launch.
+     */
+    onDownloadAndPlay: () -> Unit = onDownloadGame,
     onToggleFavorite: () -> Unit,
     onTogglePlayLater: () -> Unit,
     onAddToCollection: () -> Unit,
@@ -104,6 +113,18 @@ fun GameHeroContent(
     // the button drifted off-axis from the "..." actions menu.
     val isActivelyDownloading = state.downloadProgress?.state == DownloadState.DOWNLOADING
     val isBusy = state.isDownloading || isActivelyDownloading
+
+    // #932: a sub-threshold uncached game shows the cached-style
+    // Play/Resume/Continue button. Tap kicks off a silent
+    // download-then-launch via the ViewModel. Once we exit the silent
+    // window (state.isInstantDownload flips false), we fall back to
+    // the regular Download button + progress bar for the rest of the
+    // wait so the user knows something is happening.
+    val isInstantDownloadCandidate =
+        !state.isGameCached &&
+            game.fileSize in 1..<INSTANT_DOWNLOAD_THRESHOLD_BYTES
+    val showCachedStyleButton = state.isGameCached ||
+        (isInstantDownloadCandidate && (!state.isDownloading || state.isInstantDownload))
 
     Column(
         verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
@@ -172,7 +193,7 @@ fun GameHeroContent(
             verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
             itemVerticalAlignment = Alignment.CenterVertically,
         ) {
-            if (state.isGameCached) {
+            if (showCachedStyleButton) {
                 if (game.playable) {
                     val menuItems = buildList {
                         if (hasSaves && onPlayFromTitleScreen != null) {
@@ -198,7 +219,12 @@ fun GameHeroContent(
                         if (onCreateNetplay != null && supportsNetplay) {
                             add(SpSplitButtonMenuItem("Netplay") { onCreateNetplay(gameId) })
                         }
-                        add(SpSplitButtonMenuItem("Delete Download") { onDeleteLocalGame() })
+                        // Delete Download only meaningful when the
+                        // game is actually downloaded — skip on the
+                        // instant-download silent-Play path (#932).
+                        if (state.isGameCached) {
+                            add(SpSplitButtonMenuItem("Delete Download") { onDeleteLocalGame() })
+                        }
                     }
                     val hasRequiredBiosMissing = missingBiosFiles.any { it.required }
                     val isSyncing = syncState != null
@@ -217,9 +243,19 @@ fun GameHeroContent(
                         com.spela.player.domain.model.PlaySemantics.ResumesFromSaveState -> "Resume"
                         com.spela.player.domain.model.PlaySemantics.LaunchesFresh -> "Continue"
                     }
+                    // Click target depends on whether the game is
+                    // already on disk. Cached → direct play. Uncached
+                    // sub-threshold → silent download-then-launch via
+                    // the ViewModel; the screen LaunchedEffect will
+                    // call onPlay once download succeeds. #932.
+                    val playOnClick: () -> Unit = if (state.isGameCached) {
+                        { onPlay(gameId) }
+                    } else {
+                        onDownloadAndPlay
+                    }
                     SpSplitButton(
                         text = playLabel,
-                        onClick = { onPlay(gameId) },
+                        onClick = playOnClick,
                         modifier = Modifier
                             .autoFocus()
                             .testTag("game_detail_play_button"),
@@ -339,11 +375,16 @@ fun GameHeroContent(
         // state.isDownloading (not on dp.state) so a single in-flight
         // progress event doesn't flip the indicator on/off and reflow
         // the page each frame (#797).
+        // #932: hide download status text + bar during the silent
+        // window of an instant-download. After the 750 ms fallback,
+        // state.isInstantDownload flips false and the regular UI
+        // takes over.
+        val showDownloadStatus = state.isDownloading && !state.isInstantDownload
         val statusText = when {
             state.isScraping -> "Scraping…"
             state.isScrapeQueued -> "Scrape queued"
             syncState != null && !syncState.isTimedOut -> syncState.message
-            state.isDownloading -> {
+            showDownloadStatus -> {
                 val p = state.downloadProgress
                 if (p != null && p.totalDiscs > 1) "Downloading disc ${p.currentDisc}/${p.totalDiscs}…"
                 else "Downloading…"
@@ -371,7 +412,7 @@ fun GameHeroContent(
                 ) {
                     // Show spinner for non-download statuses (scraping, sync).
                     // Downloads already have a spinner in the button.
-                    if (!state.isDownloading) {
+                    if (!showDownloadStatus) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(14.dp),
                             strokeWidth = 2.dp,
@@ -388,7 +429,7 @@ fun GameHeroContent(
                 // Latched on isDownloading. The dp object's individual
                 // values (progress, bytes) still update continuously —
                 // only the show/hide decision is held stable.
-                if (state.isDownloading) {
+                if (showDownloadStatus) {
                     val dp = state.downloadProgress
                     SpDownloadProgressBar(
                         progress = dp?.progress ?: -1f,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -84,8 +84,12 @@ fun GameHeroContent(
      * Play/Resume/Continue button for a small uncached game routes
      * here instead of onDownloadGame, so the user experiences a
      * single-click launch.
+     *
+     * No default: the wrong fallback would silently drop the
+     * auto-launch behaviour without a compile error. Caller must
+     * supply an explicit handler.
      */
-    onDownloadAndPlay: () -> Unit = onDownloadGame,
+    onDownloadAndPlay: () -> Unit,
     onToggleFavorite: () -> Unit,
     onTogglePlayLater: () -> Unit,
     onAddToCollection: () -> Unit,
@@ -245,9 +249,14 @@ fun GameHeroContent(
                     }
                     // Click target depends on whether the game is
                     // already on disk. Cached → direct play. Uncached
-                    // sub-threshold → silent download-then-launch via
-                    // the ViewModel; the screen LaunchedEffect will
-                    // call onPlay once download succeeds. #932.
+                    // (only reachable here when isInstantDownload-
+                    // Candidate is true) → silent download-then-
+                    // launch via the ViewModel; the screen
+                    // LaunchedEffect will call onPlay once download
+                    // succeeds. The ViewModel additionally gates the
+                    // auto-launch on its own size check so this
+                    // routing can't be inadvertently broken from
+                    // elsewhere. #932.
                     val playOnClick: () -> Unit = if (state.isGameCached) {
                         { onPlay(gameId) }
                     } else {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -93,6 +93,15 @@ fun GameDetailScreen(
         onPlaySession?.invoke(gameId, sessionId)
     }
 
+    // #932: instant-download flow finished — drive the play handler
+    // and clear the flag. No-op if pendingAutoLaunch is false.
+    LaunchedEffect(state.pendingAutoLaunch) {
+        if (state.pendingAutoLaunch) {
+            onPlay(gameId)
+            viewModel.onIntent(GameDetailIntent.ConsumeAutoLaunch)
+        }
+    }
+
     if (state.isLoading && state.gameDetail == null) {
         GameDetailSkeleton(onBack = onBack)
         return
@@ -132,6 +141,7 @@ fun GameDetailScreen(
                     onPlayFresh = onPlayFresh,
                     onPlayFromTitleScreen = onPlayFromTitleScreen,
                     onDownloadGame = { viewModel.onIntent(GameDetailIntent.DownloadGame) },
+                    onDownloadAndPlay = { viewModel.onIntent(GameDetailIntent.DownloadGameAndPlay) },
                     onToggleFavorite = { viewModel.onIntent(GameDetailIntent.ToggleFavorite) },
                     onTogglePlayLater = { viewModel.onIntent(GameDetailIntent.TogglePlayLater) },
                     onAddToCollection = { viewModel.onIntent(GameDetailIntent.ShowAddToCollectionDialog) },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -424,12 +424,23 @@ class GameDetailViewModel(
         scope.launch(dispatchers.io) {
             downloadRepository.downloadGame(gameId, gameTitle).fold(
                 onSuccess = {
+                    // Auto-launch is gated on `isInstant` so an
+                    // above-threshold game never silently fires the
+                    // play handler when it finally completes (e.g. a
+                    // 2 GB ROM after a 30-minute download — the user
+                    // has likely walked away and would be surprised
+                    // to land in the emulator). Above-threshold games
+                    // would normally not reach this codepath at all
+                    // (the UI routes them to the regular Download
+                    // button), but defending here means future
+                    // routing changes can't accidentally enable the
+                    // surprise-launch.
                     _state.update {
                         it.copy(
                             isGameCached = true,
                             isDownloading = false,
                             isInstantDownload = false,
-                            pendingAutoLaunch = true,
+                            pendingAutoLaunch = isInstant,
                         )
                     }
                     currentGameId?.let { loadCheats(it) }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -23,7 +23,10 @@ import com.spela.player.domain.repository.GameStatsRepository
 import com.spela.player.presentation.intent.GameDetailIntent
 import com.spela.player.presentation.state.GameDetailState
 import com.spela.player.util.DispatcherProvider
+import com.spela.player.domain.model.INSTANT_DOWNLOAD_FALLBACK_DELAY_MS
+import com.spela.player.domain.model.INSTANT_DOWNLOAD_THRESHOLD_BYTES
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -81,6 +84,8 @@ class GameDetailViewModel(
         when (intent) {
             is GameDetailIntent.LoadGame -> loadGame(intent.gameId)
             GameDetailIntent.DownloadGame -> downloadGame()
+            GameDetailIntent.DownloadGameAndPlay -> downloadGameAndPlay()
+            GameDetailIntent.ConsumeAutoLaunch -> _state.update { it.copy(pendingAutoLaunch = false) }
             GameDetailIntent.PlayGame -> { /* Handled by UI navigation to emulation screen */ }
             GameDetailIntent.DeleteLocalGame -> deleteLocalGame()
             GameDetailIntent.ShowDeleteDownloadDialog -> _state.update {
@@ -376,6 +381,67 @@ class GameDetailViewModel(
                 },
                 onFailure = { error ->
                     _state.update { it.copy(error = error.message, isDownloading = false) }
+                },
+            )
+        }
+    }
+
+    /**
+     * Sub-threshold download-then-launch flow (#932). Tap on the
+     * Play/Resume/Continue button for a small uncached game lands
+     * here. The download is suppressed-progress for the first
+     * INSTANT_DOWNLOAD_FALLBACK_DELAY_MS; if it doesn't finish in
+     * that window, we drop back to the regular progress UI so the
+     * user isn't staring at a silent spinner. On success we raise
+     * `pendingAutoLaunch` and the screen invokes its onPlay handler.
+     *
+     * The size guard duplicates the GameHeroContent check defensively
+     * — if a caller dispatches this for an above-threshold game (or
+     * one with unknown size), we just behave like a normal download.
+     */
+    private fun downloadGameAndPlay() {
+        val gameId = currentGameId ?: return
+        val gameTitle = _state.value.gameDetail?.game?.title ?: ""
+        val fileSize = _state.value.gameDetail?.game?.fileSize ?: 0L
+        val isInstant = fileSize in 1..<INSTANT_DOWNLOAD_THRESHOLD_BYTES
+
+        _state.update {
+            it.copy(isDownloading = true, isInstantDownload = isInstant)
+        }
+
+        if (isInstant) {
+            scope.launch(dispatchers.default) {
+                delay(INSTANT_DOWNLOAD_FALLBACK_DELAY_MS)
+                // If the download is still in flight after the silent
+                // window, surface the regular progress UI. Idempotent:
+                // post-completion this branch updates a no-op.
+                if (_state.value.isDownloading) {
+                    _state.update { it.copy(isInstantDownload = false) }
+                }
+            }
+        }
+
+        scope.launch(dispatchers.io) {
+            downloadRepository.downloadGame(gameId, gameTitle).fold(
+                onSuccess = {
+                    _state.update {
+                        it.copy(
+                            isGameCached = true,
+                            isDownloading = false,
+                            isInstantDownload = false,
+                            pendingAutoLaunch = true,
+                        )
+                    }
+                    currentGameId?.let { loadCheats(it) }
+                },
+                onFailure = { error ->
+                    _state.update {
+                        it.copy(
+                            error = error.message,
+                            isDownloading = false,
+                            isInstantDownload = false,
+                        )
+                    }
                 },
             )
         }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailInstantDownloadTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailInstantDownloadTest.kt
@@ -1,0 +1,386 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.data.remote.ScrapeService
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.interceptor.TokenManager
+import com.spela.player.domain.model.AchievementPlayerRanking
+import com.spela.player.domain.model.AchievementProgress
+import com.spela.player.domain.model.AchievementTimelineData
+import com.spela.player.domain.model.Challenge
+import com.spela.player.domain.model.ChallengeAttempt
+import com.spela.player.domain.model.ChallengeLeaderboardEntry
+import com.spela.player.domain.model.Console
+import com.spela.player.domain.model.DeveloperGame
+import com.spela.player.domain.model.DownloadProgress
+import com.spela.player.domain.model.DownloadState
+import com.spela.player.domain.model.DownloadedGame
+import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.GameAchievement
+import com.spela.player.domain.model.GameCollection
+import com.spela.player.domain.model.GameCollectionDetail
+import com.spela.player.domain.model.GameDetail
+import com.spela.player.domain.model.GameRating
+import com.spela.player.domain.model.GameStats
+import com.spela.player.domain.model.INSTANT_DOWNLOAD_FALLBACK_DELAY_MS
+import com.spela.player.domain.model.INSTANT_DOWNLOAD_THRESHOLD_BYTES
+import com.spela.player.domain.model.LongestGame
+import com.spela.player.domain.model.PaginatedResult
+import com.spela.player.domain.model.RatingSummary
+import com.spela.player.domain.model.RecentAchievement
+import com.spela.player.domain.model.SharedSession
+import com.spela.player.domain.model.SharedSessionDetail
+import com.spela.player.domain.model.SharedSessionInvitation
+import com.spela.player.domain.model.SharedSessionSave
+import com.spela.player.domain.model.SharedSaveState
+import com.spela.player.domain.model.SimilarGame
+import com.spela.player.domain.model.TopListGame
+import com.spela.player.domain.model.TopRatedGame
+import com.spela.player.domain.model.UserStats
+import com.spela.player.domain.repository.ChallengeRepository
+import com.spela.player.domain.repository.CollectionRepository
+import com.spela.player.domain.repository.DownloadRepository
+import com.spela.player.domain.repository.GameRepository
+import com.spela.player.domain.repository.GameStatsRepository
+import com.spela.player.domain.repository.RatingRepository
+import com.spela.player.domain.repository.SharedSaveRepository
+import com.spela.player.domain.repository.SharedSessionRepository
+import com.spela.player.domain.usecase.AddGameToCollectionUseCase
+import com.spela.player.domain.usecase.CreateCollectionUseCase
+import com.spela.player.domain.usecase.GetGameDetailUseCase
+import com.spela.player.domain.usecase.GetGameStatsUseCase
+import com.spela.player.domain.usecase.GetMyCollectionsUseCase
+import com.spela.player.domain.usecase.ToggleFavoriteUseCase
+import com.spela.player.domain.usecase.TogglePlayLaterUseCase
+import com.spela.player.presentation.intent.GameDetailIntent
+import com.spela.player.test.NoOpMockEngineFactory
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * #932 instant-download UX tests. Verify the ViewModel side of the
+ * silent download-then-launch flow:
+ *   - sub-threshold games show isInstantDownload during the silent
+ *     window and raise pendingAutoLaunch on success
+ *   - if the download exceeds INSTANT_DOWNLOAD_FALLBACK_DELAY_MS
+ *     the silent flag drops back to false so the regular progress UI
+ *     can take over
+ *   - above-threshold games never enter the silent flow
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class GameDetailInstantDownloadTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testDispatchers = object : DispatcherProvider {
+        override val main: CoroutineDispatcher = testDispatcher
+        override val io: CoroutineDispatcher = testDispatcher
+        override val default: CoroutineDispatcher = testDispatcher
+    }
+
+    private lateinit var fakeGameRepo: InstantDlStubGameRepository
+    private lateinit var fakeDownloadRepo: BlockingDownloadRepository
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        fakeGameRepo = InstantDlStubGameRepository()
+        fakeDownloadRepo = BlockingDownloadRepository()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): GameDetailViewModel {
+        val scope = CoroutineScope(testDispatcher)
+        val apiClient = SpelaApiClient(NoOpMockEngineFactory, TokenManager())
+        return GameDetailViewModel(
+            getGameDetailUseCase = GetGameDetailUseCase(fakeGameRepo),
+            toggleFavoriteUseCase = ToggleFavoriteUseCase(fakeGameRepo),
+            togglePlayLaterUseCase = TogglePlayLaterUseCase(fakeGameRepo),
+            downloadRepository = fakeDownloadRepo,
+            ratingRepository = NoopRatingRepository(),
+            sharedSaveRepository = NoopSharedSaveRepository(),
+            getMyCollectionsUseCase = GetMyCollectionsUseCase(NoopCollectionRepository()),
+            addGameToCollectionUseCase = AddGameToCollectionUseCase(NoopCollectionRepository()),
+            createCollectionUseCase = CreateCollectionUseCase(NoopCollectionRepository()),
+            getGameStatsUseCase = GetGameStatsUseCase(NoopGameStatsRepository()),
+            gameStatsRepository = NoopGameStatsRepository(),
+            challengeRepository = NoopChallengeRepository(),
+            sharedSessionRepository = NoopSharedSessionRepository(),
+            gameRepository = fakeGameRepo,
+            preferencesRepository = com.spela.player.presentation.viewmodel.emulation.StubPreferencesRepository(),
+            apiClient = apiClient,
+            scrapeService = ScrapeService(apiClient, testDispatchers, scope),
+            dispatchers = testDispatchers,
+            scope = scope,
+        )
+    }
+
+    @Test
+    fun subThresholdDownload_setsInstantFlag_thenRaisesAutoLaunch() = runTest(testDispatcher) {
+        fakeGameRepo.fileSize = 1024 * 1024 // 1 MB — well below 16 MB threshold
+        val vm = createViewModel()
+        vm.onIntent(GameDetailIntent.LoadGame("1"))
+        advanceUntilIdle()
+
+        vm.onIntent(GameDetailIntent.DownloadGameAndPlay)
+        // Let the dispatch run but DON'T let the download complete yet.
+        advanceTimeBy(50)
+
+        assertTrue(vm.state.value.isDownloading)
+        assertTrue(
+            vm.state.value.isInstantDownload,
+            "sub-threshold game should be in the silent window",
+        )
+        assertFalse(vm.state.value.pendingAutoLaunch)
+
+        // Complete the download.
+        fakeDownloadRepo.completeDownload(Result.success("/fake"))
+        advanceUntilIdle()
+
+        assertFalse(vm.state.value.isDownloading)
+        assertFalse(vm.state.value.isInstantDownload)
+        assertTrue(
+            vm.state.value.pendingAutoLaunch,
+            "successful sub-threshold download must signal auto-launch",
+        )
+        assertTrue(vm.state.value.isGameCached)
+    }
+
+    @Test
+    fun subThresholdDownload_exceedsFallback_dropsSilentFlag() = runTest(testDispatcher) {
+        fakeGameRepo.fileSize = 1024 * 1024
+        val vm = createViewModel()
+        vm.onIntent(GameDetailIntent.LoadGame("1"))
+        advanceUntilIdle()
+
+        vm.onIntent(GameDetailIntent.DownloadGameAndPlay)
+        advanceTimeBy(50)
+        assertTrue(vm.state.value.isInstantDownload)
+
+        // Stay in flight past the silent window. The 750 ms fallback
+        // should flip the silent flag off so the regular progress UI
+        // takes over.
+        advanceTimeBy(INSTANT_DOWNLOAD_FALLBACK_DELAY_MS + 100)
+
+        assertTrue(vm.state.value.isDownloading, "still downloading")
+        assertFalse(
+            vm.state.value.isInstantDownload,
+            "after the silent window the regular UI must be visible",
+        )
+        assertFalse(vm.state.value.pendingAutoLaunch)
+    }
+
+    @Test
+    fun aboveThresholdDownload_neverEntersSilentFlow() = runTest(testDispatcher) {
+        // 32 MB — above the 16 MB threshold.
+        fakeGameRepo.fileSize = INSTANT_DOWNLOAD_THRESHOLD_BYTES + 1024
+        val vm = createViewModel()
+        vm.onIntent(GameDetailIntent.LoadGame("1"))
+        advanceUntilIdle()
+
+        vm.onIntent(GameDetailIntent.DownloadGameAndPlay)
+        advanceTimeBy(50)
+
+        assertTrue(vm.state.value.isDownloading)
+        assertFalse(
+            vm.state.value.isInstantDownload,
+            "above-threshold game must show progress UI from frame 1",
+        )
+
+        fakeDownloadRepo.completeDownload(Result.success("/fake"))
+        advanceUntilIdle()
+
+        // Note: pendingAutoLaunch still fires for above-threshold —
+        // the user dispatched DownloadGameAndPlay, so the launch is
+        // expected once the download finishes. The visual difference
+        // is only in whether the progress bar was visible.
+        assertTrue(vm.state.value.pendingAutoLaunch)
+    }
+
+    @Test
+    fun consumeAutoLaunch_clearsTheFlag() = runTest(testDispatcher) {
+        fakeGameRepo.fileSize = 1024 * 1024
+        val vm = createViewModel()
+        vm.onIntent(GameDetailIntent.LoadGame("1"))
+        advanceUntilIdle()
+
+        vm.onIntent(GameDetailIntent.DownloadGameAndPlay)
+        fakeDownloadRepo.completeDownload(Result.success("/fake"))
+        advanceUntilIdle()
+        assertTrue(vm.state.value.pendingAutoLaunch)
+
+        vm.onIntent(GameDetailIntent.ConsumeAutoLaunch)
+        assertFalse(vm.state.value.pendingAutoLaunch)
+    }
+}
+
+private class InstantDlStubGameRepository : GameRepository {
+    var fileSize: Long = 1024 * 1024 // default sub-threshold
+    private val baseGame = Game(
+        id = "1",
+        title = "Test Game",
+        consoleId = "nes",
+        consoleName = "NES",
+        scrapeAttempts = 1,
+        userRating = null,
+    )
+
+    override suspend fun getConsoles(): Result<List<Console>> = Result.success(emptyList())
+    override suspend fun getGamesForConsole(consoleId: String): Result<List<Game>> = Result.success(emptyList())
+    override suspend fun getAllGames(): Result<List<Game>> = Result.success(emptyList())
+    override suspend fun searchGames(query: String, consoleId: String?, sortBy: String?, sortOrder: String?): Result<List<Game>> = Result.success(emptyList())
+    override suspend fun getGameDetail(gameId: String): Result<GameDetail> =
+        Result.success(GameDetail(baseGame.copy(fileSize = fileSize)))
+    override suspend fun getRecentGames(): Result<List<Game>> = Result.success(emptyList())
+    override suspend fun getFavoriteGames(): Result<List<Game>> = Result.success(emptyList())
+    override suspend fun addFavorite(gameId: String): Result<Unit> = Result.success(Unit)
+    override suspend fun removeFavorite(gameId: String): Result<Unit> = Result.success(Unit)
+    override suspend fun getPlayLaterGames(): Result<List<Game>> = Result.success(emptyList())
+    override suspend fun addToPlayLater(gameId: String): Result<Unit> = Result.success(Unit)
+    override suspend fun removeFromPlayLater(gameId: String): Result<Unit> = Result.success(Unit)
+    override suspend fun getTopRatedGames(consoleId: String): Result<List<TopRatedGame>> = Result.success(emptyList())
+    override suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>> = Result.success(emptyList())
+    override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
+    override suspend fun getLongestGames(): Result<List<LongestGame>> = Result.success(emptyList())
+    override suspend fun getSimilarGames(gameId: String): Result<List<SimilarGame>> = Result.success(emptyList())
+    override suspend fun getDeveloperGames(gameId: String): Result<List<DeveloperGame>> = Result.success(emptyList())
+    override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
+    override suspend fun getGamesForConsolePaginated(consoleId: String, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+    override suspend fun getAllGamesPaginated(page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+    override suspend fun searchGamesPaginated(query: String, consoleId: String?, sortBy: String?, sortOrder: String?, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+}
+
+private class BlockingDownloadRepository : DownloadRepository {
+    private val deferred = CompletableDeferred<Result<String>>()
+
+    fun completeDownload(result: Result<String>) {
+        deferred.complete(result)
+    }
+
+    override fun observeDownloads(): Flow<List<DownloadProgress>> = MutableStateFlow(emptyList())
+    override fun observeDownload(gameId: String): Flow<DownloadProgress> =
+        MutableStateFlow(DownloadProgress(gameId, state = DownloadState.IDLE))
+    override fun observeDownloadedGames(): Flow<List<DownloadedGame>> = MutableStateFlow(emptyList())
+    override suspend fun downloadGame(gameId: String, gameTitle: String): Result<String> = deferred.await()
+    override suspend fun cancelDownload(gameId: String) {}
+    override suspend fun getLocalGamePath(gameId: String): String? = null
+    override suspend fun isGameCached(gameId: String): Boolean = false
+    override suspend fun deleteLocalGame(gameId: String) {}
+    override suspend fun getCacheSize(): Long = 0
+    override suspend fun clearCache() {}
+    override suspend fun scanForOrphanedDownloads() {}
+}
+
+private class NoopRatingRepository : RatingRepository {
+    override suspend fun rateGame(gameId: String, rating: Int, review: String): Result<GameRating> =
+        Result.success(GameRating("1", "1", "user", null, gameId, rating, review, ""))
+    override suspend fun getGameRatings(gameId: String, page: Int, pageSize: Int): Result<List<GameRating>> =
+        Result.success(emptyList())
+    override suspend fun getRatingSummary(gameId: String): Result<RatingSummary> =
+        Result.success(RatingSummary(0.0, 0, emptyMap()))
+    override suspend fun getMyRating(gameId: String): Result<GameRating?> = Result.success(null)
+    override suspend fun deleteRating(gameId: String): Result<Unit> = Result.success(Unit)
+}
+
+private class NoopSharedSaveRepository : SharedSaveRepository {
+    override suspend fun getSharedSaves(gameId: String, page: Int, pageSize: Int): Result<List<SharedSaveState>> =
+        Result.success(emptyList())
+    override suspend fun shareSave(gameId: String, name: String, description: String, saveData: ByteArray): Result<SharedSaveState> =
+        Result.success(SharedSaveState("1", "1", "user", null, gameId, name, description, saveData.size.toLong(), 0, ""))
+    override suspend fun downloadSharedSave(gameId: String, saveId: String): Result<ByteArray> =
+        Result.success(ByteArray(0))
+    override suspend fun deleteSharedSave(gameId: String, saveId: String): Result<Unit> =
+        Result.success(Unit)
+}
+
+private class NoopCollectionRepository : CollectionRepository {
+    override suspend fun getMyCollections(page: Int, pageSize: Int): Result<List<GameCollection>> =
+        Result.success(emptyList())
+    override suspend fun getPublicCollections(page: Int, pageSize: Int): Result<List<GameCollection>> =
+        Result.success(emptyList())
+    override suspend fun getCollection(id: String): Result<GameCollectionDetail> =
+        Result.failure(Exception("not found"))
+    override suspend fun createCollection(name: String, description: String?, isPublic: Boolean): Result<GameCollection> =
+        Result.success(GameCollection("1", "1", "user", name = name, description = description, isPublic = isPublic))
+    override suspend fun updateCollection(id: String, name: String?, description: String?, isPublic: Boolean?): Result<GameCollection> =
+        Result.success(GameCollection(id, "1", "user", name = name ?: "", description = description, isPublic = isPublic ?: false))
+    override suspend fun deleteCollection(id: String): Result<Unit> = Result.success(Unit)
+    override suspend fun addGameToCollection(collectionId: String, gameId: String): Result<Unit> = Result.success(Unit)
+    override suspend fun removeGameFromCollection(collectionId: String, gameId: String): Result<Unit> = Result.success(Unit)
+}
+
+private class NoopGameStatsRepository : GameStatsRepository {
+    override suspend fun getGameStats(gameId: String) = Result.success(GameStats(0, 0L, 0L, emptyList()))
+    override suspend fun getGameAchievements(gameId: String) = Result.success(emptyList<GameAchievement>())
+    override suspend fun getAchievementProgress(gameId: String) = Result.success(emptyList<AchievementProgress>())
+    override suspend fun getAchievementTimeline(gameId: String) = Result.success(
+        AchievementTimelineData(null, "", 0L, emptyList(), 0, 0, 0, 0)
+    )
+    override suspend fun getAchievementLeaderboard(gameId: String) = Result.success(emptyList<AchievementPlayerRanking>())
+    override suspend fun getUserStats() = Result.success(UserStats(0L, 0L, 0, 0, null, 0L, null))
+    override suspend fun getRecentAchievements() = Result.success(emptyList<RecentAchievement>())
+}
+
+private class NoopChallengeRepository : ChallengeRepository {
+    override suspend fun getChallenges(gameId: String?, consoleId: String?, difficulty: String?, sort: String?, page: Int) =
+        Result.success(emptyList<Challenge>())
+    override suspend fun getGameChallenges(gameId: String, page: Int) = Result.success(emptyList<Challenge>())
+    override suspend fun getMyChallenges(page: Int) = Result.success(emptyList<Challenge>())
+    override suspend fun getChallengeDetail(challengeId: String) = Result.failure<Challenge>(Exception("stub"))
+    override suspend fun getLeaderboard(challengeId: String, page: Int) = Result.success(emptyList<ChallengeLeaderboardEntry>())
+    override suspend fun createChallenge(gameId: String, name: String, description: String, type: String, difficulty: String, coreName: String, saveData: ByteArray, screenshotData: ByteArray?) =
+        Result.failure<Challenge>(Exception("stub"))
+    override suspend fun downloadChallengeSave(challengeId: String) = Result.success(byteArrayOf())
+    override suspend fun startAttempt(challengeId: String) =
+        Result.success(ChallengeAttempt("1", challengeId, "1", "test", null, "in_progress", "", null, 0, false))
+    override suspend fun completeAttempt(challengeId: String, attemptId: String) =
+        Result.success(ChallengeAttempt(attemptId, challengeId, "1", "test", null, "completed", "", "", 1000, false))
+    override suspend fun abandonAttempt(challengeId: String, attemptId: String) = Result.success(Unit)
+    override suspend fun getMyAttempts(challengeId: String) = Result.success(emptyList<ChallengeAttempt>())
+    override suspend fun deleteChallenge(challengeId: String) = Result.success(Unit)
+}
+
+private class NoopSharedSessionRepository : SharedSessionRepository {
+    override suspend fun getMySharedSessions() = Result.success(emptyList<SharedSession>())
+    override suspend fun getSharedSession(sharedSessionId: String) = Result.failure<SharedSessionDetail>(Exception("stub"))
+    override suspend fun getSharedSessionInvitations() = Result.success(emptyList<SharedSessionInvitation>())
+    override suspend fun getPendingInvitationCount() = Result.success(0)
+    override suspend fun createSharedSession(name: String, gameId: String, description: String, sourceSessionId: Long?) = Result.failure<SharedSessionDetail>(Exception("stub"))
+    override suspend fun deleteSharedSession(sharedSessionId: String) = Result.success(Unit)
+    override suspend fun inviteUser(sharedSessionId: String, username: String) = Result.success(Unit)
+    override suspend fun acceptInvitation(invitationId: String) = Result.success(Unit)
+    override suspend fun rejectInvitation(invitationId: String) = Result.success(Unit)
+    override suspend fun leaveSharedSession(sharedSessionId: String) = Result.success(Unit)
+    override suspend fun removeMember(sharedSessionId: String, userId: String) = Result.success(Unit)
+    override suspend fun getGameSharedSessions(gameId: String) = Result.success(emptyList<SharedSession>())
+    override suspend fun getSharedSessionSaves(sharedSessionId: String) = Result.success(emptyList<SharedSessionSave>())
+    override suspend fun deleteSharedSessionSave(sharedSessionId: String, saveId: Long) = Result.success(Unit)
+    override suspend fun takeTurn(sharedSessionId: String) = Result.success("stub-token")
+    override suspend fun releaseTurn(sharedSessionId: String) = Result.success(Unit)
+    override suspend fun heartbeat(sharedSessionId: String) = Result.success(Unit)
+    override suspend fun uploadSharedSessionSave(sharedSessionId: String, name: String, turnToken: String, data: ByteArray) =
+        Result.success(SharedSessionSave(id = 1, sharedSessionId = sharedSessionId, name = name))
+    override suspend fun downloadSharedSessionSave(sharedSessionId: String, saveId: Long) = Result.success(byteArrayOf())
+    override suspend fun downloadSharedSessionAutoSave(sharedSessionId: String) = Result.success(byteArrayOf())
+    override suspend fun uploadSharedSessionAutoSave(sharedSessionId: String, turnToken: String, data: ByteArray) =
+        Result.success(SharedSessionSave(id = 1, sharedSessionId = sharedSessionId, name = "Auto Save", isAuto = true))
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailInstantDownloadTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailInstantDownloadTest.kt
@@ -190,7 +190,7 @@ class GameDetailInstantDownloadTest {
     }
 
     @Test
-    fun aboveThresholdDownload_neverEntersSilentFlow() = runTest(testDispatcher) {
+    fun aboveThresholdDownload_neverEntersSilentFlow_andDoesNotAutoLaunch() = runTest(testDispatcher) {
         // 32 MB — above the 16 MB threshold.
         fakeGameRepo.fileSize = INSTANT_DOWNLOAD_THRESHOLD_BYTES + 1024
         val vm = createViewModel()
@@ -209,11 +209,36 @@ class GameDetailInstantDownloadTest {
         fakeDownloadRepo.completeDownload(Result.success("/fake"))
         advanceUntilIdle()
 
-        // Note: pendingAutoLaunch still fires for above-threshold —
-        // the user dispatched DownloadGameAndPlay, so the launch is
-        // expected once the download finishes. The visual difference
-        // is only in whether the progress bar was visible.
-        assertTrue(vm.state.value.pendingAutoLaunch)
+        // pendingAutoLaunch must NOT fire for above-threshold games:
+        // a long download (e.g. 2 GB / 30 minutes) shouldn't drop the
+        // user into the emulator on completion if they've walked
+        // away. The UI routes above-threshold uncached games to the
+        // regular Download button, but the VM defends here too so
+        // future routing changes can't enable the surprise-launch.
+        assertFalse(
+            vm.state.value.pendingAutoLaunch,
+            "above-threshold downloads must not auto-launch on completion",
+        )
+        assertTrue(vm.state.value.isGameCached)
+    }
+
+    @Test
+    fun subThresholdDownload_failure_doesNotRaiseAutoLaunch() = runTest(testDispatcher) {
+        fakeGameRepo.fileSize = 1024 * 1024
+        val vm = createViewModel()
+        vm.onIntent(GameDetailIntent.LoadGame("1"))
+        advanceUntilIdle()
+
+        vm.onIntent(GameDetailIntent.DownloadGameAndPlay)
+        fakeDownloadRepo.completeDownload(Result.failure(RuntimeException("network")))
+        advanceUntilIdle()
+
+        assertFalse(vm.state.value.isDownloading)
+        assertFalse(vm.state.value.isInstantDownload)
+        assertFalse(
+            vm.state.value.pendingAutoLaunch,
+            "failed download must never trigger auto-launch",
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #932. Sub-threshold downloads (<16 MB) no longer flash a separate Download button + progress bar — those finish faster than they can render usefully on any reasonable home connection. The Play/Resume/Continue button the user sees for cached games triggers a silent download-then-launch.

If the download exceeds 750 ms (slow network, server cold start, etc.) the regular progress UI takes over so the user isn't staring at a silent spinner.

## Pieces

- **\`DownloadThresholds.kt\`** — \`INSTANT_DOWNLOAD_THRESHOLD_BYTES = 16 MB\`, \`INSTANT_DOWNLOAD_FALLBACK_DELAY_MS = 750\`. Easily tunable.
- **Intent**: \`DownloadGameAndPlay\` (entry from the play button) + \`ConsumeAutoLaunch\` (screen acks the auto-launch signal).
- **State**: \`isInstantDownload\` (true during the silent window) + \`pendingAutoLaunch\` (true when download succeeded and the screen should call \`onPlay\`).
- **ViewModel**: \`downloadGameAndPlay\` orchestrates — flips the silent flag, schedules the fallback timer, raises \`pendingAutoLaunch\` on success.
- **\`GameHeroContent\`**: cached-style SpSplitButton when \`isGameCached || (sub-threshold && not-yet-past-fallback)\`. Click routes through new \`onDownloadAndPlay\` callback for the uncached case. Status text + progress bar gated on \`isDownloading && !isInstantDownload\`.
- **\`GameDetailScreen\`**: new \`LaunchedEffect(state.pendingAutoLaunch)\` calls \`onPlay(gameId)\` and dispatches \`ConsumeAutoLaunch\`.

## Test plan

- [x] \`GameDetailInstantDownloadTest\` (4 tests):
  - sub-threshold game enters silent window then raises auto-launch on success
  - sub-threshold game past 750 ms drops the silent flag (regular progress UI takes over)
  - above-threshold game never enters silent flow (progress visible from frame 1, but auto-launch still fires on completion)
  - ConsumeAutoLaunch clears pendingAutoLaunch
- [x] \`./gradlew :shared:desktopTest\` full suite green.
- [ ] Post-merge live test on Thor:
  - 1 MB NES game: tap Play → no progress UI, game launches in <1 s. ✅
  - 200 MB Mega Drive game: regular Download button + progress bar (no regression). ✅
  - Throttle network → ScummVM-size download exceeds 750 ms → progress bar appears mid-download. ✅

## Out of scope

- Web app / EmulatorJS — separate code path with its own download UX.
- BIOS / core downloads.
- Tuning the threshold via admin setting — kept as a simple const for easy iteration; can wire to settings later if needed.
- Pre-download size label semantics for ScummVM games (\`game.fileSize\` is the marker file size — separate concern, threaded into the #931 wire-vs-logical-bytes conversation).