### PR TITLE
docs: tighten Multiplayer section, drop relay-session jargon

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Use [conventional commits](https://www.conventionalcommits.org/):
 feat: add save state sharing
 fix: prevent crash on empty game library
 docs: update deployment guide
-test: add relay session E2E tests
+test: add shared session E2E tests
 refactor: extract metadata scraper interface
 chore: bump Go to 1.22
 ```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Think of it as your own personal Steam for retro games.
 - **One library, every device** -- your games, saves, and progress sync across Android, Windows, macOS, and Linux
 - **Play in seconds** -- browse your collection with cover art, pick a game, and you're playing. No fiddling with cores or configs
 - **Self-hosted** -- your server, your data. Runs on a Raspberry Pi, a NAS, or a VPS. No cloud dependency
-- **Multiplayer** -- play with friends via real-time netplay or async turn-based relay sessions
+- **Multiplayer** -- play with friends online, live or by taking turns
 - **Beautiful** -- dark-themed UI designed for browsing large game libraries visually
 
 ## Features
@@ -72,9 +72,8 @@ Think of it as your own personal Steam for retro games.
 
 | Feature | Description |
 |---------|-------------|
-| **Real-Time Netplay** | Two-player online multiplayer with lockstep input sync. Share a 6-character invite code and play together |
-| **Relay Sessions** | Asynchronous turn-based multiplayer -- take turns playing and pass the save to your friend |
-| **Relay Invitations** | Invite friends to join relay sessions with turn management and timeout protection |
+| **Real-Time Netplay** | Play live with a friend over the internet. Share an invite code and you're in |
+| **Shared Sessions** | Take turns asynchronously -- pass the game to a friend and pick up where they left off |
 
 ### Social
 


### PR DESCRIPTION
Closes #1069.

## Summary

The README's Multiplayer section described the network stack instead of the user experience. This trims it to focus on what users get.

## Changes

**Tagline** (line 51):
- Before: \"real-time netplay or async turn-based relay sessions\"
- After: \"online, live or by taking turns\"

**Feature table** — drop \"lockstep input sync\" and \"6-character invite code\" (implementation details), rename \"Relay Sessions\" → \"Shared Sessions\" to match the actual code naming, drop the redundant \"Relay Invitations\" row.

**CONTRIBUTING.md** — one-word fix in an example commit message (\`relay session\` → \`shared session\`).

The technical \"relay\" references that remain in the codebase (WebSocket signaling for netplay, legacy \`relays/\` filesystem path with an explanatory comment) are correct and intentional — they don't need user-facing names.

## Test plan
- [x] No source code changed; pre-push hook correctly skipped builds
- [x] \`grep -i \"relay\" README.md CONTRIBUTING.md\` returns nothing
- [x] Diff is +4/-5 lines across 2 files