### PR TITLE
fix(web): cap PageLayout content + 5-col consoles grid on wide viewports (#1071)

### DIFF
--- a/web/src/components/layout/page-layout.tsx
+++ b/web/src/components/layout/page-layout.tsx
@@ -66,7 +66,16 @@ export function PageLayout({
           )}
         </div>
       )}
-      <div className="p-6">
+      {/*
+       * #1071: cap the padded content area at the 2xl breakpoint
+       * (1536 px) and centre it. On laptop / standard desktop
+       * (≤1536 px) this is a no-op — content fills the viewport as
+       * before. On ultrawide / 4K it stops cards from ballooning
+       * into 800-px-wide near-empty rectangles. The hero / header
+       * surface above stays full-width on purpose so banners flush
+       * to the edges.
+       */}
+      <div className="p-6 mx-auto w-full max-w-screen-2xl">
         {backButtonVariant === "standard" && (
           <div className="mb-6">
             <BackButton onClick={handleBack} data-testid="page-back-button">{backLabel}</BackButton>

--- a/web/src/pages/consoles-page.tsx
+++ b/web/src/pages/consoles-page.tsx
@@ -82,7 +82,7 @@ export function ConsolesPage() {
     <PageLayout title="Consoles" subtitle="Browse your game library by platform.">
       <SectionList>
       {isLoading ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-5">
           {Array.from({ length: 8 }, (_, i) => (
             <ConsoleCardSkeleton key={i} />
           ))}
@@ -107,7 +107,7 @@ export function ConsolesPage() {
                   </span>
                 )}
               </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-5">
                 {group.consoles.map((c) => (
                   <ConsoleCard
                     key={c.id}


### PR DESCRIPTION
## Summary

Fixes the consoles page on 4K and ultrawide browsers where cards stretched into billboard-sized rectangles past the `xl` breakpoint. Two-part fix:

1. **PageLayout content cap (systemic)** — `web/src/components/layout/page-layout.tsx` wraps the padded content area with `max-w-screen-2xl mx-auto w-full`. Below 1536 px this is a no-op (content fills the viewport as before). At 1536+ px the content is centred and capped. `renderHeader` stays full-width on purpose so hero banners flush to the viewport edges. **All 47 pages using PageLayout get the cap for free.**
2. **Consoles grid density** — `web/src/pages/consoles-page.tsx` adds `2xl:grid-cols-5` to both the loading-skeleton grid and the per-generation grid. At ≥ 1536 px the cap forces 1536 px content width; five columns at `gap-5` gives ~282 px cards — the design's intended visual weight.

This matches the synthesis path the issue's UX/PO discussion converged on: page-level cap as the foundation + one density bump.

Closes #1071.

## Behaviour at the spec's regression viewports

Verified locally with `playwright-cli` against `docker-compose.e2e.yml`:

| Viewport | Layout width | Grid cols | Card width |
|---:|---:|:---:|---:|
| 1280 | 1024 (sidebar takes 256) | 4 | 229 px |
| 1440 | 1184 | 4 | 269 px |
| 1920 | 1536 (capped) | 5 | 282 px |
| 2560 | 1536 (capped) | 5 | 282 px |
| 3440 | 1536 (capped, centred with 824 px gutters) | 5 | 282 px |

No horizontal scrollbar at any viewport from 320 → 3840. Existing `sm` / `lg` / `xl` behaviour visually unchanged below the cap.

## Audit pass

The recurring `grid-cols-1 sm:2 lg:3 xl:4` pattern only appears on `consoles-page.tsx` (the issue's primary site). Other dense grid patterns:

- **`grid-cols-2 sm:3 md:4 lg:5 xl:6`** (game-grid, cover-gallery, collection-detail, shared-sessions, collections, developer-detail, publisher-detail) — already at `xl:6`. With the new content cap, cards land at ~256 px on 4K — fine, no further breakpoint bump needed.
- **`explore-wizard-page.tsx`** uses `grid-cols-1 sm:2 lg:3` (no `xl`) — option cards are intentionally text-heavy and wider, the page-level cap alone is sufficient. Left unchanged.

So only the consoles grid needed the explicit `2xl:` bump; everything else inherits the page-level cap.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` green (1600 unit tests)
- [x] Playwright at 1280 / 1440 / 1920 / 2560 / 3440 — column counts and content widths confirmed via DOM eval (table above)
- [x] Spot-check Dashboard at 3440 — content properly capped with side gutters
- [ ] CI green

## What's intentionally out of scope

- Player app — sibling issue at #1082, separate PR (different code path).
- Card content sizing (icon, typography) — `h-16 w-16` icon + `text-lg` title is the design's tile-recognition size; the issue's UX agent specifically called out not scaling content.
- A formal app-wide grid policy / design-system content-width primitive — file as follow-up if the audit reveals more recurrence.