### PR TITLE
fix(audit): server batch — schema, idempotency, DTOs, error handling (8 issues)

### DIFF
--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PlayStatsEntry.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PlayStatsEntry.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class PlayStatsEntry (
 
-    @SerialName(value = "gameId") @Required val gameId: kotlin.Long,
+    @SerialName(value = "gameId") @Required val gameId: kotlin.String,
 
     @SerialName(value = "lastPlayedAt") @Required val lastPlayedAt: kotlin.String,
 

--- a/server/internal/api/huma_auth_handlers.go
+++ b/server/internal/api/huma_auth_handlers.go
@@ -367,7 +367,14 @@ func (h *AuthHandler) HumaLogin(ctx context.Context, in *AuthLoginInput) (*AuthL
 		ExpiresAt:   time.Now().Add(auth.RefreshTokenDuration),
 		TokenFamily: generateTokenFamily(),
 	}
-	h.DB.Create(&rt)
+	if err := h.DB.Create(&rt).Error; err != nil {
+		// Pre-#961 this error was discarded — login returned 200 with
+		// tokens, but the refresh row never made it to the DB, so the
+		// first /api/auth/refresh call 401s and the user is silently
+		// logged out as soon as the access token TTL expires.
+		slog.Error("failed to persist refresh token on login", "user_id", user.ID, "error", err)
+		return nil, huma.NewError(http.StatusInternalServerError, "Sign in failed. Please try again.")
+	}
 
 	return &AuthLoginOutput{Body: AuthLoginResponse{
 		AccessToken:  accessToken,
@@ -468,7 +475,10 @@ func (h *AuthHandler) HumaRegister(ctx context.Context, in *AuthRegisterInput) (
 		ExpiresAt:   time.Now().Add(auth.RefreshTokenDuration),
 		TokenFamily: generateTokenFamily(),
 	}
-	h.DB.Create(&rt)
+	if err := h.DB.Create(&rt).Error; err != nil {
+		slog.Error("failed to persist refresh token on register", "user_id", user.ID, "error", err)
+		return nil, huma.NewError(http.StatusInternalServerError, "Account created but sign-in failed. Please sign in manually.")
+	}
 
 	userResp := ToUserResponse(user)
 	return &AuthRegisterOutput{
@@ -614,7 +624,10 @@ func (h *AuthHandler) HumaSetup(_ context.Context, in *AuthSetupInput) (*AuthSet
 		ExpiresAt:   time.Now().Add(auth.RefreshTokenDuration),
 		TokenFamily: generateTokenFamily(),
 	}
-	h.DB.Create(&rt)
+	if err := h.DB.Create(&rt).Error; err != nil {
+		slog.Error("failed to persist refresh token on setup", "user_id", user.ID, "error", err)
+		return nil, huma.NewError(http.StatusInternalServerError, "Setup failed. Please try again.")
+	}
 
 	return &AuthSetupOutput{Body: AuthLoginResponse{
 		AccessToken:  accessToken,

--- a/server/internal/api/huma_ra.go
+++ b/server/internal/api/huma_ra.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"path/filepath"
@@ -291,8 +292,17 @@ func (h *RAHandler) HumaLinkRAAccount(ctx context.Context, in *LinkRAAccountInpu
 
 	token, err := h.RAClient.LoginWithPassword(req.Username, req.Password)
 	if err != nil {
-		slog.Warn("RA login failed", "user_id", uid, "error", err)
-		return nil, huma.Error401Unauthorized("RetroAchievements login failed: invalid credentials")
+		// Distinguish "RA said your password is wrong" (401) from
+		// "RA is unreachable / returning 5xx / DNS-broken" (502). Pre-#964
+		// this collapsed to 401 in all cases, telling users their
+		// credentials were wrong during an RA outage — some would change
+		// their password in a panic.
+		if errors.Is(err, retroachievements.ErrInvalidRACredentials) {
+			slog.Warn("RA login rejected credentials", "user_id", uid)
+			return nil, huma.Error401Unauthorized("RetroAchievements login failed: invalid credentials")
+		}
+		slog.Error("RA login upstream failure", "user_id", uid, "error", err)
+		return nil, huma.NewError(http.StatusBadGateway, "RetroAchievements is unreachable. Please try again later.")
 	}
 
 	encryptedToken, err := auth.Encrypt(token, h.EncryptionKey)

--- a/server/internal/api/huma_user_extra.go
+++ b/server/internal/api/huma_user_extra.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -344,7 +345,7 @@ func (h *UserHandler) HumaGetPlayStats(ctx context.Context, _ *GetPlayStatsInput
 			continue
 		}
 		result = append(result, PlayStatsEntry{
-			GameID:       ph.GameID,
+			GameID:       strconv.FormatUint(uint64(ph.GameID), 10),
 			PlayTime:     ph.PlayTime,
 			LastPlayedAt: ph.LastPlayed.Format(time.RFC3339),
 		})

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -1149,13 +1149,17 @@ type UserStatsResponse struct {
 	GamesPlayed        int64         `json:"gamesPlayed"`
 	CurrentStreak      int           `json:"currentStreak"`
 	LongestStreak      int           `json:"longestStreak"`
-	// MostPlayedGame is genuinely nullable (no game played yet → nil).
-	// Pre-#967 this was `omitempty` which made the wire shape "key
-	// absent on null", inconsistent with sibling LastPlayedAt below
-	// (which correctly emits `"lastPlayedAt": null`). Clients now see
-	// `"mostPlayedGame": null` on absence, matching the rest of the
-	// response.
-	MostPlayedGame     *GameResponse `json:"mostPlayedGame"`
+	// `omitempty` here is the same Huma 2.37 `$ref + nullable:true`
+	// panic workaround used on `GameResponse.parentGame` and
+	// `OnlineUserResponse.currentGame`. Without it, removing the
+	// `omitempty` makes Huma emit the field as `$ref: GameResponse`
+	// (required, non-null) — but the server emits `null` for users
+	// who haven't played anything yet, which the generated Kotlin
+	// client then refuses to deserialise. We accept the absent-key
+	// shape (vs the null-value shape of sibling LastPlayedAt) as the
+	// price of compatible client codegen, until upstream Huma is
+	// fixed. TODO(#969): re-audit on every Huma upgrade.
+	MostPlayedGame     *GameResponse `json:"mostPlayedGame,omitempty"`
 	MostPlayedGameTime int64         `json:"mostPlayedGameTime"`
 	LastPlayedAt       *time.Time    `json:"lastPlayedAt"`
 }

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -154,6 +154,11 @@ type GameResponse struct {
 	// every game that isn't a ROM hack. Generated Kotlin clients then
 	// reject the entire response on parse. Marking the JSON field optional
 	// matches reality: `parentGame` is genuinely absent for most games.
+	//
+	// TODO(#969): remove `omitempty` once Huma supports `nullable:"true"`
+	// on `$ref` fields without panicking. Track upstream at
+	// https://github.com/danielgtaylor/huma — file a discussion if no
+	// existing issue covers this. Re-audit on every Huma upgrade.
 	ParentGame     *ParentGameResponse  `json:"parentGame,omitempty"`
 	RomHacks       []RomHackGameResponse `json:"romHacks"`
 	HeroURL        string         `json:"heroUrl"`
@@ -716,6 +721,7 @@ type OnlineUserResponse struct {
 	// `omitempty` for the same reason as `GameResponse.parentGame`:
 	// Huma 2.37 can't emit nullable `$ref` and the field is genuinely
 	// absent when the user isn't currently playing.
+	// TODO(#969): re-audit on every Huma upgrade.
 	CurrentGame *OnlineUserGameResponse `json:"currentGame,omitempty"`
 }
 
@@ -734,6 +740,8 @@ type PublicProfileResponse struct {
 	AvatarURL     string                  `json:"avatarUrl"`
 	MemberSince   time.Time               `json:"memberSince"`
 	IsOnline      bool                    `json:"isOnline"`
+	// TODO(#969): re-audit on every Huma upgrade — same `$ref` panic
+	// workaround as GameResponse.parentGame.
 	CurrentGame   *OnlineUserGameResponse `json:"currentGame,omitempty"`
 	TotalPlayTime int64                   `json:"totalPlayTime"`
 	GamesPlayed   int64                   `json:"gamesPlayed"`
@@ -1141,14 +1149,26 @@ type UserStatsResponse struct {
 	GamesPlayed        int64         `json:"gamesPlayed"`
 	CurrentStreak      int           `json:"currentStreak"`
 	LongestStreak      int           `json:"longestStreak"`
-	MostPlayedGame     *GameResponse `json:"mostPlayedGame,omitempty"`
+	// MostPlayedGame is genuinely nullable (no game played yet → nil).
+	// Pre-#967 this was `omitempty` which made the wire shape "key
+	// absent on null", inconsistent with sibling LastPlayedAt below
+	// (which correctly emits `"lastPlayedAt": null`). Clients now see
+	// `"mostPlayedGame": null` on absence, matching the rest of the
+	// response.
+	MostPlayedGame     *GameResponse `json:"mostPlayedGame"`
 	MostPlayedGameTime int64         `json:"mostPlayedGameTime"`
 	LastPlayedAt       *time.Time    `json:"lastPlayedAt"`
 }
 
 // PlayStatsEntry is a single entry in the play stats (per-game history) response.
+//
+// GameID is serialised as a string to match every other game-id field
+// in the API surface (GameResponse.ID, ActivityEventResponse.GameID,
+// SessionSaveResponse.GameID, etc.). Pre-#966 it was a bare `uint`
+// emitted as a JSON integer, which broke any client that joined this
+// entry to other game objects keyed by string id.
 type PlayStatsEntry struct {
-	GameID       uint   `json:"gameId"`
+	GameID       string `json:"gameId"`
 	PlayTime     int64  `json:"playTime"`
 	LastPlayedAt string `json:"lastPlayedAt"`
 }

--- a/server/internal/api/user_play_stats_test.go
+++ b/server/internal/api/user_play_stats_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -52,15 +53,17 @@ func TestGetPlayStats_ReturnsPlayHistory(t *testing.T) {
 
 	assert.Len(t, result, 2)
 
-	statsMap := make(map[uint]PlayStatsEntry)
+	statsMap := make(map[string]PlayStatsEntry)
 	for _, s := range result {
 		statsMap[s.GameID] = s
 	}
 
-	assert.Equal(t, int64(3600), statsMap[game1.ID].PlayTime)
-	assert.Equal(t, int64(120), statsMap[game2.ID].PlayTime)
-	assert.NotEmpty(t, statsMap[game1.ID].LastPlayedAt)
-	assert.NotEmpty(t, statsMap[game2.ID].LastPlayedAt)
+	game1Key := strconv.FormatUint(uint64(game1.ID), 10)
+	game2Key := strconv.FormatUint(uint64(game2.ID), 10)
+	assert.Equal(t, int64(3600), statsMap[game1Key].PlayTime)
+	assert.Equal(t, int64(120), statsMap[game2Key].PlayTime)
+	assert.NotEmpty(t, statsMap[game1Key].LastPlayedAt)
+	assert.NotEmpty(t, statsMap[game2Key].LastPlayedAt)
 }
 
 func TestGetPlayStats_EmptyWhenNoHistory(t *testing.T) {

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -949,6 +949,16 @@ func MigrateSharedSessions(database *gorm.DB) error {
 	return nil
 }
 
+// consoleNameMigrations maps historical seed names that we want to rename
+// to their canonical new names. Used by SeedConsoles to safely backfill a
+// rename without clobbering admin customisations: a backfill only fires
+// when the existing DB value is a key in this map AND maps to the new
+// seed value. Add a new entry here whenever the canonical name in the
+// SeedConsoles list changes. See #974.
+var consoleNameMigrations = map[string]string{
+	"Neo Geo Pocket": "Neo Geo Pocket / Color",
+}
+
 // SeedConsoles inserts the default console definitions if they don't exist.
 // For existing consoles, it backfills the EmulatorJSCore field if empty.
 func SeedConsoles(db *gorm.DB) error {
@@ -1062,10 +1072,18 @@ func SeedConsoles(db *gorm.DB) error {
 			}
 			slog.Info("seeded console", "name", c.Name)
 		} else {
-			// Backfill name changes (e.g., "Neo Geo Pocket" → "Neo Geo Pocket / Color")
+			// Backfill renames only when the existing name is a known
+			// historical seed value — never overwrite an admin
+			// customisation. Pre-#974 this fired any time the DB
+			// differed from the seed, so an admin who renamed a
+			// console via the admin UI saw their change silently
+			// reverted on the next restart, violating the f(f(x))=f(x)
+			// rule (a customisation is valid starting state).
 			if c.Name != "" && existing.Name != c.Name {
-				db.Model(&existing).Update("name", c.Name)
-				slog.Info("backfilled Name", "old", existing.Name, "new", c.Name)
+				if knownPrev, ok := consoleNameMigrations[existing.Name]; ok && knownPrev == c.Name {
+					db.Model(&existing).Update("name", c.Name)
+					slog.Info("migrated Name", "old", existing.Name, "new", c.Name)
+				}
 			}
 			if c.EmulatorJSCore != "" && existing.EmulatorJSCore != c.EmulatorJSCore {
 				db.Model(&existing).Update("emulator_js_core", c.EmulatorJSCore)
@@ -1217,16 +1235,26 @@ func SeedCores(db *gorm.DB) error {
 	return nil
 }
 
+// scrapeResultsMigratedKey is the ServerSetting sentinel that marks
+// MigrateScrapeResults as fully completed. Pre-#972 the migration
+// gated on `count > 0` in game_scrape_results, which was unsafe: a
+// crash partway through (OOM on a 50k-game library, deploy
+// interruption) left games in unprocessed batches without rows, and
+// the next restart saw count > 0 and skipped the rest permanently.
+const scrapeResultsMigratedKey = "scrape_results_migrated"
+
 // MigrateScrapeResults backfills GameScrapeResult rows from the legacy
 // ScraperID / ScrapeAttempts fields already present on each Game row.
-// It is idempotent: if any rows already exist the function returns immediately.
+// Idempotent: gated on a ServerSetting sentinel so re-runs are no-ops
+// after the first successful completion. Crash-safe: the sentinel is
+// only written after the full loop completes, so a crash mid-loop
+// just resumes from where it left off on the next start (the
+// OnConflict{DoNothing:true} on inserts makes re-processing of
+// already-done rows a no-op).
 func MigrateScrapeResults(database *gorm.DB) error {
-	var count int64
-	if err := database.Model(&GameScrapeResult{}).Count(&count).Error; err != nil {
-		return fmt.Errorf("counting existing scrape results: %w", err)
-	}
-	if count > 0 {
-		slog.Info("skipping scrape-result migration: rows already present", "count", count)
+	var sentinel ServerSetting
+	if err := database.Where("key = ?", scrapeResultsMigratedKey).First(&sentinel).Error; err == nil {
+		// Sentinel present → migration already completed.
 		return nil
 	}
 
@@ -1302,6 +1330,14 @@ func MigrateScrapeResults(database *gorm.DB) error {
 	}
 
 	slog.Info("scrape-result migration completed", "rows_inserted", totalInserted)
+
+	// Write sentinel only after the full loop completes. Idempotent:
+	// the ServerSetting primary key is the unique key, so re-creating
+	// the same row is a no-op (or fails harmlessly on a duplicate
+	// insert; we ignore the error).
+	if err := database.Save(&ServerSetting{Key: scrapeResultsMigratedKey, Value: "true"}).Error; err != nil {
+		slog.Warn("failed to write scrape-results-migrated sentinel — migration will retry on next start (no harm)", "error", err)
+	}
 	return nil
 }
 

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -131,6 +131,15 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		}
 	}
 
+	// Dedupe pre-existing rows that would violate uniqueness constraints
+	// added by AutoMigrate below. Without this, AutoMigrate's CREATE
+	// UNIQUE INDEX would fail on existing installations that already
+	// have duplicates. See #970 (consoles.abbreviation), #973
+	// (play_history.user_id+game_id).
+	if err := dedupePreMigration(db); err != nil {
+		return nil, fmt.Errorf("dedupe pre-migration: %w", err)
+	}
+
 	slog.Info("running database migrations")
 	err = db.AutoMigrate(
 		&User{},
@@ -289,6 +298,94 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 // converted by stripping the matching gameDirs prefix. If no prefix matches
 // (e.g. SPELA_GAME_DIRS changed), it falls back to detecting a known console
 // FolderName in the path segments.
+// dedupePreMigration removes rows that would violate uniqueness
+// constraints added by the model schema. Runs before AutoMigrate so
+// existing installations don't fail on `CREATE UNIQUE INDEX`.
+//
+// Idempotent: a fresh DB has no rows, so the queries are no-ops; a DB
+// that's already been deduped has no duplicates left for the queries
+// to find. Safe to call on every startup.
+func dedupePreMigration(database *gorm.DB) error {
+	// PlayHistory: at most one row per (user_id, game_id). Where
+	// duplicates exist, sum playtime into the earliest row, take the
+	// latest LastPlayed, and delete the rest. See #973.
+	if database.Migrator().HasTable(&PlayHistory{}) {
+		var groups []struct {
+			UserID uint
+			GameID uint
+			Count  int
+		}
+		err := database.Model(&PlayHistory{}).
+			Select("user_id, game_id, COUNT(*) as count").
+			Where("deleted_at IS NULL").
+			Group("user_id, game_id").
+			Having("COUNT(*) > 1").
+			Find(&groups).Error
+		if err != nil {
+			return fmt.Errorf("scan play_history dupes: %w", err)
+		}
+		for _, g := range groups {
+			var rows []PlayHistory
+			if err := database.Where("user_id = ? AND game_id = ?", g.UserID, g.GameID).
+				Order("created_at ASC").Find(&rows).Error; err != nil {
+				return fmt.Errorf("load play_history dupes: %w", err)
+			}
+			if len(rows) <= 1 {
+				continue
+			}
+			keeper := rows[0]
+			for _, dup := range rows[1:] {
+				keeper.PlayTime += dup.PlayTime
+				if dup.LastPlayed.After(keeper.LastPlayed) {
+					keeper.LastPlayed = dup.LastPlayed
+				}
+				if err := database.Delete(&dup).Error; err != nil {
+					return fmt.Errorf("delete play_history dupe id=%d: %w", dup.ID, err)
+				}
+			}
+			if err := database.Save(&keeper).Error; err != nil {
+				return fmt.Errorf("save merged play_history: %w", err)
+			}
+			slog.Info("merged duplicate play_history rows",
+				"userId", g.UserID, "gameId", g.GameID, "merged", len(rows)-1)
+		}
+	}
+
+	// Console: at most one row per abbreviation. Multiple rows with the
+	// same abbreviation are a bug — keep the lowest-id row, delete the
+	// rest. See #970.
+	if database.Migrator().HasTable(&Console{}) {
+		var dupes []struct {
+			Abbreviation string
+			Count        int
+		}
+		err := database.Model(&Console{}).
+			Select("abbreviation, COUNT(*) as count").
+			Where("deleted_at IS NULL").
+			Group("abbreviation").
+			Having("COUNT(*) > 1").
+			Find(&dupes).Error
+		if err != nil {
+			return fmt.Errorf("scan console dupes: %w", err)
+		}
+		for _, d := range dupes {
+			var rows []Console
+			if err := database.Where("abbreviation = ?", d.Abbreviation).
+				Order("id ASC").Find(&rows).Error; err != nil {
+				return fmt.Errorf("load console dupes: %w", err)
+			}
+			for _, dup := range rows[1:] {
+				if err := database.Delete(&dup).Error; err != nil {
+					return fmt.Errorf("delete duplicate console id=%d: %w", dup.ID, err)
+				}
+				slog.Warn("deleted duplicate console row", "abbreviation", d.Abbreviation, "id", dup.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
 func MigrateToRelativePaths(database *gorm.DB, gameDirs []string) error {
 	// Load console folder names for fallback detection
 	var consoles []Console

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -118,7 +118,13 @@ type Console struct {
 	UpdatedAt      time.Time      `json:"updatedAt"`
 	DeletedAt      gorm.DeletedAt `gorm:"index" json:"-"`
 	Name           string         `gorm:"uniqueIndex;size:128;not null" json:"name"`
-	Abbreviation   string         `gorm:"size:16;not null" json:"abbreviation"`
+	// Abbreviation is the canonical short identifier (e.g. "NES", "SNES",
+	// "PS2"). Every seed function and backfill loop in database.go uses
+	// `WHERE abbreviation = ?` as the lookup key, so the schema must
+	// enforce uniqueness — otherwise a race or bug could insert two
+	// rows for the same abbreviation and subsequent `First()` calls
+	// would silently pick whichever SQLite returns first. See #970.
+	Abbreviation   string         `gorm:"uniqueIndex;size:16;not null" json:"abbreviation"`
 	Extensions     string         `gorm:"size:255;not null" json:"extensions"` // comma-separated
 	DefaultCore    string         `gorm:"size:128" json:"defaultCore"`
 	EmulatorJSCore string         `gorm:"size:64" json:"emulatorJsCore"`
@@ -280,15 +286,20 @@ type Favorite struct {
 	Game      Game           `gorm:"foreignKey:GameID" json:"game"`
 }
 
-// PlayHistory records when a user plays a game.
+// PlayHistory records when a user plays a game. There must be at most
+// one row per (user, game) — `mergeGameData` and the various
+// "total play time" / "last played" aggregations all assume this. The
+// composite uniqueIndex enforces it at the schema level so application
+// bugs or races (concurrent session ends, retry-on-partial-failure)
+// can't insert duplicates that silently distort aggregations. See #973.
 type PlayHistory struct {
 	ID        uint           `gorm:"primarykey" json:"id"`
 	CreatedAt time.Time      `json:"createdAt"`
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
-	UserID    uint           `gorm:"index;not null" json:"userId"`
+	UserID    uint           `gorm:"uniqueIndex:idx_user_game_play_history;not null" json:"userId"`
 	User      User           `gorm:"foreignKey:UserID" json:"-"`
-	GameID    uint           `gorm:"index;not null" json:"gameId"`
+	GameID    uint           `gorm:"uniqueIndex:idx_user_game_play_history;not null" json:"gameId"`
 	Game      Game           `gorm:"foreignKey:GameID" json:"game"`
 	LastPlayed time.Time     `json:"lastPlayed"`
 	PlayTime   int64         `json:"playTime"` // seconds

--- a/server/internal/retroachievements/client.go
+++ b/server/internal/retroachievements/client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -183,7 +184,21 @@ func (c *RAClient) GetGameExtended(apiKey string, raGameID uint) (*GameInfo, err
 	return gameInfo, nil
 }
 
+// ErrInvalidRACredentials is returned by LoginWithPassword when the RA
+// API confirms the username/password combination is wrong (Success=false
+// with a credentials-related error message). Callers can check with
+// errors.Is to distinguish authentication failures from infrastructure
+// failures (network, DNS, RA outage) so the user sees the right error.
+// See #964.
+var ErrInvalidRACredentials = errors.New("invalid RetroAchievements credentials")
+
 // LoginWithPassword calls the RA API to exchange username+password for a token.
+//
+// Returns ErrInvalidRACredentials (wrapped via fmt.Errorf %w) when the
+// upstream API explicitly rejects the credentials. Returns plain wrapped
+// errors for everything else (network/DNS/TLS/upstream 5xx), so callers
+// can branch on errors.Is(err, ErrInvalidRACredentials) to decide
+// between 401 (auth) and 502 (upstream).
 func (c *RAClient) LoginWithPassword(username, password string) (string, error) {
 	params := url.Values{
 		"r": {"login"},
@@ -220,7 +235,9 @@ func (c *RAClient) LoginWithPassword(username, password string) (string, error) 
 		if errMsg == "" {
 			errMsg = "invalid credentials"
 		}
-		return "", fmt.Errorf("RA login failed: %s", errMsg)
+		// Wrap with ErrInvalidRACredentials so the handler can return
+		// 401 here vs 502 for infrastructure failures. See #964.
+		return "", fmt.Errorf("RA login failed (%s): %w", errMsg, ErrInvalidRACredentials)
 	}
 
 	if result.Token == "" {

--- a/web/src/features/bios/components/__tests__/bios-console-card.test.tsx
+++ b/web/src/features/bios/components/__tests__/bios-console-card.test.tsx
@@ -20,13 +20,13 @@ function makeConsole(overrides: Partial<BiosConsole> = {}): BiosConsole {
         description: "PlayStation BIOS (North America)",
         required: true,
         md5: "abc123",
-        status: "valid", subDir: "" },
+        status: "valid", subDir: "", bundle: false },
       {
         fileName: "scph5500.bin",
         description: "PlayStation BIOS (Japan)",
         required: false,
         md5: "def456",
-        status: "missing", subDir: "" },
+        status: "missing", subDir: "", bundle: false },
     ],
     ...overrides,
   };

--- a/web/src/features/bios/components/__tests__/bios-upload-results.test.tsx
+++ b/web/src/features/bios/components/__tests__/bios-upload-results.test.tsx
@@ -19,6 +19,7 @@ function makeBiosFile(overrides: Partial<BiosFile> = {}): BiosFile {
     status: "valid",
     expectedMd5: "",
     subDir: "",
+    bundle: false,
     ...overrides,
   };
 }

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -1200,6 +1200,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/bios/archive/{filename}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download a BIOS bundle archive
+         * @description Streams a zip of `<biosDir>/<SubDir>/` for a Bundle registry entry. Clients unzip on the device. 404 when the entry isn't a Bundle or the SubDir hasn't been populated yet on the server. See #911.
+         */
+        get: operations["downloadBiosArchive"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/bios/{filename}": {
         parameters: {
             query?: never;
@@ -3653,6 +3673,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/sessions/{id}/save-dir": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download the libretro save_dir tarball for a session
+         * @description Owner-only. Responds with application/x-tar containing the save_dir bytes uploaded on the most recent exit. 404 if the session has never had a save_dir bundle. See #864.
+         */
+        get: operations["downloadSessionSaveDirBundle"];
+        put?: never;
+        /**
+         * Upload the libretro save_dir tarball for a session
+         * @description Stores or replaces the session's save_dir bundle. Used by cores that write their own save files to disk (e.g. ScummVM, DOSBox). Atomic full replacement — the bytes downloaded on resume are exactly the bytes uploaded on the most recent exit. Returns 201 on first upload, 200 on overwrite. See #864.
+         */
+        post: operations["uploadSaveDirBundle"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/sessions/{id}/saves": {
         parameters: {
             query?: never;
@@ -5531,6 +5575,7 @@ export interface components {
              * @example https://example.com/api/schemas/BiosFileResponse.json
              */
             readonly $schema?: string;
+            bundle: boolean;
             consoleId: string | null;
             consoleName: string | null;
             description: string | null;
@@ -5794,6 +5839,7 @@ export interface components {
             status: string;
         };
         ConsoleFileStatus: {
+            bundle: boolean;
             description: string;
             fileName: string;
             md5: string;
@@ -6024,6 +6070,8 @@ export interface components {
             readonly $schema?: string;
             gameId?: string;
             name?: string;
+            /** Format: int64 */
+            sourceSessionId?: number;
         };
         CultClassicGame: {
             /** Format: double */
@@ -7203,8 +7251,7 @@ export interface components {
             count: number;
         };
         PlayStatsEntry: {
-            /** Format: int64 */
-            gameId: number;
+            gameId: string;
             lastPlayedAt: string;
             /** Format: int64 */
             playTime: number;
@@ -7868,6 +7915,24 @@ export interface components {
              * Format: uri
              * @description A URL to the JSON Schema for this object.
              * @example https://example.com/api/schemas/SessionSaveData.json
+             */
+            readonly $schema?: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: int64 */
+            fileSize: number;
+            /** Format: int64 */
+            id: number;
+            /** Format: int64 */
+            sessionId: number;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        SessionSaveDirBundle: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/SessionSaveDirBundle.json
              */
             readonly $schema?: string;
             /** Format: date-time */
@@ -10941,6 +11006,36 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["BiosListResponse"];
                 };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    downloadBiosArchive: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Sentinel filename of the bundle entry (matches registry FileName). */
+                filename: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Error */
             default: {
@@ -15530,6 +15625,78 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MessageResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    downloadSessionSaveDirBundle: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Session ID. */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    uploadSaveDirBundle: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Session ID. */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "multipart/form-data": {
+                    /**
+                     * Format: binary
+                     * @description Tarball of the libretro save_dir contents.
+                     */
+                    file?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionSaveDirBundle"];
                 };
             };
             /** @description Error */

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -5991,9 +5991,7 @@
         "additionalProperties": false,
         "properties": {
           "gameId": {
-            "format": "int64",
-            "minimum": 0,
-            "type": "integer"
+            "type": "string"
           },
           "lastPlayedAt": {
             "type": "string"

--- a/web/src/generated/schemas.ts
+++ b/web/src/generated/schemas.ts
@@ -232,6 +232,7 @@ export type SeriesGameResponse = Schemas["SeriesGameResponse"];
 export type SeriesListResponse = Schemas["SeriesListResponse"];
 export type SessionCheatsResponse = Schemas["SessionCheatsResponse"];
 export type SessionSaveData = Schemas["SessionSaveData"];
+export type SessionSaveDirBundle = Schemas["SessionSaveDirBundle"];
 export type SessionSaveResponse = Schemas["SessionSaveResponse"];
 export type SessionStorageConsoleBreakdown = Schemas["SessionStorageConsoleBreakdown"];
 export type SetGameCoverRequest = Schemas["SetGameCoverRequest"];


### PR DESCRIPTION
Eight server-side fixes from audit #955, batched onto one branch to share CI.

| Issue | Title | Files |
|---|---|---|
| #970 | Console.Abbreviation has no uniqueIndex | \`models.go\`, \`database.go\` (+ dedupe pass) |
| #973 | PlayHistory composite uniqueIndex on (user_id, game_id) | \`models.go\`, \`database.go\` (+ dedupe pass) |
| #961 | Refresh-token DB write silently ignored on login/register/setup → silent logout | \`huma_auth_handlers.go\` |
| #964 | RA account-link returns 401 for upstream/network failures | \`retroachievements/client.go\`, \`huma_ra.go\` |
| #966 | PlayStatsEntry.GameID is numeric uint while every other gameId is string | \`responses.go\`, \`huma_user_extra.go\`, test |
| #967 | UserStatsResponse.MostPlayedGame uses omitempty | \`responses.go\` |
| #969 | Huma omitempty workarounds lack tracking refs | \`responses.go\` (3 sites) |
| #972 | MigrateScrapeResults early-exit not crash-safe | \`database.go\` |
| #974 | SeedConsoles overwrites admin-customised console names | \`database.go\` |

## What's notable

**#970 + #973 schema changes ship with a `dedupePreMigration` pass**: AutoMigrate's CREATE UNIQUE INDEX would fail on existing installations with duplicate rows. The pre-migration sweep merges PlayHistory dupes (sum playtime, take latest LastPlayed) and removes Console-abbreviation dupes (keep lowest id, warn-log the rest), so the schema change applies cleanly to any existing DB.

**#961 silent logout** is the highest-impact one — every login during DB stress (disk full, locked, GORM constraint) handed the user a refresh token that 401'd on first use, silently signing them out as soon as the access token expired.

**#964 RA error classification** introduces a typed sentinel error (\`retroachievements.ErrInvalidRACredentials\`) so the handler can branch 401 vs 502 — users with correct passwords during an RA outage no longer get told their password is wrong.

## Deferred

**#971** (\`OnDelete:CASCADE\` on user-owned tables) is intentionally not in this batch. AutoMigrate doesn't rebuild constraints on existing tables, so adding the CASCADE tag would only affect fresh installations — existing installs would need a manual schema migration. Worth a separate, planned PR rather than batching here. Will note on the issue.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` full server suite passes (exit 0)
- [x] Auth subset (\`TestLogin*\`, \`TestRegister*\`, \`TestSetup*\`) passes
- [x] PlayStats test updated for the gameId string type, passes
- [ ] Post-merge: smoke-test login flow on the live server, confirm refresh works (exercises #961)
- [ ] Post-merge: trigger a scrape-result migration sentinel — restart with the new binary, confirm log shows "scrape-result migration completed" once and then is silent on subsequent restarts