### PR TITLE
test(android): assertVisible falls back to By.hint for EditText hints

### DIFF
--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import com.spela.player.di.commonModule
@@ -486,6 +487,11 @@ fun ComposeRule.assertVisible(label: String) {
     val device = uiDevice()
     val ok = device.findObject(UiSelector().textContains(label)).exists() ||
         device.findObject(UiSelector().descriptionContains(label)).exists() ||
+        // SpTextField renders its `label` as the Android EditText hint
+        // (PR #847 wraps a real EditText in AndroidView). Hints aren't
+        // covered by getText() / contentDescription, so UiSelector misses
+        // them — fall back to By.hint() (UiAutomator 2.2+, API 26+).
+        device.findObjects(By.hint(label)).isNotEmpty() ||
         composeHasText(label) ||
         composeHasDescription(label)
     check(ok) { "Expected '$label' to be visible (text or description), but not found" }


### PR DESCRIPTION
Closes #1078. Tiny follow-up to #1077.

\`assertVisible\` matched UiSelector.textContains, descriptionContains, and Compose semantics, but not the Android EditText hint. \`SpTextField\` wraps a real Android EditText (PR #847) with the \`label\` parameter set as hint — UiSelector reads from \`AccessibilityNodeInfo.getText()\` which is empty for an empty EditText, so the hint is invisible to it.

Surfaced by \`ChallengeCreationTest::challengeButtonOpensCreationForm\`: after #1075 + #1077 unblocked the form from opening, the test asserted \`Title\` was visible, but \`Title\` is the EditText hint and \`assertVisible\` couldn't see it.

Fix: add a \`By.hint(label)\` fallback (UiAutomator 2.2+, API 26+).

## Verification
- ChallengeCreationTest::challengeButtonOpensCreationForm now passes.
- Suite gets past 4 challenge test classes (Attempt, Browsing, Creation × 2 methods, plus more).

## Test plan
- [x] Single test passes
- [x] Test-only change; no production code touched