### PR TITLE
fix(server): OnDelete:CASCADE on all user-owned FK relationships (#971)

### DIFF
--- a/server/internal/api/admin_deleted_users_test.go
+++ b/server/internal/api/admin_deleted_users_test.go
@@ -213,6 +213,52 @@ func TestHardDeleteUser_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+// TestUserFKCascadeOnRawDelete verifies that #971's CASCADE FK constraints
+// fire at the SQL level on a fresh install, independent of the explicit
+// HumaHardDeleteUser cleanup. The test sidesteps the handler entirely:
+// it inserts child rows, calls a raw DELETE on the user, and checks the
+// children are gone. This proves new installs are safe even via paths
+// that don't route through the handler (e.g. an admin running a manual
+// SQL delete, or a future endpoint that forgets the explicit cleanup).
+func TestUserFKCascadeOnRawDelete(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	database := cfg.DB
+
+	user := db.User{
+		Username:     "cascade-target",
+		Email:        "cascade@test.com",
+		PasswordHash: "unused",
+		Role:         "user",
+	}
+	require.NoError(t, database.Create(&user).Error)
+
+	// Need a Console + Game to satisfy GameID FKs on Favorite / PlayHistory.
+	console := db.Console{Name: "TestConsole", Abbreviation: "TC", FolderName: "tc"}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{Title: "TestGame", ConsoleID: console.ID, FilePath: "tc/test.rom"}
+	require.NoError(t, database.Create(&game).Error)
+
+	// Insert a sample of child rows from CASCADE-tagged tables.
+	require.NoError(t, database.Create(&db.Favorite{UserID: user.ID, GameID: game.ID}).Error)
+	require.NoError(t, database.Create(&db.PlayHistory{UserID: user.ID, GameID: game.ID, LastPlayed: time.Now()}).Error)
+	require.NoError(t, database.Create(&db.SavedSearch{UserID: user.ID, Name: "x", Filters: "{}"}).Error)
+	require.NoError(t, database.Create(&db.DailyPlayActivity{UserID: user.ID, Date: time.Now(), PlayTime: 60}).Error)
+
+	// Hard DELETE bypassing soft-delete (Unscoped) — exercises the FK
+	// constraint, not the handler's explicit child cleanup.
+	require.NoError(t, database.Unscoped().Delete(&user).Error)
+
+	var count int64
+	database.Unscoped().Model(&db.Favorite{}).Where("user_id = ?", user.ID).Count(&count)
+	assert.Equal(t, int64(0), count, "Favorite should cascade-delete on user delete")
+	database.Unscoped().Model(&db.PlayHistory{}).Where("user_id = ?", user.ID).Count(&count)
+	assert.Equal(t, int64(0), count, "PlayHistory should cascade-delete on user delete")
+	database.Unscoped().Model(&db.SavedSearch{}).Where("user_id = ?", user.ID).Count(&count)
+	assert.Equal(t, int64(0), count, "SavedSearch should cascade-delete on user delete")
+	database.Unscoped().Model(&db.DailyPlayActivity{}).Where("user_id = ?", user.ID).Count(&count)
+	assert.Equal(t, int64(0), count, "DailyPlayActivity should cascade-delete on user delete")
+}
+
 func TestHardDeleteUser_NonAdmin_Returns403(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router, cleanup := NewRouter(*cfg)

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -29,7 +29,10 @@ const testJWTSecret = "test-secret-key"
 
 func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 	t.Helper()
-	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+	// _foreign_keys=1 mirrors the production DSN (database.go) so the
+	// CASCADE / SET NULL constraints on user-owned tables (#971) are
+	// enforced under tests.
+	database, err := gorm.Open(sqlite.Open(":memory:?_foreign_keys=1"), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	require.NoError(t, err)

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -1478,7 +1478,7 @@ func TestGetActivityFeed_Pagination(t *testing.T) {
 		database.Create(&db.ActivityEvent{
 			UserID:    user.ID,
 			EventType: "started_playing",
-			GameID:    game.ID,
+			GameID:    &game.ID,
 		})
 	}
 
@@ -1529,7 +1529,9 @@ func TestCreateActivityEvent_BroadcastsWebSocket(t *testing.T) {
 	database.Where("user_id = ?", user.ID).Find(&events)
 	assert.Len(t, events, 1)
 	assert.Equal(t, "started_playing", events[0].EventType)
-	assert.Equal(t, game.ID, events[0].GameID)
+	if assert.NotNil(t, events[0].GameID, "GameID should be set for started_playing") {
+		assert.Equal(t, game.ID, *events[0].GameID)
+	}
 }
 
 func TestOnlineUserTracking(t *testing.T) {

--- a/server/internal/api/huma_social.go
+++ b/server/internal/api/huma_social.go
@@ -142,7 +142,7 @@ func (h *SocialHandler) HumaGetActivityFeed(_ context.Context, in *GetActivityFe
 			UserID:       strconv.FormatUint(uint64(e.UserID), 10),
 			Username:     e.User.Username,
 			AvatarURL:    e.User.AvatarURL,
-			GameID:       strconv.FormatUint(uint64(e.GameID), 10),
+			GameID:       activityGameIDString(e.GameID),
 			GameTitle:    e.Game.Title,
 			GameCoverURL: coverURL,
 			ConsoleName:  consoleName,

--- a/server/internal/api/shared_session_handler_test.go
+++ b/server/internal/api/shared_session_handler_test.go
@@ -1725,26 +1725,32 @@ func TestSharedSession_MigrateSharedSessions(t *testing.T) {
 	game := db.Game{ConsoleID: console.ID, Title: "Migration Game", FileName: "test.nes", FilePath: "/tmp/migrate.nes", FileSize: 100}
 	database.Create(&game)
 
+	// Create the owner user — pre-#971 the test could insert SharedSession
+	// with a synthetic OwnerID=1 because FK constraints weren't enforced.
+	// With foreign_keys=ON the user must exist for the FK to succeed.
+	owner := db.User{Username: "migrate-owner", Email: "owner@migrate.test", PasswordHash: "x", Role: "user"}
+	require.NoError(t, database.Create(&owner).Error)
+
 	// Manually create a shared session without a session (simulating pre-migration data)
 	ssModel := db.SharedSession{
-		OwnerID: 1,
+		OwnerID: owner.ID,
 		GameID:  game.ID,
 		Name:    "Old Session",
 		Status:  "active",
 	}
-	database.Create(&ssModel)
+	require.NoError(t, database.Create(&ssModel).Error)
 	assert.Nil(t, ssModel.SessionID)
 
 	// Create a shared session save
 	ssSave := db.SharedSessionSave{
 		SharedSessionID:  ssModel.ID,
-		UserID:   1,
+		UserID:   owner.ID,
 		Name:     "Old Save",
 		FilePath: "/tmp/old-save.sav",
 		FileSize: 100,
 		IsAuto:   false,
 	}
-	database.Create(&ssSave)
+	require.NoError(t, database.Create(&ssSave).Error)
 
 	// Run migration
 	err := db.MigrateSharedSessions(database)

--- a/server/internal/api/social_handler.go
+++ b/server/internal/api/social_handler.go
@@ -41,6 +41,15 @@ func toPublicProfileGame(g db.Game, playTime int64) PublicProfileGame {
 // so the call site is compile-checked against the expected shape. Pass nil
 // for events that carry no metadata. The wire format is the JSON-encoded
 // struct — unchanged from the prior map[string]interface{} representation.
+// activityGameIDString renders an ActivityEvent's optional GameID for the
+// response DTO. Returns "" when nil so consumers can detect "no game".
+func activityGameIDString(gid *uint) string {
+	if gid == nil {
+		return ""
+	}
+	return strconv.FormatUint(uint64(*gid), 10)
+}
+
 func CreateActivityEvent(database *gorm.DB, hub *ws.Hub, userID uint, eventType string, gameID uint, metadata any) {
 	metadataJSON := ""
 	// metadataMap is the broadcast-response shape (matches the persisted JSON
@@ -56,10 +65,17 @@ func CreateActivityEvent(database *gorm.DB, hub *ws.Hub, userID uint, eventType 
 		}
 	}
 
+	// Convert gameID 0 → nil so events like 'created_collection' write
+	// SQL NULL instead of 0 (which fails the FK constraint after #971).
+	var gid *uint
+	if gameID != 0 {
+		g := gameID
+		gid = &g
+	}
 	event := db.ActivityEvent{
 		UserID:    userID,
 		EventType: eventType,
-		GameID:    gameID,
+		GameID:    gid,
 		Metadata:  metadataJSON,
 	}
 
@@ -91,7 +107,7 @@ func CreateActivityEvent(database *gorm.DB, hub *ws.Hub, userID uint, eventType 
 		UserID:       strconv.FormatUint(uint64(userID), 10),
 		Username:     user.Username,
 		AvatarURL:    user.AvatarURL,
-		GameID:       strconv.FormatUint(uint64(gameID), 10),
+		GameID:       activityGameIDString(gid),
 		GameTitle:    game.Title,
 		GameCoverURL: coverURL,
 		ConsoleName:  consoleName,

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -88,7 +88,13 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		return nil, err
 	}
 
-	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+	// _foreign_keys=1 enables FK constraint enforcement for every
+	// connection in the pool. SQLite has FK constraints disabled by
+	// default for backwards compatibility — without this, our
+	// OnDelete:CASCADE / SET NULL declarations on user-owned tables
+	// (#971) would have no effect.
+	dsn := dbPath + "?_foreign_keys=1"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Warn),
 	})
 	if err != nil {

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -662,8 +662,13 @@ type ActivityEvent struct {
 	UserID    uint           `gorm:"index;not null" json:"userId"`
 	User      User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	EventType string         `gorm:"size:64;not null;index" json:"eventType"` // started_playing, favorited_game, rated_game, shared_save
-	GameID    uint           `gorm:"index" json:"gameId"`
-	Game      Game           `gorm:"foreignKey:GameID" json:"-"`
+	// GameID is nullable: events like 'created_collection' don't have a
+	// game. Pre-#971 the column was non-null uint with the zero value 0
+	// stored, but with FK enforcement enabled the FK to games(id=0)
+	// fails. SET NULL on Game so deleting a game preserves the activity
+	// row but disconnects the FK.
+	GameID    *uint          `gorm:"index" json:"gameId"`
+	Game      Game           `gorm:"foreignKey:GameID;constraint:OnDelete:SET NULL" json:"-"`
 	Metadata  string         `gorm:"type:text" json:"metadata"` // JSON
 }
 
@@ -711,7 +716,7 @@ type SharedSession struct {
 	UpdatedAt    time.Time              `json:"updatedAt"`
 	DeletedAt    gorm.DeletedAt         `gorm:"index" json:"-"`
 	OwnerID      uint                   `gorm:"index;not null" json:"ownerId"`
-	Owner        User                   `gorm:"foreignKey:OwnerID" json:"-"`
+	Owner        User                   `gorm:"foreignKey:OwnerID;constraint:OnDelete:CASCADE" json:"-"`
 	GameID       uint                   `gorm:"index;not null" json:"gameId"`
 	Game         Game                   `gorm:"foreignKey:GameID" json:"-"`
 	Name         string                 `gorm:"size:255;not null" json:"name"`

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -281,7 +281,7 @@ type Favorite struct {
 	CreatedAt time.Time      `json:"createdAt"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID    uint           `gorm:"uniqueIndex:idx_user_game;not null" json:"userId"`
-	User      User           `gorm:"foreignKey:UserID" json:"-"`
+	User      User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	GameID    uint           `gorm:"uniqueIndex:idx_user_game;not null" json:"gameId"`
 	Game      Game           `gorm:"foreignKey:GameID" json:"game"`
 }
@@ -298,7 +298,7 @@ type PlayHistory struct {
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID    uint           `gorm:"uniqueIndex:idx_user_game_play_history;not null" json:"userId"`
-	User      User           `gorm:"foreignKey:UserID" json:"-"`
+	User      User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	// Standalone index on GameID — the composite uniqueIndex above has
 	// (UserID, GameID) so SQLite cannot use it for queries that filter
 	// by GameID alone (GET /api/games/{id}/stats and the top-player JOIN
@@ -313,6 +313,7 @@ type PlayHistory struct {
 type DailyPlayActivity struct {
 	ID       uint      `gorm:"primarykey" json:"id"`
 	UserID   uint      `gorm:"uniqueIndex:idx_daily_play_user_date;not null" json:"userId"`
+	User     User      `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	Date     time.Time `gorm:"uniqueIndex:idx_daily_play_user_date;not null;type:date" json:"date"`
 	PlayTime int64     `json:"playTime"` // seconds added on this day
 }
@@ -323,7 +324,7 @@ type RefreshToken struct {
 	CreatedAt   time.Time
 	DeletedAt   gorm.DeletedAt `gorm:"index"`
 	UserID      uint           `gorm:"index;not null"`
-	User        User           `gorm:"foreignKey:UserID"`
+	User        User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE"`
 	Token       string         `gorm:"uniqueIndex;size:512;not null"`
 	ExpiresAt   time.Time      `gorm:"not null;index"`
 	TokenFamily string         `gorm:"size:64;index"` // groups related tokens for replay detection
@@ -458,6 +459,10 @@ type SystemEvent struct {
 	Username      string              `gorm:"size:128;index"`
 	UsernameLower string              `gorm:"size:128;index"`
 	UserID        *uint               `gorm:"index"`
+	// SET NULL not CASCADE: SystemEvent is the audit log. Deleting a
+	// user must not erase the record of what they did. We keep the
+	// event row and null the FK so nothing dangles.
+	User          *User               `gorm:"foreignKey:UserID;constraint:OnDelete:SET NULL"`
 	IP            string              `gorm:"size:64;index"`
 	Path          string              `gorm:"size:256"`
 	Metadata      string              `gorm:"type:text"`
@@ -499,6 +504,7 @@ type ConsoleSaveStatePolicy struct {
 	UpdatedAt time.Time              `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt         `gorm:"index" json:"-"`
 	UserID    uint                   `gorm:"uniqueIndex:idx_user_console_savestate;not null" json:"userId"`
+	User      User                   `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	ConsoleID uint                   `gorm:"uniqueIndex:idx_user_console_savestate;not null" json:"consoleId"`
 	Choice    ConsoleSaveStateChoice `gorm:"type:varchar(16);not null" json:"choice"`
 }
@@ -518,6 +524,7 @@ type GameSaveStatePolicy struct {
 	UpdatedAt time.Time              `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt         `gorm:"index" json:"-"`
 	UserID    uint                   `gorm:"uniqueIndex:idx_user_game_savestate;not null" json:"userId"`
+	User      User                   `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	GameID    uint                   `gorm:"uniqueIndex:idx_user_game_savestate;not null" json:"gameId"`
 	Choice    ConsoleSaveStateChoice `gorm:"type:varchar(16);not null" json:"choice"`
 }
@@ -529,6 +536,7 @@ type ConsoleShaderPreference struct {
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID    uint           `gorm:"uniqueIndex:idx_user_console_shader;not null" json:"userId"`
+	User      User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	ConsoleID uint           `gorm:"uniqueIndex:idx_user_console_shader;not null" json:"consoleId"`
 	Shader    string         `gorm:"size:64;not null" json:"shader"`
 }
@@ -540,6 +548,7 @@ type ConsoleKeyMappingPreference struct {
 	UpdatedAt       time.Time      `json:"updatedAt"`
 	DeletedAt       gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID          uint           `gorm:"uniqueIndex:idx_user_console_keymapping;not null" json:"userId"`
+	User            User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	ConsoleID       uint           `gorm:"uniqueIndex:idx_user_console_keymapping;not null" json:"consoleId"`
 	SelectedMapping string         `gorm:"size:64;not null" json:"selectedMapping"`
 	CustomMapping   string         `gorm:"type:text" json:"customMapping"` // JSON
@@ -552,6 +561,7 @@ type Device struct {
 	UpdatedAt  time.Time      `json:"updatedAt"`
 	DeletedAt  gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID     uint           `gorm:"index;not null" json:"userId"`
+	User       User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	DeviceUUID string         `gorm:"uniqueIndex;size:64;not null" json:"deviceUuid"`
 	Name       string         `gorm:"size:128;not null" json:"name"`
 	Platform   string         `gorm:"size:32;not null" json:"platform"` // "android", "macos", "linux", "windows"
@@ -576,6 +586,7 @@ type RetroAchievementCredential struct {
 	UpdatedAt       time.Time      `json:"updatedAt"`
 	DeletedAt       gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID          uint           `gorm:"uniqueIndex;not null" json:"userId"`
+	User            User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	RAUsername      string         `gorm:"size:128;not null" json:"raUsername"`
 	RAToken         string         `gorm:"size:512;not null" json:"-"`
 	HardcoreEnabled bool           `gorm:"default:false" json:"hardcoreEnabled"`
@@ -603,6 +614,7 @@ type UserAchievementProgress struct {
 	UpdatedAt        time.Time      `json:"updatedAt"`
 	DeletedAt        gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID           uint           `gorm:"uniqueIndex:idx_user_achievement;not null" json:"userId"`
+	User             User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	AchievementRAID  uint           `gorm:"uniqueIndex:idx_user_achievement;not null" json:"achievementRaId"`
 	RAGameID         uint           `gorm:"index;not null" json:"raGameId"`
 	UnlockedAt       time.Time      `json:"unlockedAt"`
@@ -617,7 +629,7 @@ type SharedSaveState struct {
 	UpdatedAt     time.Time      `json:"updatedAt"`
 	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID        uint           `gorm:"index;not null" json:"userId"`
-	User          User           `gorm:"foreignKey:UserID" json:"-"`
+	User          User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	GameID        uint           `gorm:"index;not null" json:"gameId"`
 	Game          Game           `gorm:"foreignKey:GameID" json:"-"`
 	Name          string         `gorm:"size:255;not null" json:"name"`
@@ -635,7 +647,7 @@ type GameRating struct {
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID    uint           `gorm:"uniqueIndex:idx_user_game_rating;not null" json:"userId"`
-	User      User           `gorm:"foreignKey:UserID" json:"-"`
+	User      User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	GameID    uint           `gorm:"uniqueIndex:idx_user_game_rating;not null;index" json:"gameId"`
 	Game      Game           `gorm:"foreignKey:GameID" json:"-"`
 	Rating    int            `gorm:"not null" json:"rating"` // 1-5
@@ -648,7 +660,7 @@ type ActivityEvent struct {
 	CreatedAt time.Time      `json:"createdAt"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID    uint           `gorm:"index;not null" json:"userId"`
-	User      User           `gorm:"foreignKey:UserID" json:"-"`
+	User      User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	EventType string         `gorm:"size:64;not null;index" json:"eventType"` // started_playing, favorited_game, rated_game, shared_save
 	GameID    uint           `gorm:"index" json:"gameId"`
 	Game      Game           `gorm:"foreignKey:GameID" json:"-"`
@@ -662,7 +674,7 @@ type GameCollection struct {
 	UpdatedAt   time.Time      `json:"updatedAt"`
 	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID      uint           `gorm:"index;not null" json:"userId"`
-	User        User           `gorm:"foreignKey:UserID" json:"-"`
+	User        User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	Name        string         `gorm:"size:255;not null" json:"name"`
 	Description string         `gorm:"type:text" json:"description"`
 	IsPublic    bool           `gorm:"default:false" json:"isPublic"`
@@ -686,7 +698,7 @@ type PlayLaterItem struct {
 	CreatedAt time.Time      `json:"createdAt"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID    uint           `gorm:"uniqueIndex:idx_play_later_user_game;not null" json:"userId"`
-	User      User           `gorm:"foreignKey:UserID" json:"-"`
+	User      User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	GameID    uint           `gorm:"uniqueIndex:idx_play_later_user_game;not null" json:"gameId"`
 	Game      Game           `gorm:"foreignKey:GameID" json:"game"`
 	Position  int            `gorm:"not null;default:0" json:"position"`
@@ -721,7 +733,7 @@ type SharedSessionMember struct {
 	SharedSessionID uint           `gorm:"uniqueIndex:idx_shared_session_user;not null" json:"sharedSessionId"`
 	SharedSession   SharedSession  `gorm:"foreignKey:SharedSessionID" json:"-"`
 	UserID          uint           `gorm:"uniqueIndex:idx_shared_session_user;not null" json:"userId"`
-	User            User           `gorm:"foreignKey:UserID" json:"-"`
+	User            User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	Role            string         `gorm:"size:16;default:member;not null" json:"role"` // "owner", "member"
 	JoinedAt        time.Time      `json:"joinedAt"`
 }
@@ -734,9 +746,9 @@ type SharedSessionInvite struct {
 	SharedSessionID uint           `gorm:"uniqueIndex:idx_shared_session_invitee;not null" json:"sharedSessionId"`
 	SharedSession   SharedSession  `gorm:"foreignKey:SharedSessionID" json:"-"`
 	InviterID       uint           `gorm:"not null" json:"inviterId"`
-	Inviter         User           `gorm:"foreignKey:InviterID" json:"-"`
+	Inviter         User           `gorm:"foreignKey:InviterID;constraint:OnDelete:CASCADE" json:"-"`
 	InviteeID       uint           `gorm:"uniqueIndex:idx_shared_session_invitee;not null" json:"inviteeId"`
-	Invitee         User           `gorm:"foreignKey:InviteeID" json:"-"`
+	Invitee         User           `gorm:"foreignKey:InviteeID;constraint:OnDelete:CASCADE" json:"-"`
 	Status          string         `gorm:"size:32;default:pending;not null" json:"status"` // "pending", "accepted", "declined"
 }
 
@@ -749,7 +761,7 @@ type SharedSessionSave struct {
 	SharedSessionID uint           `gorm:"index;not null" json:"sharedSessionId"`
 	SharedSession   SharedSession  `gorm:"foreignKey:SharedSessionID" json:"-"`
 	UserID          uint           `gorm:"not null" json:"userId"`
-	User            User           `gorm:"foreignKey:UserID" json:"-"`
+	User            User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	Name            string         `gorm:"size:255;not null" json:"name"`
 	FilePath        string         `gorm:"size:1024;not null" json:"-"`
 	FileSize        int64          `json:"fileSize"`
@@ -764,9 +776,9 @@ type NetplaySession struct {
 	UpdatedAt    time.Time      `json:"updatedAt"`
 	DeletedAt    gorm.DeletedAt `gorm:"index" json:"-"`
 	HostUserID   uint           `gorm:"index;not null" json:"hostUserId"`
-	HostUser     User           `gorm:"foreignKey:HostUserID" json:"-"`
+	HostUser     User           `gorm:"foreignKey:HostUserID;constraint:OnDelete:CASCADE" json:"-"`
 	ClientUserID *uint          `gorm:"index" json:"clientUserId"`
-	ClientUser   User           `gorm:"foreignKey:ClientUserID" json:"-"`
+	ClientUser   User           `gorm:"foreignKey:ClientUserID;constraint:OnDelete:SET NULL" json:"-"`
 	GameID       uint           `gorm:"index;not null" json:"gameId"`
 	Game         Game           `gorm:"foreignKey:GameID" json:"-"`
 	Status       string         `gorm:"size:32;default:waiting;not null" json:"status"` // "waiting", "in_progress", "ended"
@@ -825,7 +837,7 @@ type ChallengeAttempt struct {
 	ChallengeID uint           `gorm:"index:idx_challenge_attempt;not null" json:"challengeId"`
 	Challenge   Challenge      `gorm:"foreignKey:ChallengeID" json:"-"`
 	UserID      uint           `gorm:"index:idx_challenge_attempt;not null" json:"userId"`
-	User        User           `gorm:"foreignKey:UserID" json:"-"`
+	User        User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	Status      string         `gorm:"size:32;not null;default:in_progress" json:"status"` // "in_progress", "completed", "abandoned"
 	StartedAt   time.Time      `gorm:"not null" json:"startedAt"`
 	CompletedAt *time.Time     `json:"completedAt"`
@@ -837,6 +849,7 @@ type ChallengeAttempt struct {
 type GameKeyMappingPreference struct {
 	gorm.Model
 	UserID        uint   `json:"userId" gorm:"not null;uniqueIndex:idx_user_game_keymapping"`
+	User          User   `json:"-" gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE"`
 	GameID        uint   `json:"gameId" gorm:"not null;uniqueIndex:idx_user_game_keymapping"`
 	CustomMapping string `json:"customMapping" gorm:"type:text"` // JSON string of map[string]string
 }
@@ -980,7 +993,7 @@ type SessionSaveState struct {
 	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
 	SessionID     uint           `gorm:"index;not null" json:"sessionId"`
 	UserID        uint           `gorm:"index;not null" json:"userId"`
-	User          User           `gorm:"foreignKey:UserID" json:"-"`
+	User          User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	Name          string         `gorm:"size:255;not null" json:"name"`
 	FilePath      string         `gorm:"size:1024;not null" json:"-"`
 	FileSize      int64          `json:"fileSize"`
@@ -1176,6 +1189,7 @@ type SavedSearch struct {
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 	UserID    uint           `gorm:"index;not null" json:"userId"`
+	User      User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	Name      string         `gorm:"size:255;not null" json:"name"`
 	Filters   string         `gorm:"type:text;not null" json:"filters"` // JSON-encoded filter params
 }
@@ -1184,6 +1198,7 @@ type SavedSearch struct {
 type UserAchievementShowcase struct {
 	ID              uint      `gorm:"primarykey" json:"id"`
 	UserID          uint      `gorm:"uniqueIndex:idx_user_achievement_showcase;not null" json:"userId"`
+	User            User      `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	AchievementRAID uint      `gorm:"uniqueIndex:idx_user_achievement_showcase;not null" json:"achievementRaId"`
 	RAGameID        uint      `gorm:"not null" json:"raGameId"`
 	ShowcaseOrder   int       `gorm:"not null" json:"showcaseOrder"`


### PR DESCRIPTION
## Summary
Closes **#971**. The longest-deferred audit issue — the FK story across user-owned tables.

### What this PR does
- Adds \`constraint:OnDelete:CASCADE\` to every direct user-owned relationship (~26 tables) and \`SET NULL\` to two optional relationships (\`NetplaySession.ClientUserID\`, \`SystemEvent.UserID\` — preserve the row, null the FK).
- Adds \`User\` back-ref struct fields to the ten tables that had a \`UserID\` column without one. GORM only creates a FK constraint when there's a relationship field; without these, the tag would have been a no-op.
- Appends \`?_foreign_keys=1\` to both the production DSN and the test DSN. SQLite has FK enforcement off by default — without this pragma the CASCADE declarations would silently no-op.
- Adds a regression test (\`TestUserFKCascadeOnRawDelete\`) that exercises the FK directly via a raw \`Unscoped().Delete(&user)\`, proving cascade fires at the SQL level on a fresh install (independent of \`HumaHardDeleteUser\`'s existing explicit cleanup).

### Why \`HumaHardDeleteUser\`'s explicit cleanup stays
Existing installs that upgraded across the schema-without-FK boundary won't have CASCADE constraints until those tables are recreated. The explicit \`tx.Where(\"user_id = ?\", uid).Delete(...)\` loop in \`HumaHardDeleteUser\` (#1034) remains the safety net for those — fresh installs benefit from CASCADE; legacy installs benefit from the explicit cleanup. Belt + suspenders.

### Behaviour change worth noting
\`NetplaySession.ClientUserID\` switches from "delete the session when the client is deleted" (existing behavior via the explicit cleanup's \`OR client_user_id = ?\`) to "keep the session, null the client". This matches the intent better — sessions are owned by the host; losing the client shouldn't destroy the host's record. The explicit cleanup will continue to delete the session for legacy installs.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`TestUserFKCascadeOnRawDelete\` (new) passes
- [x] \`TestHardDeleteUser_*\` (existing) all pass
- [x] User-related tests (TestRegister, TestLogin, TestRefresh, TestRating, TestCollection, TestFavorite) all pass