### PR TITLE
fix(audit-phase2): server auth, save atomicity, netplay, scrape, emulation lifecycle (16 issues)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ testdata/
 # OS
 .DS_Store
 Thumbs.db
+.audit-reviews/

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -229,6 +229,8 @@ class FakeAuthRepository : AuthRepository {
         tokens = null
     }
 
+    override suspend fun logout(): Result<Unit> = Result.success(Unit)
+
     override fun isLoggedIn(): Boolean = tokens != null
 
     fun preSetTokens(accessToken: String = "test-access", refreshToken: String = "test-refresh") {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -246,6 +246,10 @@ class SpelaApiClient(
         return userApi.getUserProfile().body()
     }
 
+    suspend fun logout() {
+        authApi.authLogout().body()
+    }
+
     // Consoles & Games
 
     suspend fun getConsoles(): List<com.spela.client.models.ConsoleResponse> {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/AuthRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/AuthRepositoryImpl.kt
@@ -80,6 +80,10 @@ class AuthRepositoryImpl(
         queries.deleteTokens()
     }
 
+    override suspend fun logout(): Result<Unit> = runCatching {
+        apiClient.logout()
+    }
+
     override fun isLoggedIn(): Boolean = tokenManager.hasTokens()
 
     private suspend fun persistTokens(tokens: AuthTokens) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/AuthRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/AuthRepository.kt
@@ -11,5 +11,12 @@ interface AuthRepository {
     suspend fun getStoredTokens(): AuthTokens?
     suspend fun storeTokens(tokens: AuthTokens)
     suspend fun clearTokens()
+    /**
+     * Calls POST /api/auth/logout on the server, blacklisting the access token
+     * and revoking refresh tokens. Failures are surfaced as Result.failure but
+     * callers should still proceed to clearTokens locally — a sign-out must
+     * never get stuck on a network error.
+     */
+    suspend fun logout(): Result<Unit>
     fun isLoggedIn(): Boolean
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/AuthUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/AuthUseCases.kt
@@ -11,7 +11,6 @@ class LoginUseCase(
 ) {
     suspend operator fun invoke(serverUrl: String, username: String, password: String): Result<AuthTokens> {
         return authRepository.login(serverUrl, username, password).onSuccess {
-            authRepository.storeTokens(it)
             deviceManager.registerWithServer()
         }
     }
@@ -23,7 +22,6 @@ class RegisterUseCase(
 ) {
     suspend operator fun invoke(serverUrl: String, username: String, email: String, password: String): Result<AuthTokens> {
         return authRepository.register(serverUrl, username, email, password).onSuccess {
-            authRepository.storeTokens(it)
             deviceManager.registerWithServer()
         }
     }
@@ -35,6 +33,10 @@ class GetCurrentUserUseCase(private val authRepository: AuthRepository) {
 
 class LogoutUseCase(private val authRepository: AuthRepository) {
     suspend operator fun invoke() {
+        // Best-effort server-side revocation: blacklist access token and
+        // delete refresh tokens. We swallow the network error and always
+        // clear local state — a sign-out must never get stuck.
+        authRepository.logout()
         authRepository.clearTokens()
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/AuthUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/AuthUseCases.kt
@@ -4,6 +4,7 @@ import com.spela.player.data.device.DeviceManager
 import com.spela.player.domain.model.AuthTokens
 import com.spela.player.domain.model.User
 import com.spela.player.domain.repository.AuthRepository
+import kotlinx.coroutines.withTimeoutOrNull
 
 class LoginUseCase(
     private val authRepository: AuthRepository,
@@ -35,8 +36,11 @@ class LogoutUseCase(private val authRepository: AuthRepository) {
     suspend operator fun invoke() {
         // Best-effort server-side revocation: blacklist access token and
         // delete refresh tokens. We swallow the network error and always
-        // clear local state — a sign-out must never get stuck.
-        authRepository.logout()
+        // clear local state — a sign-out must never get stuck. The 5s
+        // ceiling keeps the UX snappy even when the network drops or the
+        // server is unreachable; a longer outage falls through to the
+        // local clear so the user appears signed out immediately.
+        withTimeoutOrNull(5_000) { authRepository.logout() }
         authRepository.clearTokens()
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -87,6 +87,14 @@ class EmulationViewModel(
     private val _launchReady = MutableSharedFlow<PendingLaunch>(replay = 0, extraBufferCapacity = 1)
     val launchReady: SharedFlow<PendingLaunch> = _launchReady.asSharedFlow()
 
+    /**
+     * Cross-dispatcher: written from the main-thread intent dispatcher in
+     * `prepareLaunch`, read from a coroutine on dispatchers.io that emits
+     * `_launchReady`, and also cleared from main in `cancelLaunch`. Without
+     * `@Volatile` the IO thread can see a stale value or miss a `cancelLaunch`
+     * null-out, leading to a dropped or ghost launch on rapid double-tap.
+     */
+    @Volatile
     private var pendingLaunch: PendingLaunch? = null
 
     /**
@@ -124,6 +132,16 @@ class EmulationViewModel(
     private var currentPreferences = UserPreferences()
     private var sessionTimerJob: Job? = null
     private var stopJob: Job? = null
+    private var achievementCollectorJob: Job? = null
+
+    /**
+     * Cross-dispatcher: written from the main-thread intent dispatcher when
+     * the user taps "Try Anyway" on the BIOS dialog, read from a coroutine
+     * on dispatchers.io inside the launch flow. Without `@Volatile` the IO
+     * thread can see a stale `false` and re-show the dialog. Same reason
+     * as [pendingCoreDecisionStart].
+     */
+    @Volatile
     private var skipBiosCheck = false
 
     init {
@@ -1488,6 +1506,12 @@ class EmulationViewModel(
         challengeManager.cleanup()
         netplayManager.cleanup()
         presenceService.stopHeartbeat()
+        // Pause the core *before* the IO coroutine starts capturing memory.
+        // Some stopGame call sites (e.g. ConfirmExit, ConfirmNetplayLeave)
+        // do not pause first, so the frame loop could still be advancing
+        // while saveSramOnStop / serialize were reading core memory. Pausing
+        // here is idempotent — already-paused cores remain paused.
+        libretroController.pause()
         stopJob = scope.launch(dispatchers.io) {
             val currentState = _state.value
             val sharedSessionId = currentState.sharedSessionId
@@ -1546,6 +1570,8 @@ class EmulationViewModel(
             if (current?.gameId == stoppingGameId) null else current
         }
 
+        achievementCollectorJob?.cancel()
+        achievementCollectorJob = null
         try {
             achievementsController.deinit()
         } catch (_: Exception) {
@@ -1792,6 +1818,12 @@ class EmulationViewModel(
         // Fetch achievement list + progress from server for the tracker panel
         fetchAchievements(gameId)
 
+        // Cancel any prior collector before starting a new one — initAchievements
+        // is called once per game launch, and without this each restart leaks
+        // a collector, multiplying achievement toasts and unlock counters.
+        achievementCollectorJob?.cancel()
+        achievementCollectorJob = null
+
         scope.launch(dispatchers.io) {
             achievementsRepository.getRAToken().onSuccess { credentials ->
                 achievementsController.init()
@@ -1811,7 +1843,7 @@ class EmulationViewModel(
                 achievementsController.loadGame(gameId)
 
                 // Collect achievement events for UI + track session unlocks
-                scope.launch(dispatchers.default) {
+                achievementCollectorJob = scope.launch(dispatchers.default) {
                     achievementsController.events.collect { event ->
                         withContext(dispatchers.main) {
                             _state.update { state ->

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/domain/usecase/RestoreSessionUseCaseTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/domain/usecase/RestoreSessionUseCaseTest.kt
@@ -192,6 +192,7 @@ class RestoreSessionUseCaseTest {
         override suspend fun clearTokens() {
             clearTokensCalled = true
         }
+        override suspend fun logout(): Result<Unit> = Result.success(Unit)
         override fun isLoggedIn(): Boolean = storedTokens != null
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -436,6 +436,7 @@ class NavigationViewModelTest {
         override suspend fun getStoredTokens(): AuthTokens? = null
         override suspend fun storeTokens(tokens: AuthTokens) {}
         override suspend fun clearTokens() {}
+        override suspend fun logout(): Result<Unit> = Result.success(Unit)
         override fun isLoggedIn(): Boolean = false
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/LoginViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/LoginViewModelTest.kt
@@ -234,5 +234,6 @@ class FakeAuthRepository : AuthRepository {
     override suspend fun getStoredTokens(): AuthTokens? = stored
     override suspend fun storeTokens(tokens: AuthTokens) { stored = tokens }
     override suspend fun clearTokens() { stored = null; loggedIn = false }
+    override suspend fun logout(): Result<Unit> = Result.success(Unit)
     override fun isLoggedIn(): Boolean = loggedIn
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SettingsViewModelSaveStatePolicyTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SettingsViewModelSaveStatePolicyTest.kt
@@ -188,6 +188,7 @@ class SettingsViewModelSaveStatePolicyTest {
         override suspend fun getStoredTokens(): AuthTokens? = null
         override suspend fun storeTokens(tokens: AuthTokens) {}
         override suspend fun clearTokens() {}
+        override suspend fun logout(): Result<Unit> = Result.success(Unit)
         override fun isLoggedIn(): Boolean = false
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SocialViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SocialViewModelTest.kt
@@ -58,6 +58,7 @@ class SocialViewModelTest {
         override suspend fun getStoredTokens(): AuthTokens? = null
         override suspend fun storeTokens(tokens: AuthTokens) {}
         override suspend fun clearTokens() {}
+        override suspend fun logout(): Result<Unit> = Result.success(Unit)
         override fun isLoggedIn() = true
     }
 

--- a/server/internal/api/auth_handler.go
+++ b/server/internal/api/auth_handler.go
@@ -16,7 +16,12 @@ import (
 // generateTokenFamily creates a random token family ID for refresh token replay detection.
 func generateTokenFamily() string {
 	b := make([]byte, 16)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand from /dev/urandom never errors on Linux. Sandboxed
+		// environments where it can fail leave us with no safe fallback —
+		// a zero-filled family ID would silently break replay protection.
+		panic("crypto/rand: " + err.Error())
+	}
 	return hex.EncodeToString(b)
 }
 

--- a/server/internal/api/huma_auth_handlers.go
+++ b/server/internal/api/huma_auth_handlers.go
@@ -463,7 +463,7 @@ func (h *AuthHandler) HumaRegister(ctx context.Context, in *AuthRegisterInput) (
 		}, nil
 	}
 
-	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret)
+	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret, user.TokenVersion)
 	if err != nil {
 		return nil, huma.NewError(http.StatusInternalServerError, "Account created but sign-in failed. Please sign in manually.")
 	}
@@ -539,6 +539,12 @@ func (h *AuthHandler) HumaRefresh(_ context.Context, in *AuthRefreshInput) (*Aut
 		return nil, huma.NewError(http.StatusForbidden, "Your account has been disabled. Please contact an administrator.")
 	}
 
+	if user.PendingApproval {
+		h.DB.Where("token_family = ? AND user_id = ?", rt.TokenFamily, rt.UserID).
+			Delete(&db.RefreshToken{})
+		return nil, huma.NewError(http.StatusForbidden, "Your account is pending admin approval.")
+	}
+
 	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret, user.TokenVersion)
 	if err != nil {
 		return nil, huma.NewError(http.StatusInternalServerError, "Session refresh failed. Please sign in again.")
@@ -612,7 +618,7 @@ func (h *AuthHandler) HumaSetup(_ context.Context, in *AuthSetupInput) (*AuthSet
 		return nil, txErr
 	}
 
-	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret)
+	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret, user.TokenVersion)
 	if err != nil {
 		return nil, huma.NewError(http.StatusInternalServerError, "Setup failed. Please try again.")
 	}

--- a/server/internal/api/huma_netplay.go
+++ b/server/internal/api/huma_netplay.go
@@ -507,12 +507,25 @@ func (h *NetplayHandler) humaLoadNetplaySession(id string) (db.NetplaySession, e
 }
 
 // HumaGetNetplaySession is the huma handler for GET /api/netplay/sessions/{id}.
-func (h *NetplayHandler) HumaGetNetplaySession(_ context.Context, in *GetNetplaySessionInput) (*GetNetplaySessionOutput, error) {
+func (h *NetplayHandler) HumaGetNetplaySession(ctx context.Context, in *GetNetplaySessionInput) (*GetNetplaySessionOutput, error) {
+	uid := UserIDFromContext(ctx)
 	session, err := h.humaLoadNetplaySession(in.ID)
 	if err != nil {
 		return nil, err
 	}
-	return &GetNetplaySessionOutput{Body: h.toSessionResponse(session)}, nil
+	isHost := session.HostUserID == uid
+	isClient := session.ClientUserID != nil && *session.ClientUserID == uid
+	if !isHost && !isClient {
+		return nil, huma.Error403Forbidden("not a participant of this session")
+	}
+	resp := h.toSessionResponse(session)
+	// Only the host should see the invite code; clients (and anyone else)
+	// don't need it after they've joined, and exposing it would let any
+	// participant share it with non-invited users.
+	if !isHost {
+		resp.InviteCode = ""
+	}
+	return &GetNetplaySessionOutput{Body: resp}, nil
 }
 
 // HumaDeleteNetplaySession is the huma handler for DELETE /api/netplay/sessions/{id}.
@@ -715,12 +728,29 @@ func (h *NetplayHandler) HumaAcceptNetplayInviteByCode(ctx context.Context, in *
 		return nil, huma.Error500InternalServerError("failed to accept invite")
 	}
 
+	// Fill the session slot — same atomic update pattern as
+	// HumaJoinNetplayByInviteCode. Without this the session stays in
+	// 'waiting' with no client set and the host never sees the invitee
+	// arrive (the notification-accept and code-join flows must reach the
+	// same end state).
+	now := time.Now()
+	result := h.DB.Model(&db.NetplaySession{}).
+		Where("id = ? AND client_user_id IS NULL AND status = ?", invite.NetplaySessionID, "waiting").
+		Updates(map[string]interface{}{
+			"client_user_id": uid,
+			"status":         "in_progress",
+			"started_at":     now,
+		})
+	if result.RowsAffected == 0 {
+		return nil, huma.Error409Conflict("this session already has two players")
+	}
+
 	h.DB.Model(&db.NetplayInvite{}).
 		Where("netplay_session_id = ? AND id != ? AND status = ?", invite.NetplaySessionID, invite.ID, "pending").
 		Update("status", "expired")
 
 	h.DB.Preload("Inviter").Preload("Invitee").
-		Preload("NetplaySession").Preload("NetplaySession.HostUser").
+		Preload("NetplaySession").Preload("NetplaySession.HostUser").Preload("NetplaySession.ClientUser").
 		Preload("NetplaySession.Game").Preload("NetplaySession.Game.Console").
 		First(&invite, invite.ID)
 
@@ -728,6 +758,7 @@ func (h *NetplayHandler) HumaAcceptNetplayInviteByCode(ctx context.Context, in *
 
 	if h.Hub != nil {
 		h.Hub.Broadcast(ws.Event{Type: ws.EventNetplayInviteAccepted, Payload: resp})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventNetplayPlayerJoined, Payload: h.toSessionResponse(invite.NetplaySession)})
 	}
 
 	return &AcceptNetplayInviteByCodeOutput{Body: resp}, nil

--- a/server/internal/api/huma_netplay.go
+++ b/server/internal/api/huma_netplay.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -723,26 +724,38 @@ func (h *NetplayHandler) HumaAcceptNetplayInviteByCode(ctx context.Context, in *
 		return nil, huma.Error400BadRequest("session is no longer accepting players")
 	}
 
-	invite.Status = "accepted"
-	if err := h.DB.Save(&invite).Error; err != nil {
-		return nil, huma.Error500InternalServerError("failed to accept invite")
-	}
-
-	// Fill the session slot — same atomic update pattern as
-	// HumaJoinNetplayByInviteCode. Without this the session stays in
-	// 'waiting' with no client set and the host never sees the invitee
-	// arrive (the notification-accept and code-join flows must reach the
-	// same end state).
+	// Mark the invite accepted AND fill the session slot in one transaction.
+	// If the slot-fill fails (someone joined first via the code-join flow),
+	// the invite-status update is rolled back so a retry can still succeed.
 	now := time.Now()
-	result := h.DB.Model(&db.NetplaySession{}).
-		Where("id = ? AND client_user_id IS NULL AND status = ?", invite.NetplaySessionID, "waiting").
-		Updates(map[string]interface{}{
-			"client_user_id": uid,
-			"status":         "in_progress",
-			"started_at":     now,
-		})
-	if result.RowsAffected == 0 {
+	var slotTaken bool
+	txErr := h.DB.Transaction(func(tx *gorm.DB) error {
+		invite.Status = "accepted"
+		if err := tx.Save(&invite).Error; err != nil {
+			return err
+		}
+		// Same atomic slot-fill pattern as HumaJoinNetplayByInviteCode.
+		result := tx.Model(&db.NetplaySession{}).
+			Where("id = ? AND client_user_id IS NULL AND status = ?", invite.NetplaySessionID, "waiting").
+			Updates(map[string]interface{}{
+				"client_user_id": uid,
+				"status":         "in_progress",
+				"started_at":     now,
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			slotTaken = true
+			return fmt.Errorf("session already has two players")
+		}
+		return nil
+	})
+	if slotTaken {
 		return nil, huma.Error409Conflict("this session already has two players")
+	}
+	if txErr != nil {
+		return nil, huma.Error500InternalServerError("failed to accept invite")
 	}
 
 	h.DB.Model(&db.NetplayInvite{}).

--- a/server/internal/api/huma_session_uploads.go
+++ b/server/internal/api/huma_session_uploads.go
@@ -387,6 +387,7 @@ func (h *SessionHandler) HumaUpsertSlotSave(ctx context.Context, in *SessionSlot
 		}
 		h.DB.Create(&rec)
 	} else {
+		oldPath := rec.FilePath
 		rec.FilePath = path
 		rec.FileSize = size
 		rec.ScreenshotURL = screenshotURL
@@ -394,6 +395,12 @@ func (h *SessionHandler) HumaUpsertSlotSave(ctx context.Context, in *SessionSlot
 		rec.CoreSha256 = sanitizeCoreSha256(body.CoreSha256)
 		rec.Compression = sanitizeCompression(body.Compression)
 		h.DB.Save(&rec)
+		// Delete the old slot-save file once the new one is committed in the
+		// DB. Without this, every slot overwrite leaks one file on disk and
+		// eventually exhausts the user's storage quota.
+		if oldPath != "" && oldPath != path {
+			_ = h.Storage.DeleteSave(oldPath)
+		}
 	}
 
 	now := time.Now()

--- a/server/internal/scraper/queue.go
+++ b/server/internal/scraper/queue.go
@@ -306,9 +306,13 @@ func (q *ScrapeQueue) MergeGames(jobID uint, gameIDs []uint) (int, error) {
 		return 0, nil
 	}
 
+	// Include in_progress as well as pending — an item the worker has
+	// already dequeued but not yet finished must not be re-enqueued, or
+	// the game gets scraped twice and TotalItems over-counts so the job
+	// never reaches completion (CompletedItems + FailedItems >= TotalItems).
 	var existingGameIDs []uint
 	if err := q.db.Model(&db.ScrapeQueueItem{}).
-		Where("job_id = ? AND status = ? AND game_id IN ?", jobID, "pending", gameIDs).
+		Where("job_id = ? AND status IN ? AND game_id IN ?", jobID, []string{"pending", "in_progress"}, gameIDs).
 		Pluck("game_id", &existingGameIDs).Error; err != nil {
 		return 0, fmt.Errorf("querying existing items: %w", err)
 	}

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spela/server/internal/igdb"
 	"github.com/spela/server/internal/scanner"
 	"github.com/spela/server/internal/storage"
+	"gorm.io/gorm"
 )
 
 // ScrapeGame fetches metadata from IGDB (if configured) and images from IGDB/LibRetro.
@@ -45,8 +46,19 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 		game.ScreenshotURL = ""
 		game.LibRetroCoverURL = ""
 		game.IGDBCoverURL = ""
-		// Clear IGDB-sourced scalar metadata so new match can overwrite
+		// Clear IGDB-sourced scalar metadata so a new match can overwrite.
+		// applyIGDBMatch uses `if field == ""` guards on the text fields, so
+		// any field still populated by a previous scrape would be retained
+		// even when the new match is for a different game (CRC rename) —
+		// resulting in mismatched description/developer/etc. paired with the
+		// new title. Resetting all IGDB-sourced fields keeps records coherent.
+		game.Description = ""
 		game.Storyline = ""
+		game.Developer = ""
+		game.Publisher = ""
+		game.Genre = ""
+		game.GameModes = ""
+		game.Players = 0
 		game.TotalRating = 0
 		game.TotalRatingCount = 0
 		game.IGDBUserRating = 0
@@ -519,30 +531,37 @@ func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.G
 		}
 	}
 
-	// Regional release dates — batch upsert in one transaction
+	// Regional release dates — batch upsert in one transaction. Use the
+	// GORM helper so an error in any FirstOrCreate triggers automatic
+	// rollback; the previous bare Begin/Commit pattern with no error checks
+	// or deferred Rollback could leak a SQLite write connection on commit
+	// failure, eventually starving the worker pool.
 	if len(match.ReleaseDates) > 0 {
-		rdTx := s.DB.Begin()
-		for _, rd := range match.ReleaseDates {
-			regionName := igdb.RegionName(rd.Region)
-			if regionName == "" || rd.Date == 0 {
-				continue
+		_ = s.DB.Transaction(func(tx *gorm.DB) error {
+			for _, rd := range match.ReleaseDates {
+				regionName := igdb.RegionName(rd.Region)
+				if regionName == "" || rd.Date == 0 {
+					continue
+				}
+				t := time.Unix(rd.Date, 0)
+				platformName := ""
+				if rd.Platform != nil {
+					platformName = rd.Platform.Name
+				}
+				releaseDate := db.GameReleaseDate{
+					GameID:   game.ID,
+					Region:   regionName,
+					Date:     t.Format("2006-01-02"),
+					Platform: platformName,
+				}
+				if err := tx.Where("game_id = ? AND region = ?", game.ID, regionName).
+					Assign(releaseDate).
+					FirstOrCreate(&releaseDate).Error; err != nil {
+					return err
+				}
 			}
-			t := time.Unix(rd.Date, 0)
-			platformName := ""
-			if rd.Platform != nil {
-				platformName = rd.Platform.Name
-			}
-			releaseDate := db.GameReleaseDate{
-				GameID:   game.ID,
-				Region:   regionName,
-				Date:     t.Format("2006-01-02"),
-				Platform: platformName,
-			}
-			rdTx.Where("game_id = ? AND region = ?", game.ID, regionName).
-				Assign(releaseDate).
-				FirstOrCreate(&releaseDate)
-		}
-		rdTx.Commit()
+			return nil
+		})
 	}
 
 	// Download cover art and screenshots concurrently.

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -537,7 +537,7 @@ func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.G
 	// or deferred Rollback could leak a SQLite write connection on commit
 	// failure, eventually starving the worker pool.
 	if len(match.ReleaseDates) > 0 {
-		_ = s.DB.Transaction(func(tx *gorm.DB) error {
+		if err := s.DB.Transaction(func(tx *gorm.DB) error {
 			for _, rd := range match.ReleaseDates {
 				regionName := igdb.RegionName(rd.Region)
 				if regionName == "" || rd.Date == 0 {
@@ -561,7 +561,9 @@ func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.G
 				}
 			}
 			return nil
-		})
+		}); err != nil {
+			slog.Warn("failed to upsert IGDB release dates", "game", game.Title, "game_id", game.ID, "error", err)
+		}
 	}
 
 	// Download cover art and screenshots concurrently.

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -484,7 +484,9 @@ func (s *Storage) SessionScreenshotPath(sessionID uint, filename string) string 
 	return filepath.Join(s.SaveDir, "sessions", fmt.Sprintf("session_%d", sessionID), "screenshots", safe)
 }
 
-// WriteSessionSave stores a session save state file.
+// WriteSessionSave stores a session save state file. Writes go to a `.tmp`
+// sibling and atomically rename on success, so an interrupted upload cannot
+// leave a partial file in place of a known-good save state.
 func (s *Storage) WriteSessionSave(sessionID uint, filename string, data io.Reader) (string, int64, error) {
 	path := s.SessionSaveStatePath(sessionID, filename)
 
@@ -504,17 +506,25 @@ func (s *Storage) WriteSessionSave(sessionID uint, filename string, data io.Read
 		return "", 0, fmt.Errorf("creating session save directory: %w", err)
 	}
 
-	f, err := os.Create(path)
+	tmpPath := path + ".tmp"
+	f, err := os.Create(tmpPath)
 	if err != nil {
-		return "", 0, fmt.Errorf("creating session save file: %w", err)
+		return "", 0, fmt.Errorf("creating session save tmp file: %w", err)
 	}
-	defer f.Close()
-
 	n, err := io.Copy(f, data)
+	closeErr := f.Close()
 	if err != nil {
+		_ = os.Remove(tmpPath)
 		return "", 0, fmt.Errorf("writing session save file: %w", err)
 	}
-
+	if closeErr != nil {
+		_ = os.Remove(tmpPath)
+		return "", 0, fmt.Errorf("closing session save tmp file: %w", closeErr)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", 0, fmt.Errorf("replacing session save file: %w", err)
+	}
 	return path, n, nil
 }
 
@@ -563,7 +573,9 @@ func (s *Storage) WriteSessionSaveDirBundle(sessionID uint, data io.Reader) (str
 	return path, n, nil
 }
 
-// WriteSessionSRAM stores a session SRAM/save data file.
+// WriteSessionSRAM stores a session SRAM/save data file. Writes go to a
+// `.tmp` sibling and atomically rename on success, so an interrupted upload
+// cannot leave a partial file in place of a known-good SRAM image.
 func (s *Storage) WriteSessionSRAM(sessionID uint, filename string, data io.Reader) (string, int64, error) {
 	path := s.SessionSRAMPath(sessionID, filename)
 
@@ -583,17 +595,25 @@ func (s *Storage) WriteSessionSRAM(sessionID uint, filename string, data io.Read
 		return "", 0, fmt.Errorf("creating session SRAM directory: %w", err)
 	}
 
-	f, err := os.Create(path)
+	tmpPath := path + ".tmp"
+	f, err := os.Create(tmpPath)
 	if err != nil {
-		return "", 0, fmt.Errorf("creating session SRAM file: %w", err)
+		return "", 0, fmt.Errorf("creating session SRAM tmp file: %w", err)
 	}
-	defer f.Close()
-
 	n, err := io.Copy(f, data)
+	closeErr := f.Close()
 	if err != nil {
+		_ = os.Remove(tmpPath)
 		return "", 0, fmt.Errorf("writing session SRAM file: %w", err)
 	}
-
+	if closeErr != nil {
+		_ = os.Remove(tmpPath)
+		return "", 0, fmt.Errorf("closing session SRAM tmp file: %w", closeErr)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", 0, fmt.Errorf("replacing session SRAM file: %w", err)
+	}
 	return path, n, nil
 }
 


### PR DESCRIPTION
## Summary
Phase 2 critical-path audit — 16 high-confidence findings from focused reviewers covering auth, save state, game launch, netplay, and scrape pipeline.

### Auth (#988, #989, #990, #991, #992)
- `LogoutUseCase` now POSTs `/api/auth/logout` so the server blacklists the access token and revokes refresh tokens. Previously logout was client-only — refresh tokens persisted for the full 90-day TTL.
- Drop redundant `storeTokens()` call in Login/Register use cases (login already persists; second call only added a silent error window).
- `HumaRegister` and `HumaSetup` now pass `user.TokenVersion` to `GenerateAccessToken`, mirroring login/refresh.
- `HumaRefresh` now rejects accounts with `PendingApproval` (login already did).
- `generateTokenFamily` now panics on `crypto/rand` failure instead of silently producing zero-filled family IDs.

### Save state (#993, #995)
- `WriteSessionSRAM` and `WriteSessionSave` switch to atomic temp-file + `os.Rename` (matching `WriteSessionSaveDirBundle`). Interrupted upload no longer truncates a known-good save.
- `HumaUpsertSlotSave` now deletes the previous slot-save file after the DB record points at the new path. Was leaking one file per overwrite.

### Emulation (#999, #1000, #1001)
- `@Volatile` on `skipBiosCheck` and `pendingLaunch` (cross-dispatcher reads); siblings already had this annotation.
- `stopGame()` calls `libretroController.pause()` before launching `stopJob`. Some call paths (ConfirmExit, ConfirmNetplayLeave) reach stopGame without first pausing — IO coroutine read core memory while frame loop was still running.
- Track `achievementCollectorJob` so each game launch cancels the previous collector (was leaking one per launch → duplicate toasts).

### Netplay (#1002, #1003, #1004)
- `HumaGetNetplaySession` now requires the caller to be a participant; `InviteCode` is scrubbed for non-host viewers.
- `HumaAcceptNetplayInviteByCode` now atomically fills the session slot (was disconnected from `HumaJoinNetplayByInviteCode` — invitee never appeared in the session).

### Scrape (#1009, #1010, #1012)
- `applyIGDBMatch`'s release-date upsert now uses `gorm.Transaction` (was leaking SQLite connection on commit failure).
- `MergeGames` dedupe now matches both `pending` and `in_progress` (was re-enqueuing in-flight items, blocking job completion).
- Re-scrape clears Description/Developer/Publisher/Genre/GameModes/Players (apply-path uses `if field == ""` guards, so partial old data persisted on CRC-rename re-scrapes).

### Skipped from this batch
- #998 (lifecycleResume always unpauses) — re-traced; `lifecyclePause` already skips when user-paused, so the bug doesn't trigger. Will close as not-a-bug after PR.
- #994, #997, #996 (client SRAM atomic, drain race, loadState UX), #1005, #1006, #1007, #1008, #1011 — left for follow-up.

## Test plan
- [x] `go build ./...` clean
- [x] Auth-targeted Go tests pass (`./internal/auth/...`)
- [x] Storage tests pass
- [x] Desktop test compile clean
- [x] Web tests still pass (no web changes)
- [ ] Full Go suite — has a known pre-existing flake in `internal/api` test ordering (DB connection leak on SLOW machine, not caused by these changes; CI ran green for the same pattern on #987).

Phase 2 audit references issue #955.