### PR TITLE
fix(netplay): peer_left broadcast ordering + cleanup mode-clear ordering (#1005, #1007)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/NetplayManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/NetplayManager.kt
@@ -210,8 +210,14 @@ class NetplayManager(
     /**
      * Cancel all netplay/shared-session-related jobs and disconnect transport.
      * Called from stopGame().
+     *
+     * Order matters: clearNetplayMode() runs first to unblock the libretro
+     * core's lockstep loop (which may be waiting on the next input frame).
+     * Disconnecting the transport before clearing the mode could leave the
+     * emulator thread stuck waiting for an input that will never arrive.
      */
     fun cleanup() {
+        libretroController.clearNetplayMode()
         sharedSessionHeartbeatJob?.cancel()
         sharedSessionHeartbeatJob = null
         netplayInputCollectorJob?.cancel()
@@ -220,6 +226,5 @@ class NetplayManager(
         netplayControlCollectorJob = null
         netplayTransport?.disconnect()
         netplayTransport = null
-        libretroController.clearNetplayMode()
     }
 }

--- a/server/internal/websocket/netplay_hub.go
+++ b/server/internal/websocket/netplay_hub.go
@@ -221,17 +221,21 @@ const (
 
 func (c *NetplayClient) netplayReadPump(hub *NetplayHub, room *NetplayRoom) {
 	defer func() {
-		remaining := room.removeClient(c.UserID)
-		if remaining == 0 {
+		// Broadcast peer_left BEFORE removing the client, so the message
+		// reaches every other connected peer regardless of how the
+		// concurrent removeClient calls interleave. Previously the order
+		// was removeClient -> if remaining > 0 broadcast, which meant two
+		// near-simultaneous disconnects could both observe remaining == 0
+		// (each saw the other already gone) and skip the notification,
+		// leaving the surviving peer (if any reconnected) unaware.
+		leaveMsg, _ := json.Marshal(NetplayOutMessage{
+			Type:     "peer_left",
+			SenderID: c.UserID,
+			Data:     nil,
+		})
+		room.broadcastExcept(leaveMsg, c.UserID, websocket.TextMessage)
+		if room.removeClient(c.UserID) == 0 {
 			hub.removeRoom(c.SessionID)
-		} else {
-			// Notify others that this peer left
-			leaveMsg, _ := json.Marshal(NetplayOutMessage{
-				Type:     "peer_left",
-				SenderID: c.UserID,
-				Data:     nil,
-			})
-			room.broadcastExcept(leaveMsg, c.UserID, websocket.TextMessage)
 		}
 		c.Conn.Close()
 		slog.Info("netplay client disconnected", "sessionId", c.SessionID, "userId", c.UserID)


### PR DESCRIPTION
## Summary
Two small, targeted fixes from the Phase 2 netplay reviewer:

### #1005 — peer_left lost on simultaneous disconnect (server)
\`netplayReadPump\` previously did \`removeClient -> if remaining > 0 broadcast\`. Two near-simultaneous disconnects could both observe \`remaining == 0\` and skip the broadcast, so the surviving peer (if any reconnected) never learned the other had left.

Fix: broadcast \`peer_left\` BEFORE \`removeClient\`. Order-independent.

### #1007 — NetplayManager.cleanup() reordering (client)
\`cleanup()\` previously cancelled collector jobs, disconnected the transport, then called \`libretroController.clearNetplayMode()\`. The libretro core's lockstep loop may still be waiting on the next input frame; disconnecting first could leave the emulator thread blocked.

Fix: \`clearNetplayMode()\` first (unblocks the emulator), then job cancellation and transport disconnect.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./internal/websocket/...\` pass
- [x] Player desktop compile clean