### PR TITLE
fix(audit-phase3): module-by-module sweep — 17 fixes across web, player, server

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
@@ -119,4 +119,11 @@ sealed interface GameDetailIntent {
         val description: String = "",
     ) : GameDetailIntent
     data object ConsumeShareSessionCreatedNavigation : GameDetailIntent
+    /**
+     * Marks playFromSharedSaveSessionId as consumed after the screen has
+     * dispatched the navigation. Without this, recomposition can re-fire
+     * the LaunchedEffect and push duplicate emulation screens onto the
+     * back-stack.
+     */
+    data object ConsumePlayFromSharedSaveNavigation : GameDetailIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -248,6 +248,13 @@ data class EmulationState(
     val showChallengeCreation: Boolean = false,
     val isCreatingChallenge: Boolean = false,
     val challengeCreationSuccess: Boolean = false,
+    /**
+     * Increments each time a challenge is successfully created. The toast's
+     * dismiss LaunchedEffect keys on this so a second creation within the
+     * 5s window of the first restarts the timer instead of letting the
+     * original 5s timer dismiss the second toast prematurely (#1019).
+     */
+    val challengeCreationSuccessCount: Int = 0,
     val showGiveUpConfirm: Boolean = false,
     val challengeCompletedAttempt: com.spela.player.domain.model.ChallengeAttempt? = null,
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -87,10 +87,14 @@ fun GameDetailScreen(
         viewModel.onIntent(GameDetailIntent.LoadGame(gameId))
     }
 
-    // Navigate to play when a session is created from a shared save
+    // Navigate to play when a session is created from a shared save.
+    // Mark the ID consumed immediately after dispatching navigation so a
+    // later recomposition with the same state value doesn't re-fire and
+    // push a duplicate emulation screen onto the back-stack.
     LaunchedEffect(state.playFromSharedSaveSessionId) {
         val sessionId = state.playFromSharedSaveSessionId ?: return@LaunchedEffect
         onPlaySession?.invoke(gameId, sessionId)
+        viewModel.onIntent(GameDetailIntent.ConsumePlayFromSharedSaveNavigation)
     }
 
     // #932: instant-download flow finished — drive the play handler

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -496,7 +497,11 @@ private fun DeviceNameBanner(
     deviceName: String,
     onSave: (String) -> Unit,
 ) {
-    var nameInput by remember { mutableStateOf("") }
+    // rememberSaveable: the banner lives inside an AnimatedVisibility that
+    // can exit and re-enter the composition (and on Android, config changes
+    // reset remember state). Saving across these transitions preserves typed
+    // text instead of dropping it on, e.g., orientation change.
+    var nameInput by rememberSaveable { mutableStateOf("") }
 
     AnimatedVisibility(
         visible = deviceName.isBlank(),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -128,19 +128,21 @@ fun HomeScreen(
     if (sawLoading && !state.isLoading) hasInitiallyLoaded = true
 
     LaunchedEffect(Unit) {
-        println("[HomeScreen] LaunchedEffect(Unit) fired — loading dashboard")
         viewModel.onIntent(GameListIntent.LoadDashboard)
         socialViewModel.onIntent(SocialIntent.RefreshAll)
         settingsViewModel?.onIntent(SettingsIntent.LoadSettings)
     }
 
-    // Retry if dashboard loaded empty (server may still be scanning on startup)
+    // Retry once if the first dashboard fetch returns empty (server may still
+    // be scanning on startup). The hasRetried guard prevents an infinite loop
+    // on a permanently-empty library — without it, every load->isLoading=true
+    // ->isLoading=false->isEmpty=true edge would retrigger this effect.
     val isEmpty = state.consoles.isEmpty() && state.recentGames.isEmpty() && !state.isLoading
+    var hasRetried by remember { mutableStateOf(false) }
     LaunchedEffect(isEmpty) {
-        if (isEmpty) {
-            println("[HomeScreen] Dashboard empty, retrying in 3s (consoles=${state.consoles.size}, recent=${state.recentGames.size}, loading=${state.isLoading})")
+        if (isEmpty && !hasRetried) {
+            hasRetried = true
             kotlinx.coroutines.delay(3000)
-            println("[HomeScreen] Retrying dashboard load")
             viewModel.onIntent(GameListIntent.LoadDashboard)
             socialViewModel.onIntent(SocialIntent.RefreshAll)
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -220,7 +220,11 @@ fun InGameOverlay(
     // a usable window to assert the toast text — at 2 s the test
     // raced cold-container POST latency and missed the toast (#837).
     if (state.challengeCreationSuccess) {
-        LaunchedEffect(Unit) {
+        // Key on the success counter so a second challenge creation within
+        // the 5s window of the first re-launches the dismiss timer. Keying
+        // on Unit (or just the boolean flag) would leave the original
+        // timer pointing at the second toast and dismiss it prematurely.
+        LaunchedEffect(state.challengeCreationSuccessCount) {
             delay(5000)
             viewModel.onIntent(EmulationIntent.DismissChallengeCreation)
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ChallengeManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ChallengeManager.kt
@@ -120,6 +120,7 @@ class ChallengeManager(
                                 showChallengeCreation = false,
                                 isCreatingChallenge = false,
                                 challengeCreationSuccess = true,
+                                challengeCreationSuccessCount = it.challengeCreationSuccessCount + 1,
                                 statusMessage = "Challenge created!",
                             )
                         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -158,6 +158,8 @@ class GameDetailViewModel(
                 createSharedSessionFromSession(intent.sourceSessionId, intent.name, intent.description)
             GameDetailIntent.ConsumeShareSessionCreatedNavigation ->
                 _state.update { it.copy(shareSessionCreatedId = null) }
+            GameDetailIntent.ConsumePlayFromSharedSaveNavigation ->
+                _state.update { it.copy(playFromSharedSaveSessionId = null) }
 
             // Admin actions
             GameDetailIntent.AdminScrapeGame -> adminScrapeGame()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -1094,10 +1094,14 @@ class SaveManager(
                         runCatching { fileStorage.deleteFile(tempPath) }
                         withContext(dispatchers.main) {
                             _state.update {
+                                // The "Load" button (no slot selected) loads
+                                // the auto-save endpoint, not a slot — so the
+                                // toast must say so. Slot-based loads use
+                                // loadFromSlot() instead. See #996.
                                 it.copy(
                                     statusMessage = "State loaded",
                                     secondaryToast = SecondaryToastData(
-                                        message = "Loaded Slot ${it.activeSlot}",
+                                        message = "Auto-save loaded",
                                         type = SecondaryToastType.LOAD,
                                     ),
                                 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SocialViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SocialViewModel.kt
@@ -14,6 +14,7 @@ import com.spela.player.presentation.intent.SocialIntent
 import com.spela.player.presentation.state.SocialState
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -34,6 +35,7 @@ class SocialViewModel(
 ) {
     private val _state = MutableStateFlow(SocialState())
     val state: StateFlow<SocialState> = _state.asStateFlow()
+    private var profileJob: Job? = null
 
     fun onIntent(intent: SocialIntent) {
         when (intent) {
@@ -143,39 +145,45 @@ class SocialViewModel(
     }
 
     private fun loadPublicProfile(userId: String) {
+        // Cancel any in-flight load for the previous profile so its
+        // _state.update calls don't land after the screen has reset to a
+        // different profile and clobber the new data.
+        profileJob?.cancel()
         _state.update { it.copy(isLoadingProfile = true, publicProfile = null, heatmapData = emptyList(), showcaseAchievements = emptyList(), isOwnProfile = false) }
-        // Detect own profile
-        scope.launch(dispatchers.io) {
-            authRepository.getCurrentUser().onSuccess { user ->
-                _state.update { it.copy(isOwnProfile = user.id == userId) }
+        profileJob = scope.launch(dispatchers.io) {
+            // Detect own profile
+            launch {
+                authRepository.getCurrentUser().onSuccess { user ->
+                    _state.update { it.copy(isOwnProfile = user.id == userId) }
+                }
             }
-        }
-        scope.launch(dispatchers.io) {
-            getPublicProfileUseCase(userId).fold(
-                onSuccess = { profile ->
-                    _state.update { it.copy(publicProfile = profile, isLoadingProfile = false) }
-                },
-                onFailure = { error ->
-                    _state.update { it.copy(error = error.message, isLoadingProfile = false) }
-                },
-            )
-        }
-        // Load heatmap data in parallel — best effort, non-critical
-        scope.launch(dispatchers.io) {
-            try {
-                val entries = getPlayHeatmapUseCase(userId).getOrDefault(emptyList())
-                _state.update { it.copy(heatmapData = entries) }
-            } catch (_: Exception) {
-                // Best effort — heatmap is non-critical
+            launch {
+                getPublicProfileUseCase(userId).fold(
+                    onSuccess = { profile ->
+                        _state.update { it.copy(publicProfile = profile, isLoadingProfile = false) }
+                    },
+                    onFailure = { error ->
+                        _state.update { it.copy(error = error.message, isLoadingProfile = false) }
+                    },
+                )
             }
-        }
-        // Load achievement showcase in parallel — best effort, non-critical
-        scope.launch(dispatchers.io) {
-            try {
-                val entries = getPublicShowcaseUseCase(userId).getOrDefault(emptyList())
-                _state.update { it.copy(showcaseAchievements = entries) }
-            } catch (_: Exception) {
-                // Best effort — showcase is non-critical
+            // Load heatmap data in parallel — best effort, non-critical
+            launch {
+                try {
+                    val entries = getPlayHeatmapUseCase(userId).getOrDefault(emptyList())
+                    _state.update { it.copy(heatmapData = entries) }
+                } catch (_: Exception) {
+                    // Best effort — heatmap is non-critical
+                }
+            }
+            // Load achievement showcase in parallel — best effort, non-critical
+            launch {
+                try {
+                    val entries = getPublicShowcaseUseCase(userId).getOrDefault(emptyList())
+                    _state.update { it.copy(showcaseAchievements = entries) }
+                } catch (_: Exception) {
+                    // Best effort — showcase is non-critical
+                }
             }
         }
     }

--- a/server/internal/api/huma_admin_multipart.go
+++ b/server/internal/api/huma_admin_multipart.go
@@ -523,8 +523,18 @@ func (h *RomHackHandler) HumaCreateRomHack(_ context.Context, in *AdminCreateRom
 		return nil, huma.NewError(http.StatusConflict, "a ROM file with this name already exists: "+patchedFileName)
 	}
 
-	if err := os.WriteFile(targetPath, patchedData, 0644); err != nil {
-		slog.Warn("failed to write patched ROM", "path", targetPath, "error", err)
+	// Atomic write: a server crash between os.WriteFile starting and
+	// completing would otherwise leave a partial ROM at targetPath, and
+	// the next admin request for the same name hits the os.Stat conflict
+	// check above and gets locked into 409 Conflict permanently.
+	tmpPath := targetPath + ".tmp"
+	if err := os.WriteFile(tmpPath, patchedData, 0644); err != nil {
+		slog.Warn("failed to write patched ROM tmp file", "path", tmpPath, "error", err)
+		return nil, huma.NewError(http.StatusInternalServerError, "failed to write patched ROM file")
+	}
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		_ = os.Remove(tmpPath)
+		slog.Warn("failed to rename patched ROM into place", "path", targetPath, "error", err)
 		return nil, huma.NewError(http.StatusInternalServerError, "failed to write patched ROM file")
 	}
 

--- a/server/internal/api/huma_admin_multipart.go
+++ b/server/internal/api/huma_admin_multipart.go
@@ -253,11 +253,19 @@ func (h *BiosHandler) HumaUploadBiosFile(_ context.Context, in *AdminUploadBiosI
 		match := matches[0]
 		if match.SubDir != "" {
 			subDirPath := match.FilePath(h.Storage.BiosDir)
-			if err := os.MkdirAll(filepath.Dir(subDirPath), 0755); err == nil {
-				if err := os.Rename(safePath, subDirPath); err == nil {
-					safePath = subDirPath
-				}
+			if err := os.MkdirAll(filepath.Dir(subDirPath), 0755); err != nil {
+				_ = os.Remove(safePath)
+				return nil, huma.Error500InternalServerError("failed to create BIOS subdirectory: " + err.Error())
 			}
+			if err := os.Rename(safePath, subDirPath); err != nil {
+				// Cross-device or other rename failure leaves the file at
+				// safePath (top-level BIOS dir) where libretro cores can't
+				// find it. Surface the error rather than silently misplacing
+				// the upload.
+				_ = os.Remove(safePath)
+				return nil, huma.Error500InternalServerError("failed to move BIOS file to subdirectory: " + err.Error())
+			}
+			safePath = subDirPath
 		}
 		consoleName := names[match.ConsoleID]
 		consoleID := match.ConsoleID

--- a/server/internal/patcher/ips.go
+++ b/server/internal/patcher/ips.go
@@ -131,6 +131,17 @@ func applyIPS32(romData, patchData []byte) ([]byte, error) {
 
 		// Check for EEOF marker
 		if string(patchData[pos:pos+4]) == ips32EOF {
+			// Optional truncation marker (4 bytes after EEOF, big-endian).
+			// Mirrors applyIPSStandard's handling — without this, patches
+			// that include the marker leave the ROM longer than intended,
+			// which some emulators tolerate and others crash on.
+			pos += 4
+			if pos+4 <= len(patchData) {
+				truncSize := int(binary.BigEndian.Uint32(patchData[pos : pos+4]))
+				if truncSize < len(result) {
+					result = result[:truncSize]
+				}
+			}
 			break
 		}
 

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -500,7 +500,40 @@ type ScanResult struct {
 
 // parseM3U reads an .m3u file and returns resolved file paths.
 // Blank lines and lines starting with # are skipped.
-func parseM3U(m3uPath string) ([]string, error) {
+// pathInsideAllowedDirs reports whether [target] (already cleaned) is
+// contained within any of [allowedDirs]. Uses filepath.Rel rather than
+// storage.ValidateROMPath because the latter calls EvalSymlinks on the
+// target — and m3u entries can legitimately reference files that don't
+// yet exist on disk (e.g. mid-scan with companion .bin files), in which
+// case EvalSymlinks falls back to the unresolved path while the dir is
+// resolved, yielding false negatives on platforms where the temp/games
+// path passes through a symlink (macOS /var → /private/var).
+func pathInsideAllowedDirs(target string, allowedDirs []string) bool {
+	for _, dir := range allowedDirs {
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+		absTarget, err := filepath.Abs(target)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(absDir, absTarget)
+		if err != nil {
+			continue
+		}
+		if rel == "." || (!strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseM3U reads an .m3u file and returns resolved file paths.
+// Entries that resolve outside [allowedDirs] are dropped with a warning so
+// a crafted .m3u (e.g. containing "../../etc/passwd") cannot smuggle paths
+// outside the configured game directories into the scanner output.
+func parseM3U(m3uPath string, allowedDirs []string) ([]string, error) {
 	f, err := os.Open(m3uPath)
 	if err != nil {
 		return nil, fmt.Errorf("opening .m3u file: %w", err)
@@ -519,7 +552,12 @@ func parseM3U(m3uPath string) ([]string, error) {
 		if !filepath.IsAbs(resolved) {
 			resolved = filepath.Join(dir, resolved)
 		}
-		paths = append(paths, filepath.Clean(resolved))
+		cleaned := filepath.Clean(resolved)
+		if len(allowedDirs) > 0 && !pathInsideAllowedDirs(cleaned, allowedDirs) {
+			slog.Warn(".m3u entry resolves outside game directories, skipping", "m3u", m3uPath, "entry", cleaned)
+			continue
+		}
+		paths = append(paths, cleaned)
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("reading .m3u file: %w", err)
@@ -996,7 +1034,7 @@ func (s *Scanner) scanMultiDisc(dir string, consoleMap map[string]*db.Console, f
 
 	// Process .m3u files first
 	for _, m3uPath := range m3uFiles {
-		discFiles, err := parseM3U(m3uPath)
+		discFiles, err := parseM3U(m3uPath, s.GameDirs)
 		if err != nil {
 			slog.Warn("failed to parse .m3u", "path", m3uPath, "error", err)
 			continue

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -863,7 +863,7 @@ func (s *Scanner) scanScummVMGames(result *ScanResult, foundPaths map[string]boo
 			continue
 		}
 
-		filepath.WalkDir(scummRoot, func(path string, d fs.DirEntry, err error) error {
+		if walkErr := filepath.WalkDir(scummRoot, func(path string, d fs.DirEntry, err error) error {
 			if err != nil || d.IsDir() {
 				return nil
 			}
@@ -927,7 +927,9 @@ func (s *Scanner) scanScummVMGames(result *ScanResult, foundPaths map[string]boo
 			}
 			slog.Info("found ScummVM game", "title", title, "path", relPath)
 			return nil
-		})
+		}); walkErr != nil {
+			slog.Warn("ScummVM walk error", "dir", scummRoot, "error", walkErr)
+		}
 	}
 	return nil
 }

--- a/server/internal/scanner/scanner_test.go
+++ b/server/internal/scanner/scanner_test.go
@@ -377,11 +377,27 @@ func TestParseM3U(t *testing.T) {
 	content := "disc1.cue\n\ndisc2.cue\n# comment\n"
 	require.NoError(t, os.WriteFile(m3uPath, []byte(content), 0644))
 
-	paths, err := parseM3U(m3uPath)
+	paths, err := parseM3U(m3uPath, []string{dir})
 	require.NoError(t, err)
 	assert.Len(t, paths, 2)
 	assert.Equal(t, filepath.Join(dir, "disc1.cue"), paths[0])
 	assert.Equal(t, filepath.Join(dir, "disc2.cue"), paths[1])
+}
+
+func TestParseM3UDropsEntriesOutsideAllowedDirs(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "evil.cue"), []byte("FILE \"evil.bin\" BINARY\n"), 0644))
+	m3uPath := filepath.Join(dir, "game.m3u")
+	// Mix a legitimate relative entry with an absolute path that escapes
+	// the allowed dirs and a "../" relative escape attempt.
+	content := "disc1.cue\n" + filepath.Join(outside, "evil.cue") + "\n../../etc/passwd\n"
+	require.NoError(t, os.WriteFile(m3uPath, []byte(content), 0644))
+
+	paths, err := parseM3U(m3uPath, []string{dir})
+	require.NoError(t, err)
+	require.Len(t, paths, 1, "only the in-dir entry should be retained")
+	assert.Equal(t, filepath.Join(dir, "disc1.cue"), paths[0])
 }
 
 func TestDiscPattern(t *testing.T) {

--- a/web/src/components/ui/modal.tsx
+++ b/web/src/components/ui/modal.tsx
@@ -8,6 +8,14 @@ interface ModalProps {
   title?: string;
   children: ReactNode;
   className?: string;
+  /**
+   * Override the body container's classes. Default is `p-6`. Pass `p-0`
+   * (and apply your own padding inside) when the body should render
+   * edge-to-edge — e.g. a scrollable list whose scrollbar should sit at
+   * the modal's outer rounded edge. Avoids the negative-margin escape
+   * hatch that the project rule forbids.
+   */
+  bodyClassName?: string;
   size?: "sm" | "md" | "lg" | "xl";
 }
 
@@ -24,6 +32,7 @@ export function Modal({
   title,
   children,
   className,
+  bodyClassName = "p-6",
   size = "md",
 }: ModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -83,7 +92,7 @@ export function Modal({
             </button>
           </div>
         )}
-        <div className="p-6">{children}</div>
+        <div className={bodyClassName}>{children}</div>
       </div>
     </div>
   );

--- a/web/src/hooks/use-auto-save.ts
+++ b/web/src/hooks/use-auto-save.ts
@@ -32,13 +32,4 @@ export function useAutoSave({
       }
     };
   }, [emulatorStatus, autoSaveEnabled, requestAutoSave]);
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      if (autoSaveIntervalRef.current) {
-        clearInterval(autoSaveIntervalRef.current);
-      }
-    };
-  }, []);
 }

--- a/web/src/hooks/use-disc-manager.ts
+++ b/web/src/hooks/use-disc-manager.ts
@@ -200,7 +200,10 @@ export function useDiscManager({
   const retryDisc = useCallback(
     (discNumber: number) => {
       if (!game) return;
-      downloadSingleDisc(game.id, discNumber);
+      // Pass the same abort signal the background loop uses so a
+      // user-initiated retry that's still mid-flight when the
+      // component unmounts gets cancelled too.
+      downloadSingleDisc(game.id, discNumber, abortControllerRef.current?.signal);
     },
     [game?.id],
   );

--- a/web/src/hooks/use-disc-manager.ts
+++ b/web/src/hooks/use-disc-manager.ts
@@ -59,20 +59,35 @@ export function useDiscManager({
     );
   }, [game?.id, isMultiDisc]);
 
+  // AbortController for the in-flight disc download so an unmount cancels
+  // the fetch + stream reader instead of letting them keep consuming
+  // network and calling setState on an unmounted component.
+  const abortControllerRef = useRef<AbortController | null>(null);
+
   // Start background downloading when game starts playing
   useEffect(() => {
     if (!isMultiDisc || emulatorStatus !== "playing" || !game?.discs) return;
     if (downloadingRef.current) return;
 
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
     downloadingRef.current = true;
-    downloadDiscsSequentially(game.id, game.discs.length);
+    downloadDiscsSequentially(game.id, game.discs.length, controller.signal);
 
     return () => {
       downloadingRef.current = false;
+      controller.abort();
+      if (abortControllerRef.current === controller) {
+        abortControllerRef.current = null;
+      }
     };
   }, [isMultiDisc, emulatorStatus, game?.id]);
 
-  async function downloadSingleDisc(gameId: string, discNumber: number) {
+  async function downloadSingleDisc(
+    gameId: string,
+    discNumber: number,
+    signal?: AbortSignal,
+  ) {
     setDiscStates((prev) =>
       prev.map((d) =>
         d.discNumber === discNumber
@@ -88,7 +103,7 @@ export function useDiscManager({
         : "";
       const url = `/api/games/${gameId}/discs/${discNumber}/download?format=zip${tokenParam}`;
 
-      const response = await fetch(url);
+      const response = await fetch(url, { signal });
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }
@@ -141,6 +156,13 @@ export function useDiscManager({
         ),
       );
     } catch (err) {
+      // AbortError is expected on unmount — don't surface as a download error.
+      if (
+        err instanceof DOMException &&
+        err.name === "AbortError"
+      ) {
+        return;
+      }
       const message =
         err instanceof Error ? err.message : "Download failed";
       setDiscStates((prev) =>
@@ -155,9 +177,11 @@ export function useDiscManager({
   async function downloadDiscsSequentially(
     gameId: string,
     discCount: number,
+    signal?: AbortSignal,
   ) {
     for (let i = 1; i <= discCount; i++) {
       if (!downloadingRef.current) break;
+      if (signal?.aborted) break;
       // Don't re-download a disc that already finished during a
       // previous pass. `emulatorStatus` flips through "saving" →
       // "playing" during a disc switch (requestSaveState), which
@@ -169,7 +193,7 @@ export function useDiscManager({
         (d) => d.discNumber === i,
       );
       if (current?.status === "ready" && current.data) continue;
-      await downloadSingleDisc(gameId, i);
+      await downloadSingleDisc(gameId, i, signal);
     }
   }
 

--- a/web/src/hooks/use-games.ts
+++ b/web/src/hooks/use-games.ts
@@ -97,6 +97,7 @@ export function useToggleFavorite() {
 }
 
 export function useScrapeIfNeeded() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (gameId: string) =>
       unwrap(
@@ -104,6 +105,13 @@ export function useScrapeIfNeeded() {
           params: { path: { id: gameId } },
         }),
       ),
+    onSuccess: (_, gameId) => {
+      // Refresh the game record so scrapeAttempts moves off 0 and the
+      // page-level useEffect that triggers this mutation no longer
+      // fires on subsequent renders. Without this the effect can
+      // re-call the endpoint indefinitely while the server is slow.
+      queryClient.invalidateQueries({ queryKey: ["game", gameId] });
+    },
   });
 }
 

--- a/web/src/hooks/use-save-queue.ts
+++ b/web/src/hooks/use-save-queue.ts
@@ -25,6 +25,14 @@ export function useSaveQueue({
   const [isSaving, setIsSaving] = useState(false);
   const saveQueueRef = useRef<SaveQueueItem[]>([]);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Stash callbacks in refs so processQueue can stay stable across the
+  // recursive calls. Without this, every parent re-render with new inline
+  // lambdas would rebuild processQueue, and a recursion taken between
+  // upload start and recursion completion could fire a stale callback.
+  const onSaveSuccessRef = useRef(onSaveSuccess);
+  const onSaveErrorRef = useRef(onSaveError);
+  onSaveSuccessRef.current = onSaveSuccess;
+  onSaveErrorRef.current = onSaveError;
 
   const processQueue = useCallback(async () => {
     if (saveQueueRef.current.length === 0) {
@@ -70,14 +78,14 @@ export function useSaveQueue({
       }
 
       saveQueueRef.current.shift();
-      onSaveSuccess?.(item.isAuto);
+      onSaveSuccessRef.current?.(item.isAuto);
 
       processQueue();
     } catch {
       item.retries++;
       if (item.retries >= MAX_RETRIES) {
         saveQueueRef.current.shift();
-        onSaveError?.(`Save failed after ${MAX_RETRIES} attempts`, item.isAuto);
+        onSaveErrorRef.current?.(`Save failed after ${MAX_RETRIES} attempts`, item.isAuto);
         processQueue();
       } else {
         retryTimerRef.current = setTimeout(() => {
@@ -85,7 +93,7 @@ export function useSaveQueue({
         }, RETRY_DELAY_MS);
       }
     }
-  }, [onSaveSuccess, onSaveError]);
+  }, []);
 
   const enqueueSave = useCallback(
     (sessionId: string, data: string, isAuto: boolean, name?: string, screenshot?: string) => {

--- a/web/src/hooks/use-social.ts
+++ b/web/src/hooks/use-social.ts
@@ -1,10 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { typedApi, unwrap } from "@/lib/api-client";
 import { useWebSocketEvent } from "@/hooks/use-websocket";
-import type {
-  ActivityEvent,
-  ActivityFeedResponse,
-} from "@/types/api";
 
 export function useOnlineUsers() {
   return useQuery({
@@ -52,18 +48,12 @@ export function useRecentPartners() {
 export function useActivityRealtime() {
   const queryClient = useQueryClient();
 
-  useWebSocketEvent("activity_new", (payload: ActivityEvent) => {
-    queryClient.setQueryData<ActivityFeedResponse>(
-      ["social", "activity", 1, 20],
-      (old) => {
-        if (!old) return old;
-        return {
-          ...old,
-          data: [payload, ...(old.data ?? [])],
-          total: old.total + 1,
-        };
-      },
-    );
+  useWebSocketEvent("activity_new", () => {
+    // Invalidate every activity feed cache regardless of (page, pageSize) —
+    // the previous setQueryData targeted only ["social", "activity", 1, 20]
+    // and silently dropped realtime updates for any caller that passed a
+    // different pageSize (e.g. the home dashboard's maxItems=5 feed).
+    queryClient.invalidateQueries({ queryKey: ["social", "activity"] });
   });
 
   useWebSocketEvent("online_status", () => {

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -102,8 +102,8 @@ function CollectionPickerModal({
   }
 
   return (
-    <Modal open={open} onClose={onClose} title="Add to Collection" size="sm">
-      <div className="max-h-64 overflow-y-auto -mx-6 -mb-6 px-6 pb-6">
+    <Modal open={open} onClose={onClose} title="Add to Collection" size="sm" bodyClassName="px-6 pb-6 pt-0">
+      <div className="max-h-64 overflow-y-auto">
         {collections.length === 0 ? (
           <p className="py-4 text-sm text-surface-500 text-center">
             No collections yet. Create one first.


### PR DESCRIPTION
## Summary
Phase 3 module-by-module audit. Three reviewers covered:
1. Web frontend (React + TanStack Query hooks, components, pages)
2. Player presentation (Compose ViewModels and screens we hadn't covered in Phase 2)
3. Server scanner / patcher / bios / cheats

17 high-confidence findings, 17 issues filed, 16 closed by this PR (1 deferred as feature-level work needing UI coordination — closed as not-planned).

### Web (6 fixes)
- **#1020** Modal exposes \`bodyClassName\` slot; CollectionPickerModal stops using forbidden \`-mx-6 -mb-6\` negative margins.
- **#1021** \`useScrapeIfNeeded\` invalidates the \`game\` query on success so \`scrapeAttempts\` moves off 0 and the page-level useEffect doesn't keep firing.
- **#1024** Remove dead second cleanup useEffect in \`useAutoSave\`.
- **#1026** \`useActivityRealtime\` switches from hardcoded-key \`setQueryData\` to \`invalidateQueries\` so all activity feed consumers (any pageSize) get realtime updates.
- **#1027** \`useDiscManager\` aborts in-flight disc downloads on unmount via AbortController.
- **#1028** \`useSaveQueue.processQueue\` reads onSave callbacks through refs so it stays stable across parent re-renders.

### Player (6 fixes)
- **#996** \`loadState()\` toast says \"Auto-save loaded\" instead of misleading \"Loaded Slot N\".
- **#1016** \`SocialViewModel.loadPublicProfile\` tracks all parallel loads as children of a single \`profileJob\`; cancels on profile switch so stale data can't clobber the new profile.
- **#1017** \`HomeScreen\` empty-state retry guarded by \`hasRetried\` (prevents infinite loop on permanently-empty libraries); leftover \`println\` debug removed.
- **#1018** \`GameDetailScreen\` consumes \`playFromSharedSaveSessionId\` after dispatching navigation (new \`ConsumePlayFromSharedSaveNavigation\` intent) — no more duplicate emulation screens on recompose.
- **#1019** \`InGameOverlay\` keys the challenge-success dismiss timer on a counter so a second creation re-launches the 5s delay.
- **#1025** \`DeviceNameBanner.nameInput\` uses \`rememberSaveable\` so typed text survives AnimatedVisibility exit/re-enter and Android config changes.

### Server (5 fixes)
- **#1022** \`HumaUploadBiosFile\` surfaces BIOS subdir rename failures instead of silently misplacing the upload.
- **#1023** \`scanScummVMGames\` logs \`filepath.WalkDir\` errors.
- **#1029** \`parseM3U\` validates entries stay inside the configured game dirs (rejects \`../\` escapes and out-of-tree absolute paths).
- **#1030** \`HumaCreateRomHack\` writes patched ROMs atomically (temp+rename) so a server crash mid-write doesn't 409-lock the admin out of recreating the hack.
- **#1032** \`applyIPS32\` handles the optional 4-byte truncation marker (matching \`applyIPSStandard\`).

### Deferred
- **#1031** Async cheat import — closed as not-planned. Server-only fix would break the existing sync UI; needs coordinated UI changes which are feature-level.

### Other open Phase 2 issues (still deferred, need design)
- #997 (drain race), #996 already done above? Confirm — yes, #996 is in this PR's player batch.
- #1006 (netplay state-chunk handshake), #968 (OpenAPI nullable), #971 (CASCADE migration plan).

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./internal/scanner/...\` (incl. new \`TestParseM3UDropsEntriesOutsideAllowedDirs\`)
- [x] \`go test ./internal/patcher/...\`
- [x] Player desktop test compile clean
- [x] \`npx tsc --noEmit\` for web clean
- [x] Web tests: 1600/1600 passing (no test changes; verified before PR)

One commit per issue, per project convention.