### PR TITLE
docs(server): explain MostPlayedGame omitempty re-audit (#967)

### DIFF
--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -1159,6 +1159,13 @@ type UserStatsResponse struct {
 	// shape (vs the null-value shape of sibling LastPlayedAt) as the
 	// price of compatible client codegen, until upstream Huma is
 	// fixed. TODO(#969): re-audit on every Huma upgrade.
+	//
+	// Re-audited and verified in #967 (closed): any `*T` `$ref` field
+	// hits this constraint regardless of whether it's embedded or
+	// top-level — the position of the field doesn't change Huma's
+	// schema emission. Confirmed by removing `omitempty` and dumping
+	// the OpenAPI: `mostPlayedGame` came out as a bare `$ref` listed
+	// in `required`, with no `nullable` / `type: [..., "null"]`.
 	MostPlayedGame     *GameResponse `json:"mostPlayedGame,omitempty"`
 	MostPlayedGameTime int64         `json:"mostPlayedGameTime"`
 	LastPlayedAt       *time.Time    `json:"lastPlayedAt"`


### PR DESCRIPTION
## Summary

- Tighten the inline comment on `UserStatsResponse.MostPlayedGame` to head off a re-audit that re-flagged this field as a no-`omitempty` rule violation.
- The original audit in #967 drew an embedded-vs-top-level distinction that doesn't reflect Huma 2.37's actual behaviour. Verified by removing the tag and dumping `cmd/dump-openapi`: the field comes out as a bare `\$ref` listed in `required`, with no `nullable` / `type: [..., null]` — identical to the documented embedded-`\$ref` panic shape, just without the panic. Server emits `null` for users with zero plays, so removing `omitempty` would still break the generated Kotlin client.
- No code change, comment-only.

Closes #967.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/api/ -run "Stats|Huma"` passes