### PR TITLE
feat(player): play time in game-detail Resume / Continue CTA (#1098)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -240,13 +240,14 @@ fun GameHeroContent(
                     //   LaunchesFresh → "Continue" (session exists
                     //     but engine starts at title screen, e.g.
                     //     ScummVM or user opted out of save states)
-                    // The single-source-of-truth resolver lives in
-                    // GameDetailState.playSemantics.
-                    val playLabel = when (state.playSemantics) {
-                        com.spela.player.domain.model.PlaySemantics.NoSession -> "New game"
-                        com.spela.player.domain.model.PlaySemantics.ResumesFromSaveState -> "Resume"
-                        com.spela.player.domain.model.PlaySemantics.LaunchesFresh -> "Continue"
-                    }
+                    // Suffix "— {h m}" when the targeted session has a
+                    // meaningful play time (≥ 60 s). Resolver is pure —
+                    // unit-tested in PlayCtaLabelTest. See #1098 and
+                    // [gameDetailPlayLabel].
+                    val playLabel = gameDetailPlayLabel(
+                        semantics = state.playSemantics,
+                        sessionPlayTimeSeconds = state.sessions.firstOrNull()?.totalPlayTime ?: 0L,
+                    )
                     // Click target depends on whether the game is
                     // already on disk. Cached → direct play. Uncached
                     // (only reachable here when isInstantDownload-

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/PlayCtaLabel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/PlayCtaLabel.kt
@@ -1,0 +1,39 @@
+package com.spela.player.presentation.ui.feature.gamedetail
+
+import com.spela.player.domain.model.PlaySemantics
+import com.spela.player.util.formatPlayTime
+
+/**
+ * Resolves the user-facing label for the game-detail hero's primary
+ * play button. Pure function — moved out of GameHeroContent so the
+ * "should we suffix the play time?" decision is unit-testable without
+ * spinning up Compose.
+ *
+ * Rules:
+ *  - NoSession → "New game" (nothing meaningful to suffix)
+ *  - ResumesFromSaveState / LaunchesFresh, no playtime → "Resume" / "Continue"
+ *  - ResumesFromSaveState / LaunchesFresh + playtime ≥ 60 s →
+ *    "Resume — {h m}" / "Continue — {h m}"
+ *
+ * The 60-second threshold is intentional: [formatPlayTime] returns
+ * `"< 1 min"` for sub-minute durations which would render as
+ * "Resume — < 1 min" — true but visually noisy. Below the threshold we
+ * keep the bare label and let the user start playing without the button
+ * advertising the trivial play time. (Mirrors the Hyrule design's
+ * intuition that the suffix should add concrete signal, not just text.)
+ */
+fun gameDetailPlayLabel(
+    semantics: PlaySemantics,
+    sessionPlayTimeSeconds: Long,
+): String {
+    val base = when (semantics) {
+        PlaySemantics.NoSession -> return "New game"
+        PlaySemantics.ResumesFromSaveState -> "Resume"
+        PlaySemantics.LaunchesFresh -> "Continue"
+    }
+    return if (sessionPlayTimeSeconds >= 60) {
+        "$base — ${formatPlayTime(sessionPlayTimeSeconds)}"
+    } else {
+        base
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/ui/feature/gamedetail/PlayCtaLabelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/ui/feature/gamedetail/PlayCtaLabelTest.kt
@@ -1,0 +1,65 @@
+package com.spela.player.presentation.ui.feature.gamedetail
+
+import com.spela.player.domain.model.PlaySemantics
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Unit tests for the pure resolver behind the game-detail hero's
+ * primary play button label. Captures the contract the user sees on
+ * the button text — getting this wrong silently misleads (e.g.
+ * "Resume" on a no-session game promises a save that doesn't exist).
+ */
+class PlayCtaLabelTest {
+
+    @Test
+    fun noSessionAlwaysReturnsNewGameRegardlessOfPlayTime() {
+        // The playtime input is irrelevant when there's no session;
+        // both branches must return the same label, otherwise the
+        // hero would advertise "Resume — 0m" before any save existed.
+        assertEquals("New game", gameDetailPlayLabel(PlaySemantics.NoSession, 0L))
+        assertEquals("New game", gameDetailPlayLabel(PlaySemantics.NoSession, 9999L))
+    }
+
+    @Test
+    fun resumesFromSaveStateWithoutPlayTimeStaysBare() {
+        // A session exists but the user only logged a few seconds —
+        // not worth surfacing "< 1 min" on a hero CTA.
+        assertEquals("Resume", gameDetailPlayLabel(PlaySemantics.ResumesFromSaveState, 0L))
+        assertEquals("Resume", gameDetailPlayLabel(PlaySemantics.ResumesFromSaveState, 59L))
+    }
+
+    @Test
+    fun launchesFreshWithoutPlayTimeStaysBare() {
+        assertEquals("Continue", gameDetailPlayLabel(PlaySemantics.LaunchesFresh, 0L))
+        assertEquals("Continue", gameDetailPlayLabel(PlaySemantics.LaunchesFresh, 59L))
+    }
+
+    @Test
+    fun resumeAtThresholdGetsMinuteSuffix() {
+        // 60 s is the exact threshold — formatPlayTime returns "1m"
+        // here, NOT "< 1 min". Both labels should reflect that.
+        assertEquals("Resume — 1m", gameDetailPlayLabel(PlaySemantics.ResumesFromSaveState, 60L))
+    }
+
+    @Test
+    fun resumeWithHoursAndMinutesUsesTheSameSuffixFormatAsRestOfApp() {
+        // 27h 14m mirrors the Chrono Trigger reference value used by
+        // the Hyrule design exploration. Format must match the rest
+        // of the app's `formatPlayTime` so the button text stays
+        // consistent with the SessionsSection / SessionDetail / etc.
+        val twentySevenHoursFourteenMinutes = 27L * 3600 + 14L * 60
+        assertEquals(
+            "Resume — 27h 14m",
+            gameDetailPlayLabel(PlaySemantics.ResumesFromSaveState, twentySevenHoursFourteenMinutes),
+        )
+    }
+
+    @Test
+    fun continueWithMinutesOnly() {
+        // LaunchesFresh covers ScummVM and console-save-state-disabled
+        // games. The label must be "Continue", not "Resume" — getting
+        // this wrong is exactly the bug PlaySemantics fixed in #884.
+        assertEquals("Continue — 45m", gameDetailPlayLabel(PlaySemantics.LaunchesFresh, 45L * 60))
+    }
+}


### PR DESCRIPTION
## Summary
- Hero CTA on game detail now reads "Resume — 27h 14m" (or "Continue — 45m") when the targeted session has ≥ 60 s of play time logged. Below the threshold the bare label stays so the button doesn't advertise a noisy "< 1 min".
- Resolver lifted out of `GameHeroContent` into a pure function `gameDetailPlayLabel(semantics, sessionPlayTimeSeconds)` so the threshold + label rules are unit-testable without spinning up Compose.
- 6 unit tests in `PlayCtaLabelTest` cover the full PlaySemantics × playtime matrix (NoSession ignores playtime, ResumesFromSaveState / LaunchesFresh stay bare under 60 s, exact-threshold "1m" suffix, h+m formatting matches the rest of the app via shared `formatPlayTime`, ScummVM "Continue" preserved).

Implements the suggestion filed as #1098.

## Test plan
- [x] `:shared:desktopTest --tests com.spela.player.presentation.ui.feature.gamedetail.PlayCtaLabelTest` — 6/6 pass.
- [x] Full desktop suite — 794 tests, 0 failures.
- [ ] Manual smoke on the desktop app: open a game detail with a session ≥ 1 min played, expect "Resume — 1h 23m"; open one with < 1 min played, expect bare "Resume"; open a fresh game, expect "New game".
- [ ] Manual: verify ScummVM-style game with auto-load disabled keeps the "Continue — Xh Ym" label, not "Resume".

## Related
- Builds on the PlaySemantics taxonomy from #884.
- Threshold + format chosen to match `formatPlayTime` (`com/spela/player/util/FormatUtils.kt`) — same suffix the SessionsSection / SessionDetail already use.