### PR TITLE
fix(netplay): client-READY handshake before initial state sync (#1006)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/netplay/NetplayProtocol.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/netplay/NetplayProtocol.kt
@@ -8,6 +8,18 @@ object NetplayProtocol {
     const val MSG_STATE_CHUNK: Byte = 0x01
     const val MSG_INPUT_FRAME: Byte = 0x02
     const val MSG_DESYNC_CHECK: Byte = 0x03
+    /** Client → host signal: client has subscribed to remoteBinary and is ready
+     * to receive state chunks. The host waits for this before sending state to
+     * close the race where the host's chunks would otherwise arrive before the
+     * client started collecting (silently dropped). See #1006. */
+    const val MSG_CLIENT_READY: Byte = 0x04
+    private val CLIENT_READY_PAYLOAD = byteArrayOf(MSG_CLIENT_READY)
+
+    /** Returns the single-byte client-ready signal. */
+    fun encodeClientReady(): ByteArray = CLIENT_READY_PAYLOAD.copyOf()
+
+    /** True if [data] is the client-ready signal. */
+    fun isClientReady(data: ByteArray): Boolean = data.size == 1 && data[0] == MSG_CLIENT_READY
 
     private const val INPUT_FRAME_SIZE = 12
     private const val DESYNC_CHECK_SIZE = 9

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/NetplayManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/NetplayManager.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
@@ -108,19 +109,31 @@ class NetplayManager(
         // Connect to the WebSocket
         transport.connect()
 
-        // Small delay to let the WebSocket connection establish
-        delay(500)
-
         val inputBuffer = NetplayInputBuffer()
 
-        // Initial state sync: host serializes and sends, client waits to receive
+        // Initial state sync: host waits for the client's READY signal before
+        // sending state chunks, client signals ready before subscribing to
+        // chunks. The previous fixed 500ms delay was a race — chunks arriving
+        // before the client started collecting transport.remoteBinary were
+        // silently dropped, leading to a desync at game start. See #1006.
         if (isHost) {
-            val stateData = libretroController.serialize()
-            if (stateData != null) {
-                sendStateChunks(transport, stateData)
+            // Wait for the client to signal it's ready (or timeout after 10s).
+            val clientReady = withTimeoutOrNull(10_000) {
+                transport.remoteBinary.first { com.spela.player.netplay.NetplayProtocol.isClientReady(it.data) }
+                true
+            }
+            if (clientReady != null) {
+                val stateData = libretroController.serialize()
+                if (stateData != null) {
+                    sendStateChunks(transport, stateData)
+                }
             }
         } else {
-            // Client waits for state chunks from host
+            // Send the ready signal first, THEN start collecting state chunks.
+            // sendBinary is fire-and-forget but the WebSocket library queues
+            // messages until the connection is open, so this is safe to send
+            // immediately after connect().
+            transport.sendBinary(com.spela.player.netplay.NetplayProtocol.encodeClientReady())
             val stateData = receiveStateChunks(transport)
             if (stateData != null) {
                 libretroController.unserialize(stateData)


### PR DESCRIPTION
## Summary
**#1006** — Replace the fixed 500ms delay with an explicit client-READY signal so the host doesn't transmit state chunks before the client is collecting them.

### Before
- Host: \`transport.connect()\` → \`delay(500)\` → \`sendStateChunks()\`.
- Client: \`transport.connect()\` → \`delay(500)\` → start collecting \`transport.remoteBinary\`.

If the client's connect+subscribe took longer than 500ms (slow network, cold WS path), the host's chunks arrived before the client was collecting and were silently dropped. Client then timed out at 10s in \`receiveStateChunks\`, leaving the emulator running with the wrong initial state and immediate desync.

### After
- New \`MSG_CLIENT_READY\` (1 byte, 0x04) protocol message.
- Client: \`transport.connect()\` → \`sendBinary(encodeClientReady())\` → \`receiveStateChunks()\`.
- Host: \`transport.connect()\` → wait (10s timeout) for the READY message on \`remoteBinary\` → \`sendStateChunks()\`.

WebSocket libraries queue messages until the connection is open, so sending the READY immediately after connect is safe.

### Compatibility
This is a protocol change but ships in both client and server (well, client-only — server is just a relay) at the same time. Same-release rollouts of the player app see the fix consistently. Mixed-version netplay between an updated and a non-updated client would fail — but netplay isn't a federated protocol, both peers are running the same player binary.

## Test plan
- [x] Player desktop test compile clean
- [x] Existing netplay tests pass