### PR TITLE
fix(audit): security batch — Ktor token logging, bcrypt cost, logout query-param (#975 #976 #977)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -69,6 +69,15 @@ class SpelaApiClient(
 
         install(Logging) {
             level = LogLevel.HEADERS
+            // Redact the Authorization header from logs (#975).
+            // LogLevel.HEADERS dumps every request/response header by
+            // default, including `Authorization: Bearer <token>`. On
+            // Android these go to logcat (readable by any READ_LOGS-
+            // permission app and any rooted device); on desktop they
+            // hit stdout/stderr. Sanitising means logs still show
+            // header NAMES (useful for debugging) but the bearer
+            // token's value is replaced by a placeholder.
+            sanitizeHeader { header -> header == HttpHeaders.Authorization }
         }
 
         install(Auth) {

--- a/server/internal/api/auth_handler.go
+++ b/server/internal/api/auth_handler.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/spela/server/internal/auth"
 	"github.com/spela/server/internal/db"
+	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
 
@@ -20,13 +22,32 @@ func generateTokenFamily() string {
 
 const (
 	maxLoginAttempts = 5
-
-	// dummyBcryptHash is a pre-computed bcrypt hash used when a login attempt
-	// targets a non-existent username. Running bcrypt.CompareHashAndPassword
-	// against this hash ensures the response time is indistinguishable from a
-	// real password check, preventing timing-based username enumeration.
-	dummyBcryptHash = "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"
 )
+
+// dummyBcryptHash is generated at startup at the same cost factor used
+// by HashPassword (auth.BcryptCost). Running bcrypt.CompareHashAndPassword
+// against this hash makes the response time for a non-existent username
+// indistinguishable from a real password check.
+//
+// Pre-#976 this was a hardcoded constant at cost 10 while real passwords
+// hash at cost 12 — each bcrypt cost level doubles work, so cost 12 is
+// ~4× slower than cost 10. That discrepancy let an attacker measure
+// response times to enumerate usernames despite the dummy-hash defence.
+// Generating at startup keeps the dummy and real costs aligned for free
+// when the real cost factor changes.
+var dummyBcryptHash string
+
+func init() {
+	b, err := bcrypt.GenerateFromPassword([]byte("dummy-timing-protection"), auth.BcryptCost)
+	if err != nil {
+		// bcrypt.GenerateFromPassword only fails on invalid cost; we
+		// control auth.BcryptCost so this can't fire in practice.
+		// Panic so a misconfiguration is loud rather than silently
+		// degrading enumeration protection.
+		panic("dummyBcryptHash init: " + err.Error())
+	}
+	dummyBcryptHash = string(b)
+}
 
 // hashUsername returns a SHA-256 hex digest of the username so raw usernames
 // are never stored in the login_attempts table.

--- a/server/internal/api/huma_auth_handlers.go
+++ b/server/internal/api/huma_auth_handlers.go
@@ -117,11 +117,15 @@ type SetupStatusOutput struct {
 }
 
 // AuthLogoutInput captures the Authorization header so the handler can
-// blacklist the bearer access token. The header is optional — clients can
-// also pass the token via ?token= as a fallback (matches the gin handler).
+// blacklist the bearer access token. The historical gin handler also
+// accepted ?token= as a fallback; that fallback was removed in #977
+// because reverse proxies (nginx, HAProxy, Caddy) log the full URL and
+// the access token would land in their access logs in cleartext.
+// Logout is always invoked programmatically — there is no <img>/<video>
+// constraint that would prevent a client setting the Authorization
+// header on a POST.
 type AuthLogoutInput struct {
 	Authorization string `header:"Authorization" doc:"Bearer access token to blacklist."`
-	TokenQuery    string `query:"token" doc:"Fallback access token to blacklist when no Authorization header is sent."`
 }
 
 // AuthLogoutResponse mirrors the historical gin response body.
@@ -673,9 +677,6 @@ func (h *AuthHandler) HumaLogout(ctx context.Context, in *AuthLogoutInput) (*Aut
 		if len(parts) == 2 && parts[0] == "Bearer" {
 			token = parts[1]
 		}
-	}
-	if token == "" {
-		token = in.TokenQuery
 	}
 
 	if token != "" {

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -29,13 +29,21 @@ type Claims struct {
 // Passwords longer than this are silently truncated by bcrypt.
 const MaxBcryptPasswordLen = 72
 
+// BcryptCost is the cost factor used for production password hashes.
+// 12 is comfortably above OWASP's minimum (10) and sized for ~250 ms
+// hash time on modern server CPUs. Exported so the timing-protection
+// dummy hash in api.dummyBcryptHash can be generated at the same cost
+// — keeping login response times for valid and invalid usernames
+// indistinguishable. See #976.
+const BcryptCost = 12
+
 // HashPassword hashes a password using bcrypt. Returns an error if the
 // password exceeds bcrypt's 72-byte limit.
 func HashPassword(password string) (string, error) {
 	if len(password) > MaxBcryptPasswordLen {
 		return "", fmt.Errorf("password exceeds maximum length of %d bytes", MaxBcryptPasswordLen)
 	}
-	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 12)
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), BcryptCost)
 	if err != nil {
 		return "", fmt.Errorf("hashing password: %w", err)
 	}

--- a/server/internal/auth/auth_test.go
+++ b/server/internal/auth/auth_test.go
@@ -7,7 +7,35 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 )
+
+// TestBcryptCostIsAtLeast12 pins the cost factor used by HashPassword.
+// The matching dummyBcryptHash in api/auth_handler.go is generated at
+// auth.BcryptCost so the timing-protection check on login takes the
+// same wall time for valid and invalid usernames. Lowering the cost
+// re-opens the timing-based username enumeration described in #976:
+// each cost level below 12 halves bcrypt's work, making the dummy
+// comparison measurably faster than a real one and leaking whether
+// the username exists.
+func TestBcryptCostIsAtLeast12(t *testing.T) {
+	assert.GreaterOrEqual(t, BcryptCost, 12,
+		"BcryptCost must stay at 12 (OWASP minimum is 10; 12 is the value the dummy "+
+			"hash generation in api.dummyBcryptHash relies on for timing parity — see #976)")
+}
+
+// TestHashPasswordUsesBcryptCost confirms HashPassword actually uses
+// the BcryptCost constant and not a different hardcoded value. Catches
+// the regression where someone updates the constant but forgets the
+// call site.
+func TestHashPasswordUsesBcryptCost(t *testing.T) {
+	hash, err := HashPassword("probe")
+	require.NoError(t, err)
+	cost, err := bcrypt.Cost([]byte(hash))
+	require.NoError(t, err)
+	assert.Equal(t, BcryptCost, cost,
+		"HashPassword's bcrypt cost must match the exported BcryptCost constant")
+}
 
 func TestHashPassword(t *testing.T) {
 	hash, err := HashPassword("testpassword123")


### PR DESCRIPTION
Three security fixes from audit #955, batched on a single branch to share CI.

## Changes

| Issue | Title | File(s) | Severity |
|---|---|---|---|
| #975 | Ktor client logs bearer tokens on every request | \`SpelaApiClient.kt\` | High — logs are readable on Android with READ_LOGS / on rooted devices |
| #976 | dummyBcryptHash uses cost 10 while real passwords use cost 12 | \`auth_handler.go\`, \`auth/auth.go\` | High — partially defeats username-enumeration protection |
| #977 | POST /api/auth/logout accepts \`?token=\` query param | \`huma_auth_handlers.go\` | High — JWT in proxy access logs in cleartext |

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/auth/... ./internal/api/ -run "TestLogin|TestLogout|TestRegister|TestSetup"\` passes
- [x] \`./gradlew :shared:compileKotlinDesktop\` clean
- [ ] Post-merge: spot-check Android logcat from a debug build to confirm Authorization header values are redacted
- [ ] Post-merge: time a login attempt for non-existent vs existing user and confirm both take ~250 ms (close enough to be indistinguishable)

## Backwards-compat

- #977 removes a query-param fallback. The web client and player app both use header-based auth; the only callers that would have used \`?token=\` were custom curl scripts. Reasonable to drop without a deprecation window — no real-world breakage expected.
- #976 — every server restart now spends ~250 ms generating the dummy hash at \`init()\`. One-time cost, irrelevant in practice.
- #975 — purely additive (header still logged by name; only its value is redacted).