### PR TITLE
fix: client SRAM atomic write + IGDB rate-limit backoff (#994, #1011)

### DIFF
--- a/player/shared/src/androidMain/kotlin/com/spela/player/platform/AndroidFileStorage.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/platform/AndroidFileStorage.kt
@@ -27,6 +27,25 @@ class AndroidFileStorage(private val context: Context) : FileStorage {
         file.writeBytes(data)
     }
 
+    override suspend fun atomicWriteFile(path: String, data: ByteArray) = withContext(Dispatchers.IO) {
+        val target = File(path)
+        target.parentFile?.mkdirs()
+        val tmp = File(path + ".tmp")
+        tmp.writeBytes(data)
+        if (!tmp.renameTo(target)) {
+            // POSIX-correct rename should overwrite atomically. If renameTo
+            // refuses (e.g. cross-device or concurrent issue), fall back to
+            // a copy + delete so the write still completes — non-atomic but
+            // matches the prior in-place write semantics. Then propagate.
+            target.delete()
+            if (!tmp.renameTo(target)) {
+                target.writeBytes(data)
+                tmp.delete()
+            }
+        }
+        Unit
+    }
+
     override suspend fun readFile(path: String): ByteArray = withContext(Dispatchers.IO) {
         File(path).readBytes()
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SaveDataRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SaveDataRepositoryImpl.kt
@@ -11,7 +11,11 @@ class SaveDataRepositoryImpl(
         val dir = "${fileStorage.getSavesDir()}/sram/$gameId"
         val path = "$dir/active.srm"
         fileStorage.createDirectory(dir)
-        fileStorage.writeFile(path, data)
+        // Atomic write: temp-file + rename. A process kill mid-write
+        // (Android OOM, rotation crash) no longer leaves a truncated
+        // active.srm that loadLocalSRAM would feed to the core as
+        // corrupt save data. See #994.
+        fileStorage.atomicWriteFile(path, data)
     }
 
     override suspend fun loadLocalSRAM(gameId: String): ByteArray? {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/FileStorage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/FileStorage.kt
@@ -11,6 +11,21 @@ interface FileStorage {
     fun getBiosDir(): String
     suspend fun createDirectory(path: String)
     suspend fun writeFile(path: String, data: ByteArray)
+    /**
+     * Writes [data] to a temporary sibling file then atomically renames it
+     * into place at [path]. If the process is killed mid-write (Android OOM,
+     * desktop crash, signal), the existing file at [path] is left untouched
+     * — the next read sees the prior known-good content rather than a
+     * truncated partial write. Used for SRAM and save state writes (#994).
+     *
+     * Default falls back to non-atomic [writeFile]; production platform
+     * implementations (AndroidFileStorage, DesktopFileStorage) override this
+     * with a tmp-write + atomic-rename. Test stubs that don't care about
+     * crash safety can keep the default.
+     */
+    suspend fun atomicWriteFile(path: String, data: ByteArray) {
+        writeFile(path, data)
+    }
     suspend fun readFile(path: String): ByteArray
     suspend fun fileExists(path: String): Boolean
     suspend fun deleteFile(path: String)

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/platform/DesktopFileStorage.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/platform/DesktopFileStorage.kt
@@ -4,6 +4,8 @@ import com.spela.player.util.FileStorage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 class DesktopFileStorage : FileStorage {
 
@@ -32,6 +34,19 @@ class DesktopFileStorage : FileStorage {
         val file = File(path)
         file.parentFile?.mkdirs()
         file.writeBytes(data)
+    }
+
+    override suspend fun atomicWriteFile(path: String, data: ByteArray) = withContext(Dispatchers.IO) {
+        val target = File(path)
+        target.parentFile?.mkdirs()
+        val tmp = File(path + ".tmp")
+        tmp.writeBytes(data)
+        // Files.move with ATOMIC_MOVE + REPLACE_EXISTING gives a POSIX-style
+        // atomic rename when supported by the filesystem; the existing
+        // contents at [path] are never observable in a partially-written
+        // state by a concurrent reader.
+        Files.move(tmp.toPath(), target.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        Unit
     }
 
     override suspend fun readFile(path: String): ByteArray = withContext(Dispatchers.IO) {

--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -2,6 +2,7 @@ package igdb
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -12,6 +13,11 @@ import (
 	"sync"
 	"time"
 )
+
+// ErrRateLimit is returned (wrapped) when the IGDB API responds with HTTP 429.
+// Callers should detect via errors.Is and apply a backoff before retrying so
+// the rate-limit window can reset.
+var ErrRateLimit = errors.New("igdb: rate limit")
 
 // API base URLs (variables for testability).
 var (
@@ -525,6 +531,9 @@ func (c *Client) SearchGame(name string, platformIDs []int) ([]Game, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
+		}
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -589,6 +598,9 @@ func (c *Client) SearchGameExact(name string, platformIDs []int) ([]Game, error)
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
+		}
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -643,6 +655,9 @@ func (c *Client) GetGameByID(igdbID int) (*Game, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
+		}
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -695,6 +710,9 @@ func (c *Client) GetTimeToBeat(igdbGameID int) (*TimeToBeat, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
+		}
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -770,6 +788,9 @@ func (c *Client) GetTopGames(platformIDs []int, limit int) ([]TopGame, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
+		}
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -827,6 +848,9 @@ func (c *Client) GetSimilarGames(igdbGameID int) ([]SimilarGame, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
+		}
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -878,6 +902,9 @@ func (c *Client) GetSimilarGames(igdbGameID int) ([]SimilarGame, error) {
 
 	if resp2.StatusCode != http.StatusOK {
 		body2, _ := io.ReadAll(resp2.Body)
+		if resp2.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp2.StatusCode, string(body2), ErrRateLimit)
+		}
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp2.StatusCode, string(body2))
 	}
 
@@ -947,6 +974,9 @@ func (c *Client) GetCompanyByID(igdbID int) (*CompanyDetail, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
+		}
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -1039,6 +1069,9 @@ func (c *Client) SearchCompanyByName(name string) (*CompanyDetail, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
+		}
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -1262,6 +1295,9 @@ func (c *Client) GetGameEnrichment(igdbID int) (*GameEnrichment, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
+		}
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -1381,6 +1417,9 @@ func (c *Client) GetCollection(collectionID int) (*CollectionData, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
+		}
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -1436,6 +1475,9 @@ func (c *Client) GetFranchise(franchiseID int) (*FranchiseData, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
+		}
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/server/internal/scraper/worker.go
+++ b/server/internal/scraper/worker.go
@@ -2,14 +2,22 @@ package scraper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/igdb"
 	ws "github.com/spela/server/internal/websocket"
 	"gorm.io/gorm"
 )
+
+// igdbRateLimitBackoff is the cooldown applied after an IGDB 429 response.
+// IGDB's documented rate limit is 4 req/sec with a hard cap on bursts; a
+// 60-second cooldown gives the window time to reset and prevents the worker
+// from burning through the remaining queue on fast-fail retries.
+const igdbRateLimitBackoff = 60 * time.Second
 
 // ScrapeWorker processes items from the scrape queue in the background.
 type ScrapeWorker struct {
@@ -152,6 +160,16 @@ func (w *ScrapeWorker) processItem(ctx context.Context, item *db.ScrapeQueueItem
 				jobDone, _ := w.queue.MarkFailed(item, err.Error())
 				w.broadcastProgress(item, &game, false, jobDone)
 				w.broadcastScrapeStatus(game.ID, "idle")
+				// On IGDB rate-limit, sleep before processing the next item
+				// so the rate-limit window can reset. Without this, a 429
+				// storm fast-fails every remaining item in the queue.
+				if errors.Is(err, igdb.ErrRateLimit) {
+					slog.Warn("scrape worker: IGDB rate limit hit, backing off", "duration", igdbRateLimitBackoff)
+					select {
+					case <-ctx.Done():
+					case <-time.After(igdbRateLimitBackoff):
+					}
+				}
 				return
 			}
 			w.scraperConsecutiveFailures = 0


### PR DESCRIPTION
## Summary

### #994 — Client SRAM atomic write
\`SaveDataRepositoryImpl.saveLocalSRAM\` now writes via the new \`FileStorage.atomicWriteFile\` helper. Android and Desktop implementations write to a sibling \`.tmp\` and atomic-rename. A process kill mid-write (Android OOM, rotation crash) no longer leaves a truncated \`active.srm\` that \`loadLocalSRAM\` would feed to libretro as corrupt save data.

The interface defines a default that delegates to the non-atomic \`writeFile\`, so test stubs continue to work without changes — only production platform impls need the override.

### #1011 — IGDB rate-limit backoff
The IGDB client now wraps HTTP 429 responses with a sentinel \`igdb.ErrRateLimit\` error. The scrape worker detects via \`errors.Is\` and sleeps for 60s before processing the next item. Previously a 429 was treated as a normal failure and the worker fast-failed the entire remaining queue inside the same rate-limit window.

## Test plan
- [x] \`go build ./...\` clean
- [x] Player desktop + test compile clean (`./gradlew :shared:compileTestKotlinDesktop :desktop:compileTestKotlinDesktop`)
- [x] \`go test ./internal/scraper/...\` pass (47s)