### PR TITLE
fix(audit-phase5): 13 fixes across player flow, web TanStack/pages, and server data layer

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
@@ -27,8 +27,15 @@ class PresenceService(
     private val scope: CoroutineScope,
     private val scrapeService: ScrapeService? = null,
 ) {
+    // Cross-dispatcher: startHeartbeat/stopHeartbeat run on the main
+    // dispatcher while the heartbeat loop body reads currentGameId from
+    // dispatchers.io. Without @Volatile a write on one thread is not
+    // guaranteed to be visible to the other.
+    @Volatile
     private var wsJob: Job? = null
+    @Volatile
     private var heartbeatJob: Job? = null
+    @Volatile
     private var currentGameId: String? = null
 
     @Volatile

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/SyncEngine.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/SyncEngine.kt
@@ -4,6 +4,7 @@ import com.spela.player.domain.repository.GameRepository
 import com.spela.player.domain.repository.PreferencesRepository
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -25,14 +26,23 @@ class SyncEngine(
 ) {
     private val _syncState = MutableStateFlow(SyncState())
     val syncState: StateFlow<SyncState> = _syncState.asStateFlow()
+    private var collectJob: Job? = null
 
     fun start() {
-        // Observe reconnection events
-        scope.launch(dispatchers.io) {
+        // Observe reconnection events. Cancel any previous collector
+        // first so re-calling start (server switch, re-login) doesn't
+        // stack collectors and fire syncAll N times per reconnect.
+        collectJob?.cancel()
+        collectJob = scope.launch(dispatchers.io) {
             connectivityMonitor.onReconnect.collect {
                 syncAll()
             }
         }
+    }
+
+    fun stop() {
+        collectJob?.cancel()
+        collectJob = null
     }
 
     suspend fun syncAll() {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/JobManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/JobManager.kt
@@ -17,6 +17,15 @@ import kotlin.coroutines.EmptyCoroutineContext
  * `ExploreViewModel`. Lives in `util/` so other ViewModels with
  * the same pattern (NetplayManager, achievement loaders, etc.) can
  * adopt it.
+ *
+ * Thread safety: ExploreViewModel.load() fires 13 parallel
+ * `jobs.launch(...)` calls on `dispatchers.io`. The previous
+ * `mutableMapOf` was a plain HashMap and not safe for concurrent
+ * mutation — corrupted entries or lost cancellations were possible.
+ * All public methods now serialise through a synchronized() block
+ * over the map; the lambda body of [launch] still runs in the caller's
+ * coroutine context (the lock only covers the map mutation itself).
+ * See #1044 for the broader cross-thread audit.
  */
 class JobManager(private val scope: CoroutineScope) {
     private val jobs = mutableMapOf<String, Job>()
@@ -26,6 +35,7 @@ class JobManager(private val scope: CoroutineScope) {
      * under the same key. [context] is forwarded to the underlying
      * `scope.launch` (e.g. `dispatchers.io`).
      */
+    @Synchronized
     fun launch(
         key: String,
         context: CoroutineContext = EmptyCoroutineContext,
@@ -36,6 +46,7 @@ class JobManager(private val scope: CoroutineScope) {
     }
 
     /** Cancel the job under [key] if any; no-op otherwise. */
+    @Synchronized
     fun cancel(key: String) {
         jobs.remove(key)?.cancel()
     }
@@ -45,9 +56,11 @@ class JobManager(private val scope: CoroutineScope) {
      * running. Used by callers that want to skip re-entrant work
      * (e.g. "if featured load is already in flight, don't restart").
      */
+    @Synchronized
     fun isActive(key: String): Boolean = jobs[key]?.isActive == true
 
     /** Cancel every job currently tracked. Call from VM cleanup. */
+    @Synchronized
     fun cancelAll() {
         jobs.values.forEach { it.cancel() }
         jobs.clear()

--- a/server/internal/api/huma_collections.go
+++ b/server/internal/api/huma_collections.go
@@ -416,8 +416,19 @@ func (h *CollectionHandler) HumaDeleteCollection(ctx context.Context, in *Delete
 		return nil, huma.Error403Forbidden("not authorized")
 	}
 
-	h.DB.Where("collection_id = ?", cid).Delete(&db.CollectionItem{})
-	h.DB.Delete(&collection)
+	// Wrap both deletes in a transaction. Without it, an error between
+	// the two statements (process killed, DB error mid-request) would
+	// leave the GameCollection row alive but with all its items gone —
+	// a permanently empty, undeletable-via-normal-means orphan. Surface
+	// errors instead of silently discarding them.
+	if err := h.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("collection_id = ?", cid).Delete(&db.CollectionItem{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&collection).Error
+	}); err != nil {
+		return nil, huma.Error500InternalServerError("failed to delete collection")
+	}
 
 	return &DeleteCollectionOutput{Body: MessageResponse{Message: "collection deleted"}}, nil
 }

--- a/server/internal/api/huma_console.go
+++ b/server/internal/api/huma_console.go
@@ -205,13 +205,25 @@ func (h *ConsoleHandler) HumaListConsoles(_ context.Context, _ *ListConsolesInpu
 		return nil, huma.Error500InternalServerError("failed to fetch consoles")
 	}
 
-	// Attach game counts (only primary, non-pre-release games — matches what users see)
+	// Attach game counts (only primary, non-pre-release games — matches what users see).
+	// One GROUP BY query instead of N COUNT queries — on a 40-console install this turns
+	// 41 round-trips into 2.
+	type countRow struct {
+		ConsoleID uint
+		Cnt       int64
+	}
+	var rows []countRow
+	h.DB.Model(&db.Game{}).
+		Select("console_id, COUNT(*) AS cnt").
+		Where("is_primary = ? AND is_pre_release = ?", true, false).
+		Group("console_id").
+		Scan(&rows)
+	counts := make(map[uint]int64, len(rows))
+	for _, r := range rows {
+		counts[r.ConsoleID] = r.Cnt
+	}
 	for i := range consoles {
-		var count int64
-		h.DB.Model(&db.Game{}).
-			Where("console_id = ? AND is_primary = ? AND is_pre_release = ?", consoles[i].ID, true, false).
-			Count(&count)
-		consoles[i].GameCount = int(count)
+		consoles[i].GameCount = int(counts[consoles[i].ID])
 	}
 
 	// Only return consoles that have at least one game

--- a/server/internal/api/huma_game.go
+++ b/server/internal/api/huma_game.go
@@ -243,15 +243,24 @@ func (h *GameHandler) HumaListGames(ctx context.Context, in *ListGamesInput) (*L
 	}
 	if consoles != "" {
 		abbrs := strings.Split(consoles, ",")
-		var consoleIDs []uint
+		// Resolve all abbreviations in one query rather than one per item.
+		// Previously a request like ?consoles=snes,nes,gba issued one
+		// First() round-trip per entry — a multi-console filter on a
+		// large library could fire 5+ queries before the main games
+		// query even started.
+		lowerAbbrs := make([]string, 0, len(abbrs))
 		for _, abbr := range abbrs {
-			abbr = strings.TrimSpace(abbr)
-			if abbr == "" {
-				continue
+			trimmed := strings.TrimSpace(abbr)
+			if trimmed != "" {
+				lowerAbbrs = append(lowerAbbrs, strings.ToLower(trimmed))
 			}
-			var console db.Console
-			if err := h.DB.Where("LOWER(abbreviation) = LOWER(?)", abbr).First(&console).Error; err == nil {
-				consoleIDs = append(consoleIDs, console.ID)
+		}
+		var consoleIDs []uint
+		if len(lowerAbbrs) > 0 {
+			var resolved []db.Console
+			h.DB.Where("LOWER(abbreviation) IN ?", lowerAbbrs).Find(&resolved)
+			for _, c := range resolved {
+				consoleIDs = append(consoleIDs, c.ID)
 			}
 		}
 		if len(consoleIDs) == 0 {

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -299,7 +299,11 @@ type PlayHistory struct {
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID    uint           `gorm:"uniqueIndex:idx_user_game_play_history;not null" json:"userId"`
 	User      User           `gorm:"foreignKey:UserID" json:"-"`
-	GameID    uint           `gorm:"uniqueIndex:idx_user_game_play_history;not null" json:"gameId"`
+	// Standalone index on GameID — the composite uniqueIndex above has
+	// (UserID, GameID) so SQLite cannot use it for queries that filter
+	// by GameID alone (GET /api/games/{id}/stats and the top-player JOIN
+	// were full-scanning play_histories).
+	GameID    uint           `gorm:"uniqueIndex:idx_user_game_play_history;not null;index:idx_play_history_game" json:"gameId"`
 	Game      Game           `gorm:"foreignKey:GameID" json:"game"`
 	LastPlayed time.Time     `json:"lastPlayed"`
 	PlayTime   int64         `json:"playTime"` // seconds

--- a/web/src/features/game-detail/components/scrape-match-modal.tsx
+++ b/web/src/features/game-detail/components/scrape-match-modal.tsx
@@ -25,7 +25,13 @@ export function ScrapeMatchModal({
   onClose,
 }: ScrapeMatchModalProps) {
   return (
-    <Modal open={open} onClose={onClose} title="Fix Scrape Match" size="lg">
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Fix Scrape Match"
+      size="lg"
+      bodyClassName="px-6 pb-6 pt-4"
+    >
       {open && (
         <ScrapeMatchContent
           key={`${gameId}-${currentTitle}`}
@@ -118,7 +124,7 @@ function ScrapeMatchContent({
         </div>
       ) : (
         <div
-          className="max-h-96 overflow-y-auto -mx-6 px-6 space-y-1"
+          className="max-h-96 overflow-y-auto space-y-1"
           data-testid="igdb-search-results"
         >
           {isLoading && debouncedQuery.length >= 2 && (

--- a/web/src/features/game-detail/components/star-rating.tsx
+++ b/web/src/features/game-detail/components/star-rating.tsx
@@ -31,6 +31,8 @@ export function StarRating({
       className="inline-flex items-center gap-0.5"
       onMouseLeave={() => interactive && setHovered(0)}
       data-testid="star-rating"
+      role="group"
+      aria-label={interactive ? "Rate this game" : `Rated ${value} out of 5 stars`}
     >
       {[1, 2, 3, 4, 5].map((star) => (
         <button
@@ -46,6 +48,11 @@ export function StarRating({
           onMouseEnter={() => interactive && setHovered(star)}
           onClick={() => interactive && onChange(star)}
           data-testid={`star-${star}`}
+          aria-label={
+            interactive
+              ? `Rate ${star} out of 5 stars`
+              : `${star} out of 5 stars`
+          }
         >
           <Star
             className={cn(

--- a/web/src/features/game-detail/components/user-rating.tsx
+++ b/web/src/features/game-detail/components/user-rating.tsx
@@ -19,6 +19,7 @@ export function UserRating({ gameId }: UserRatingProps) {
   const currentReview = myRating?.review ?? "";
 
   const handleRate = (rating: number) => {
+    if (rateGame.isPending) return;
     rateGame.mutate({
       gameId,
       rating,
@@ -28,6 +29,7 @@ export function UserRating({ gameId }: UserRatingProps) {
 
   const handleSubmitReview = () => {
     if (currentRating === 0) return;
+    if (rateGame.isPending) return;
     rateGame.mutate({
       gameId,
       rating: currentRating,
@@ -37,6 +39,7 @@ export function UserRating({ gameId }: UserRatingProps) {
   };
 
   const handleDelete = () => {
+    if (deleteRating.isPending) return;
     deleteRating.mutate(gameId);
     setReview("");
     setShowReviewInput(false);
@@ -95,7 +98,12 @@ export function UserRating({ gameId }: UserRatingProps) {
             rows={3}
           />
           <div className="flex gap-2">
-            <Button size="sm" onClick={handleSubmitReview}>
+            <Button
+              size="sm"
+              onClick={handleSubmitReview}
+              loading={rateGame.isPending}
+              disabled={rateGame.isPending}
+            >
               Save Review
             </Button>
             <Button

--- a/web/src/features/setup/components/igdb-step.tsx
+++ b/web/src/features/setup/components/igdb-step.tsx
@@ -144,6 +144,7 @@ export function IgdbStep({ onSkip, onSave }: IgdbStepProps) {
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <Input
+          id="igdb-client-id"
           label="Client ID"
           placeholder="Twitch Client ID"
           value={clientId}
@@ -153,6 +154,7 @@ export function IgdbStep({ onSkip, onSave }: IgdbStepProps) {
           }}
         />
         <Input
+          id="igdb-client-secret"
           label="Client Secret"
           type="password"
           placeholder="Twitch Client Secret"

--- a/web/src/hooks/use-challenges.ts
+++ b/web/src/hooks/use-challenges.ts
@@ -179,6 +179,7 @@ export function useDeleteChallenge() {
 }
 
 export function useStartAttempt() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (challengeId: string) => {
       const data = await unwrap(
@@ -187,6 +188,13 @@ export function useStartAttempt() {
         }),
       );
       return data;
+    },
+    onSuccess: (_, challengeId) => {
+      // Match useCompleteAttempt's invalidation set so the UI moves out
+      // of the pre-attempt state immediately instead of waiting for the
+      // next background refetch.
+      queryClient.invalidateQueries({ queryKey: ["challenge", challengeId, "my-attempts"] });
+      queryClient.invalidateQueries({ queryKey: ["challenge", challengeId] });
     },
   });
 }
@@ -222,6 +230,7 @@ export function useCompleteAttempt() {
 }
 
 export function useAbandonAttempt() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({
       challengeId,
@@ -235,6 +244,10 @@ export function useAbandonAttempt() {
           params: { path: { id: challengeId, aid: attemptId } },
         }),
       ),
+    onSuccess: (_, { challengeId }) => {
+      queryClient.invalidateQueries({ queryKey: ["challenge", challengeId, "my-attempts"] });
+      queryClient.invalidateQueries({ queryKey: ["challenge", challengeId] });
+    },
   });
 }
 

--- a/web/src/hooks/use-netplay.ts
+++ b/web/src/hooks/use-netplay.ts
@@ -192,6 +192,8 @@ export function usePendingNetplayInviteCount() {
     queryKey: ["netplay", "invites", "count"],
     queryFn: () => unwrap(typedApi.GET("/api/netplay/invites/count")),
     refetchInterval: 30000,
+    // Don't poll a backgrounded tab — convention from #959.
+    refetchIntervalInBackground: false,
   });
 }
 

--- a/web/src/hooks/use-shared-sessions.ts
+++ b/web/src/hooks/use-shared-sessions.ts
@@ -75,6 +75,8 @@ export function usePendingInvitationCount() {
     queryFn: () =>
       unwrap(typedApi.GET("/api/user/shared-session-invites/count")),
     refetchInterval: 30000,
+    // Don't poll a backgrounded tab — convention from #959.
+    refetchIntervalInBackground: false,
   });
 }
 

--- a/web/src/hooks/use-social.ts
+++ b/web/src/hooks/use-social.ts
@@ -7,6 +7,9 @@ export function useOnlineUsers() {
     queryKey: ["social", "online"],
     queryFn: () => unwrap(typedApi.GET("/api/social/online")),
     refetchInterval: 30000,
+    // Don't burn quota when the tab is backgrounded — same convention
+    // as the admin polling hooks (see #959).
+    refetchIntervalInBackground: false,
   });
 }
 
@@ -35,6 +38,9 @@ export function useSearchUsers(
           params: { query: { q: query, page, pageSize } },
         }),
       ),
+    // Don't fire a search request before the user types — convention
+    // matches useGame/useConsoleGames/useSession's enabled gates.
+    enabled: query.length >= 1,
   });
 }
 


### PR DESCRIPTION
## Summary
Phase 5 reviewer sweep — **13 issues fixed in 13 commits, one PR.** Four reviewers ran in parallel covering server data layer, web TanStack hooks, web user-facing pages + a11y, and player flow collectors.

### Player (3 fixes)
- **#1050** \`JobManager\` mutates an internal map under \`@Synchronized\` so 13+ parallel \`scope.launch(...)\` calls from \`ExploreViewModel.load()\` don't corrupt entries or lose cancellations.
- **#1051** \`SyncEngine.start()\` tracks the reconnect collector and cancels before relaunching; adds matching \`stop()\`. Prevents N collectors stacking on server-switch / re-login.
- **#1052** \`PresenceService.{wsJob, heartbeatJob, currentGameId}\` are now \`@Volatile\` (sibling \`paused\` already was).

### Web hooks (3 fixes)
- **#1053** + **#1054** \`useOnlineUsers\`, \`usePendingNetplayInviteCount\`, \`usePendingInvitationCount\` add \`refetchIntervalInBackground: false\` (matches the #959 admin-hook pattern). \`useSearchUsers\` adds \`enabled: query.length >= 1\`.
- **#1055** \`useStartAttempt\` and \`useAbandonAttempt\` now invalidate \`["challenge", id, "my-attempts"]\` and \`["challenge", id]\` on success — matches \`useCompleteAttempt\`.

### Web pages + a11y (4 fixes)
- **#1056** ScrapeMatchModal stops using \`-mx-6\` negative margin; uses Modal's \`bodyClassName\` slot (introduced in #1020).
- **#1057** UserRating guards \`handleRate\`/\`handleSubmitReview\`/\`handleDelete\` with \`isPending\`; Save Review button gets \`loading\` + \`disabled\`.
- **#1058** StarRating buttons get \`aria-label\` per star; container gets \`role="group"\` + aria-label.
- **#1059** IgdbStep \`<Input>\`s get \`id\` so labels associate properly.

### Server data layer (4 fixes)
- **#1060** HumaListConsoles uses a single \`GROUP BY\` query for game counts instead of one COUNT per console. 41→2 round-trips on a 40-console install.
- **#1061** HumaListGames console-abbreviation filter resolves all abbreviations in one IN query instead of one First() per entry.
- **#1062** HumaDeleteCollection wraps both deletes in a transaction with proper error handling — orphan-collection bug fixed.
- **#1063** PlayHistory.GameID gets a standalone index. The composite \`(UserID, GameID)\` couldn't be used for queries that filter by GameID alone (game-stats endpoint was full-scanning).

### Deferred (open issues)
- **#1044** native audio/video/input cross-thread state — needs architectural work + Android hardware testing.
- F3, F4 (ExploreViewModel/SharedSessionsViewModel mass JobManager refactor — significant churn for low individual yield, would benefit from its own pass).
- WP4 (Modal focus trap — needs custom hook).
- WP5 (CollectionsPage hand-rolled tabs — refactor to StateTabNav).
- T3 (useSessionSaves/useAutoSaveInfo shared queryKey — speculative; no active corruption).
- D2 (HumaGetTopRatedGlobal N+1 — needs reuse refactor).
- D6 (string-concat in ratingFilter SQL — non-exploitable; would benefit from allowlist).
- D7 (dedupePreMigration not transactional — minor; one-shot startup path).

## Test plan
- [x] \`go build ./...\` clean
- [x] Targeted server tests (TestListConsoles, TestListGames, TestDeleteCollection, TestPlayHistory) pass
- [x] \`npx tsc --noEmit\` clean
- [x] Player desktop test compile clean

One commit per issue, single push, one CI cycle. Per recent feedback to ship more issues per PR.