### PR TITLE
test(desktop): unbreak 4 E2E failures from #932 + stale fake

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameBrowsingAndSelectionTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameBrowsingAndSelectionTest.kt
@@ -100,8 +100,11 @@ class GameBrowsingAndSelectionTest {
 
         setContent { harness.App() }
 
+        // Game id="6" (FF6) is > 16 MB so it follows the legacy
+        // Download-button path. Sub-threshold games trigger the silent
+        // instant-download flow (#932) and show the Play button instead.
         harness.navigationViewModel.onIntent(
-            NavigationIntent.NavigateTo(SpScreen.GameDetail("1"))
+            NavigationIntent.NavigateTo(SpScreen.GameDetail("6"))
         )
         advance(harness)
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailActionsMenuTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailActionsMenuTest.kt
@@ -37,7 +37,10 @@ class GameDetailActionsMenuTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
-        navigateToGameDetail(harness, "1")
+        // Game id="6" (FF6) is > 16 MB so it follows the legacy
+        // Download-button path (#932 routes sub-threshold games to a
+        // silent instant-download Play button instead).
+        navigateToGameDetail(harness, "6")
 
         onNodeWithTag("game_detail_download_button").assertIsDisplayed()
     }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailCommunitySectionsTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailCommunitySectionsTest.kt
@@ -98,8 +98,10 @@ class GameDetailCommunitySectionsTest {
         onNodeWithText("SpeedKing").performClick()
         advance(harness)
 
-        // UserProfile screen should be shown (profile fails to load in fake repo, shows fallback)
-        onNodeWithText("Profile not found").assertIsDisplayed()
+        // UserProfile screen should be shown — assert by the screen's
+        // root testTag so we don't depend on whether the fake repo
+        // returns a profile or a fallback.
+        onNodeWithTag("user_profile_screen").assertIsDisplayed()
     }
 
     @Test

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDownloadAndLaunchTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDownloadAndLaunchTest.kt
@@ -20,10 +20,12 @@ class GameDownloadAndLaunchTest {
     fun downloadGameThenShowPlayButton() = runComposeUiTest {
         val harness = SpelaTestHarness(StandardTestDispatcher())
 
-        // Start at game detail for Castlevania (not cached)
+        // Start at game detail for FF6 (id="6", > 16 MB, not cached). This
+        // is the legacy Download-button path; sub-threshold games take the
+        // silent instant-download Play-button path instead (#932).
         harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
         harness.navigationViewModel.onIntent(
-            NavigationIntent.NavigateTo(SpScreen.GameDetail("1"))
+            NavigationIntent.NavigateTo(SpScreen.GameDetail("6"))
         )
 
         setContent { harness.App() }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -341,6 +341,24 @@ class FakeGameRepository : GameRepository {
             fileName = "supermetroid.sfc",
             scrapeAttempts = 1,
         ),
+        // 24 MB — above INSTANT_DOWNLOAD_THRESHOLD_BYTES (16 MB), so the
+        // GameDetail UI shows the legacy Download button rather than the
+        // silent-instant-download Play button (#932). Tests that need to
+        // exercise the download-then-play path navigate to this id.
+        Game(
+            id = "6",
+            title = "Final Fantasy VI",
+            consoleId = "snes",
+            consoleName = "SNES",
+            description = "An epic 16-bit RPG about an empire and a magical girl.",
+            developer = "Square",
+            publisher = "Square",
+            releaseDate = "1994",
+            genre = "RPG",
+            fileSize = 25_165_824,
+            fileName = "ff6.sfc",
+            scrapeAttempts = 1,
+        ),
     )
 
     override suspend fun getConsoles(): Result<List<Console>> {


### PR DESCRIPTION
Closes #1072.

## Failures
\`./run-desktop-tests.sh\` was producing 4 failures out of 789 tests.

### 3× same root cause: #932 instant-download UI change
\`GameHeroContent.kt:127-131\` now hides the Download button for uncached games below \`INSTANT_DOWNLOAD_THRESHOLD_BYTES\` (16 MB), routing them to a silent instant-download Play button. All 5 seeded fake games in \`TestFakes.kt\` have fileSize between 40 KB and 4 MB, so every one of them now takes the instant-download path:

- \`GameBrowsingAndSelectionTest::gameDetailShowsDownloadButtonWhenNotCached\`
- \`GameDetailActionsMenuTest::uncachedGameShowsDownloadButton\`
- \`GameDownloadAndLaunchTest::downloadGameThenShowPlayButton\`

### 4th: stale assertion on fake's default
\`GameDetailCommunitySectionsTest::clickingTopPlayerNavigatesToUserProfile\` asserted on the \"Profile not found\" fallback text. \`FakeSocialRepository.getPublicProfile\` returns success by default (synthetic profile data), so the fallback never renders. The test's intent is navigation, not the not-found branch.

## Fix
- Add a 6th seed game (id=\"6\", FF6, 24 MB) above the threshold; route the 3 download-button tests to it
- Switch the 4th test's assertion to the \`user_profile_screen\` testTag

## Verification
- All 4 originally failing test classes pass: 31/31 tests green
- Full \`./run-desktop-tests.sh\`: **789 tests, 0 failures, 0 errors, 0 skipped**

## Test plan
- [x] Affected test classes run green individually (31 tests)
- [x] Full desktop suite green (789 tests, 0 failures)
- [x] No source code changed; only test fakes + 4 test files