### PR TITLE
fix(audit): player UI batch — error toast, invite mapper, share-save bytes (#962 #965 #979)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -347,10 +347,16 @@ fun com.spela.client.models.SharedSessionInviteResponse.toDomain(): SharedSessio
     id = id,
     sharedSessionId = sharedSessionId,
     sharedSessionName = sharedSessionName,
+    gameId = gameId,
     gameTitle = gameTitle,
-    // gameId / gameCoverUrl / gameConsoleName / inviterAvatarUrl are not sent —
-    // domain defaults apply.
+    gameCoverUrl = gameCoverUrl.takeIf { it.isNotEmpty() },
+    gameConsoleName = consoleName,
+    inviterId = inviterId,
     inviterUsername = inviterUsername,
+    inviterAvatarUrl = inviterAvatarUrl.takeIf { it.isNotEmpty() },
+    inviteeId = inviteeId,
+    inviteeUsername = inviteeUsername,
+    status = status,
     createdAt = createdAt.toString(),
 )
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -490,8 +490,12 @@ data class SharedSessionInvitation(
     val gameTitle: String = "",
     val gameCoverUrl: String? = null,
     val gameConsoleName: String = "",
+    val inviterId: String = "",
     val inviterUsername: String = "",
     val inviterAvatarUrl: String? = null,
+    val inviteeId: String = "",
+    val inviteeUsername: String = "",
+    val status: String = "",
     val createdAt: String = "",
 )
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -47,6 +47,11 @@ sealed interface EmulationIntent {
     data object DismissExitConfirm : EmulationIntent
     data object ConfirmExit : EmulationIntent
     data object DismissStatus : EmulationIntent
+    /**
+     * Clears [com.spela.player.presentation.state.EmulationState.error]
+     * after the in-game overlay's error toast auto-dismisses. See #962.
+     */
+    data object DismissError : EmulationIntent
     data object ClearExitRequest : EmulationIntent
 
     // Lifecycle pause/resume (e.g. clamshell close on Android)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
@@ -35,7 +35,18 @@ sealed interface GameDetailIntent {
     data class RateGame(val rating: Int, val review: String = "") : GameDetailIntent
     data object DeleteRating : GameDetailIntent
     data object LoadSharedSaves : GameDetailIntent
-    data class ShareSave(val saveId: String, val name: String, val description: String) : GameDetailIntent
+    /**
+     * Upload a session save to the public shared-saves library.
+     * Pre-#979 this intent only carried [saveId] and the VM uploaded
+     * an empty ByteArray placeholder; [sessionId] is required to
+     * resolve the actual bytes via SessionRepository.downloadSessionSave.
+     */
+    data class ShareSave(
+        val sessionId: String,
+        val saveId: String,
+        val name: String,
+        val description: String,
+    ) : GameDetailIntent
     data class DownloadSharedSave(val saveId: String) : GameDetailIntent
     data class DeleteSharedSave(val saveId: String) : GameDetailIntent
     data class PlayFromSharedSave(val saveId: String) : GameDetailIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -169,6 +169,20 @@ fun InGameOverlay(
         OverlayToast(message = message)
     }
 
+    // #962: SaveManager raises critical save errors via state.error
+    // (auto-save quota exceeded, slot save/load failures, hardcore-
+    // mode save block). Pre-fix nothing read state.error in this
+    // overlay, so the user lost their save silently. Mirror state.error
+    // through the same toast surface as statusMessage so the message
+    // actually reaches the screen.
+    state.error?.let { error ->
+        LaunchedEffect(error) {
+            delay(4000) // longer than status — these are real failures
+            viewModel.onIntent(EmulationIntent.DismissError)
+        }
+        OverlayToast(message = error)
+    }
+
     // Challenge timer HUD (visible during challenge gameplay, top left)
     if (state.isChallengeMode && state.isRunning && !state.showOverlay) {
         ChallengeTimerHud(challengeElapsedMs = state.challengeElapsedMs)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -240,6 +240,7 @@ class EmulationViewModel(
                 stopGame()
             }
             EmulationIntent.DismissStatus -> _state.update { it.copy(statusMessage = null) }
+            EmulationIntent.DismissError -> _state.update { it.copy(error = null) }
             EmulationIntent.ClearExitRequest -> _state.update { it.copy(requestExit = false) }
 
             EmulationIntent.LifecyclePause -> lifecyclePause()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -101,7 +101,7 @@ class GameDetailViewModel(
             is GameDetailIntent.RateGame -> rateGame(intent.rating, intent.review)
             GameDetailIntent.DeleteRating -> deleteRating()
             GameDetailIntent.LoadSharedSaves -> loadSharedSaves()
-            is GameDetailIntent.ShareSave -> shareSave(intent.saveId, intent.name, intent.description)
+            is GameDetailIntent.ShareSave -> shareSave(intent.sessionId, intent.saveId, intent.name, intent.description)
             is GameDetailIntent.DownloadSharedSave -> downloadSharedSave(intent.saveId)
             is GameDetailIntent.DeleteSharedSave -> deleteSharedSave(intent.saveId)
             is GameDetailIntent.PlayFromSharedSave -> playFromSharedSave(intent.saveId)
@@ -589,17 +589,24 @@ class GameDetailViewModel(
         }
     }
 
-    private fun shareSave(saveId: String, name: String, description: String) {
+    private fun shareSave(sessionId: String, saveId: String, name: String, description: String) {
         val gameId = currentGameId ?: return
         _state.update { it.copy(isSharing = true) }
         scope.launch(dispatchers.io) {
-            // Use session repository to get save data
+            // Resolve the save's actual bytes via the session repo.
+            // Pre-#979 this method passed ByteArray(0) unconditionally —
+            // every "share save" upload was a zero-byte payload — and
+            // the test fake masked the bug by accepting any bytes.
             val repo = sessionRepository
             if (repo == null) {
                 _state.update { it.copy(error = "Sessions not available", isSharing = false) }
                 return@launch
             }
-            sharedSaveRepository.shareSave(gameId, name, description, ByteArray(0)).fold(
+            val saveBytes = repo.downloadSessionSave(sessionId, saveId).getOrElse { error ->
+                _state.update { it.copy(error = "Failed to load save: ${error.message}", isSharing = false) }
+                return@launch
+            }
+            sharedSaveRepository.shareSave(gameId, name, description, saveBytes).fold(
                 onSuccess = { shared ->
                     _state.update {
                         it.copy(

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
@@ -137,12 +137,16 @@ class GameDetailSharedSaveTest {
         advanceUntilIdle()
         assertEquals(0, vm.state.value.sharedSaves.size)
 
-        vm.onIntent(GameDetailIntent.ShareSave("save1", "My Save", "Beat level 3"))
+        vm.onIntent(GameDetailIntent.ShareSave("session1", "save1", "My Save", "Beat level 3"))
         advanceUntilIdle()
 
         assertFalse(vm.state.value.isSharing)
         assertEquals(1, vm.state.value.sharedSaves.size)
         assertEquals("My Save", vm.state.value.sharedSaves[0].name)
+        // #979 — uploaded payload must be the actual save bytes, not
+        // ByteArray(0). The fake session repo returns 1024 bytes; the
+        // fake shared-save repo records what it received as fileSize.
+        assertEquals(1024L, vm.state.value.sharedSaves[0].fileSize)
     }
 
     @Test
@@ -152,7 +156,7 @@ class GameDetailSharedSaveTest {
         vm.onIntent(GameDetailIntent.LoadGame("1"))
         advanceUntilIdle()
 
-        vm.onIntent(GameDetailIntent.ShareSave("save1", "My Save", "desc"))
+        vm.onIntent(GameDetailIntent.ShareSave("session1", "save1", "My Save", "desc"))
         advanceUntilIdle()
 
         assertNotNull(vm.state.value.error)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -496,7 +496,13 @@ class StubSessionRepository : SessionRepository {
         lastUploadCompression = compression
         return uploadSessionSaveResult
     }
-    override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(byteArrayOf())
+    /**
+     * Returns 1024-byte payload by default — non-empty so tests that
+     * upload these bytes (e.g. ShareSave in #979) can assert that the
+     * actual data, not an empty placeholder, was forwarded.
+     */
+    var downloadedSaveBytes: ByteArray = ByteArray(1024)
+    override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(downloadedSaveBytes)
     override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<Unit> {
         uploadSessionAutoSaveCallCount++
         return Result.success(Unit)


### PR DESCRIPTION
Three player-side audit fixes.

| Issue | Title | File |
|---|---|---|
| #962 | EmulationState.error never rendered → silent quota loss | \`InGameOverlay.kt\` (+ intent + VM) |
| #965 | SharedSessionInviteResponse Kotlin mapper drops 8 wire fields | \`DtoMappers.kt\`, \`Models.kt\` |
| #979 | shareSave uploads ByteArray(0) instead of actual save data | \`GameDetailViewModel.kt\` (+ intent + test) |

## #979 is the user-impact-worst

Every "share save" action since the code shipped has uploaded a zero-byte payload to the server. The fake repo masked the bug by accepting any bytes. The intent now carries \`sessionId\` and the VM resolves actual bytes via \`SessionRepository.downloadSessionSave\` before forwarding.

## Note on #962

The fix is the smaller of the two options the issue raised — mirror \`state.error\` to the same toast surface as \`statusMessage\`. Doesn't change SaveManager itself; the existing \`state.error\` writers are unchanged. Longer dismiss timer (4 s vs 2 s) so users have a real chance to read the message.

## Test plan

- [x] \`./gradlew :shared:desktopTest\` full suite passes.
- [x] Specific tests touched: \`GameDetailSharedSaveTest\` (asserts non-empty bytes propagated) — passing.
- [ ] Post-merge: trigger an auto-save with disk full → confirm overlay shows the quota-exceeded toast.
- [ ] Post-merge: open a shared session invite → confirm the card now shows game cover, console name, inviter avatar.