### PR TITLE
test(android): --emulator flag for run-e2e.sh

### DIFF
--- a/player/run-e2e.sh
+++ b/player/run-e2e.sh
@@ -32,15 +32,48 @@ fi
 # Opt-out with --skip-reset when iterating fast on a single test and you
 # know the state is already clean (e.g. you just ran a reset five minutes
 # ago). Default is always: reset before every run.
+#
+# --emulator overrides ADB_SERIAL with the first running emulator
+# (emulator-NNNN) so the suite runs against the seeded `spela-test` AVD
+# instead of the AYN Thor — single-display, no Screen-2 routing, safer
+# for daily-driver hardware. See docs/e2e-testing.md for the AVD setup.
 RESET_BACKEND=true
+USE_EMULATOR=false
 ARGS=()
 for arg in "$@"; do
   case "$arg" in
     --skip-reset) RESET_BACKEND=false ;;
+    --emulator) USE_EMULATOR=true ;;
     *) ARGS+=("$arg") ;;
   esac
 done
 set -- "${ARGS[@]+"${ARGS[@]}"}"
+
+if [ "$USE_EMULATOR" = true ]; then
+  EMU_SERIAL=$(adb devices | awk '/^emulator-[0-9]+/ && $2 == "device" {print $1; exit}')
+  if [ -z "$EMU_SERIAL" ]; then
+    echo "Error: --emulator passed but no running emulator found." >&2
+    echo "Start the spela-test AVD first:" >&2
+    echo "  emulator -avd spela-test -no-snapshot-load &" >&2
+    exit 1
+  fi
+  ADB_SERIAL="$EMU_SERIAL"
+  DEVICE_PIN=""  # emulator AVD has no PIN
+  echo "── Targeting emulator: $ADB_SERIAL (overrides ADB_SERIAL from .env) ──"
+
+  # Pre-confirm Android's "use full screen" / immersive mode dialog. On a
+  # fresh AVD the system pops a confirmation overlay the first time the
+  # app goes immersive, which silently blocks all UiAutomator input.
+  adb -s "$ADB_SERIAL" shell settings put secure immersive_mode_confirmations confirmed >/dev/null 2>&1 || true
+
+  # Disable system animations to reduce Choreographer pressure. Compose
+  # animations are independent of these (gated by LocalAnimationsEnabled
+  # which the test mode already flips to false), but every bit helps on
+  # a slower-than-physical emulator.
+  adb -s "$ADB_SERIAL" shell settings put global window_animation_scale 0 >/dev/null 2>&1 || true
+  adb -s "$ADB_SERIAL" shell settings put global transition_animation_scale 0 >/dev/null 2>&1 || true
+  adb -s "$ADB_SERIAL" shell settings put global animator_duration_scale 0 >/dev/null 2>&1 || true
+fi
 
 if [ "$RESET_BACKEND" = true ]; then
   echo "── Resetting backend (docker compose down -v) ──"


### PR DESCRIPTION
Closes #1080.

Adds a \`--emulator\` flag to \`run-e2e.sh\` that auto-detects the first running \`emulator-NNNN\` device and overrides \`ADB_SERIAL\` (and clears \`DEVICE_PIN\`).

## Why
- Locally: keep E2E off the AYN Thor when it's in use as a daily driver.
- CI: \`ubuntu-latest\` runners support KVM, so the seeded \`spela-test\` AVD can boot via \`reactivecircus/android-emulator-runner@v2\`. The \`--emulator\` flag is the entry-point that makes \`run-e2e.sh\` work in that context.

## What's included
- \`--emulator\`: auto-detect first online emulator, override device targeting.
- Pre-confirm \`immersive_mode_confirmations\` (without this, a system overlay silently blocks UiAutomator on a fresh AVD).
- Zero system animation scales (Compose animations are gated by \`LocalAnimationsEnabled\` already, but reduces emulator frame budget pressure).
- Bails out clearly if no emulator is running, with a hint to start \`spela-test\`.

## What's NOT included (follow-up needed)
The full Android suite still hits \`AppNotIdleException\` on the emulator. Compose recomposition cycles keep the Choreographer busy past the 3-second \`IdlingPolicy\` timeout (\`TestHelpers.kt:51-52\`). Bumping the timeout is a band-aid; the real fix is moving emulator interactions to UiAutomator-only paths (similar to what \`tapOn()\` already does during gameplay). Tracked separately — out of scope for this PR.

Verified locally: the \`--emulator\` flag correctly targets \`emulator-5554\`, app installs and launches, login flow works, base setup completes. The first test class fails inside its body with \`AppNotIdleException\` on the emulator (unchanged from pre-flag baseline behavior — same root cause as the issue mentioned in \`docs/e2e-testing.md\` "Continuous Compose animations").

## Test plan
- [x] Verified \`--emulator\` flag picks up running \`emulator-5554\`
- [x] Bails out cleanly if no emulator is running
- [x] AYN Thor path unchanged (default behavior preserved)
- [x] Test-only / shell-only change; no production code touched