### PR TITLE
docs: extract Supported Consoles tables into their own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <p align="center"><em>Nu spelar vi!</em> — Your retro game library, self-hosted. Play anywhere.</p>
 
 <p align="center">
-  <a href="#supported-consoles">59 Consoles</a> &bull;
+  <a href="docs/supported-consoles.md">59 Consoles</a> &bull;
   <a href="#features">Features</a> &bull;
   <a href="#quick-start">Quick Start</a> &bull;
   <a href="#downloads">Downloads</a> &bull;
@@ -101,98 +101,11 @@ Think of it as your own personal Steam for retro games.
 
 ## Supported Consoles
 
-59 playable systems. Each console shows whether it supports **save states** and **browser play** (via EmulatorJS, no install needed). The seed list also includes scaffolding for newer-gen consoles (Switch, PS5, Wii U, etc.) that aren't yet playable — they show up greyed out in the admin browser.
+**59 playable systems** spanning every major Nintendo, Sega, Sony, Atari, NEC, and SNK platform up through the 7th generation, plus arcade (MAME), home computers (Commodore 64/128/Amiga, MSX, Atari 8-bit/ST, DOS), handhelds (WonderSwan, Lynx, Game Boy, Game & Watch), and curiosities like 3DO, Philips CD-i, Vectrex, ScummVM, and Pokémon Mini.
 
-### Nintendo
+Most systems also work in the browser via [EmulatorJS](https://emulatorjs.org) — no app install needed. Save states are universal except where the underlying core doesn't support them.
 
-| Console | Core | Save States | Browser Play | Extensions |
-|---------|------|:-----------:|:------------:|------------|
-| NES | Nestopia | :white_check_mark: | :white_check_mark: | `.nes` |
-| Famicom Disk System | Nestopia | :white_check_mark: | :white_check_mark: | `.fds` |
-| SNES | Snes9x | :white_check_mark: | :white_check_mark: | `.sfc` `.smc` |
-| Game Boy | Gambatte | :white_check_mark: | :white_check_mark: | `.gb` |
-| Game Boy Color | Gambatte | :white_check_mark: | :white_check_mark: | `.gbc` |
-| Game Boy Advance | mGBA | :white_check_mark: | :white_check_mark: | `.gba` |
-| Nintendo 64 | Mupen64Plus | :white_check_mark: | :white_check_mark: | `.n64` `.z64` `.v64` |
-| Nintendo DS | DeSmuME | :white_check_mark: | :white_check_mark: | `.nds` |
-| Virtual Boy | Beetle VB | :white_check_mark: | :white_check_mark: | `.vb` `.vboy` |
-| Nintendo GameCube | Dolphin | :white_check_mark: | | `.iso` `.gcm` `.gcz` `.ciso` `.rvz` |
-| Nintendo 3DS | Azahar | :white_check_mark: | | `.3ds` `.cci` `.cia` |
-| Pokemon Mini | PokeMini | :white_check_mark: | | `.min` |
-| Game & Watch | gw | :white_check_mark: | | `.mgw` |
-
-### Sega
-
-| Console | Core | Save States | Browser Play | Extensions |
-|---------|------|:-----------:|:------------:|------------|
-| Sega SG-1000 | Genesis Plus GX | :white_check_mark: | :white_check_mark: | `.sg` `.sc` `.sf7` `.bin` |
-| Sega Master System | Genesis Plus GX | :white_check_mark: | :white_check_mark: | `.sms` |
-| Sega Genesis / Mega Drive | Genesis Plus GX | :white_check_mark: | :white_check_mark: | `.md` `.gen` `.bin` |
-| Game Gear | Genesis Plus GX | :white_check_mark: | :white_check_mark: | `.gg` |
-| Sega CD | ClownMDEmu | :white_check_mark: | :white_check_mark: | `.iso` `.bin` `.cue` `.m3u` |
-| Sega 32X | PicoDrive | :white_check_mark: | :white_check_mark: | `.32x` |
-| Sega Saturn | Yabause | :white_check_mark: | :white_check_mark: | `.iso` `.bin` `.cue` `.chd` `.m3u` |
-| Dreamcast | Flycast | :white_check_mark: | | `.gdi` `.cdi` `.chd` `.cue` `.bin` `.m3u` |
-
-### Sony
-
-| Console | Core | Save States | Browser Play | Extensions |
-|---------|------|:-----------:|:------------:|------------|
-| PlayStation | Beetle PSX HW | :white_check_mark: | :white_check_mark: | `.bin` `.cue` `.iso` `.pbp` `.m3u` |
-| PlayStation 2 | Play! | :white_check_mark: | | `.iso` `.bin` `.cue` `.chd` `.m3u` |
-| PSP | PPSSPP | :white_check_mark: | :white_check_mark: | `.iso` `.cso` `.chd` |
-
-### Atari
-
-| Console | Core | Save States | Browser Play | Extensions |
-|---------|------|:-----------:|:------------:|------------|
-| Atari 2600 | Stella | :white_check_mark: | :white_check_mark: | `.a26` `.bin` |
-| Atari 5200 | Atari800 | :white_check_mark: | | `.a52` `.bin` |
-| Atari 7800 | ProSystem | :white_check_mark: | :white_check_mark: | `.a78` `.bin` |
-| Atari Lynx | Handy | :white_check_mark: | :white_check_mark: | `.lnx` `.lyx` |
-| Atari Jaguar | Virtual Jaguar | | :white_check_mark: | `.j64` `.jag` |
-| Atari 8-bit (400/800/XL/XE) | Atari800 | :white_check_mark: | | `.atr` `.atx` `.xex` `.car` `.com` `.bin` `.rom` |
-| Atari ST | Hatari | :white_check_mark: | | `.st` `.stx` `.msa` `.dim` `.m3u` |
-
-### NEC
-
-| Console | Core | Save States | Browser Play | Extensions |
-|---------|------|:-----------:|:------------:|------------|
-| TurboGrafx-16 / PC Engine | Beetle PCE | :white_check_mark: | :white_check_mark: | `.pce` |
-| TurboGrafx-CD / PC Engine CD | Beetle PCE | :white_check_mark: | :white_check_mark: | `.chd` `.cue` `.iso` `.m3u` |
-| PC Engine SuperGrafx | Beetle SuperGrafx | :white_check_mark: | | `.sgx` `.pce` |
-| PC-FX | Beetle PC-FX | :white_check_mark: | :white_check_mark: | `.iso` `.cue` `.m3u` |
-
-### SNK
-
-| Console | Core | Save States | Browser Play | Extensions |
-|---------|------|:-----------:|:------------:|------------|
-| Neo Geo | FBNeo | :white_check_mark: | :white_check_mark: | `.zip` |
-| Neo Geo CD | NeoCD | :white_check_mark: | | `.chd` `.cue` `.iso` |
-| Neo Geo Pocket / Color | Beetle NGP | :white_check_mark: | :white_check_mark: | `.ngp` `.ngc` |
-
-### Other
-
-| Console | Core | Save States | Browser Play | Extensions |
-|---------|------|:-----------:|:------------:|------------|
-| 3DO | Opera | :white_check_mark: | :white_check_mark: | `.iso` `.bin` `.cue` `.chd` |
-| Philips CD-i | SAME CDi | :white_check_mark: | :white_check_mark: | `.chd` `.cue` `.iso` |
-| Arcade (MAME) | MAME 2003+ | :white_check_mark: | :white_check_mark: | `.zip` |
-| ScummVM | ScummVM | :white_check_mark: | :white_check_mark: | `.scummvm` (game folders) |
-| WonderSwan | Beetle WonderSwan | :white_check_mark: | :white_check_mark: | `.ws` `.wsc` |
-| ColecoVision | Gearcoleco | :white_check_mark: | :white_check_mark: | `.col` `.rom` |
-| Mattel Intellivision | FreeIntv | :white_check_mark: | | `.int` `.bin` `.rom` |
-| Magnavox Odyssey 2 | O2EM | :white_check_mark: | | `.bin` `.o2` |
-| Fairchild Channel F | FreeChaF | :white_check_mark: | | `.bin` `.chf` |
-| GCE Vectrex | Vecx | :white_check_mark: | | `.bin` `.vec` |
-| MSX / MSX2 | BlueMSX | :white_check_mark: | | `.rom` `.dsk` `.cas` `.mx1` `.mx2` |
-| Commodore 64 | VICE | :white_check_mark: | :white_check_mark: | `.d64` `.t64` `.prg` `.crt` `.tap` |
-| Commodore 128 | VICE | :white_check_mark: | :white_check_mark: | `.d64` `.d71` `.d81` `.t64` `.prg` `.crt` |
-| Commodore VIC-20 | VICE | :white_check_mark: | :white_check_mark: | `.prg` `.d64` `.t64` `.crt` |
-| Commodore Plus/4 | VICE | :white_check_mark: | :white_check_mark: | `.prg` `.d64` `.t64` |
-| Commodore PET | VICE | :white_check_mark: | :white_check_mark: | `.prg` `.d64` `.t64` |
-| Commodore Amiga | PUAE | :white_check_mark: | :white_check_mark: | `.adf` `.hdf` `.lha` `.dms` `.zip` |
-| DOS | DOSBox Pure | :white_check_mark: | :white_check_mark: | `.exe` `.com` `.bat` `.conf` |
+For the full per-family breakdown — cores used, file extensions accepted, and which systems support browser play vs. native-only — see **[docs/supported-consoles.md](docs/supported-consoles.md)**.
 
 ## Quick Start
 
@@ -253,6 +166,7 @@ If you don't want to install anything, the web UI's **browser play** mode works 
 
 | Guide | Description |
 |-------|-------------|
+| [Supported Consoles](docs/supported-consoles.md) | Full per-family tables: cores, extensions, browser-play matrix |
 | [Deploy Guide](docs/DEPLOY.md) | Production deployment, HTTPS, TURN server, backups |
 | [Development Guide](docs/DEVELOPMENT.md) | Building from source, architecture, testing |
 | [Contributing](CONTRIBUTING.md) | Code style, commit conventions, pull requests |

--- a/docs/supported-consoles.md
+++ b/docs/supported-consoles.md
@@ -1,0 +1,96 @@
+# Supported Consoles
+
+59 playable systems. Each console shows whether it supports **save states** and **browser play** (via EmulatorJS, no install needed). The seed list also includes scaffolding for newer-gen consoles (Switch, PS5, Wii U, Xbox Series, etc.) that aren't yet playable — they show up greyed out in the admin browser.
+
+For an at-a-glance summary, see [the README's Supported Consoles section](../README.md#supported-consoles). The full per-family tables live below.
+
+## Nintendo
+
+| Console | Core | Save States | Browser Play | Extensions |
+|---------|------|:-----------:|:------------:|------------|
+| NES | Nestopia | :white_check_mark: | :white_check_mark: | `.nes` |
+| Famicom Disk System | Nestopia | :white_check_mark: | :white_check_mark: | `.fds` |
+| SNES | Snes9x | :white_check_mark: | :white_check_mark: | `.sfc` `.smc` |
+| Game Boy | Gambatte | :white_check_mark: | :white_check_mark: | `.gb` |
+| Game Boy Color | Gambatte | :white_check_mark: | :white_check_mark: | `.gbc` |
+| Game Boy Advance | mGBA | :white_check_mark: | :white_check_mark: | `.gba` |
+| Nintendo 64 | Mupen64Plus | :white_check_mark: | :white_check_mark: | `.n64` `.z64` `.v64` |
+| Nintendo DS | DeSmuME | :white_check_mark: | :white_check_mark: | `.nds` |
+| Virtual Boy | Beetle VB | :white_check_mark: | :white_check_mark: | `.vb` `.vboy` |
+| Nintendo GameCube | Dolphin | :white_check_mark: | | `.iso` `.gcm` `.gcz` `.ciso` `.rvz` |
+| Nintendo 3DS | Azahar | :white_check_mark: | | `.3ds` `.cci` `.cia` |
+| Pokemon Mini | PokeMini | :white_check_mark: | | `.min` |
+| Game & Watch | gw | :white_check_mark: | | `.mgw` |
+
+## Sega
+
+| Console | Core | Save States | Browser Play | Extensions |
+|---------|------|:-----------:|:------------:|------------|
+| Sega SG-1000 | Genesis Plus GX | :white_check_mark: | :white_check_mark: | `.sg` `.sc` `.sf7` `.bin` |
+| Sega Master System | Genesis Plus GX | :white_check_mark: | :white_check_mark: | `.sms` |
+| Sega Genesis / Mega Drive | Genesis Plus GX | :white_check_mark: | :white_check_mark: | `.md` `.gen` `.bin` |
+| Game Gear | Genesis Plus GX | :white_check_mark: | :white_check_mark: | `.gg` |
+| Sega CD | ClownMDEmu | :white_check_mark: | :white_check_mark: | `.iso` `.bin` `.cue` `.m3u` |
+| Sega 32X | PicoDrive | :white_check_mark: | :white_check_mark: | `.32x` |
+| Sega Saturn | Yabause | :white_check_mark: | :white_check_mark: | `.iso` `.bin` `.cue` `.chd` `.m3u` |
+| Dreamcast | Flycast | :white_check_mark: | | `.gdi` `.cdi` `.chd` `.cue` `.bin` `.m3u` |
+
+## Sony
+
+| Console | Core | Save States | Browser Play | Extensions |
+|---------|------|:-----------:|:------------:|------------|
+| PlayStation | Beetle PSX HW | :white_check_mark: | :white_check_mark: | `.bin` `.cue` `.iso` `.pbp` `.m3u` |
+| PlayStation 2 | Play! | :white_check_mark: | | `.iso` `.bin` `.cue` `.chd` `.m3u` |
+| PSP | PPSSPP | :white_check_mark: | :white_check_mark: | `.iso` `.cso` `.chd` |
+
+## Atari
+
+| Console | Core | Save States | Browser Play | Extensions |
+|---------|------|:-----------:|:------------:|------------|
+| Atari 2600 | Stella | :white_check_mark: | :white_check_mark: | `.a26` `.bin` |
+| Atari 5200 | Atari800 | :white_check_mark: | | `.a52` `.bin` |
+| Atari 7800 | ProSystem | :white_check_mark: | :white_check_mark: | `.a78` `.bin` |
+| Atari Lynx | Handy | :white_check_mark: | :white_check_mark: | `.lnx` `.lyx` |
+| Atari Jaguar | Virtual Jaguar | | :white_check_mark: | `.j64` `.jag` |
+| Atari 8-bit (400/800/XL/XE) | Atari800 | :white_check_mark: | | `.atr` `.atx` `.xex` `.car` `.com` `.bin` `.rom` |
+| Atari ST | Hatari | :white_check_mark: | | `.st` `.stx` `.msa` `.dim` `.m3u` |
+
+## NEC
+
+| Console | Core | Save States | Browser Play | Extensions |
+|---------|------|:-----------:|:------------:|------------|
+| TurboGrafx-16 / PC Engine | Beetle PCE | :white_check_mark: | :white_check_mark: | `.pce` |
+| TurboGrafx-CD / PC Engine CD | Beetle PCE | :white_check_mark: | :white_check_mark: | `.chd` `.cue` `.iso` `.m3u` |
+| PC Engine SuperGrafx | Beetle SuperGrafx | :white_check_mark: | | `.sgx` `.pce` |
+| PC-FX | Beetle PC-FX | :white_check_mark: | :white_check_mark: | `.iso` `.cue` `.m3u` |
+
+## SNK
+
+| Console | Core | Save States | Browser Play | Extensions |
+|---------|------|:-----------:|:------------:|------------|
+| Neo Geo | FBNeo | :white_check_mark: | :white_check_mark: | `.zip` |
+| Neo Geo CD | NeoCD | :white_check_mark: | | `.chd` `.cue` `.iso` |
+| Neo Geo Pocket / Color | Beetle NGP | :white_check_mark: | :white_check_mark: | `.ngp` `.ngc` |
+
+## Other
+
+| Console | Core | Save States | Browser Play | Extensions |
+|---------|------|:-----------:|:------------:|------------|
+| 3DO | Opera | :white_check_mark: | :white_check_mark: | `.iso` `.bin` `.cue` `.chd` |
+| Philips CD-i | SAME CDi | :white_check_mark: | :white_check_mark: | `.chd` `.cue` `.iso` |
+| Arcade (MAME) | MAME 2003+ | :white_check_mark: | :white_check_mark: | `.zip` |
+| ScummVM | ScummVM | :white_check_mark: | :white_check_mark: | `.scummvm` (game folders) |
+| WonderSwan | Beetle WonderSwan | :white_check_mark: | :white_check_mark: | `.ws` `.wsc` |
+| ColecoVision | Gearcoleco | :white_check_mark: | :white_check_mark: | `.col` `.rom` |
+| Mattel Intellivision | FreeIntv | :white_check_mark: | | `.int` `.bin` `.rom` |
+| Magnavox Odyssey 2 | O2EM | :white_check_mark: | | `.bin` `.o2` |
+| Fairchild Channel F | FreeChaF | :white_check_mark: | | `.bin` `.chf` |
+| GCE Vectrex | Vecx | :white_check_mark: | | `.bin` `.vec` |
+| MSX / MSX2 | BlueMSX | :white_check_mark: | | `.rom` `.dsk` `.cas` `.mx1` `.mx2` |
+| Commodore 64 | VICE | :white_check_mark: | :white_check_mark: | `.d64` `.t64` `.prg` `.crt` `.tap` |
+| Commodore 128 | VICE | :white_check_mark: | :white_check_mark: | `.d64` `.d71` `.d81` `.t64` `.prg` `.crt` |
+| Commodore VIC-20 | VICE | :white_check_mark: | :white_check_mark: | `.prg` `.d64` `.t64` `.crt` |
+| Commodore Plus/4 | VICE | :white_check_mark: | :white_check_mark: | `.prg` `.d64` `.t64` |
+| Commodore PET | VICE | :white_check_mark: | :white_check_mark: | `.prg` `.d64` `.t64` |
+| Commodore Amiga | PUAE | :white_check_mark: | :white_check_mark: | `.adf` `.hdf` `.lha` `.dms` `.zip` |
+| DOS | DOSBox Pure | :white_check_mark: | :white_check_mark: | `.exe` `.com` `.bat` `.conf` |


### PR DESCRIPTION
The README's per-family console tables ran ~95 lines and pushed every other section below the fold. Most people landing on the README want a quick sense of what Spela is, not an exhaustive matrix of file extensions per core.

- Move the Nintendo / Sega / Sony / Atari / NEC / SNK / Other tables into \`docs/supported-consoles.md\`.
- README's Supported Consoles section becomes a 4-line summary + link.
- Top-of-README "59 Consoles" link now points at the new file directly.
- Documentation table at the bottom adds an entry for the new file.

Pure docs change.