### PR TITLE
fix(audit-phase4): server middleware + native JNI + web admin (8 issues)

### DIFF
--- a/player/native/src/libretro_achievements.c
+++ b/player/native/src/libretro_achievements.c
@@ -37,7 +37,6 @@ typedef struct {
 /* Module state */
 static struct {
     rc_client_t *client;
-    JNIEnv *jni_env;
     jobject jni_thiz;
     jclass jni_class;
     jmethodID on_achievement_event_method;
@@ -47,6 +46,42 @@ static struct {
 } ach_state = {0};
 
 static pending_request_t pending_requests[MAX_PENDING_REQUESTS];
+
+/*
+ * Get a JNIEnv* for the current thread by attaching to the JVM.
+ * Sets [*needs_detach] to true iff the thread was newly attached and
+ * the caller must DetachCurrentThread before returning.
+ *
+ * rc_server_call and rc_event_handler are invoked from the emulation
+ * thread (rc_client_do_frame), not the Kotlin thread that called
+ * achievements_init. JNIEnv is strictly thread-local, so a cached
+ * JNIEnv* from init time is invalid here — the previous code crashed
+ * on strict JVMs and was undefined behaviour everywhere else (#1040).
+ */
+static JNIEnv *attach_thread_env(bool *needs_detach) {
+    extern JavaVM *g_jvm;
+    *needs_detach = false;
+    if (!g_jvm) return NULL;
+    JNIEnv *env = NULL;
+    int status = (*g_jvm)->GetEnv(g_jvm, (void **)&env, JNI_VERSION_1_6);
+    if (status == JNI_EDETACHED) {
+        if ((*g_jvm)->AttachCurrentThread(g_jvm, (void **)&env, NULL) != JNI_OK) {
+            return NULL;
+        }
+        *needs_detach = true;
+    } else if (status != JNI_OK) {
+        return NULL;
+    }
+    return env;
+}
+
+static void detach_thread_env_if_needed(bool needs_detach) {
+    if (!needs_detach) return;
+    extern JavaVM *g_jvm;
+    if (g_jvm) {
+        (*g_jvm)->DetachCurrentThread(g_jvm);
+    }
+}
 
 /* --- rcheevos callbacks --- */
 
@@ -80,7 +115,7 @@ static void rc_server_call(const rc_api_request_t *request, rc_client_server_cal
                             void *callback_data, rc_client_t *client) {
     (void)client;
 
-    if (!ach_state.initialized || !ach_state.jni_env) {
+    if (!ach_state.initialized) {
         ACH_LOGE("Server call requested but achievements not initialized");
         rc_api_server_response_t response = {0};
         response.http_status_code = 0;
@@ -105,13 +140,22 @@ static void rc_server_call(const rc_api_request_t *request, rc_client_server_cal
         return;
     }
 
+    bool needs_detach = false;
+    JNIEnv *env = attach_thread_env(&needs_detach);
+    if (!env) {
+        ACH_LOGE("Failed to attach thread for JNI in rc_server_call");
+        rc_api_server_response_t response = {0};
+        response.http_status_code = 0;
+        callback(&response, callback_data);
+        return;
+    }
+
     int request_id = ++ach_state.next_request_id;
     pending_requests[slot].request_id = request_id;
     pending_requests[slot].callback = callback;
     pending_requests[slot].callback_data = callback_data;
     pending_requests[slot].active = true;
 
-    JNIEnv *env = ach_state.jni_env;
     jstring url_jstr = (*env)->NewStringUTF(env, request->url ? request->url : "");
     jstring post_data_jstr = request->post_data
         ? (*env)->NewStringUTF(env, request->post_data)
@@ -124,6 +168,7 @@ static void rc_server_call(const rc_api_request_t *request, rc_client_server_cal
     if (post_data_jstr) {
         (*env)->DeleteLocalRef(env, post_data_jstr);
     }
+    detach_thread_env_if_needed(needs_detach);
 }
 
 /*
@@ -133,9 +178,12 @@ static void rc_server_call(const rc_api_request_t *request, rc_client_server_cal
 static void rc_event_handler(const rc_client_event_t *event, rc_client_t *client) {
     (void)client;
 
-    if (!ach_state.initialized || !ach_state.jni_env) return;
+    if (!ach_state.initialized) return;
 
-    JNIEnv *env = ach_state.jni_env;
+    bool needs_detach = false;
+    JNIEnv *env = attach_thread_env(&needs_detach);
+    if (!env) return;
+
     jint event_type = (jint)event->type;
     jlong achievement_id = 0;
     jstring title_jstr = NULL;
@@ -158,6 +206,7 @@ static void rc_event_handler(const rc_client_event_t *event, rc_client_t *client
 
     if (title_jstr) (*env)->DeleteLocalRef(env, title_jstr);
     if (desc_jstr) (*env)->DeleteLocalRef(env, desc_jstr);
+    detach_thread_env_if_needed(needs_detach);
 }
 
 /* --- Login/load callbacks --- */
@@ -195,7 +244,6 @@ void achievements_init(JNIEnv *env, jobject thiz) {
     memset(&ach_state, 0, sizeof(ach_state));
     memset(pending_requests, 0, sizeof(pending_requests));
 
-    ach_state.jni_env = env;
     ach_state.jni_thiz = (*env)->NewGlobalRef(env, thiz);
 
     jclass cls = (*env)->GetObjectClass(env, thiz);

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -853,6 +853,11 @@ JNI_FUNC(jboolean, nativeLoadCore)(JNIEnv *env, jobject thiz, jstring corePath) 
     }
 
     const char *path = (*env)->GetStringUTFChars(env, corePath, NULL);
+    if (!path) {
+        /* GetStringUTFChars returns NULL on OOM; passing NULL to dlopen
+         * is platform-defined (Android may crash). Fail closed. */
+        return JNI_FALSE;
+    }
     int result = core_load(path);
     (*env)->ReleaseStringUTFChars(env, corePath, path);
     return result == 0 ? JNI_TRUE : JNI_FALSE;
@@ -885,6 +890,11 @@ JNI_FUNC(jboolean, nativeLoadGame)(JNIEnv *env, jobject thiz, jstring gamePath) 
     if (!g_core.handle || !g_core.initialized) return JNI_FALSE;
 
     const char *path = (*env)->GetStringUTFChars(env, gamePath, NULL);
+    if (!path) {
+        /* GetStringUTFChars returns NULL on OOM. Bail rather than calling
+         * fopen(NULL) / passing NULL into retro_load_game. */
+        return JNI_FALSE;
+    }
 
     struct retro_game_info game_info = {0};
     game_info.path = path;
@@ -902,7 +912,19 @@ JNI_FUNC(jboolean, nativeLoadGame)(JNIEnv *env, jobject thiz, jstring gamePath) 
 
             void *buf = malloc(game_info.size);
             if (buf) {
-                fread(buf, 1, game_info.size, f);
+                /* Verify fread fully populated the buffer. A short read
+                 * (truncated download, transient I/O error) would otherwise
+                 * silently pass a partial buffer to retro_load_game and the
+                 * core would interpret the tail as garbage memory. */
+                size_t read_bytes = fread(buf, 1, game_info.size, f);
+                if (read_bytes != game_info.size) {
+                    LOGE("Short read from ROM: got %zu of %zu bytes",
+                         read_bytes, game_info.size);
+                    free(buf);
+                    fclose(f);
+                    (*env)->ReleaseStringUTFChars(env, gamePath, path);
+                    return JNI_FALSE;
+                }
                 game_info.data = buf;
             }
             fclose(f);

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -29,10 +29,15 @@ import (
 var version = "dev"
 
 func main() {
-	// Start pprof profiling server on :6060
+	// Start pprof profiling server bound to localhost only.
+	// pprof exposes heap dumps, goroutine stacks, CPU profiles — i.e. the
+	// full memory contents of the running process, including JWT secrets
+	// and session tokens. The previous ":6060" bind exposed all of this
+	// to any peer on the same network on a self-hosted instance.
 	go func() {
-		slog.Info("pprof profiling server started on :6060")
-		if err := http.ListenAndServe(":6060", nil); err != nil {
+		addr := "127.0.0.1:6060"
+		slog.Info("pprof profiling server started", "addr", addr)
+		if err := http.ListenAndServe(addr, nil); err != nil {
 			slog.Warn("pprof server failed", "error", err)
 		}
 	}()

--- a/server/internal/api/huma_auth_handlers.go
+++ b/server/internal/api/huma_auth_handlers.go
@@ -31,7 +31,7 @@ type AuthLoginRequest struct {
 // email; min=8, max=72 for password).
 type AuthRegisterRequest struct {
 	Username string `json:"username" minLength:"3" maxLength:"64" pattern:"^[a-zA-Z0-9]+$" doc:"New account username (3-64 alphanumeric characters)."`
-	Email    string `json:"email" format:"email" doc:"New account email."`
+	Email    string `json:"email" format:"email" maxLength:"254" doc:"New account email (RFC 5321 cap)."`
 	Password string `json:"password" minLength:"8" maxLength:"72" doc:"New account password (8-72 characters)."`
 }
 

--- a/server/internal/api/middleware.go
+++ b/server/internal/api/middleware.go
@@ -53,8 +53,13 @@ func maxSaveStorageBytes() int64 {
 // checkStorageQuota verifies that adding additionalBytes would not exceed the user's quota.
 func checkStorageQuota(database *gorm.DB, userID uint, additionalBytes int64) error {
 	var totalBytes int64
-	database.Model(&db.SessionSaveState{}).Where("user_id = ?", userID).
-		Select("COALESCE(SUM(file_size), 0)").Scan(&totalBytes)
+	// Surface DB errors instead of silently treating them as totalBytes=0,
+	// which would let an unbounded payload through whenever the DB is
+	// momentarily unavailable. Prefer to fail closed.
+	if err := database.Model(&db.SessionSaveState{}).Where("user_id = ?", userID).
+		Select("COALESCE(SUM(file_size), 0)").Scan(&totalBytes).Error; err != nil {
+		return fmt.Errorf("checking storage quota: %w", err)
+	}
 	if totalBytes+additionalBytes > maxSaveStorageBytes() {
 		return fmt.Errorf("storage quota exceeded")
 	}

--- a/server/internal/api/requests.go
+++ b/server/internal/api/requests.go
@@ -30,9 +30,9 @@ type UpdatePreferencesRequest struct {
 	AutoSaveEnabled         *bool                           `json:"autoSaveEnabled,omitempty"`
 	AutoLoadSaveEnabled     *bool                           `json:"autoLoadSaveEnabled,omitempty"`
 	AutoUpdateCoresEnabled  *bool                           `json:"autoUpdateCoresEnabled,omitempty"`
-	SelectedShader          *string                         `json:"selectedShader,omitempty"`
-	SelectedTheme           *string                         `json:"selectedTheme,omitempty"`
-	DefaultSecondScreenPage *string                         `json:"defaultSecondScreenPage,omitempty"`
+	SelectedShader          *string                         `json:"selectedShader,omitempty" maxLength:"128"`
+	SelectedTheme           *string                         `json:"selectedTheme,omitempty" maxLength:"128"`
+	DefaultSecondScreenPage *string                         `json:"defaultSecondScreenPage,omitempty" maxLength:"128"`
 	ConsoleShaders          map[string]string               `json:"consoleShaders,omitempty"`
 	// Per-console save-state opt-out upserts. Keys are console
 	// abbreviations (case-insensitive on the server). Allowed values
@@ -47,7 +47,7 @@ type UpdatePreferencesRequest struct {
 	// Unknown game IDs are skipped (no row written). See #804
 	// phase 4b spec point (c).
 	GameSaveStatePolicies    map[string]string              `json:"gameSaveStatePolicies,omitempty"`
-	SelectedKeyMapping      *string                         `json:"selectedKeyMapping,omitempty"`
+	SelectedKeyMapping      *string                         `json:"selectedKeyMapping,omitempty" maxLength:"128"`
 	CustomKeyMapping        map[string]string               `json:"customKeyMapping,omitempty"`
 	ConsoleKeyMappings      map[string]ConsoleKeyMappingDTO `json:"consoleKeyMappings,omitempty"`
 	PreferredRegions        *[]string                       `json:"preferredRegions,omitempty"`
@@ -69,7 +69,7 @@ type UpdateGameKeyMappingRequest struct {
 // and reserved-name allocation. Length and password strength still apply.
 type AdminCreateUserRequest struct {
 	Username string      `json:"username" minLength:"3" maxLength:"64" doc:"New account username (3-64 characters)."`
-	Email    string      `json:"email" minLength:"1" doc:"New account email."`
+	Email    string      `json:"email" minLength:"1" maxLength:"254" doc:"New account email (RFC 5321 cap)."`
 	Password string      `json:"password" minLength:"8" maxLength:"72" doc:"New account password (8-72 characters)."`
 	Role     db.UserRole `json:"role,omitempty"`
 }
@@ -77,8 +77,8 @@ type AdminCreateUserRequest struct {
 // AdminUpdateUserRequest is the body for PUT /api/admin/users/:id.
 type AdminUpdateUserRequest struct {
 	Role            db.UserRole `json:"role,omitempty"`
-	Email           string      `json:"email,omitempty"`
-	Password        string      `json:"password,omitempty"`
+	Email           string      `json:"email,omitempty" maxLength:"254"`
+	Password        string      `json:"password,omitempty" maxLength:"72"`
 	Disabled        *bool       `json:"disabled,omitempty"`
 	PendingApproval *bool       `json:"pendingApproval,omitempty"`
 }

--- a/web/src/features/setup/components/steamgriddb-step.tsx
+++ b/web/src/features/setup/components/steamgriddb-step.tsx
@@ -12,6 +12,7 @@ export function SteamGridDBStep({ onSkip, onSave }: SteamGridDBStepProps) {
   const { data: status, isLoading } = useSteamGridDBStatus();
   const [apiKey, setApiKey] = useState("");
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [instructionsExpanded, setInstructionsExpanded] = useState(true);
   const updateSettings = useUpdateSettings();
 
@@ -45,14 +46,22 @@ export function SteamGridDBStep({ onSkip, onSave }: SteamGridDBStepProps) {
 
   async function handleSaveAndContinue() {
     setSaving(true);
+    setError(null);
     try {
       await updateSettings.mutateAsync({
         steamgriddb_api_key: apiKey,
       });
       onSave();
-    } catch {
-      // Silently continue — the key will be validated when artwork is fetched
-      onSave();
+    } catch (err) {
+      // Surface the error and stay on this step. Silently advancing here
+      // would let the wizard finish with the API key never persisted —
+      // the user would think setup completed but artwork fetches would
+      // all fail later.
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to save API key. Try again or skip this step.",
+      );
     } finally {
       setSaving(false);
     }
@@ -108,8 +117,17 @@ export function SteamGridDBStep({ onSkip, onSave }: SteamGridDBStepProps) {
         type="password"
         placeholder="SteamGridDB API Key"
         value={apiKey}
-        onChange={(e) => setApiKey(e.target.value)}
+        onChange={(e) => {
+          setApiKey(e.target.value);
+          if (error) setError(null);
+        }}
       />
+
+      {error && (
+        <div className="rounded-xl bg-error-500/10 border border-error-500/30 px-4 py-3">
+          <p className="text-sm text-error-500">{error}</p>
+        </div>
+      )}
 
       <div className="flex items-center justify-between pt-2">
         <Button variant="secondary" onClick={onSkip}>

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -205,7 +205,11 @@ export function useDeleteUser() {
       );
     },
     onSuccess: () => {
+      // Both lists need to refresh: the user disappears from "active" and
+      // appears in "deleted". Invalidating only the parent key would leave
+      // the Deleted Users tab stale until a background refetch.
       queryClient.invalidateQueries({ queryKey: ["admin", "users"] });
+      queryClient.invalidateQueries({ queryKey: ["admin", "users", "deleted"] });
     },
   });
 }

--- a/web/src/pages/admin/users-page.tsx
+++ b/web/src/pages/admin/users-page.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Plus } from "lucide-react";
 import { PageLayout, SectionList } from "@/components/layout";
-import { Button, StateTabNav, StateTabItem } from "@/components/ui";
+import { Button, StateTabNav, StateTabItem, useToast } from "@/components/ui";
 import {
   useAdminUsers,
   useAdminStats,
@@ -27,6 +27,7 @@ export function AdminUsersPage() {
   const { data: deletedUsers, isLoading: isLoadingDeleted } = useDeletedUsers();
   const { user: currentUser } = useAuth();
   const { mutate: updateUser } = useUpdateUser();
+  const { toast } = useToast();
 
   const [tab, setTab] = useState<Tab>("active");
   const [editingUser, setEditingUser] = useState<User | null>(null);
@@ -38,7 +39,17 @@ export function AdminUsersPage() {
   const [showCreate, setShowCreate] = useState(false);
 
   function handleApprove(user: User) {
-    updateUser({ id: user.id, data: { pendingApproval: false } });
+    updateUser(
+      { id: user.id, data: { pendingApproval: false } },
+      {
+        onSuccess: () => toast("success", `${user.username} approved`),
+        onError: (err) =>
+          toast(
+            "error",
+            err instanceof Error ? err.message : "Approval failed",
+          ),
+      },
+    );
   }
 
   const deletedCount = deletedUsers?.length ?? 0;


### PR DESCRIPTION
## Summary
Phase 4 reviewer sweep — 11 high-confidence findings filed across server middleware, native JNI bridge, and web admin pages. This PR closes 8 of them; the remaining 3 (N3 partial, N4, N5) are larger native-code refactors filed for follow-up.

### Server (3 fixes)
- **#1037** \`pprof\` server bound to \`127.0.0.1:6060\` instead of \`:6060\`. The previous bind exposed full process memory (JWT secrets, plaintext passwords, session tokens) to any peer on the same network.
- **#1038** \`checkStorageQuota\` now returns the DB error instead of treating it as totalBytes=0. The previous fail-open let unbounded uploads through any time the DB returned an error.
- **#1039** maxLength bounds on \`Email\` (254 / RFC 5321), \`SelectedShader\`/\`SelectedTheme\`/\`SelectedKeyMapping\`/\`DefaultSecondScreenPage\` (128 each), and \`AdminUpdateUserRequest.Password\` (72) — closes a DoS / DB-bloat surface where unbounded strings were written into DB columns.

### Web (3 fixes)
- **#1045** \`handleApprove\` now shows success/error toasts. Previously a server failure was completely silent.
- **#1046** \`useDeleteUser\` invalidates both \`['admin', 'users']\` and \`['admin', 'users', 'deleted']\`. Previously the Deleted Users tab showed stale data after a soft-delete.
- **#1047** \`SteamGridDBStep\` surfaces save errors and stays on the step instead of silently advancing.

### Native (2 fixes + 1 partial)
- **#1040** \`libretro_achievements.c\` callbacks (\`rc_server_call\`, \`rc_event_handler\`) attach the calling thread to the JVM and use the per-thread JNIEnv\* instead of a stale cached one from init time. The cached pointer was used on the emulation thread, which is a different thread from where it was captured — undefined behaviour, crashes strict JVMs.
- **#1041** \`fread\` in \`core_load\` checks the return value matches the requested size; short reads no longer silently produce corrupt game state.
- **#1042 (partial)** \`GetStringUTFChars\` NULL guards added on \`corePath\` (nativeLoadCore) and \`gamePath\` (nativeLoadGame) — the two paths most likely to crash on Android with a NULL value. Six other sites have the same gap and are left for a follow-up.

### Deferred to follow-up
- **#1042 (full)** — 6 more \`GetStringUTFChars\` NULL-check sites in \`libretro_bridge.c\`.
- **#1043** GetPrimitiveArrayCritical during Vulkan readback — needs careful refactor of the GPU readback path.
- **#1044** audio_state / video_state / input_state cross-thread atomics or restructure — significant refactor; should be done as a focused effort.

## Test plan
- [x] \`go build ./...\` clean
- [x] Targeted server tests (\`TestRegister\`, \`TestLogin\`, etc.) pass
- [x] Player desktop test compile clean
- [x] Web TypeScript check clean