### PR TITLE
fix(player): cap console card width + denser grid breakpoints (#1082)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/LibraryConsolesTabWidthCapTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/LibraryConsolesTabWidthCapTest.kt
@@ -1,0 +1,93 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.*
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.Console
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.ui.TestTags
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * #1082 regression test: console cards must never stretch past 340 dp wide
+ * regardless of viewport size, so the design's intended ~1.9:1 aspect
+ * ratio holds on AYN Thor landscape and any windowed desktop wider than
+ * ~1100 dp. Pre-fix the grid stayed at 3 columns past 700 dp and each
+ * card grew unbounded with the viewport (≥ 600 dp at 1920 dp containers).
+ *
+ * The breakpoint logic itself is unit-tested in
+ * `ConsoleColumnsForWidthTest`; this test is the UI-level cap assertion.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class LibraryConsolesTabWidthCapTest {
+
+    private fun createHarnessWithConsoles(count: Int): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.authRepo.preSetTokens()
+        harness.gameRepo.consoles = (1..count).map { i ->
+            Console(
+                id = "console$i",
+                name = "Console $i",
+                abbreviation = "C$i",
+                gameCount = i,
+                colorTheme = "#333333",
+            )
+        }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Consoles))
+        return harness
+    }
+
+    @Test
+    fun cardWidthCappedAtWideViewport() = runComposeUiTest {
+        // 12 consoles spans multiple rows at any column count from 1 to 5,
+        // so the assertion catches a cap regression in any branch of the
+        // breakpoint `when`.
+        val harness = createHarnessWithConsoles(12)
+
+        // Force a wide viewport so the test actually exercises the
+        // ≥1500 dp branch where the per-card widthIn cap is the only
+        // thing stopping cards from stretching past 340 dp. Without an
+        // explicit width the test ran at whatever the default Compose
+        // desktop test window happens to be (often narrow enough that
+        // cards naturally fit under the cap), which would let a cap
+        // regression slip through.
+        setContent {
+            Box(
+                modifier = Modifier
+                    .width(2400.dp)
+                    .height(1080.dp),
+            ) {
+                harness.App()
+            }
+        }
+        advance(harness)
+
+        // Every console card on screen must respect the 340 dp width cap.
+        // Asserting on each card individually (vs. just the first) so a
+        // partial-row regression in the existing weight(1f) Spacer logic
+        // is also caught.
+        //
+        // SemanticsNode.size is pixels; the density() helper on
+        // ComposeUiTest converts the dp ceiling into the equivalent pixel
+        // budget for comparison. Tolerance of 1 px absorbs sub-pixel
+        // rounding in Compose's measurement pipeline.
+        val maxWidthPx = with(density) { 340.dp.toPx() }
+        repeat(12) { i ->
+            val node = onNodeWithTag(TestTags.consoleCard("console${i + 1}"))
+                .fetchSemanticsNode()
+            val widthPx = node.size.width.toFloat()
+            assertTrue(
+                widthPx <= maxWidthPx + 1f,
+                "console${i + 1} width was ${widthPx} px, expected ≤ ${maxWidthPx} px (340 dp)",
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -84,6 +84,32 @@ private val HeroTextPrimary    = Color.White.copy(alpha = 0.90f)
 private val HeroTextSecondary  = Color.White.copy(alpha = 0.70f)
 private val HeroBadgeBackground = Color.White.copy(alpha = 0.10f)
 
+// #1082: Per-card width cap. With the fixed 120 dp card height, anything
+// past ~340 dp degrades the design's intended 1.9:1 aspect ratio into a
+// thin strip. Keeps the card content (140 dp watermark icon, 0.65-width
+// logo, bottom-left metadata) coherent on all viewports — same visual
+// weight at 1920 dp and at 700 dp tablets, just more cards per row.
+internal val ConsoleCardMaxWidth = 340.dp
+
+/**
+ * #1082: Column count for the consoles grid given the available container
+ * width. Extracted so the breakpoint logic is unit-testable without
+ * spinning up Compose UI.
+ *
+ * Pairs with [ConsoleCardMaxWidth] — the breakpoints aim to keep density
+ * up at standard desktop widths (1100+ → 4 cols, 1500+ → 5 cols), and
+ * the per-card width cap then stops cards from stretching past the
+ * design's intended ~340 dp width when the row's available width
+ * exceeds `cols × 340 dp`.
+ */
+internal fun consoleColumnsForWidth(width: androidx.compose.ui.unit.Dp): Int = when {
+    width >= 1500.dp -> 5
+    width >= 1100.dp -> 4
+    width >= 700.dp  -> 3
+    width >= 400.dp  -> 2
+    else             -> 1
+}
+
 private fun generationLabel(generation: Int): String = when (generation) {
     2 -> "2nd Generation · 1976–1992"
     3 -> "3rd Generation · 1983–1992"
@@ -131,11 +157,23 @@ internal fun ConsolesGrid(
                     horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
                 ) {
                     rowConsoles.forEach { console ->
+                        // #1082: weight allocates equal share, then widthIn
+                        // clamps the result so cards never stretch past their
+                        // intended visual weight on wide windows. Beyond the
+                        // cap, leftover row width distributes via the existing
+                        // weight(1f) Spacer logic below for partial last rows.
                         val cardModifier = if (isFirstCard) {
                             isFirstCard = false
-                            Modifier.weight(1f).autoFocus().rememberFocus(console.id)
+                            Modifier
+                                .weight(1f)
+                                .widthIn(max = ConsoleCardMaxWidth)
+                                .autoFocus()
+                                .rememberFocus(console.id)
                         } else {
-                            Modifier.weight(1f).rememberFocus(console.id)
+                            Modifier
+                                .weight(1f)
+                                .widthIn(max = ConsoleCardMaxWidth)
+                                .rememberFocus(console.id)
                         }
                         ConsoleCard(
                             console = console,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/LibraryConsolesTab.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/LibraryConsolesTab.kt
@@ -72,16 +72,11 @@ internal fun LibraryConsolesTab(
                         SpScreenTopSpacer()
                         SpMainContentPadding {
                             BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-                                val columnsPerRow = when {
-                                    maxWidth >= 700.dp -> 3
-                                    maxWidth >= 400.dp -> 2
-                                    else -> 1
-                                }
                                 ConsolesGrid(
                                     consoles = state.consoles,
                                     onConsoleSelected = onConsoleSelected,
                                     consolesWithMissingBios = state.consolesWithMissingBios,
-                                    columnsPerRow = columnsPerRow,
+                                    columnsPerRow = consoleColumnsForWidth(maxWidth),
                                 )
                             }
                         }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleColumnsForWidthTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleColumnsForWidthTest.kt
@@ -1,0 +1,51 @@
+package com.spela.player.presentation.ui.feature.library
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * #1082 regression test: column-count breakpoints for the consoles grid.
+ * Pure unit test — no Compose UI runtime required.
+ */
+class ConsoleColumnsForWidthTest {
+
+    @Test
+    fun phonePortrait_oneColumn() {
+        assertEquals(1, consoleColumnsForWidth(320.dp))
+        assertEquals(1, consoleColumnsForWidth(399.dp))
+    }
+
+    @Test
+    fun phoneLandscape_twoColumns() {
+        assertEquals(2, consoleColumnsForWidth(400.dp))
+        assertEquals(2, consoleColumnsForWidth(699.dp))
+    }
+
+    @Test
+    fun smallTablet_threeColumns() {
+        assertEquals(3, consoleColumnsForWidth(700.dp))
+        assertEquals(3, consoleColumnsForWidth(1099.dp))
+    }
+
+    @Test
+    fun laptopWindowed_fourColumns() {
+        // The breakpoint that fixes the issue's headline symptom:
+        // before #1082 a 1280 dp window stayed at 3 columns and
+        // each card ballooned to ~415 dp wide.
+        assertEquals(4, consoleColumnsForWidth(1100.dp))
+        assertEquals(4, consoleColumnsForWidth(1280.dp))
+        assertEquals(4, consoleColumnsForWidth(1499.dp))
+    }
+
+    @Test
+    fun aynThorLandscapeAndUltrawide_fiveColumns() {
+        // AYN Thor in landscape (~1920 dp) lands here. Beyond 1500 dp
+        // we cap at 5 columns; the per-card widthIn(max = 340 dp)
+        // handles the leftover width by clamping each card.
+        assertEquals(5, consoleColumnsForWidth(1500.dp))
+        assertEquals(5, consoleColumnsForWidth(1920.dp))
+        assertEquals(5, consoleColumnsForWidth(3440.dp))
+        assertEquals(5, consoleColumnsForWidth(3840.dp))
+    }
+}


### PR DESCRIPTION
## Summary

`LibraryConsolesTab` stayed at 3 columns past 700 dp, so each console card stretched into a thin strip on AYN Thor landscape (1920 dp → ~625 dp / 5.2:1 aspect) and any windowed desktop wider than ~1100 dp. Card height is fixed at 120 dp, so the 140 dp watermark icon ended up taller than the card itself and the centred logo got stretched horizontally.

Two-part fix, mirroring the synthesis from #1071:

1. **Extra breakpoints**: 4 cols at ≥ 1100 dp, 5 cols at ≥ 1500 dp. Stops AYN Thor from sitting in the 3-col branch; gives a windowed 1280 dp desktop the density today's 700 dp tablet already has. Extracted to a pure `consoleColumnsForWidth(Dp): Int` so the breakpoint logic is unit-testable without Compose UI.
2. **Per-card `widthIn(max = 340.dp)`** (named `ConsoleCardMaxWidth`). Safety net for both partial last rows and the wide-viewport case where `row width > cols × 340 dp`. Weight allocates the natural share, then `widthIn` clamps. The existing `Spacer(Modifier.weight(1f))` placeholder logic for partial rows keeps working unchanged.

Card height stays 120 dp at all widths — the design's intended visual weight. The 64 dp icon, 0.65-width logo, and bottom-left metadata were calibrated against that constant.

Closes #1082.

## Behaviour at the spec's regression viewports

| Viewport | Cols | Card width before | Card width after |
|---:|:---:|---:|---:|
| 700 dp (small tablet) | 3 → 3 | ~225 dp | ~225 dp (unchanged) |
| 1280 dp (laptop windowed) | 3 → 4 | ~415 dp | ~315 dp |
| 1920 dp (AYN Thor landscape) | 3 → 5 | ~625 dp | 340 dp (capped) |
| 3440 dp (ultrawide) | 3 → 5 | ~1130 dp | 340 dp (capped) |

Phones / small tablets keep their existing 1- or 2-col branches.

## Tests

- **`ConsoleColumnsForWidthTest`** (`shared/desktopTest`) — 5 pure unit tests covering every breakpoint boundary, including the headline-bug AYN Thor 1920 dp + the post-fix laptop 1280 dp.
- **`LibraryConsolesTabWidthCapTest`** (`desktop/desktopTest`) — Compose UI test that renders the full app inside a 2400 dp wide Box (forces the ≥1500 dp branch where the cap is the only thing keeping cards under 340 dp) and asserts every visible card respects `ConsoleCardMaxWidth`.

## Test plan

- [x] `./gradlew :shared:desktopTest --tests ConsoleColumnsForWidthTest` passes (5/5)
- [x] `./gradlew :desktop:desktopTest --tests LibraryConsolesTabWidthCapTest` passes (1/1)
- [x] `./gradlew :desktop:desktopTest --tests ScrollPositionTest` still green (2/2) — refactored breakpoint extraction didn't break the existing nav test
- [x] `./gradlew :desktop:desktopTest --tests ConsoleScreenImprovementsTest` still green (23/23) — sibling console-screen tests not regressed
- [ ] CI green
- [ ] Manual: desktop player app windowed wide; Library → Consoles tab shows cards at sensible widths, no thin strips

## What's intentionally out of scope

- Replacing `ConsolesGrid`'s manual `chunked()` row layout with `LazyVerticalGrid` + adaptive columns — bigger refactor, file as follow-up if more grids hit the same issue.
- Systemic content-width cap on `SpScreen` / `SpMainContentPadding` parallel to web's PageLayout cap from #1071 — file as follow-up if more screens need it.
- Audit pass on other player-app grids (game grids, cover gallery, etc.) — separate audit.

## Related

- #1071 — same bug shape in the web app, landed in #1090. This PR mirrors that synthesis adapted to Compose's fixed-height + width-cap pattern.