### PR TITLE
fix(player): autoLoadSaveState awaits drainMutex before downloading (#997)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -345,6 +346,16 @@ class SaveManager(
      */
     suspend fun autoLoadSaveState(gameId: String): AutoLoadResult {
         val sessionId = currentSessionId ?: return AutoLoadResult.NoSave
+
+        // Wait for any in-flight drain from the previous game to complete
+        // before downloading the auto-save. Without this, when the new game
+        // reuses the same session ID (ensureSession's "reuse most recent"
+        // path), the drain's upload of the old game's final save can race
+        // with this download — the user could resume from a stale state and
+        // the drain's upload could then overwrite the server's auto-save
+        // with an older snapshot, silently losing forward progress on the
+        // next launch. See #997.
+        drainMutex.withLock { /* await drain completion */ }
 
         println("[SaveManager] autoLoadSaveState: checking session $sessionId for core compatibility")
 


### PR DESCRIPTION
## Summary
**#997** — Fixes a silent forward-progress loss when the user switches games quickly and \`ensureSession\` reuses the same session ID for the new game.

### The race
1. Game A's \`stopGame\` → \`autoSaveOnStop\` → \`drainPendingUploads()\` starts uploading the prior session's final save in the background.
2. User immediately starts Game B → \`startGame\` → \`autoLoadSaveState\` downloads the same session's auto-save (because the session ID was reused).
3. The upload from (1) lands AFTER the download from (2), overwriting the server's auto-save with an older snapshot.
4. Next launch resumes from the stale snapshot — forward progress is silently lost.

### Fix
\`autoLoadSaveState\` acquires \`drainMutex.withLock { /* no-op */ }\` at the top, blocking until any in-flight drain finishes. The drain runs in its own \`scope.launch\` and uses \`tryLock\` for redundant triggers, so this is just a sequencer — no deadlock surface.

## Test plan
- [x] Player desktop test compile clean
- [x] All SaveManager tests pass