### PR TITLE
fix(player): drop duplicate focus target on clickable cards (#1096)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/SpCardFirstClickTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/SpCardFirstClickTest.kt
@@ -1,0 +1,135 @@
+package com.spela.player.desktop.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.*
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpGradientCard
+import com.spela.player.presentation.ui.components.SpInnerCard
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * #1096 regression: SpCard / SpInnerCard / SpGradientCard previously stacked
+ * `Modifier.clickable(...).gamepadFocusable(...)` on the same node.
+ * `gamepadFocusable` added its own `.focusable()`, creating a second focus
+ * target on top of `.clickable`'s built-in focus. On desktop with mouse
+ * input, the very first click on an unfocused card was consumed by the
+ * inner focusable as a focus-acquisition event, never reaching `onClick`.
+ * The fix passes `addFocusable = false` to `gamepadFocusable` from the
+ * three card variants, leaving `.clickable`'s focus target as the only one.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SpCardFirstClickTest {
+
+    @Test
+    fun spCard_firstClick_firesOnClick() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            SpCard(
+                modifier = Modifier.testTag("card").size(120.dp),
+                onClick = { clicks++ },
+            ) {
+                Box(modifier = Modifier.size(120.dp))
+            }
+        }
+
+        onNodeWithTag("card").assertIsDisplayed()
+        // First click — before #1096 fix this was swallowed by the duplicate
+        // focusable; only the second click would fire onClick.
+        onNodeWithTag("card").performClick()
+        assertEquals(1, clicks)
+    }
+
+    @Test
+    fun spInnerCard_firstClick_firesOnClick() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            SpInnerCard(
+                modifier = Modifier.testTag("inner").size(120.dp),
+                onClick = { clicks++ },
+            ) {
+                Box(modifier = Modifier.size(120.dp))
+            }
+        }
+
+        onNodeWithTag("inner").performClick()
+        assertEquals(1, clicks)
+    }
+
+    @Test
+    fun spGradientCard_firstClick_firesOnClick() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            SpGradientCard(
+                modifier = Modifier.testTag("gradient").size(120.dp),
+                onClick = { clicks++ },
+            ) {
+                Box(modifier = Modifier.size(120.dp))
+            }
+        }
+
+        onNodeWithTag("gradient").performClick()
+        assertEquals(1, clicks)
+    }
+
+    @Test
+    fun spCard_hasSingleFocusTarget_notDuplicated() = runComposeUiTest {
+        setContent {
+            SpCard(
+                modifier = Modifier.testTag("card").size(120.dp),
+                onClick = { },
+            ) {
+                Box(modifier = Modifier.size(120.dp))
+            }
+        }
+
+        // The bug was a double `.focusable()` from
+        // `.clickable(...).gamepadFocusable(...)` — two focus targets sharing
+        // one interaction source. With the fix there is exactly one node in
+        // the semantics tree exposing the RequestFocus semantics action.
+        val requestFocusMatcher = SemanticsMatcher.keyIsDefined(SemanticsActions.RequestFocus)
+        val focusTargets = onAllNodes(requestFocusMatcher).fetchSemanticsNodes().size
+        assertEquals(
+            expected = 1,
+            actual = focusTargets,
+            message = "Expected exactly one RequestFocus target on SpCard; found $focusTargets — duplicate focus target would re-introduce #1096",
+        )
+    }
+
+    @Test
+    fun spInnerCard_hasSingleFocusTarget_notDuplicated() = runComposeUiTest {
+        setContent {
+            SpInnerCard(
+                modifier = Modifier.testTag("inner").size(120.dp),
+                onClick = { },
+            ) {
+                Box(modifier = Modifier.size(120.dp))
+            }
+        }
+
+        val requestFocusMatcher = SemanticsMatcher.keyIsDefined(SemanticsActions.RequestFocus)
+        val focusTargets = onAllNodes(requestFocusMatcher).fetchSemanticsNodes().size
+        assertEquals(1, focusTargets, "duplicate RequestFocus targets re-introduce #1096")
+    }
+
+    @Test
+    fun spGradientCard_hasSingleFocusTarget_notDuplicated() = runComposeUiTest {
+        setContent {
+            SpGradientCard(
+                modifier = Modifier.testTag("gradient").size(120.dp),
+                onClick = { },
+            ) {
+                Box(modifier = Modifier.size(120.dp))
+            }
+        }
+
+        val requestFocusMatcher = SemanticsMatcher.keyIsDefined(SemanticsActions.RequestFocus)
+        val focusTargets = onAllNodes(requestFocusMatcher).fetchSemanticsNodes().size
+        assertEquals(1, focusTargets, "duplicate RequestFocus targets re-introduce #1096")
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/EmulationActionButton.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/EmulationActionButton.kt
@@ -84,7 +84,7 @@ fun EmulationActionButton(
                 indication = null,
                 onClick = onClick,
             )
-            .then(if (useFocusRing) Modifier.gamepadFocusable(shape = RoundedCornerShape(16.dp)) else Modifier)
+            .then(if (useFocusRing) Modifier.gamepadFocusable(shape = RoundedCornerShape(16.dp), addFocusable = false) else Modifier)
             .semantics {
                 contentDescription = label
                 role = Role.Button

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCard.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCard.kt
@@ -104,7 +104,11 @@ fun SpCard(
                         interactionSource = interactionSource,
                         indication = null,
                         onClick = onClick,
-                    ).gamepadFocusable(shape = shape, interactionSource = interactionSource)
+                    ).gamepadFocusable(
+                        shape = shape,
+                        interactionSource = interactionSource,
+                        addFocusable = false,
+                    )
                 } else Modifier
             )
     ) {
@@ -157,7 +161,11 @@ fun SpInnerCard(
                     interactionSource = interactionSource,
                     indication = null,
                     onClick = onClick,
-                ).gamepadFocusable(shape = shape, interactionSource = interactionSource) else Modifier
+                ).gamepadFocusable(
+                    shape = shape,
+                    interactionSource = interactionSource,
+                    addFocusable = false,
+                ) else Modifier
             )
     ) {
         content()
@@ -185,7 +193,11 @@ fun SpGradientCard(
                     interactionSource = interactionSource,
                     indication = null,
                     onClick = onClick,
-                ).gamepadFocusable(shape = shape, interactionSource = interactionSource) else Modifier
+                ).gamepadFocusable(
+                    shape = shape,
+                    interactionSource = interactionSource,
+                    addFocusable = false,
+                ) else Modifier
             )
     ) {
         content()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpFab.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpFab.kt
@@ -41,7 +41,7 @@ fun SpFab(
             .clip(CircleShape)
             .background(Color.White.copy(alpha = 0.15f))
             .clickable(onClick = onClick)
-            .gamepadFocusable(shape = CircleShape, scaleOnFocus = true)
+            .gamepadFocusable(shape = CircleShape, scaleOnFocus = true, addFocusable = false)
             .semantics {
                 contentDescription = description
                 role = Role.Button

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpIconButton.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpIconButton.kt
@@ -76,7 +76,7 @@ fun SpIconButton(
                 .clip(CircleShape)
                 .background(background)
                 .clickable(interactionSource = interactionSource, indication = null, onClick = onClick)
-                .gamepadFocusable(shape = CircleShape, interactionSource = interactionSource)
+                .gamepadFocusable(shape = CircleShape, interactionSource = interactionSource, addFocusable = false)
                 .semantics {
                     this.contentDescription = contentDescription
                     this.role = Role.Button

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -207,17 +207,24 @@ fun GamepadHandler(
  * @param shape Shape for the focus ring outline.
  * @param scaleOnFocus Whether to scale up slightly when focused.
  * @param interactionSource Optional shared interaction source for the focusable modifier.
+ * @param addFocusable Whether to attach `.focusable()`. Set to `false` when the
+ *   parent already supplies focusability — typically a `.clickable(...)` earlier
+ *   in the modifier chain or a Material `Button`. Stacking a second focus target
+ *   (the default) on top of an already-focusable parent on desktop swallows the
+ *   first mouse click as a focus-acquisition event so the click never reaches
+ *   the underlying handler. See #1096.
  */
 fun Modifier.gamepadFocusable(
     shape: Shape = RoundedCornerShape(12.dp),
     scaleOnFocus: Boolean = false,
     interactionSource: MutableInteractionSource? = null,
+    addFocusable: Boolean = true,
 ): Modifier = composed {
     val source = interactionSource ?: remember { MutableInteractionSource() }
     this
         .centerOnFocus(interactionSource = source)
         .spFocusRing(shape = shape, scaleOnFocus = scaleOnFocus, interactionSource = source)
-        .focusable(interactionSource = source)
+        .let { if (addFocusable) it.focusable(interactionSource = source) else it }
 }
 
 /**


### PR DESCRIPTION
## Summary
- `SpCard`, `SpInnerCard`, `SpGradientCard`, `SpFab`, `SpIconButton`, and `EmulationActionButton` previously stacked `Modifier.clickable(...).gamepadFocusable(...)` on the same node. `gamepadFocusable` unconditionally appended `.focusable()`, creating a second focus target on top of `.clickable`'s built-in focus.
- Adds an `addFocusable: Boolean = true` parameter to `gamepadFocusable` and passes `false` from those six wrappers, leaving `.clickable`'s focus target as the only one.
- Visible focus ring, scale-on-focus, and scroll-on-focus behaviour are unchanged — `centerOnFocus` and `spFocusRing` still attach.

Fixes #1096.

## Why this matters

On desktop with mouse input the very first click on an unfocused card was consumed by the inner focusable as a focus-acquisition event and never reached `onClick` — Continue Playing rows visibly required two clicks to navigate. Touch input on Android was unaffected because the press interaction bypasses the focus claim.

## Test plan
- [x] New `SpCardFirstClickTest` covers each of the three `SpCard` variants — first `performClick()` fires `onClick`, and the semantics tree exposes exactly one node with `SemanticsActions.RequestFocus` (a duplicate would re-introduce the bug).
- [x] `./run-desktop-tests.sh` — 800 tests, only one local flake (`AppLaunchAndConnectionTest.addServerValidatesAndSavesOnSuccess`, the documented `advanceFully` flake category — passes in isolation).
- [ ] Manual smoke on the desktop app: load a console with Continue Playing, click a card before any other interaction, expect navigation on the **first** click.
- [ ] Gamepad activation (Enter / Space / DPad-center) still routes through `.clickable`'s focus + the keyboard handlers it provides.
- [ ] Android regression smoke — touch input behaviour unchanged.