### PR TITLE
fix(audit): tighten web admin polling and test stubs (#959, #960, #980, #981, #982)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -929,18 +929,36 @@ class FakeGameStatsRepository : GameStatsRepository {
 class FakeSocialRepository : SocialRepository {
     var onlineUsers: List<OnlineUser> = emptyList()
     var activityEvents: List<ActivityEvent> = emptyList()
+    var publicProfileResult: Result<com.spela.player.domain.model.PublicProfile>? = null
+    var heatmapEntries: List<com.spela.player.domain.model.HeatmapEntry> = emptyList()
+    var publicShowcase: List<com.spela.player.domain.model.ShowcaseAchievement> = emptyList()
+    var unlockedAchievements: List<com.spela.player.domain.model.UnlockedAchievement> = emptyList()
 
     override suspend fun getOnlineUsers(): Result<List<OnlineUser>> = Result.success(onlineUsers)
     override suspend fun getActivityFeed(page: Int, pageSize: Int): Result<List<ActivityEvent>> =
         Result.success(activityEvents)
     override suspend fun getPublicProfile(userId: String): Result<com.spela.player.domain.model.PublicProfile> =
-        Result.failure(Exception("Not implemented in fake"))
+        publicProfileResult ?: Result.success(
+            com.spela.player.domain.model.PublicProfile(
+                id = userId,
+                username = "fake-user-$userId",
+                avatarUrl = null,
+                memberSince = "2024-01-01",
+                isOnline = false,
+                currentGame = null,
+                totalPlayTime = 0,
+                gamesPlayed = 0,
+                favoriteGames = emptyList(),
+                recentGames = emptyList(),
+                topGames = emptyList(),
+            ),
+        )
     override suspend fun getPlayHeatmap(userId: String): Result<List<com.spela.player.domain.model.HeatmapEntry>> =
-        Result.success(emptyList())
+        Result.success(heatmapEntries)
     override suspend fun getPublicShowcase(userId: String): Result<List<com.spela.player.domain.model.ShowcaseAchievement>> =
-        Result.success(emptyList())
+        Result.success(publicShowcase)
     override suspend fun getUnlockedAchievements(): Result<List<com.spela.player.domain.model.UnlockedAchievement>> =
-        Result.success(emptyList())
+        Result.success(unlockedAchievements)
     override suspend fun updateShowcase(achievements: List<com.spela.player.domain.model.ShowcaseAchievement>): Result<List<com.spela.player.domain.model.ShowcaseAchievement>> =
         Result.success(achievements)
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -418,10 +418,10 @@ class NavigationViewModelTest {
         override suspend fun getServers(): List<ServerConnection> = emptyList()
         override suspend fun getActiveServer(): ServerConnection? = null
         override suspend fun addServer(name: String, url: String): ServerConnection =
-            throw UnsupportedOperationException()
-        override suspend fun removeServer(id: String) = throw UnsupportedOperationException()
-        override suspend fun setActiveServer(id: String) = throw UnsupportedOperationException()
-        override suspend fun validateServer(url: String): Boolean = throw UnsupportedOperationException()
+            error("NoSessionServerRepository: addServer not used in this test")
+        override suspend fun removeServer(id: String) {}
+        override suspend fun setActiveServer(id: String) {}
+        override suspend fun validateServer(url: String): Boolean = false
     }
 
     private class NoSessionAuthRepository : AuthRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -425,16 +425,17 @@ class NavigationViewModelTest {
     }
 
     private class NoSessionAuthRepository : AuthRepository {
+        private fun unsupported(): NotImplementedError = NotImplementedError("NoSessionAuthRepository: not used in this test")
         override suspend fun login(serverUrl: String, username: String, password: String): Result<AuthTokens> =
-            throw UnsupportedOperationException()
+            Result.failure(unsupported())
         override suspend fun register(serverUrl: String, username: String, email: String, password: String): Result<AuthTokens> =
-            throw UnsupportedOperationException()
+            Result.failure(unsupported())
         override suspend fun refreshToken(serverUrl: String, refreshToken: String): Result<AuthTokens> =
-            throw UnsupportedOperationException()
-        override suspend fun getCurrentUser(): Result<User> = throw UnsupportedOperationException()
+            Result.failure(unsupported())
+        override suspend fun getCurrentUser(): Result<User> = Result.failure(unsupported())
         override suspend fun getStoredTokens(): AuthTokens? = null
-        override suspend fun storeTokens(tokens: AuthTokens) = throw UnsupportedOperationException()
-        override suspend fun clearTokens() = throw UnsupportedOperationException()
+        override suspend fun storeTokens(tokens: AuthTokens) {}
+        override suspend fun clearTokens() {}
         override fun isLoggedIn(): Boolean = false
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -18,6 +18,7 @@ import com.spela.player.domain.model.Challenge
 import com.spela.player.domain.model.ChallengeAttempt
 import com.spela.player.domain.model.ChallengeLeaderboardEntry
 import com.spela.player.domain.model.DownloadProgress
+import com.spela.player.domain.model.DownloadState
 import com.spela.player.domain.model.DownloadedGame
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.GameDetail
@@ -213,9 +214,16 @@ class StubGameRepository(
 }
 
 class StubDownloadRepository : DownloadRepository {
-    override fun observeDownloads(): Flow<List<DownloadProgress>> = emptyFlow()
-    override fun observeDownload(gameId: String): Flow<DownloadProgress> = emptyFlow()
-    override fun observeDownloadedGames(): Flow<List<DownloadedGame>> = emptyFlow()
+    private val downloadsFlow = MutableStateFlow<List<DownloadProgress>>(emptyList())
+    private val downloadedGamesFlow = MutableStateFlow<List<DownloadedGame>>(emptyList())
+    private val perGameFlows = mutableMapOf<String, MutableStateFlow<DownloadProgress>>()
+
+    override fun observeDownloads(): Flow<List<DownloadProgress>> = downloadsFlow
+    override fun observeDownload(gameId: String): Flow<DownloadProgress> =
+        perGameFlows.getOrPut(gameId) {
+            MutableStateFlow(DownloadProgress(gameId = gameId, gameTitle = "", state = DownloadState.IDLE))
+        }
+    override fun observeDownloadedGames(): Flow<List<DownloadedGame>> = downloadedGamesFlow
     override suspend fun downloadGame(gameId: String, gameTitle: String) = Result.success("/path/to/game.rom")
     override suspend fun cancelDownload(gameId: String) {}
     override suspend fun getLocalGamePath(gameId: String): String = "/path/to/game.rom"

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -261,19 +261,34 @@ export function useTestIgdbCredentials() {
   });
 }
 
-export function useScrapeStatus() {
+/**
+ * Admin-only polling hooks. Both gate `enabled` on the `enabled`
+ * parameter so non-admin components or unmounted/background tabs
+ * don't fire 3s/req for the lifetime of the component. `staleTime`
+ * is set just under the polling interval so a window-focus refetch
+ * inside one cycle doesn't double-fire on top of the scheduled
+ * request. `refetchIntervalInBackground: false` keeps the timer
+ * paused while the tab is inactive. See #959.
+ */
+export function useScrapeStatus(enabled: boolean = true) {
   return useQuery({
     queryKey: ["admin", "scrape-status"],
     queryFn: () => unwrap(typedApi.GET("/api/admin/scrape/status")),
-    refetchInterval: 3000, // Poll every 3s to catch status changes
+    refetchInterval: 3000,
+    refetchIntervalInBackground: false,
+    staleTime: 2500,
+    enabled,
   });
 }
 
-export function useScanStatus() {
+export function useScanStatus(enabled: boolean = true) {
   return useQuery({
     queryKey: ["admin", "scan-status"],
     queryFn: () => unwrap(typedApi.GET("/api/admin/games/scan/status")),
     refetchInterval: 3000,
+    refetchIntervalInBackground: false,
+    staleTime: 2500,
+    enabled,
   });
 }
 

--- a/web/src/hooks/use-grouping-progress.ts
+++ b/web/src/hooks/use-grouping-progress.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useWebSocketEvent } from "@/hooks/use-websocket";
 
 interface GroupingProgressEvent {
@@ -17,19 +17,25 @@ export function useGroupingProgress() {
   const [current, setCurrent] = useState(0);
   const [total, setTotal] = useState(0);
 
-  useWebSocketEvent("grouping_progress", (payload: GroupingProgressEvent) => {
-    setActive(true);
-    setMessage(payload.message || "Grouping variants...");
-    setCurrent(payload.current || 0);
-    setTotal(payload.total || 0);
-  });
+  useWebSocketEvent(
+    "grouping_progress",
+    useCallback((payload: GroupingProgressEvent) => {
+      setActive(true);
+      setMessage(payload.message || "Grouping variants...");
+      setCurrent(payload.current || 0);
+      setTotal(payload.total || 0);
+    }, []),
+  );
 
-  useWebSocketEvent("grouping_complete", () => {
-    setActive(false);
-    setMessage("");
-    setCurrent(0);
-    setTotal(0);
-  });
+  useWebSocketEvent(
+    "grouping_complete",
+    useCallback(() => {
+      setActive(false);
+      setMessage("");
+      setCurrent(0);
+      setTotal(0);
+    }, []),
+  );
 
   return { active, message, current, total };
 }

--- a/web/src/hooks/use-scan-progress.ts
+++ b/web/src/hooks/use-scan-progress.ts
@@ -34,8 +34,8 @@ export interface ScanProgressState {
   dismiss: () => void;
 }
 
-export function useScanProgress(): ScanProgressState {
-  const { data: initialStatus } = useScanStatus();
+export function useScanProgress(enabled: boolean = true): ScanProgressState {
+  const { data: initialStatus } = useScanStatus(enabled);
   const queryClient = useQueryClient();
 
   const [phase, setPhase] = useState<ScanPhase>("idle");

--- a/web/src/hooks/use-scan-progress.ts
+++ b/web/src/hooks/use-scan-progress.ts
@@ -44,20 +44,22 @@ export function useScanProgress(enabled: boolean = true): ScanProgressState {
   const [total, setTotal] = useState(0);
   const [result, setResult] = useState<ScanCompletePayload | null>(null);
   const [error, setError] = useState<string | null>(null);
-  // Sync from polled status — this runs on every status refetch (3s interval).
-  // Allows the UI to pick up status after page refresh or WebSocket disconnect.
+  // Sync from polled status — runs on every refetch (3s interval) so the UI
+  // recovers after page refresh or WebSocket disconnect. The `complete`/`error`
+  // early return prevents the (lagging) poll response from clobbering a
+  // terminal phase the WebSocket has already set.
   useEffect(() => {
     if (!initialStatus) return;
+    if (phase === "complete" || phase === "error") return;
     if (initialStatus.active) {
       setPhase("active");
       setMessage(initialStatus.message || "Scanning...");
       setCurrent(initialStatus.current);
       setTotal(initialStatus.total);
     } else if (phase === "active") {
-      // Status went from active to inactive — scan finished while we were polling
       setPhase("idle");
     }
-  }, [initialStatus]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialStatus, phase]);
 
   useWebSocketEvent(
     "scan_started",

--- a/web/src/hooks/use-scrape-progress.ts
+++ b/web/src/hooks/use-scrape-progress.ts
@@ -40,8 +40,8 @@ export interface ScrapeProgressState {
   dismiss: () => void;
 }
 
-export function useScrapeProgress(): ScrapeProgressState {
-  const { data: initialStatus } = useScrapeStatus();
+export function useScrapeProgress(enabled: boolean = true): ScrapeProgressState {
+  const { data: initialStatus } = useScrapeStatus(enabled);
 
   const [phase, setPhase] = useState<ScrapePhase>("idle");
   const [current, setCurrent] = useState(0);

--- a/web/src/hooks/use-scrape-progress.ts
+++ b/web/src/hooks/use-scrape-progress.ts
@@ -54,12 +54,15 @@ export function useScrapeProgress(enabled: boolean = true): ScrapeProgressState 
   const [failures, setFailures] = useState(0);
   const [verified, setVerified] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  // Sync from polled status — this runs on every status refetch (3s interval).
-  // Allows the UI to pick up status after page refresh or WebSocket disconnect.
-  // gameId/gameName/consoleName/consoleAbbr only arrive via the WebSocket
-  // scrape_progress event; the polled status endpoint only exposes counters.
+  // Sync from polled status — runs on every refetch (3s interval) so the UI
+  // recovers after page refresh or WebSocket disconnect. gameId/gameName/
+  // consoleName/consoleAbbr only arrive via the WebSocket scrape_progress
+  // event; the polled status endpoint only exposes counters. The
+  // `complete`/`error` early return prevents the (lagging) poll response from
+  // clobbering a terminal phase the WebSocket has already set.
   useEffect(() => {
     if (!initialStatus) return;
+    if (phase === "complete" || phase === "error") return;
     if (initialStatus.active) {
       setPhase("active");
       setCurrent(initialStatus.current);
@@ -68,10 +71,9 @@ export function useScrapeProgress(enabled: boolean = true): ScrapeProgressState 
       setFailures(initialStatus.failures);
       setVerified(initialStatus.verified);
     } else if (phase === "active") {
-      // Status went from active to inactive — scrape finished while we were polling
       setPhase("idle");
     }
-  }, [initialStatus]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialStatus, phase]);
 
   useWebSocketEvent(
     "scrape_started",


### PR DESCRIPTION
## Summary
Last batch of the audit-driven cleanups, covering small but real issues the cross-cutting reviewer flagged in the web hooks layer and the player-app test stubs.

### Web hooks
- **#959** `useScrapeStatus` and `useScanStatus` now accept an `enabled` flag, set `staleTime: 2500` (just under the 3s polling interval to avoid a focus-refetch racing the scheduled refetch), and disable `refetchIntervalInBackground` so the background tab does not keep firing 3s/req. Wrappers (`useScanProgress`, `useScrapeProgress`) thread the flag through.
- **#960** `useGroupingProgress` wraps its WebSocket handlers in `useCallback` so the listener registration is stable across rerenders (matches the pattern in the other progress hooks).

### Player-app test stubs
- **#980** `FakeSocialRepository.getPublicProfile` now returns a configurable `publicProfileResult` (defaulting to a benign success). The previous implementation always returned `Result.failure`, forcing every consumer that needs success to define a custom subclass.
- **#981** `StubDownloadRepository.observe*` flows switch from `emptyFlow()` to `MutableStateFlow`, so collectors emit at least one value (matching the production repo's `StateFlow` contract). `emptyFlow` never emits, which masks bugs where the consumer assumes an initial value.
- **#982** `NoSessionAuthRepository` in `NavigationViewModelTest` stops throwing `UnsupportedOperationException` for never-called paths and instead returns `Result.failure(NotImplementedError(...))` for the suspend methods that return `Result`, and `Unit` for the void suspends. A test stub that throws on unrelated paths fails the wrong test when production code adds a benign call to one of those methods.

## Test plan
- [x] `npm run test -- --run` (web) — 1600/1600 passing
- [x] `./gradlew :shared:compileTestKotlinDesktop` — clean
- [x] `./gradlew :desktop:compileTestKotlinDesktop` — clean
- [x] `./gradlew :shared:desktopTest --tests "...NavigationViewModelTest"` — passing