### PR TITLE
fix(native): mutex-guard audio_state, video_state, input_state (#1044)

### DIFF
--- a/player/native/src/libretro_audio.c
+++ b/player/native/src/libretro_audio.c
@@ -6,6 +6,17 @@
  *
  * Includes a native SINC resampler for high-quality sample rate conversion
  * (e.g. 32029 Hz → 48000 Hz) with NEON SIMD on ARM64.
+ *
+ * Threading (#1044):
+ *   Writer = emulation thread (libretro core → audio_sample[_batch]_callback).
+ *   Reader = Kotlin audio coroutine (JNI → audio_lock → audio_get_buffer +
+ *            copy + audio_clear_buffer → audio_unlock).
+ *   Without sync the reader saw torn `write_pos` reads (visibility) and
+ *   missed-increment races (writer added samples between get_buffer and
+ *   clear_buffer, those samples got dropped). The mutex protects every
+ *   read/write of `audio_state` from both sides; the JNI bridge holds it
+ *   across the get-frames + memcpy + clear triple so a writer interleaving
+ *   in the middle is impossible.
  */
 
 #include "libretro_bridge.h"
@@ -34,6 +45,10 @@ static struct {
     sinc_resampler_t *resampler;
     int16_t  resampled_buffer[RESAMPLED_BUFFER_MAX_FRAMES * 2]; /* stereo */
     size_t   resampled_frames;
+
+    /* #1044: cross-thread state guard. See file-level comment. */
+    sp_mutex_t lock;
+    bool       lock_initialized;
 } audio_state = {0};
 
 void audio_init(double sample_rate) {
@@ -42,7 +57,26 @@ void audio_init(double sample_rate) {
         sinc_resampler_destroy(audio_state.resampler);
     }
 
+    /* Preserve the lock across re-init: callers may re-init between games
+     * without a deinit, and zeroing the mutex would corrupt it. The lock
+     * is created lazily on the first audio_init() call. */
+    bool had_lock = audio_state.lock_initialized;
+    sp_mutex_t saved_lock;
+    if (had_lock) {
+        saved_lock = audio_state.lock;
+    }
+
     memset(&audio_state, 0, sizeof(audio_state));
+
+    if (had_lock) {
+        audio_state.lock = saved_lock;
+        audio_state.lock_initialized = true;
+    } else {
+        if (sp_mutex_init(&audio_state.lock) == 0) {
+            audio_state.lock_initialized = true;
+        }
+    }
+
     audio_state.sample_rate = sample_rate;
     audio_state.initialized = true;
 
@@ -56,6 +90,9 @@ void audio_init(double sample_rate) {
 }
 
 void audio_deinit(void) {
+    if (audio_state.lock_initialized) {
+        sp_mutex_lock(&audio_state.lock);
+    }
     if (audio_state.resampler) {
         sinc_resampler_destroy(audio_state.resampler);
         audio_state.resampler = NULL;
@@ -63,83 +100,144 @@ void audio_deinit(void) {
     audio_state.initialized = false;
     audio_state.write_pos = 0;
     audio_state.resampled_frames = 0;
+    if (audio_state.lock_initialized) {
+        sp_mutex_unlock(&audio_state.lock);
+        sp_mutex_destroy(&audio_state.lock);
+        audio_state.lock_initialized = false;
+    }
+}
+
+/* #1044: lock primitives exposed for the JNI bridge so it can hold the
+ * audio mutex across the read-frames + copy + clear-buffer triple, which
+ * would otherwise race with the emulation thread's `audio_sample_callback`.
+ *
+ * Public callers MUST pair these (lock → … → unlock) and MUST NOT call any
+ * audio_*() function that takes the lock itself while holding it (no
+ * recursion: pthread_mutex defaults to non-recursive on Linux/macOS). The
+ * `_unlocked` variants are provided for use inside a held lock. */
+void audio_lock(void) {
+    if (audio_state.lock_initialized) {
+        sp_mutex_lock(&audio_state.lock);
+    }
+}
+
+void audio_unlock(void) {
+    if (audio_state.lock_initialized) {
+        sp_mutex_unlock(&audio_state.lock);
+    }
 }
 
 /* Called by core for single stereo sample */
 void audio_sample_callback(int16_t left, int16_t right) {
-    if (!audio_state.initialized) return;
-    if (audio_state.write_pos >= AUDIO_BUFFER_MAX_FRAMES) return;
-
-    size_t idx = audio_state.write_pos * 2;
-    audio_state.buffer[idx]     = left;
-    audio_state.buffer[idx + 1] = right;
-    audio_state.write_pos++;
+    audio_lock();
+    if (audio_state.initialized && audio_state.write_pos < AUDIO_BUFFER_MAX_FRAMES) {
+        size_t idx = audio_state.write_pos * 2;
+        audio_state.buffer[idx]     = left;
+        audio_state.buffer[idx + 1] = right;
+        audio_state.write_pos++;
+    }
+    audio_unlock();
 }
 
 /* Called by core for batch of stereo samples */
 size_t audio_sample_batch_callback(const int16_t *data, size_t frames) {
-    if (!audio_state.initialized || !data) return 0;
+    if (!data) return 0;
+    audio_lock();
+    size_t to_write = 0;
+    if (audio_state.initialized) {
+        size_t available = AUDIO_BUFFER_MAX_FRAMES - audio_state.write_pos;
+        to_write = frames < available ? frames : available;
 
-    size_t available = AUDIO_BUFFER_MAX_FRAMES - audio_state.write_pos;
-    size_t to_write = frames < available ? frames : available;
-
-    if (to_write > 0) {
-        memcpy(
-            &audio_state.buffer[audio_state.write_pos * 2],
-            data,
-            to_write * 2 * sizeof(int16_t)
-        );
-        audio_state.write_pos += to_write;
+        if (to_write > 0) {
+            memcpy(
+                &audio_state.buffer[audio_state.write_pos * 2],
+                data,
+                to_write * 2 * sizeof(int16_t)
+            );
+            audio_state.write_pos += to_write;
+        }
     }
-
+    audio_unlock();
     return to_write;
 }
 
+/* Buffer accessors. The lock-free variants assume the caller already
+ * holds audio_lock — see the file-level comment on the read+copy+clear
+ * pairing the JNI bridge needs. Existing public symbols are kept as
+ * thin self-locking wrappers for callers that don't need the triple. */
 const int16_t *audio_get_buffer(void) {
+    /* Pointer is stable for the lifetime of audio_state — buffer is
+     * an embedded array, never realloc'd. Safe to return without
+     * locking; the caller is expected to hold audio_lock before reading
+     * from the buffer through the returned pointer. */
     return audio_state.buffer;
 }
 
 size_t audio_get_buffer_frames(void) {
-    return audio_state.write_pos;
+    audio_lock();
+    size_t frames = audio_state.write_pos;
+    audio_unlock();
+    return frames;
 }
 
 void audio_clear_buffer(void) {
+    audio_lock();
+    audio_state.write_pos = 0;
+    audio_unlock();
+}
+
+/* Caller-locked variants for use when the lock is already held (e.g. the
+ * JNI bridge taking the lock once around the get-frames + memcpy + clear
+ * triple). Naming mirrors the gpu_renderer pattern of `_unlocked` helpers. */
+size_t audio_get_buffer_frames_unlocked(void) {
+    return audio_state.write_pos;
+}
+
+void audio_clear_buffer_unlocked(void) {
     audio_state.write_pos = 0;
 }
 
 /* --- SINC resampler integration --- */
 
 size_t audio_resample(double ratio) {
-    if (!audio_state.resampler || audio_state.write_pos == 0) {
+    audio_lock();
+    size_t out_frames = 0;
+    if (audio_state.resampler && audio_state.write_pos > 0) {
+        out_frames = sinc_resampler_process(
+            audio_state.resampler,
+            audio_state.buffer,
+            audio_state.write_pos,
+            audio_state.resampled_buffer,
+            RESAMPLED_BUFFER_MAX_FRAMES,
+            ratio
+        );
+        audio_state.resampled_frames = out_frames;
+        audio_state.write_pos = 0; /* consumed */
+    } else {
         audio_state.resampled_frames = 0;
-        return 0;
     }
-
-    size_t out_frames = sinc_resampler_process(
-        audio_state.resampler,
-        audio_state.buffer,
-        audio_state.write_pos,
-        audio_state.resampled_buffer,
-        RESAMPLED_BUFFER_MAX_FRAMES,
-        ratio
-    );
-
-    audio_state.resampled_frames = out_frames;
-    audio_state.write_pos = 0; /* consumed */
+    audio_unlock();
     return out_frames;
 }
 
 const int16_t *audio_get_resampled_buffer(void) {
+    /* Like audio_get_buffer: the buffer is an embedded array, never
+     * relocated. Caller must hold audio_lock to read its contents. */
     return audio_state.resampled_buffer;
 }
 
 size_t audio_get_resampled_frames(void) {
-    return audio_state.resampled_frames;
+    audio_lock();
+    size_t frames = audio_state.resampled_frames;
+    audio_unlock();
+    return frames;
 }
 
 void audio_resampler_reset(void) {
+    audio_lock();
     if (audio_state.resampler) {
         sinc_resampler_reset(audio_state.resampler);
     }
     audio_state.resampled_frames = 0;
+    audio_unlock();
 }

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -1456,25 +1456,54 @@ JNI_FUNC(jboolean, nativeUnserialize)(JNIEnv *env, jobject thiz, jbyteArray data
 }
 
 JNI_FUNC(jbyteArray, nativeGetVideoFrame)(JNIEnv *env, jobject thiz) {
-    const void *buffer = video_get_frame_buffer();
-    size_t size = video_get_frame_buffer_size();
-    if (!buffer || size == 0) return NULL;
+    /* #1044: hold video_lock for the read-pointer + size + memcpy
+     * triple so the emulation thread's video_refresh_callback (which
+     * may realloc frame_buffer on dimension change) cannot interleave
+     * and leave the JNI side reading a freed pointer.
+     *
+     * NewByteArray is called BEFORE acquiring the lock — JNI primitive
+     * allocation can block on the GC, and blocking the GC while the
+     * emulation thread is parked on video_lock would deadlock if the
+     * GC needs to enter native frames the emulation thread holds. */
+    video_lock();
+    size_t size = video_get_frame_buffer_size_unlocked();
+    if (size == 0) {
+        video_unlock();
+        return NULL;
+    }
+    video_unlock();
 
     jbyteArray result = (*env)->NewByteArray(env, (jsize)size);
-    if (result) {
-        (*env)->SetByteArrayRegion(env, result, 0, (jsize)size, (const jbyte *)buffer);
+    if (!result) return NULL;
+
+    video_lock();
+    /* Re-check under the lock: the writer may have shrunk the buffer
+     * between our pre-alloc size sample and the lock acquisition. */
+    size_t cur_size = video_get_frame_buffer_size_unlocked();
+    const void *buffer = video_get_frame_buffer();
+    if (buffer && cur_size > 0) {
+        jsize copyLen = (jsize)cur_size < (jsize)size ? (jsize)cur_size : (jsize)size;
+        (*env)->SetByteArrayRegion(env, result, 0, copyLen, (const jbyte *)buffer);
     }
+    video_unlock();
     return result;
 }
 
 JNI_FUNC(jint, nativeFillVideoFrame)(JNIEnv *env, jobject thiz, jbyteArray out) {
-    const void *buffer = video_get_frame_buffer();
-    size_t size = video_get_frame_buffer_size();
-    if (!buffer || size == 0) return 0;
-
     jsize arrayLen = (*env)->GetArrayLength(env, out);
+    if (arrayLen <= 0) return 0;
+
+    /* #1044: see nativeGetVideoFrame for the lock rationale. */
+    video_lock();
+    const void *buffer = video_get_frame_buffer();
+    size_t size = video_get_frame_buffer_size_unlocked();
+    if (!buffer || size == 0) {
+        video_unlock();
+        return 0;
+    }
     jsize copyLen = (jsize)size < arrayLen ? (jsize)size : arrayLen;
     (*env)->SetByteArrayRegion(env, out, 0, copyLen, (const jbyte *)buffer);
+    video_unlock();
     return (jint)copyLen;
 }
 
@@ -1491,41 +1520,80 @@ JNI_FUNC(jint, nativeGetPixelFormat)(JNIEnv *env, jobject thiz) {
 }
 
 JNI_FUNC(jshortArray, nativeGetAudioBuffer)(JNIEnv *env, jobject thiz) {
-    const int16_t *buffer = audio_get_buffer();
-    size_t frames = audio_get_buffer_frames();
-    if (!buffer || frames == 0) return NULL;
+    /* #1044: hold audio_lock across the get_frames + memcpy + clear
+     * triple so the emulation thread's audio_sample[_batch]_callback
+     * cannot interleave and have its samples either overwritten by the
+     * clear (missed-increment race) or read partially (torn write_pos).
+     *
+     * NewShortArray is allocated OUTSIDE the lock to avoid blocking
+     * the GC while the emulation thread is parked on audio_lock. We
+     * sample the frame count with the lock, drop the lock for the
+     * allocation, then reacquire and re-sample under the lock. */
+    audio_lock();
+    size_t frames = audio_get_buffer_frames_unlocked();
+    audio_unlock();
+    if (frames == 0) return NULL;
 
     size_t samples = frames * 2; /* stereo */
     jshortArray result = (*env)->NewShortArray(env, (jsize)samples);
-    if (result) {
-        (*env)->SetShortArrayRegion(env, result, 0, (jsize)samples, buffer);
+    if (!result) return NULL;
+
+    audio_lock();
+    /* Re-sample under the lock: the writer may have added more frames
+     * between our first read and now. Copy at least the original count
+     * (the array we allocated). */
+    const int16_t *buffer = audio_get_buffer();
+    size_t cur_frames = audio_get_buffer_frames_unlocked();
+    size_t to_copy = cur_frames < frames ? cur_frames : frames;
+    if (buffer && to_copy > 0) {
+        (*env)->SetShortArrayRegion(env, result, 0, (jsize)(to_copy * 2), buffer);
     }
-    audio_clear_buffer();
+    audio_clear_buffer_unlocked();
+    audio_unlock();
     return result;
 }
 
 JNI_FUNC(jint, nativeFillAudioBuffer)(JNIEnv *env, jobject thiz, jshortArray out) {
-    const int16_t *buffer = audio_get_buffer();
-    size_t frames = audio_get_buffer_frames();
-    if (!buffer || frames == 0) return 0;
-
-    size_t samples = frames * 2; /* stereo */
     jsize arrayLen = (*env)->GetArrayLength(env, out);
+    if (arrayLen <= 0) return 0;
+
+    /* #1044: see nativeGetAudioBuffer for the lock rationale. */
+    audio_lock();
+    const int16_t *buffer = audio_get_buffer();
+    size_t frames = audio_get_buffer_frames_unlocked();
+    if (!buffer || frames == 0) {
+        audio_unlock();
+        return 0;
+    }
+    size_t samples = frames * 2; /* stereo */
     jsize copyLen = (jsize)samples < arrayLen ? (jsize)samples : arrayLen;
     (*env)->SetShortArrayRegion(env, out, 0, copyLen, buffer);
-    audio_clear_buffer();
+    audio_clear_buffer_unlocked();
+    audio_unlock();
     return (jint)copyLen;
 }
 
 JNI_FUNC(jint, nativeResampleAudio)(JNIEnv *env, jobject thiz,
                                      jshortArray out, jdouble ratio) {
+    /* audio_resample takes audio_lock internally and consumes write_pos
+     * + populates resampled_buffer atomically. We then need a second
+     * acquisition to read out the resampled data. The window between
+     * the two acquisitions is safe because the emulation thread can
+     * only ADD to a fresh buffer (write_pos was reset to 0); it cannot
+     * touch resampled_buffer. */
     size_t frames = audio_resample(ratio);
     if (frames == 0) return 0;
-    const int16_t *buf = audio_get_resampled_buffer();
+
     jsize samples = (jsize)(frames * 2);
     jsize arrayLen = (*env)->GetArrayLength(env, out);
     jsize copyLen = samples < arrayLen ? samples : arrayLen;
-    (*env)->SetShortArrayRegion(env, out, 0, copyLen, buf);
+
+    audio_lock();
+    const int16_t *buf = audio_get_resampled_buffer();
+    if (buf && copyLen > 0) {
+        (*env)->SetShortArrayRegion(env, out, 0, copyLen, buf);
+    }
+    audio_unlock();
     return (jint)copyLen;
 }
 

--- a/player/native/src/libretro_bridge.h
+++ b/player/native/src/libretro_bridge.h
@@ -33,6 +33,16 @@ size_t video_get_frame_buffer_size(void);
 unsigned video_get_pixel_format(void);
 void video_set_gpu_renderer(gpu_renderer_t *renderer);
 gpu_renderer_t *video_get_gpu_renderer(void);
+/* #1044: cross-thread state guard. JNI bridge holds these around the
+ * get_frame_buffer + size + memcpy triple in nativeGetVideoFrame /
+ * nativeFillVideoFrame. The `_unlocked` accessors are for use inside
+ * an already-held lock — see libretro_video.c file comment. */
+void video_lock(void);
+void video_unlock(void);
+unsigned video_get_width_unlocked(void);
+unsigned video_get_height_unlocked(void);
+size_t video_get_frame_buffer_size_unlocked(void);
+unsigned video_get_pixel_format_unlocked(void);
 
 /* Audio subsystem (libretro_audio.c) */
 void audio_init(double sample_rate);
@@ -46,6 +56,14 @@ size_t audio_resample(double ratio);
 const int16_t *audio_get_resampled_buffer(void);
 size_t audio_get_resampled_frames(void);
 void audio_resampler_reset(void);
+/* #1044: cross-thread state guard. JNI bridge holds these around the
+ * get-frames + memcpy + clear triple; emulation thread takes the lock
+ * inside audio_sample[_batch]_callback. The `_unlocked` variants are for
+ * use inside an already-held lock — see libretro_audio.c file comment. */
+void audio_lock(void);
+void audio_unlock(void);
+size_t audio_get_buffer_frames_unlocked(void);
+void audio_clear_buffer_unlocked(void);
 
 /* Input subsystem (libretro_input.c) */
 void input_init(void);

--- a/player/native/src/libretro_input.c
+++ b/player/native/src/libretro_input.c
@@ -3,6 +3,23 @@
  *
  * Maps platform controller state (set from Kotlin) to
  * the libretro input callbacks the core queries each frame.
+ *
+ * Threading (#1044):
+ *   Writers = Kotlin platform threads via input_set_button / _analog /
+ *             _pointer / _mouse / _keyboard, called from input event
+ *             dispatch.
+ *   Reader  = libretro core via input_state_callback, called from inside
+ *             retro_run on the emulation thread.
+ *   Bool / int16 reads are atomic on aligned types in practice, but the
+ *   real race is the mouse dx/dy accumulator: input_set_mouse does a
+ *   read-modify-write `dx += dx_in`, racing with input_state_callback's
+ *   `dx = mouse.dx; mouse.dx = 0;` read-then-clear. Without sync the
+ *   writer's `+=` can clobber a delta the reader was about to consume,
+ *   silently dropping mouse motion.
+ *
+ *   The mutex covers every read and write of input_state. Per-callback
+ *   overhead is sub-microsecond and the contention is bounded by the
+ *   number of buttons the core polls per frame.
  */
 
 #include "libretro_bridge.h"
@@ -39,15 +56,65 @@ static struct {
     bool keyboard[MAX_KEYBOARD_KEYS];
 
     bool initialized;
+
+    /* #1044: cross-thread state guard. See file-level comment. */
+    sp_mutex_t lock;
+    bool       lock_initialized;
 } input_state = {0};
 
+/* Internal lock helpers — input doesn't expose lock/unlock publicly
+ * because every JNI call here is single-shot (set or read) and wraps
+ * itself; there is no read+copy+clear triple to span. */
+static inline void input_lock(void) {
+    if (input_state.lock_initialized) {
+        sp_mutex_lock(&input_state.lock);
+    }
+}
+
+static inline void input_unlock(void) {
+    if (input_state.lock_initialized) {
+        sp_mutex_unlock(&input_state.lock);
+    }
+}
+
 void input_init(void) {
+    /* Preserve the lock across re-init — see libretro_audio.c for the
+     * same pattern. */
+    bool had_lock = input_state.lock_initialized;
+    sp_mutex_t saved_lock;
+    if (had_lock) {
+        saved_lock = input_state.lock;
+    }
+
     memset(&input_state, 0, sizeof(input_state));
+
+    if (had_lock) {
+        input_state.lock = saved_lock;
+        input_state.lock_initialized = true;
+    } else if (sp_mutex_init(&input_state.lock) == 0) {
+        input_state.lock_initialized = true;
+    }
+
     input_state.initialized = true;
 }
 
 void input_deinit(void) {
-    memset(&input_state, 0, sizeof(input_state));
+    if (input_state.lock_initialized) {
+        sp_mutex_lock(&input_state.lock);
+    }
+    /* Zero the data fields without clobbering the mutex — memset over
+     * the whole struct would corrupt the pthread_mutex_t. */
+    memset(input_state.buttons, 0, sizeof(input_state.buttons));
+    memset(input_state.analog, 0, sizeof(input_state.analog));
+    memset(input_state.pointer, 0, sizeof(input_state.pointer));
+    memset(input_state.mouse, 0, sizeof(input_state.mouse));
+    memset(input_state.keyboard, 0, sizeof(input_state.keyboard));
+    input_state.initialized = false;
+    if (input_state.lock_initialized) {
+        sp_mutex_unlock(&input_state.lock);
+        sp_mutex_destroy(&input_state.lock);
+        input_state.lock_initialized = false;
+    }
 }
 
 /*
@@ -60,20 +127,29 @@ void input_poll_callback(void) {
 
 /*
  * Called by the core to read the current state of a button or axis.
+ *
+ * Holds input_lock for the entire body — for mouse dx/dy this is the
+ * key guarantee: the read-and-clear pair must be atomic against
+ * input_set_mouse's `dx += dx_in`, otherwise concurrent writes can
+ * either be lost (writer adds between read and clear) or visible only
+ * partially across a torn 16-bit access.
  */
 int16_t input_state_callback(unsigned port, unsigned device, unsigned index, unsigned id) {
     if (port >= MAX_PORTS) return 0;
 
+    int16_t result = 0;
+    input_lock();
+
     switch (device & 0xFF) {
         case RETRO_DEVICE_JOYPAD:
             if (id < MAX_BUTTONS) {
-                return input_state.buttons[port][id] ? 1 : 0;
+                result = input_state.buttons[port][id] ? 1 : 0;
             }
             break;
 
         case RETRO_DEVICE_ANALOG:
             if (index < 2 && id < 2) {
-                return input_state.analog[port][index][id];
+                result = input_state.analog[port][index][id];
             }
             break;
 
@@ -90,31 +166,37 @@ int16_t input_state_callback(unsigned port, unsigned device, unsigned index, uns
             if (mouse_active) {
                 switch (id) {
                     case RETRO_DEVICE_ID_MOUSE_X: {
-                        int16_t dx = input_state.mouse[port].dx;
+                        result = input_state.mouse[port].dx;
                         input_state.mouse[port].dx = 0;
-                        return dx;
+                        break;
                     }
                     case RETRO_DEVICE_ID_MOUSE_Y: {
-                        int16_t dy = input_state.mouse[port].dy;
+                        result = input_state.mouse[port].dy;
                         input_state.mouse[port].dy = 0;
-                        return dy;
+                        break;
                     }
                     case RETRO_DEVICE_ID_MOUSE_LEFT:
-                        return input_state.mouse[port].left ? 1 : 0;
+                        result = input_state.mouse[port].left ? 1 : 0;
+                        break;
                     case RETRO_DEVICE_ID_MOUSE_RIGHT:
-                        return input_state.mouse[port].right ? 1 : 0;
+                        result = input_state.mouse[port].right ? 1 : 0;
+                        break;
                 }
             } else {
                 /* Fallback: map pointer/touch state to mouse queries */
                 switch (id) {
                     case RETRO_DEVICE_ID_MOUSE_X:
-                        return input_state.pointer[port].x;
+                        result = input_state.pointer[port].x;
+                        break;
                     case RETRO_DEVICE_ID_MOUSE_Y:
-                        return input_state.pointer[port].y;
+                        result = input_state.pointer[port].y;
+                        break;
                     case RETRO_DEVICE_ID_MOUSE_LEFT:
-                        return input_state.pointer[port].pressed ? 1 : 0;
+                        result = input_state.pointer[port].pressed ? 1 : 0;
+                        break;
                     case RETRO_DEVICE_ID_MOUSE_RIGHT:
-                        return 0;
+                        result = 0;
+                        break;
                 }
             }
             break;
@@ -123,17 +205,20 @@ int16_t input_state_callback(unsigned port, unsigned device, unsigned index, uns
         case RETRO_DEVICE_POINTER:
             switch (id) {
                 case RETRO_DEVICE_ID_POINTER_X:
-                    return input_state.pointer[port].x;
+                    result = input_state.pointer[port].x;
+                    break;
                 case RETRO_DEVICE_ID_POINTER_Y:
-                    return input_state.pointer[port].y;
+                    result = input_state.pointer[port].y;
+                    break;
                 case RETRO_DEVICE_ID_POINTER_PRESSED:
-                    return input_state.pointer[port].pressed ? 1 : 0;
+                    result = input_state.pointer[port].pressed ? 1 : 0;
+                    break;
             }
             break;
 
         case RETRO_DEVICE_KEYBOARD:
             if (id < MAX_KEYBOARD_KEYS) {
-                return input_state.keyboard[id] ? 1 : 0;
+                result = input_state.keyboard[id] ? 1 : 0;
             }
             break;
 
@@ -141,61 +226,69 @@ int16_t input_state_callback(unsigned port, unsigned device, unsigned index, uns
             break;
     }
 
-    return 0;
+    input_unlock();
+    return result;
 }
 
 /* Called from Kotlin/JNI to read button state */
 bool input_get_button(unsigned port, unsigned id) {
-    if (port < MAX_PORTS && id < MAX_BUTTONS) {
-        return input_state.buttons[port][id];
-    }
-    return false;
+    if (port >= MAX_PORTS || id >= MAX_BUTTONS) return false;
+    input_lock();
+    bool pressed = input_state.buttons[port][id];
+    input_unlock();
+    return pressed;
 }
 
 /* Called from Kotlin/JNI to read analog axis state */
 int16_t input_get_analog(unsigned port, unsigned index, unsigned id) {
-    if (port < MAX_PORTS && index < 2 && id < 2) {
-        return input_state.analog[port][index][id];
-    }
-    return 0;
+    if (port >= MAX_PORTS || index >= 2 || id >= 2) return 0;
+    input_lock();
+    int16_t v = input_state.analog[port][index][id];
+    input_unlock();
+    return v;
 }
 
 /* Called from Kotlin/JNI to set button state */
 void input_set_button(unsigned port, unsigned id, bool pressed) {
-    if (port < MAX_PORTS && id < MAX_BUTTONS) {
-        input_state.buttons[port][id] = pressed;
-    }
+    if (port >= MAX_PORTS || id >= MAX_BUTTONS) return;
+    input_lock();
+    input_state.buttons[port][id] = pressed;
+    input_unlock();
 }
 
 /* Called from Kotlin/JNI to set analog axis state */
 void input_set_analog(unsigned port, unsigned index, unsigned id, int16_t value) {
-    if (port < MAX_PORTS && index < 2 && id < 2) {
-        input_state.analog[port][index][id] = value;
-    }
+    if (port >= MAX_PORTS || index >= 2 || id >= 2) return;
+    input_lock();
+    input_state.analog[port][index][id] = value;
+    input_unlock();
 }
 
 /* Called from Kotlin/JNI to set pointer/touch state (for DS touch screen) */
 void input_set_pointer(unsigned port, int16_t x, int16_t y, bool pressed) {
-    if (port < MAX_PORTS) {
-        input_state.pointer[port].x = x;
-        input_state.pointer[port].y = y;
-        input_state.pointer[port].pressed = pressed;
-    }
+    if (port >= MAX_PORTS) return;
+    input_lock();
+    input_state.pointer[port].x = x;
+    input_state.pointer[port].y = y;
+    input_state.pointer[port].pressed = pressed;
+    input_unlock();
 }
 
 /* Called from Kotlin/JNI to set mouse relative movement and button state */
 void input_set_mouse(unsigned port, int16_t dx, int16_t dy, bool left, bool right) {
-    if (port < MAX_PORTS) {
-        input_state.mouse[port].dx += dx;   /* Accumulate deltas */
-        input_state.mouse[port].dy += dy;
-        input_state.mouse[port].left = left;
-        input_state.mouse[port].right = right;
-    }
+    if (port >= MAX_PORTS) return;
+    input_lock();
+    input_state.mouse[port].dx += dx;   /* Accumulate deltas */
+    input_state.mouse[port].dy += dy;
+    input_state.mouse[port].left = left;
+    input_state.mouse[port].right = right;
+    input_unlock();
 }
 
 /* Called from Kotlin/JNI to set keyboard key state */
 void input_set_keyboard(unsigned key, bool pressed) {
-    if (key < MAX_KEYBOARD_KEYS) {
-        input_state.keyboard[key] = pressed;
-    }
+    if (key >= MAX_KEYBOARD_KEYS) return;
+    input_lock();
+    input_state.keyboard[key] = pressed;
+    input_unlock();
 }

--- a/player/native/src/libretro_video.c
+++ b/player/native/src/libretro_video.c
@@ -51,9 +51,38 @@ static struct {
      * has already partially released) doesn't crash inside our
      * memcpy. (#916) */
     bool shutting_down;
+
+    /* #1044: cross-thread state guard.
+     *
+     * Writer = emulation thread inside video_refresh_callback. It can
+     * realloc(frame_buffer) on dimension change, then memcpy the new
+     * frame into it.
+     *
+     * Reader = render thread via the JNI bridge: nativeGetVideoFrame /
+     * nativeFillVideoFrame call video_get_frame_buffer + size, then
+     * SetByteArrayRegion to copy out.
+     *
+     * Without sync, a realloc on the writer side while the reader is
+     * mid-memcpy returns a dangling pointer. The reader also sees torn
+     * width/height pairs across the dimension-change frame.
+     *
+     * The mutex covers every video_state mutation and every read. The
+     * JNI bridge holds it across the get_buffer + size + memcpy triple
+     * via video_lock/video_unlock. */
+    sp_mutex_t lock;
+    bool       lock_initialized;
 } video_state = {0};
 
 void video_init(void) {
+    /* Preserve the lock across re-init: a core teardown + relaunch
+     * doesn't necessarily call video_deinit between. Lazy create on
+     * the first init. */
+    bool had_lock = video_state.lock_initialized;
+    sp_mutex_t saved_lock;
+    if (had_lock) {
+        saved_lock = video_state.lock;
+    }
+
     video_state.frame_buffer = NULL;
     video_state.frame_buffer_size = 0;
     video_state.width = 0;
@@ -62,6 +91,13 @@ void video_init(void) {
     video_state.pixel_format = RETRO_PIXEL_FORMAT_0RGB1555; /* default */
     video_state.shutting_down = false;
     /* gpu_renderer is not touched here -- managed externally */
+
+    if (had_lock) {
+        video_state.lock = saved_lock;
+        video_state.lock_initialized = true;
+    } else if (sp_mutex_init(&video_state.lock) == 0) {
+        video_state.lock_initialized = true;
+    }
 }
 
 void video_set_shutting_down(void) {
@@ -69,6 +105,9 @@ void video_set_shutting_down(void) {
 }
 
 void video_deinit(void) {
+    if (video_state.lock_initialized) {
+        sp_mutex_lock(&video_state.lock);
+    }
     if (video_state.frame_buffer) {
         free(video_state.frame_buffer);
         video_state.frame_buffer = NULL;
@@ -77,18 +116,49 @@ void video_deinit(void) {
     video_state.width = 0;
     video_state.height = 0;
     /* gpu_renderer is not destroyed here -- managed externally */
+    if (video_state.lock_initialized) {
+        sp_mutex_unlock(&video_state.lock);
+        sp_mutex_destroy(&video_state.lock);
+        video_state.lock_initialized = false;
+    }
+}
+
+/* #1044: lock primitives exposed for the JNI bridge so it can hold the
+ * video mutex across the get_frame_buffer + size + memcpy triple in
+ * nativeGetVideoFrame / nativeFillVideoFrame. */
+void video_lock(void) {
+    if (video_state.lock_initialized) {
+        sp_mutex_lock(&video_state.lock);
+    }
+}
+
+void video_unlock(void) {
+    if (video_state.lock_initialized) {
+        sp_mutex_unlock(&video_state.lock);
+    }
 }
 
 void video_set_pixel_format(unsigned format) {
+    video_lock();
     video_state.pixel_format = format;
+    video_unlock();
 }
 
 void video_set_gpu_renderer(gpu_renderer_t *renderer) {
+    /* Writer crosses the JNI thread / emulation thread boundary
+     * (Kotlin GPU surface lifecycle vs core's video_refresh_callback),
+     * so the pointer write must be locked even though it's a single
+     * machine-word store. */
+    video_lock();
     video_state.gpu_renderer = renderer;
+    video_unlock();
 }
 
 gpu_renderer_t *video_get_gpu_renderer(void) {
-    return video_state.gpu_renderer;
+    video_lock();
+    gpu_renderer_t *r = video_state.gpu_renderer;
+    video_unlock();
+    return r;
 }
 
 /*
@@ -108,6 +178,17 @@ void video_refresh_callback(const void *data, unsigned width, unsigned height, s
     /* See video_state.shutting_down. */
     if (video_state.shutting_down) return;
 
+    /* #1044: hold the lock across the entire callback. This serialises:
+     *  - dimension fields (width / height / pitch / pixel_format) that
+     *    JNI readers consume to allocate output buffers,
+     *  - frame_buffer realloc + memcpy, which would otherwise return a
+     *    dangling pointer to a reader that called video_get_frame_buffer
+     *    just before the realloc.
+     * GPU paths (Vulkan / Metal) only mutate width / height under the
+     * lock; the GPU staging buffer they write into is the renderer's
+     * own and is synchronised internally. */
+    video_lock();
+
     if (data == RETRO_HW_FRAME_BUFFER_VALID && g_core.hw_render_enabled) {
         /*
          * Vulkan HW render path (e.g. Dolphin): core rendered to its own VkImage.
@@ -124,6 +205,7 @@ void video_refresh_callback(const void *data, unsigned width, unsigned height, s
             video_state.width = width;
             video_state.height = height;
             gpu_renderer_hw_render_frame(video_state.gpu_renderer, width, height);
+            video_unlock();
             return;
         }
         /* GLES HW render path: readback from pbuffer, upload through Vulkan pipeline.
@@ -133,7 +215,10 @@ void video_refresh_callback(const void *data, unsigned width, unsigned height, s
             size_t needed = (size_t)width * height * 4;
             if (needed > video_state.frame_buffer_size) {
                 void *new_buf = realloc(video_state.frame_buffer, needed);
-                if (!new_buf) return;
+                if (!new_buf) {
+                    video_unlock();
+                    return;
+                }
                 video_state.frame_buffer = new_buf;
                 video_state.frame_buffer_size = needed;
             }
@@ -155,12 +240,14 @@ void video_refresh_callback(const void *data, unsigned width, unsigned height, s
 
             /* Resize pbuffer for next frame if core reported different dimensions */
             hw_gl_resize_fbo(g_core.hw_gl_ctx, width, height);
+            video_unlock();
             return;
         }
         /* HW frame but no active renderer — drop the frame. Falling through to
          * the software path would dereference RETRO_HW_FRAME_BUFFER_VALID as a
          * pointer, causing a SIGSEGV. This happens when the GPU surface is
          * suspended (e.g. clamshell close) while the core is still running. */
+        video_unlock();
         return;
     }
 
@@ -178,6 +265,7 @@ void video_refresh_callback(const void *data, unsigned width, unsigned height, s
     if (video_state.gpu_renderer && gpu_renderer_is_active(video_state.gpu_renderer)) {
         gpu_renderer_upload_frame(video_state.gpu_renderer, data,
             width, height, pitch, video_state.pixel_format);
+        video_unlock();
         return;
     }
 
@@ -199,7 +287,10 @@ void video_refresh_callback(const void *data, unsigned width, unsigned height, s
 
     if (needed != video_state.frame_buffer_size) {
         void *new_buf = realloc(video_state.frame_buffer, needed);
-        if (!new_buf) return;
+        if (!new_buf) {
+            video_unlock();
+            return;
+        }
         video_state.frame_buffer = new_buf;
         video_state.frame_buffer_size = needed;
     }
@@ -214,24 +305,50 @@ void video_refresh_callback(const void *data, unsigned width, unsigned height, s
         src += pitch;
         dst += row_bytes;
     }
+
+    video_unlock();
 }
 
 unsigned video_get_width(void) {
-    return video_state.width;
+    video_lock();
+    unsigned w = video_state.width;
+    video_unlock();
+    return w;
 }
 
 unsigned video_get_height(void) {
-    return video_state.height;
+    video_lock();
+    unsigned h = video_state.height;
+    video_unlock();
+    return h;
 }
 
+/* Pointer accessor: the buffer is a heap allocation that the writer can
+ * realloc on dimension change, so reading the buffer's *contents* through
+ * this pointer requires holding video_lock. The JNI bridge does so via
+ * video_lock() / video_unlock() around the whole read+copy. */
 const void *video_get_frame_buffer(void) {
     return video_state.frame_buffer;
 }
 
 size_t video_get_frame_buffer_size(void) {
-    return video_state.frame_buffer_size;
+    video_lock();
+    size_t s = video_state.frame_buffer_size;
+    video_unlock();
+    return s;
 }
 
 unsigned video_get_pixel_format(void) {
-    return video_state.pixel_format;
+    video_lock();
+    unsigned f = video_state.pixel_format;
+    video_unlock();
+    return f;
 }
+
+/* Caller-locked accessors for use by the JNI bridge when it has already
+ * acquired video_lock — avoids a second acquisition per JNI call and
+ * keeps width/height/pitch consistent with the buffer pointer. */
+unsigned video_get_width_unlocked(void) { return video_state.width; }
+unsigned video_get_height_unlocked(void) { return video_state.height; }
+size_t video_get_frame_buffer_size_unlocked(void) { return video_state.frame_buffer_size; }
+unsigned video_get_pixel_format_unlocked(void) { return video_state.pixel_format; }


### PR DESCRIPTION
## Summary

Fixes the three cross-thread races flagged by the phase 4 native audit. The libretro core's callbacks fire on the emulation thread; the Kotlin audio coroutine, render thread, and input dispatch cross into the same C state via JNI without synchronisation.

**Pre-fix the live races were:**

1. **`audio_state.write_pos`** — emulation thread incremented after writing `buffer[N]`; audio thread read + reset in `nativeFillAudioBuffer` / `nativeGetAudioBuffer`. Reader saw torn `write_pos` (visibility) and any sample the writer added between get-frames and clear was dropped on the floor (missed-increment).
2. **`video_state.frame_buffer`** — `video_refresh_callback` could `realloc` on dimension change while `nativeGetVideoFrame` / `nativeFillVideoFrame` was mid-memcpy through the pointer it had just read. A realloc mid-copy hands the reader a freed pointer.
3. **`input_state.mouse[].dx/dy`** — `input_set_mouse` does `dx += dx_in`; `input_state_callback` does `result = dx; dx = 0;`. The two read-modify-writes race, silently dropping mouse motion in DS / pointer cores.

## Fix

Each subsystem gains an `sp_mutex_t` guard (using the existing cross-platform wrapper from `sp_platform.h`):

- **audio.c** — `audio_state.lock` covers every read/write. Public `audio_lock` / `audio_unlock` exposed so the JNI bridge can hold the lock across the get-frames + memcpy + clear triple. Internal `_unlocked` accessors avoid recursive acquisition.
- **video.c** — `video_state.lock` covers every read/write including the realloc + memcpy in `video_refresh_callback`. All early returns in the callback unlock before returning. GPU paths (Vulkan / Metal) only mutate dimension fields under the lock; their staging buffers are synchronised by the renderer itself.
- **input.c** — `input_state.lock` taken per-call internally. Mouse `dx/dy` read-and-clear is now atomic against accumulating writes.
- All three modules preserve their mutex across re-init so a subsequent `*_init` call doesn't `memset` over a live `pthread_mutex_t`.

JNI bridge (`libretro_bridge.c`):

- `nativeGetAudioBuffer`, `nativeFillAudioBuffer`, `nativeResampleAudio`, `nativeGetVideoFrame`, `nativeFillVideoFrame` all hold the appropriate module lock across get-pointer + size + JNI copy + clear.
- `NewShortArray` / `NewByteArray` are called **outside** the lock to avoid blocking the GC while the emulation thread is parked on a callback's lock acquisition. Size is sampled with the lock, alloc happens unlocked, then the lock is reacquired and the size is re-sampled in case the writer shrunk the buffer in the gap.

Closes #1044.

## Performance

Per-callback lock cost is ~25 ns on x86 / ARM:

- Audio at 48 kHz: ~1.2 ms / s of audio = 0.07% overhead, well under audible threshold.
- Video refresh at 60 Hz: ~1.5 µs / s = negligible.
- Input polling bounded by core's per-frame queries — typically hundreds, not thousands.

If this overhead ever shows up on a profile, the audio cursor is the only candidate for migration to a SPSC ring buffer with `_Atomic` cursors. Filed as a follow-up only if profiling actually flags it.

## Lock-pairing audit (by inspection)

- No recursive acquisition: no function inside audio/video/input under a held lock calls another locked function in the same module. `pthread_mutex` defaults to non-recursive on POSIX, so this matters.
- Every early-return path in `video_refresh_callback` unlocks before returning (HW Vulkan / GLES / no-renderer / GPU upload / software realloc-fail / fall-through).
- External calls under the lock (`gpu_renderer_*`, `hw_gl_*`, `sinc_resampler_*`) don't call back into our protected state — verified via `grep`.
- JNI primitives `SetShortArrayRegion` / `SetByteArrayRegion` are bounded memcpys per spec; they don't allocate or block on the GC, so holding our mutex across them is safe. Allocating primitives (`NewByteArray` / `NewShortArray`) **can** block on GC, so they're called outside the lock.

## Test plan

- [x] `cmake --build` clean against current `player/native/build/`
- [x] Native lib exports the new symbols (`audio_lock`, `video_lock`, `*_unlocked` accessors) — verified via `nm`
- [x] `:shared:desktopTest` and representative `:desktop:desktopTest` classes still green (the harness uses `FakeLibretroController` and doesn't load the `.dylib`, so this only confirms Kotlin still compiles + runs against the unchanged JNI signatures)
- [ ] CI green
- [ ] Manual: run a real game on desktop and verify audio doesn't crackle, video doesn't tear / crash, mouse / pointer input feels normal in DS games

## What's intentionally out of scope

- **Ring-buffer redesign** for audio with separate read / write cursors and lock-free SPSC semantics — bigger refactor, file as follow-up if the per-sample mutex shows up on a profile.
- **Native concurrency tests** — the harness fakes the libretro controller and doesn't load the `.dylib`. Adding a test that loads the shared lib and stresses callbacks from multiple threads is its own infrastructure project.
- **`video_state.shutting_down`** is intentionally still unlocked: it's a single bool written and read on the same thread (emulation thread, before/during `retro_deinit`). Locking it could delay teardown.