### PR TITLE
feat(player): show achievement banner on primary game surface (#1087)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/AchievementPopupOnPrimaryTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/AchievementPopupOnPrimaryTest.kt
@@ -1,0 +1,146 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.AchievementEvent
+import com.spela.player.domain.model.AchievementEventType
+import com.spela.player.domain.model.RACredentials
+import com.spela.player.presentation.intent.EmulationIntent
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+
+/**
+ * Regression test for #1087: achievement unlocks must surface a top-anchored
+ * banner on the primary in-game surface (not just the secondary screen).
+ *
+ * The mount lives in `InGameOverlay` and reads `state.achievementEvent`;
+ * `EmulationViewModel.initAchievements` collects from the controller's
+ * `events` flow into that field after RA is linked. The harness exposes
+ * `achievementsRepo` and `achievementsCtrl` so each test can fake an
+ * "RA linked, unlock fires" path without touching the network.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class AchievementPopupOnPrimaryTest {
+
+    private fun createHarnessWithRALinked(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        // Default fake says "Not linked" — flipping to success enables
+        // the achievement event collector when the game launches.
+        harness.achievementsRepo.raTokenResult =
+            Result.success(RACredentials(username = "tester", token = "tok"))
+        harness.downloadRepo.preCacheGame("1")
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.GameDetail("1"))
+        )
+        return harness
+    }
+
+    private fun ComposeUiTest.startGame(harness: SpelaTestHarness) {
+        setContent { harness.App() }
+        advance(harness)
+
+        // Launch the game. The pause overlay is hidden by default
+        // immediately after launch, which matches the real flow:
+        // the user is staring at the game frame, and that's the
+        // surface we want the achievement banner to overlay.
+        onNodeWithTag("game_detail_play_button").performClick()
+        advance(harness)
+    }
+
+    @Test
+    fun achievementUnlockShowsBannerOnPrimarySurface() = runComposeUiTest {
+        val harness = createHarnessWithRALinked()
+        startGame(harness)
+
+        harness.achievementsCtrl.emitEvent(
+            AchievementEvent(
+                type = AchievementEventType.ACHIEVEMENT_TRIGGERED,
+                achievementId = 42L,
+                title = "Tutorial Complete",
+                description = "Beat the first level",
+                points = 10,
+            ),
+        )
+        // advanceQuick (2 mainClock seconds) is well under the popup's
+        // 4 s auto-dismiss timer, so the banner is still on screen.
+        advanceQuick(harness)
+
+        onNodeWithText("Achievement Unlocked!").assertIsDisplayed()
+        onNodeWithText("Tutorial Complete").assertIsDisplayed()
+        onNodeWithText("Beat the first level").assertIsDisplayed()
+        onNodeWithText("10").assertIsDisplayed()
+    }
+
+    @Test
+    fun gameCompletedEventShowsCompletionCopy() = runComposeUiTest {
+        val harness = createHarnessWithRALinked()
+        startGame(harness)
+
+        harness.achievementsCtrl.emitEvent(
+            AchievementEvent(
+                type = AchievementEventType.GAME_COMPLETED,
+                title = "Spela Quest",
+                description = "All achievements unlocked",
+            ),
+        )
+        advanceQuick(harness)
+
+        onNodeWithText("Game Completed!").assertIsDisplayed()
+        onNodeWithText("Spela Quest").assertIsDisplayed()
+    }
+
+    @Test
+    fun dismissIntentClearsBanner() = runComposeUiTest {
+        val harness = createHarnessWithRALinked()
+        startGame(harness)
+
+        harness.achievementsCtrl.emitEvent(
+            AchievementEvent(
+                type = AchievementEventType.ACHIEVEMENT_TRIGGERED,
+                title = "Speedrun",
+                description = "Finished in under 5 minutes",
+                points = 25,
+            ),
+        )
+        advanceQuick(harness)
+        onNodeWithText("Speedrun").assertIsDisplayed()
+
+        // Tap-equivalent dismiss path: same intent the auto-dismiss timer
+        // fires after 4 s. Asserting via the intent confirms the wiring
+        // (state → popup → onDismiss → VM clears event) without depending
+        // on mainClock advancement past the timer boundary, which would
+        // race the harness's bounded advance loop.
+        harness.emulationViewModel.onIntent(EmulationIntent.DismissAchievement)
+        advanceQuick(harness)
+
+        onNodeWithText("Speedrun").assertDoesNotExist()
+    }
+
+    @Test
+    fun tappingBannerDismissesIt() = runComposeUiTest {
+        val harness = createHarnessWithRALinked()
+        startGame(harness)
+
+        harness.achievementsCtrl.emitEvent(
+            AchievementEvent(
+                type = AchievementEventType.ACHIEVEMENT_TRIGGERED,
+                title = "Combo x10",
+                description = "Chained ten hits",
+                points = 5,
+            ),
+        )
+        advanceQuick(harness)
+        onNodeWithText("Combo x10").assertIsDisplayed()
+
+        // The banner's clickable wraps the inner Row with role=Button;
+        // semantics merging surfaces the descendant text on the click
+        // target, so clicking the title text invokes onDismiss.
+        onNodeWithText("Combo x10").performClick()
+        advanceQuick(harness)
+
+        onNodeWithText("Combo x10").assertDoesNotExist()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -168,6 +168,13 @@ class SpelaTestHarness(
     val keyMappingRepo = FakeKeyMappingRepository()
     val gamepadPortManager = GamepadPortManager(keyMappingRepo, scope)
 
+    // Achievement fakes are exposed so tests can drive the popup wiring:
+    // set `achievementsRepo.raTokenResult = Result.success(...)` to enable
+    // the VM's event collector at game launch, then call
+    // `achievementsCtrl.emitEvent(...)` to fire an unlock.
+    val achievementsRepo = FakeAchievementsRepository()
+    val achievementsCtrl = FakeAchievementsController()
+
     private val emulationState = MutableStateFlow(EmulationState())
 
     private val saveManager = SaveManager(
@@ -204,8 +211,8 @@ class SpelaTestHarness(
         prepareGameUseCase = PrepareGameUseCase(downloadRepo, coreRepo),
         getGameDetailUseCase = GetGameDetailUseCase(gameRepo),
         preferencesRepository = preferencesRepo,
-        achievementsRepository = FakeAchievementsRepository(),
-        achievementsController = FakeAchievementsController(),
+        achievementsRepository = achievementsRepo,
+        achievementsController = achievementsCtrl,
         libretroController = libretroController,
         secondaryDisplay = secondaryDisplay,
         presenceService = presenceService,

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.TestDispatcher
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.SpScreen
@@ -789,14 +788,32 @@ class FakePreferencesRepository : PreferencesRepository {
 }
 
 class FakeAchievementsRepository : AchievementsRepository {
-    override suspend fun getRAStatus(): Result<RAStatus> = Result.success(RAStatus())
-    override suspend fun linkRA(username: String, password: String): Result<RAStatus> = Result.success(RAStatus())
+    // Default: RA not linked (matches a fresh player install). Tests
+    // that need the achievement event collector active set this to
+    // Result.success(RACredentials(...)) before launching a game.
+    var raTokenResult: Result<RACredentials> = Result.failure(Exception("Not linked"))
+    var raStatus: RAStatus = RAStatus()
+
+    override suspend fun getRAStatus(): Result<RAStatus> = Result.success(raStatus)
+    override suspend fun linkRA(username: String, password: String): Result<RAStatus> = Result.success(raStatus)
     override suspend fun unlinkRA(): Result<Unit> = Result.success(Unit)
-    override suspend fun getRAToken(): Result<RACredentials> = Result.failure(Exception("Not linked"))
-    override suspend fun updateRASettings(hardcoreEnabled: Boolean): Result<RAStatus> = Result.success(RAStatus())
+    override suspend fun getRAToken(): Result<RACredentials> = raTokenResult
+    override suspend fun updateRASettings(hardcoreEnabled: Boolean): Result<RAStatus> = Result.success(raStatus)
 }
 
 class FakeAchievementsController : com.spela.player.domain.controller.AchievementsController {
+    // Replay = 0 so tests don't see stale events from a prior game; replayed
+    // events would re-fire the popup mid-test. extraBufferCapacity is enough
+    // for the longest plausible burst (game-completed + a couple of stacked
+    // unlocks in quick succession).
+    private val _events = MutableSharedFlow<AchievementEvent>(extraBufferCapacity = 16)
+    override val events: Flow<AchievementEvent> = _events.asSharedFlow()
+
+    /** Test hook: emit an achievement event onto the controller's flow. */
+    fun emitEvent(event: AchievementEvent) {
+        _events.tryEmit(event)
+    }
+
     override fun init() {}
     override fun deinit() {}
     override fun login(username: String, token: String) {}
@@ -804,7 +821,6 @@ class FakeAchievementsController : com.spela.player.domain.controller.Achievemen
     override fun doFrame() {}
     override val isHardcore: Boolean = false
     override fun setHardcore(enabled: Boolean) {}
-    override val events: Flow<AchievementEvent> = flow {}
     override fun httpComplete(requestId: Int, responseCode: Int, responseBody: ByteArray) {}
 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/AchievementPopup.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/AchievementPopup.kt
@@ -4,6 +4,8 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,9 +16,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
 import com.spela.player.domain.model.AchievementEvent
 import com.spela.player.domain.model.AchievementEventType
 import com.spela.player.presentation.ui.theme.SpColor
@@ -48,10 +52,21 @@ fun AchievementPopup(
                     .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Small),
                 contentAlignment = Alignment.TopCenter,
             ) {
+                // Tap-to-dismiss: explicit interaction source + null indication
+                // skips the ripple — the banner already animates out, a ripple
+                // on top would feel double-stamped. Role.Button keeps the node
+                // accessible to screen readers and gamepad navigation.
+                val interactionSource = remember { MutableInteractionSource() }
                 Row(
                     modifier = Modifier
                         .clip(RoundedCornerShape(SpSpacing.RadiusLarge))
                         .background(SpColor.PrimaryContainer)
+                        .clickable(
+                            interactionSource = interactionSource,
+                            indication = null,
+                            role = Role.Button,
+                            onClick = onDismiss,
+                        )
                         .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Medium),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -31,6 +31,7 @@ import com.spela.player.presentation.ui.feature.ingame.NetplayPauseOverlay
 import com.spela.player.presentation.ui.feature.ingame.NetplaySessionExpiredOverlay
 import com.spela.player.presentation.ui.feature.ingame.OverlayConfirmDialog
 import com.spela.player.presentation.ui.feature.ingame.OverlayToast
+import com.spela.player.presentation.ui.components.AchievementPopup
 import com.spela.player.presentation.intent.KeyMappingIntent
 import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.components.SpCountdownOverlay
@@ -54,6 +55,28 @@ fun InGameOverlay(
     val state by viewModel.state.collectAsState()
     val continueFocusRequester = remember { FocusRequester() }
     val hasGamepadConfig = gamepadConfigViewModel != null
+
+    // #1087: top-anchored achievement banner on the primary in-game
+    // surface. Reads `state.achievementEvent`, which the VM pumps from
+    // the RetroAchievements controller during initAchievements; before
+    // this mount, the popup primitive existed but was never wired up —
+    // only the secondary-screen celebration fired, and the user is
+    // usually looking at the primary surface during gameplay. Auto-
+    // dismiss + slide animation belong to AchievementPopup itself.
+    //
+    // Rendered first so every later overlay (pause menu, dialogs,
+    // sheets) renders on top of the banner — i.e. opening the pause
+    // menu while a banner is on screen hides the banner until the
+    // menu closes (or until the 4 s timer expires).
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        AchievementPopup(
+            event = state.achievementEvent,
+            onDismiss = { viewModel.onIntent(EmulationIntent.DismissAchievement) },
+        )
+    }
 
     AnimatedVisibility(
         visible = state.showOverlay,


### PR DESCRIPTION
## Summary

- Mount `AchievementPopup` on the primary in-game surface so RetroAchievements unlocks, game-completion, and leaderboard events surface a top-anchored banner on the screen the user is actually watching during gameplay. Before this PR the popup primitive existed but was never wired up — only the secondary-screen celebration fired, which most users don't see while playing.
- Add tap-to-dismiss to `AchievementPopup` (`role = Button`, no ripple — the slide-out animation already gives feedback). Auto-dismiss after 4 s was already in place.
- Z-order: banner is rendered first inside `InGameOverlay`, so the pause menu, sheets, and dialogs render on top of it (matches the spec in the issue: "above the game frame, below modal overlays").
- Test fakes (`FakeAchievementsRepository`, `FakeAchievementsController`) gain a configurable RA token + an `emitEvent` hook, exposed on `SpelaTestHarness` as `achievementsRepo` / `achievementsCtrl`. Tests now drive a realistic "RA linked → unlock fires" path without touching the network.

Closes #1087.

## Test plan

- [x] `./gradlew :desktop:desktopTest --tests AchievementPopupOnPrimaryTest` passes (4/4: unlock banner, game-completed copy, intent-driven dismiss, tap-to-dismiss)
- [x] `./gradlew :desktop:desktopTest --tests InGameOverlayTest` still green (7/7) — z-order change didn't regress the existing overlay tests
- [x] `./gradlew :shared:desktopTest` green (628 tests)
- [ ] CI desktop suite green
- [ ] Manual: launch a RA-linked game on desktop, trigger an achievement, verify banner appears top-center, auto-dismisses after ~4 s, and tap-to-dismiss works mid-animation

## What's intentionally out of scope

- Multi-event queue on the primary surface — sequential unlocks within 4 s queue serially (second event waits for first to clear). The issue's AC accepts this v1.
- Audio / haptic feedback — the RetroAchievements core plays its own chime; a Spela-branded sound is a separate feature.
- Web app — different code path; if RA is surfaced in EmulatorJS at all, that's a separate audit.