### PR TITLE
fix(server): default Sega CD to genesis_plus_gx (#943)

### DIFF
--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -986,7 +986,17 @@ func SeedConsoles(db *gorm.DB) error {
 		{Name: "Neo Geo", Abbreviation: "NEOGEO", Extensions: ".zip", DefaultCore: "fbneo", EmulatorJSCore: "fbneo", FolderName: "neogeo", ColorTheme: "#ffcc00", Generation: 4, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		{Name: "Neo Geo CD", Abbreviation: "NEOCD", Extensions: ".chd,.cue,.iso", DefaultCore: "neocd", EmulatorJSCore: "", FolderName: "neogeocd", ColorTheme: "#ffcc00", Generation: 4, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		{Name: "Atari Lynx", Abbreviation: "LYNX", Extensions: ".lnx,.lyx", DefaultCore: "handy", EmulatorJSCore: "handy", FolderName: "atarilynx", ColorTheme: "#8b4513", CoverAspect: "1:1", Generation: 4, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
-		{Name: "Sega CD", Abbreviation: "SCD", Extensions: ".iso,.bin,.cue,.m3u", DefaultCore: "clownmdemu", EmulatorJSCore: "segaCD", FolderName: "segacd", ColorTheme: "#1a1a1a", Generation: 4, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
+		// #943: ClownMDEmu's Sega CD support is incomplete — the BIOS
+		// boot path enters an infinite loop on `UNRECOGNISED BIOS CALL
+		// 0x08 / 0x87` because their CDBIOS handlers aren't implemented
+		// yet, so every Sega CD title hangs on the BIOS region screen.
+		// Genesis Plus GX has complete CDBIOS / CDC / CDD / sub-CPU /
+		// PRG-RAM emulation and uses the same BIOS file naming we ship
+		// (`bios_CD_U.bin` / `bios_CD_E.bin` / `bios_CD_J.bin`, see
+		// internal/bios/registry.go). ClownMDEmu remains in SeedCores
+		// as a non-default option so users can opt in once upstream
+		// catches up.
+		{Name: "Sega CD", Abbreviation: "SCD", Extensions: ".iso,.bin,.cue,.m3u", DefaultCore: "genesis_plus_gx", EmulatorJSCore: "segaCD", FolderName: "segacd", ColorTheme: "#1a1a1a", Generation: 4, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		{Name: "Philips CD-i", Abbreviation: "CDI", Extensions: ".chd,.cue,.iso", DefaultCore: "same_cdi", EmulatorJSCore: "same_cdi", FolderName: "cdi", ColorTheme: "#006633", Generation: 4, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		// 5th Generation
 		{Name: "PlayStation", Abbreviation: "PSX", Extensions: ".bin,.cue,.iso,.pbp,.m3u", DefaultCore: "beetle_psx_hw", EmulatorJSCore: "mednafen_psx_hw", FolderName: "psx", ColorTheme: "#003087", CoverAspect: "1:1", Generation: 5, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicyMedium, Playable: true},

--- a/server/internal/db/segacd_default_core_test.go
+++ b/server/internal/db/segacd_default_core_test.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// #943: ClownMDEmu's Sega CD BIOS-call emulation is incomplete (the boot
+// path enters an infinite loop on `UNRECOGNISED BIOS CALL 0x08 / 0x87`),
+// so every Sega CD title hangs on the BIOS region screen. The default
+// core must stay genesis_plus_gx until upstream catches up.
+//
+// This test guards against an accidental revert via copy-paste, AI tool,
+// or "rebase ate my edit" mishap.
+func TestSegaCDDefaultCoreIsGenesisPlusGx(t *testing.T) {
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&Console{}))
+	require.NoError(t, SeedConsoles(database))
+
+	var scd Console
+	require.NoError(t, database.Where("abbreviation = ?", "SCD").First(&scd).Error)
+	require.Equal(t, "genesis_plus_gx", scd.DefaultCore,
+		"Sega CD default core regressed — see #943 for why ClownMDEmu can't be the default")
+}
+
+// Existing servers that booted on a pre-#943 build and persisted the
+// `clownmdemu` value to disk must be migrated by SeedConsoles' backfill
+// path on next restart. This test exercises the upgrade path so a future
+// refactor of SeedConsoles' backfill loop doesn't silently leave existing
+// installs stuck on the broken core.
+func TestSegaCDDefaultCoreBackfillsFromClownMDEmu(t *testing.T) {
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&Console{}))
+
+	// Pre-seed the DB to mimic a server that booted on the pre-#943
+	// build: Sega CD already exists with the broken default core.
+	preExisting := Console{
+		Name:         "Sega CD",
+		Abbreviation: "SCD",
+		Extensions:   ".iso,.bin,.cue,.m3u",
+		DefaultCore:  "clownmdemu",
+		FolderName:   "segacd",
+	}
+	require.NoError(t, database.Create(&preExisting).Error)
+
+	require.NoError(t, SeedConsoles(database))
+
+	var scd Console
+	require.NoError(t, database.Where("abbreviation = ?", "SCD").First(&scd).Error)
+	require.Equal(t, "genesis_plus_gx", scd.DefaultCore,
+		"SeedConsoles must backfill DefaultCore from clownmdemu to genesis_plus_gx on existing rows")
+}


### PR DESCRIPTION
## Summary

Sega CD games hang on the BIOS region screen because ClownMDEmu v1.6.10's CDBIOS-call emulation is incomplete: calls `0x08` and `0x87` aren't implemented, so the BIOS boot path enters an infinite loop alternating between the two unrecognised calls (~80 ms apart, **1441 of them in one minute** of capture). The user sees fragments of the BIOS region prompt rendered against a partially-initialised VDP and then nothing.

Genesis Plus GX has complete CDBIOS / CDC / CDD / sub-CPU / PRG-RAM emulation and uses the same BIOS file naming we already ship via `internal/bios/registry.go` (`bios_CD_U.bin`, `bios_CD_E.bin`, `bios_CD_J.bin`).

Closes #943.

## Existing-server migration

Existing servers persist `clownmdemu` to disk on first boot. The backfill loop in `SeedConsoles` already migrates `DefaultCore` on every restart when the seed and DB diverge (`database.go:1098`), so the seed change reaches existing installs **automatically on next restart** — no separate migration step.

The new `TestSegaCDDefaultCoreBackfillsFromClownMDEmu` exercises that path end-to-end: pre-seeds a Console row with `clownmdemu`, runs `SeedConsoles`, and asserts it migrates to `genesis_plus_gx`.

## Tests

- `TestSegaCDDefaultCoreIsGenesisPlusGx` — guards the seed value from accidental revert (copy-paste, AI tool, rebase mishap).
- `TestSegaCDDefaultCoreBackfillsFromClownMDEmu` — exercises the upgrade path so a future refactor of `SeedConsoles`' backfill loop doesn't silently leave existing installs stuck on the broken core.
- Existing `TestSeedCoresCoversEveryConsoleDefaultCore` continues to pass — `genesis_plus_gx` was already in `SeedCores`.

## Test plan

- [x] `go test ./internal/db/...` green (3 SCD-related tests + drift guard)
- [x] `go test ./...` green (all server packages)
- [ ] CI green
- [ ] Manual: server restart picks up the migration; launch Sherlock Holmes / Sonic CD / Lunar — BIOS region prompt advances, game boots normally

## What's intentionally out of scope

- ClownMDEmu remains in `SeedCores` as a non-default option so users can opt back in once upstream finishes its CD support.
- The earlier warnings in the boot trace (`Unimplemented instruction IM at 0x4`, `invalid MCD 68k address 0xFF8000`, `SUB-CPU stop watch register`) confirm ClownMDEmu's Sega CD support is broadly incomplete — not just two missing BIOS calls. Tracking upstream is out of scope here; the default-core swap is the actionable fix.

## Related

- ClownMDEmu upstream: https://github.com/Clownacy/clownmdemu-libretro — Sega CD support documented as work-in-progress.