### PR TITLE
fix(audit): player concurrency batch — 5 ViewModel/repo fixes

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/interceptor/AuthInterceptor.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/interceptor/AuthInterceptor.kt
@@ -1,17 +1,27 @@
 package com.spela.player.data.remote.interceptor
 
 import io.ktor.client.plugins.auth.providers.*
+import kotlin.concurrent.Volatile
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 /**
  * Manages token storage and refresh logic for API requests.
+ *
+ * The two token fields are `@Volatile` so non-suspend readers
+ * (`hasTokens`, `toBearerTokens`) see the latest value written by the
+ * suspend setters even though they don't acquire the mutex. The mutex
+ * still serialises writes so concurrent setTokens / clearTokens calls
+ * can't tear an intermediate state into the volatile slot. See #978.
  */
 class TokenManager {
     private val mutex = Mutex()
 
+    @Volatile
     var accessToken: String? = null
         private set
+
+    @Volatile
     var refreshToken: String? = null
         private set
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
@@ -40,15 +40,28 @@ class DownloadRepositoryImpl(
      *  entry in a finally block. See #845. */
     private val activeJobs = mutableMapOf<String, Job>()
 
+    // The speedTrackers / activeJobs / lastEmittedBytes maps are
+    // accessed concurrently from progress callbacks invoked on the
+    // IO dispatcher's thread pool — multiple simultaneous downloads
+    // race on every map mutation. Pre-#957 these were unsynchronized
+    // mutableMapOf and could throw ConcurrentModificationException
+    // or silently lose writes (the lost-write on lastEmittedBytes
+    // directly broke the monotonic guard from #931).
+    //
+    // @Synchronized provides a per-instance monitor — every helper
+    // below acquires it before touching any map, and that's enough
+    // because no helper holds the lock across a suspension point.
+    @Synchronized
     private fun recordSpeed(gameId: String, bytesDownloaded: Long): Long =
         speedTrackers.getOrPut(gameId) { SpeedTracker() }.record(bytesDownloaded)
 
+    @Synchronized
     private fun resetSpeed(gameId: String) {
         speedTrackers.remove(gameId)
         // Reset the monotonic high-water mark together with the speed
         // tracker — both have the same lifecycle (cleared whenever a
         // download terminates: completed, failed, or cancelled).
-        resetMonotonic(gameId)
+        lastEmittedBytes.remove(gameId)
     }
 
     /*
@@ -63,6 +76,7 @@ class DownloadRepositoryImpl(
      */
     private val lastEmittedBytes = mutableMapOf<String, Long>()
 
+    @Synchronized
     private fun monotonicBytes(gameId: String, candidate: Long): Long {
         val prev = lastEmittedBytes[gameId] ?: 0L
         val next = maxOf(prev, candidate)
@@ -70,8 +84,14 @@ class DownloadRepositoryImpl(
         return next
     }
 
-    private fun resetMonotonic(gameId: String) {
-        lastEmittedBytes.remove(gameId)
+    @Synchronized
+    private fun setActiveJob(gameId: String, job: Job) {
+        activeJobs[gameId] = job
+    }
+
+    @Synchronized
+    private fun takeActiveJob(gameId: String): Job? {
+        return activeJobs.remove(gameId)
     }
 
     init {
@@ -149,7 +169,7 @@ class DownloadRepositoryImpl(
         // Capture the caller's Job so cancelDownload can interrupt it.
         // The download work below runs on the SAME coroutine, so cancelling
         // this Job is what actually aborts the in-flight HTTP fetch.
-        activeJobs[gameId] = coroutineContext[Job]!!
+        setActiveJob(gameId, coroutineContext[Job]!!)
         return runCatching {
             downloads.update { it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.QUEUED)) }
             downloads.update { it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING)) }
@@ -181,9 +201,9 @@ class DownloadRepositoryImpl(
             val now = kotlin.time.Clock.System.now().toEpochMilliseconds()
             database.spelaDatabaseQueries.insertDownload(gameId, path, fileSize, now)
             refreshDownloadedGames()
-            activeJobs.remove(gameId)
+            takeActiveJob(gameId)
         }.onFailure { error ->
-            activeJobs.remove(gameId)
+            takeActiveJob(gameId)
             cleanupPartialDownload(gameId)
             resetSpeed(gameId)
             // User-initiated cancel surfaces as CancellationException via runCatching.
@@ -465,7 +485,7 @@ class DownloadRepositoryImpl(
         // cleanupPartialDownload via the onFailure branch — so disk space is
         // reclaimed automatically. cancelDownload itself doesn't need to call
         // cleanup directly.
-        activeJobs.remove(gameId)?.cancel(CancellationException("download cancelled by user"))
+        takeActiveJob(gameId)?.cancel(CancellationException("download cancelled by user"))
         // Defensive: if the job already completed (or never started), drop the
         // in-memory progress entry and tracker manually.
         downloads.update { it - gameId }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -141,6 +141,14 @@ class EmulationViewModel(
                             } else {
                                 gamepadPortManager.loadAllMappings(consoleId)
                             }
+                        } catch (e: kotlinx.coroutines.CancellationException) {
+                            // Re-throw so cooperative cancellation works.
+                            // Pre-#963 the broad `catch (_: Exception)` below
+                            // silently swallowed CancellationException too,
+                            // hanging anything waiting on this coroutine to
+                            // terminate cleanly when the parent scope was
+                            // cancelled (e.g. on Android lifecycle destroy).
+                            throw e
                         } catch (_: Exception) {
                             // Best effort - defaults will be used
                         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -26,6 +26,7 @@ import com.spela.player.util.DispatcherProvider
 import com.spela.player.domain.model.INSTANT_DOWNLOAD_FALLBACK_DELAY_MS
 import com.spela.player.domain.model.INSTANT_DOWNLOAD_THRESHOLD_BYTES
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -62,6 +63,16 @@ class GameDetailViewModel(
     val state: StateFlow<GameDetailState> = _state.asStateFlow()
 
     private var currentGameId: String? = null
+
+    // Per-game collector jobs. Cancelled and re-launched on every
+    // loadGame so navigating away and back (or to a different game)
+    // doesn't leak collectors. Pre-#956 these were unbounded `scope.
+    // launch { collect { ... } }` calls — each loadGame multiplied
+    // the active collectors, so after two visits two writers raced
+    // on state.downloadProgress and two reloads fired on every
+    // scrape-done event.
+    private var downloadObserveJob: Job? = null
+    private var scrapeObserveJobs: List<Job> = emptyList()
 
     // Session + achievement CRUD extracted into their own managers
     // (#691). Each shares this VM's `_state` so updates land
@@ -234,6 +245,13 @@ class GameDetailViewModel(
         currentGameId = gameId
         _state.update { GameDetailState(isLoading = true) }
 
+        // Cancel any observers from a previous loadGame call (a
+        // back-and-forth nav, or a switch to a different game) so
+        // we don't accumulate concurrent collectors. See #956.
+        downloadObserveJob?.cancel()
+        scrapeObserveJobs.forEach { it.cancel() }
+        scrapeObserveJobs = emptyList()
+
         scope.launch(dispatchers.io) {
             getGameDetailUseCase(gameId).fold(
                 onSuccess = { detail ->
@@ -295,7 +313,7 @@ class GameDetailViewModel(
             )
         }
 
-        scope.launch(dispatchers.io) {
+        downloadObserveJob = scope.launch(dispatchers.io) {
             downloadRepository.observeDownload(gameId).collect { progress ->
                 _state.update { it.copy(downloadProgress = progress) }
             }
@@ -329,21 +347,21 @@ class GameDetailViewModel(
 
     private fun observeScrapeStatus(gameId: String) {
         // Track scraping state from WebSocket events
-        scope.launch(dispatchers.io) {
+        val scrapingJob = scope.launch(dispatchers.io) {
             scrapeService.scrapingGameIds.collect { scrapingIds ->
                 _state.update { it.copy(isScraping = gameId in scrapingIds) }
             }
         }
         // Track queued state — game has a pending ScrapeQueueItem the
         // worker hasn't picked up yet. Drives the "Scrape queued" hint.
-        scope.launch(dispatchers.io) {
+        val queuedJob = scope.launch(dispatchers.io) {
             scrapeService.queuedGameIds.collect { queuedIds ->
                 _state.update { it.copy(isScrapeQueued = gameId in queuedIds) }
             }
         }
 
         // Reload game data when scraping finishes
-        scope.launch(dispatchers.io) {
+        val doneJob = scope.launch(dispatchers.io) {
             scrapeService.gameScrapeDone.collect { doneGameId ->
                 if (doneGameId == gameId) {
                     getGameDetailUseCase(gameId).fold(
@@ -355,6 +373,8 @@ class GameDetailViewModel(
                 }
             }
         }
+
+        scrapeObserveJobs = listOf(scrapingJob, queuedJob, doneJob)
     }
 
     private fun scrapeAndRefresh(gameId: String) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -287,18 +287,30 @@ class GameListViewModel(
         searchJob?.cancel()
         searchJob = scope.launch(dispatchers.io) {
             delay(300) // debounce
+            // Capture the query that was current at dispatch time so a
+            // late-arriving prior coroutine that survived the debounce
+            // window doesn't run the API call with a NEWER query that's
+            // since landed in state. Then verify after the delay that
+            // we're still relevant before firing the network call —
+            // and one more time before applying results, so search
+            // results from a previous query can't overwrite fresh
+            // loadGamesForConsole results. See #958.
+            val captured = _state.value.searchQuery
+            if (captured != query) return@launch
             _state.update { it.copy(isLoading = true) }
             val current = _state.value
             searchGamesUseCase(
-                query = current.searchQuery,
+                query = captured,
                 consoleId = current.effectiveConsoleId,
                 sortBy = current.sortBy,
                 sortOrder = current.sortOrder,
             ).fold(
                 onSuccess = { games ->
+                    if (_state.value.searchQuery != captured) return@fold
                     _state.update { it.copy(games = games, isLoading = false) }
                 },
                 onFailure = { error ->
+                    if (_state.value.searchQuery != captured) return@fold
                     _state.update { it.copy(error = error.message, isLoading = false) }
                 },
             )


### PR DESCRIPTION
Five concurrency fixes from audit #955, all in player/shared/.

| Issue | Title | File |
|---|---|---|
| #956 | GameDetailViewModel.loadGame leaks Flow collectors | \`GameDetailViewModel.kt\` |
| #957 | DownloadRepositoryImpl data race on shared maps | \`DownloadRepositoryImpl.kt\` |
| #958 | GameListViewModel.searchGames stale searchQuery after debounce | \`GameListViewModel.kt\` |
| #963 | EmulationViewModel swallows CancellationException | \`EmulationViewModel.kt\` |
| #978 | TokenManager.hasTokens/toBearerTokens read without @Volatile | \`AuthInterceptor.kt\` |

## Most-impactful

**#956 + #957** are the user-visible ones. The Flow leak meant every back-nav to game detail multiplied concurrent collectors and reload triggers. The data race directly compromised the monotonic-guard contract from #931 — `lastEmittedBytes` was racing between concurrent downloads, so the bar could visibly retreat (the exact symptom the guard was added to prevent).

**#963** is small but correct concurrent-Kotlin hygiene: every broad `catch (_: Exception)` should re-throw `CancellationException` first.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop\` clean
- [x] \`./gradlew :shared:desktopTest\` full suite passes
- [ ] Post-merge: open game detail, navigate back, navigate to a different game, navigate back to first; observe in logcat that only one downloadProgress collector is active per game
- [ ] Post-merge: kick off 2-3 simultaneous downloads, confirm progress bars don't visibly retreat (reproducer for the data race fix)