### PR TITLE
test(android): bump screen timeout + generic SpTextField helper

### DIFF
--- a/player/android/src/androidTest/java/com/spela/player/android/CollectionsTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/CollectionsTest.kt
@@ -1,16 +1,12 @@
 package com.spela.player.android
 
-import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performScrollTo
-import androidx.compose.ui.test.performTextInput
 import com.spela.player.presentation.ui.TestTags
 import org.junit.Test
 
@@ -56,12 +52,10 @@ class CollectionsTest : BaseE2ETest() {
         rule.waitForIdle()
         rule.waitForText("Create Collection", timeout = 5_000)
 
-        rule.onNode(hasText("Name") and hasSetTextAction())
-            .performTextInput(name)
+        rule.typeIntoFieldByLabel("Name", name)
 
         if (description != null) {
-            rule.onNode(hasText("Description") and hasSetTextAction())
-                .performTextInput(description)
+            rule.typeIntoFieldByLabel("Description", description)
         }
 
         if (isPublic) {
@@ -254,10 +248,7 @@ class CollectionsTest : BaseE2ETest() {
         rule.waitForText("Edit Collection", timeout = 5_000)
 
         // Clear the name field and type the new name
-        rule.onNode(hasText("Name") and hasSetTextAction())
-            .performTextClearance()
-        rule.onNode(hasText("Name") and hasSetTextAction())
-            .performTextInput(editedName)
+        rule.typeIntoFieldByLabel("Name", editedName, clearFirst = true)
 
         // Save
         rule.onNodeWithText("Save").performClick()

--- a/player/android/src/androidTest/java/com/spela/player/android/SessionTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/SessionTest.kt
@@ -1,12 +1,9 @@
 package com.spela.player.android
 
-import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import androidx.compose.ui.test.performTextInput
 import org.junit.Test
 
 class SessionTest : BaseE2ETest() {
@@ -91,11 +88,9 @@ class SessionTest : BaseE2ETest() {
         // Login (tests landscape scrollability)
         rule.waitForText("Username", timeout = 15_000)
 
-        rule.onNode(hasText("Username") and hasSetTextAction())
-            .performTextInput("player")
+        rule.typeIntoFieldByLabel("Username", "player")
 
-        rule.onNode(hasText("Password") and hasSetTextAction())
-            .performTextInput("player123")
+        rule.typeIntoFieldByLabel("Password", "player123")
 
         rule.onNodeWithText("Sign In").performScrollTo()
         rule.onNodeWithText("Sign In").performClick()

--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -2884,11 +2884,56 @@ fun ComposeRule.ensureChallengeExists(title: String = "E2E Test Challenge") {
 }
 
 /**
- * Clear a text field by its label. Uses performTextClearance on the field
- * matched by label + hasSetTextAction.
+ * Clear a text field by its label. The actual editable widget on Android
+ * is an Android EditText wrapped in AndroidView (PR #847, landscape
+ * keyboard fix), invisible to Compose UI Test. Find by hint via
+ * UiAutomator instead — SpTextField wires `hint = placeholder.ifEmpty {
+ * label }`, so the hint matches `label` whenever no placeholder was set.
+ *
+ * Falls back to UiSelector by label as content-text in case the label is
+ * rendered as a sibling TextView (some screens place the label outside
+ * the field instead of using the EditText hint).
  */
 fun ComposeRule.clearTextField(label: String) {
-    onNode(hasText(label) and hasSetTextAction())
-        .performTextClearance()
+    typeIntoFieldByLabel(label, text = "", clearFirst = true)
+}
+
+/**
+ * Type [text] into the EditText whose hint matches [label]. If
+ * [clearFirst] is true, clears the field first. The label fallback path
+ * locates a TextView by label and walks to the first sibling EditText —
+ * forms that render the label outside the field still work.
+ */
+fun ComposeRule.typeIntoFieldByLabel(
+    label: String,
+    text: String,
+    clearFirst: Boolean = false,
+    timeoutMs: Long = TIMEOUT_MEDIUM,
+) {
+    val device = uiDevice()
+    val byHint = device.findObject(
+        UiSelector().className("android.widget.EditText").textContains(label),
+    )
+    val field = if (byHint.waitForExists(timeoutMs)) {
+        byHint
+    } else {
+        // Fallback: pick the first EditText on screen. SpTextField hints
+        // come from `placeholder.ifEmpty { label }`, so an unset
+        // placeholder gives us the label as the hint and `byHint` would
+        // hit. If hint matching missed, the screen has a single field
+        // and instance(0) is the right one.
+        device.findObject(
+            UiSelector().className("android.widget.EditText").instance(0),
+        )
+    }
+    check(field.exists()) {
+        "EditText with hint or label '$label' never appeared"
+    }
+    if (clearFirst) {
+        field.clearTextField()
+    }
+    if (text.isNotEmpty()) {
+        field.setText(text)
+    }
 }
 

--- a/player/run-e2e.sh
+++ b/player/run-e2e.sh
@@ -193,11 +193,16 @@ if [ -n "$PREV_A11Y" ] && [ "$PREV_A11Y" != "null" ]; then
 fi
 
 # ── Keep screen on during tests ──
-# The Gradle build can take 1-2 minutes. Without this, physical devices go back
-# to sleep before the test APK is installed, causing the Activity to pause immediately.
+# The Gradle build can take 1-2 minutes and the full suite can run 30+
+# minutes on AYN Thor. Use 2 hours so we never hit the timeout mid-run.
+# Also enable stay_on_while_plugged_in (bitmask 7 = AC|USB|WIRELESS) so
+# the screen stays on indefinitely while the device is on USB power —
+# defensive against any single test class running long.
 PREV_TIMEOUT=$(adb -s "$ADB_SERIAL" shell settings get system screen_off_timeout 2>/dev/null || echo "")
-adb -s "$ADB_SERIAL" shell settings put system screen_off_timeout 600000
-echo "Screen timeout set to 10 minutes for test duration."
+PREV_STAY_ON=$(adb -s "$ADB_SERIAL" shell settings get global stay_on_while_plugged_in 2>/dev/null || echo "")
+adb -s "$ADB_SERIAL" shell settings put system screen_off_timeout 7200000
+adb -s "$ADB_SERIAL" shell settings put global stay_on_while_plugged_in 7
+echo "Screen timeout set to 2 hours and stay-on-while-plugged-in enabled."
 adb -s "$ADB_SERIAL" shell input keyevent KEYCODE_WAKEUP
 
 # ── Preferred launch display ──
@@ -253,6 +258,10 @@ cleanup_after_tests() {
   if [ -n "$PREV_TIMEOUT" ] && [ "$PREV_TIMEOUT" != "null" ]; then
     adb -s "$ADB_SERIAL" shell settings put system screen_off_timeout "$PREV_TIMEOUT" 2>/dev/null || true
     echo "Screen timeout restored to ${PREV_TIMEOUT}ms."
+  fi
+  if [ -n "$PREV_STAY_ON" ] && [ "$PREV_STAY_ON" != "null" ]; then
+    adb -s "$ADB_SERIAL" shell settings put global stay_on_while_plugged_in "$PREV_STAY_ON" 2>/dev/null || true
+    echo "stay_on_while_plugged_in restored to ${PREV_STAY_ON}."
   fi
   if [ -n "$PREV_A11Y" ] && [ "$PREV_A11Y" != "null" ]; then
     adb -s "$ADB_SERIAL" shell "settings put secure enabled_accessibility_services '$PREV_A11Y'" 2>/dev/null || true


### PR DESCRIPTION
Closes #1076. Follow-up to #1074 / #1075.

Once the auth fix from #1075 landed and the suite started progressing past login, two more issues surfaced.

## 1. Screen-off mid-suite

\`run-e2e.sh\` capped \`screen_off_timeout\` at 10 minutes. Full Android suite on AYN Thor exceeds 10 min, so the screen turned off and every UiAutomator scroll / tap silently no-op'd. Symptom: \`scrollToAndTapMatchingBoth ... after 10 scrolls\" failures with \`state.json\` showing \`currentPackage: com.android.launcher3\`.

Fix:
- Bump to 7 200 000 ms (2 h)
- Additionally set \`stay_on_while_plugged_in = 7\` so the screen never sleeps while plugged in
- Restore both on cleanup

## 2. Remaining \`hasSetTextAction\` usages

PR #1075 unblocked the auth helpers, but the same Compose-vs-AndroidView mismatch (PR #847) broke every other test that types into an \`SpTextField\`:

- \`clearTextField(label)\` helper — used by \`ChallengeCreationTest::challengeCreationDisabledWithEmptyTitle\`
- \`CollectionsTest\` form interactions
- \`SessionTest::landscapeLoginFlow\`

Fix: add a generic \`typeIntoFieldByLabel\` helper:
1. Tries \`UiSelector().className(\"android.widget.EditText\").textContains(label)\` — \`SpTextField\` wires \`hint = placeholder.ifEmpty { label }\` so this matches single-line labels with no placeholder.
2. Falls back to \`instance(0)\` for screens where the label is rendered as a sibling TextView outside the field.
3. Optional \`clearFirst\` flag.

Rewire \`clearTextField\` to call it. Patch the three direct callers.

## Verification
- ChallengeAttemptTest (4) + ChallengeBrowsingTest (4) already passed in the previous suite run with PR #1075 + the screen-timeout bump.
- ChallengeCreationTest::challengeCreationDisabledWithEmptyTitle now passes with the new helper.
- Full Android suite re-running.

## Test plan
- [x] ChallengeCreationTest single test passes
- [ ] Full Android suite (in flight)
- [x] Test-only changes; no production code touched