### PR TITLE
feat: enlarge game-detail box art and hero on web + player (#1097)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
@@ -89,7 +89,11 @@ fun GameDetailLayout(
 
         if (isLandscape) {
             val isSmallLandscape = maxHeight < 500.dp
-            val coverWidth = if (isSmallLandscape) 200.dp else 256.dp
+            // #1097 — bumped from 200/256 dp so the cover reads cinematic
+            // on standard desktop / tablet windows. The compact branch
+            // (AYN Thor in landscape, ~700 dp tall) keeps a smaller
+            // value so vertical real estate isn't eaten by the hero.
+            val coverWidth = if (isSmallLandscape) 280.dp else 380.dp
             LandscapeLayout(
                 coverWidth = coverWidth,
                 isCompact = isSmallLandscape,
@@ -132,7 +136,10 @@ private fun LandscapeLayout(
     fullWidthSections: @Composable () -> Unit,
 ) {
     val verticalPad = if (isCompact) SpSpacing.Medium else SpSpacing.XLarge
-    val bannerHeight = 200.dp + SpSpacing.TopBarHeight + SpSpacing.Large
+    // #1097 — banner sized to host the bigger cover (max-height 280/360 dp
+    // depending on isCompact) plus top/bottom padding.
+    val coverMaxHeight = if (isCompact) 280.dp else 360.dp
+    val bannerHeight = coverMaxHeight + SpSpacing.TopBarHeight + SpSpacing.Large
 
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
@@ -219,7 +226,7 @@ private fun LandscapeLayout(
                         Box(
                             modifier = Modifier
                                 .widthIn(max = coverWidth)
-                                .heightIn(max = 200.dp)
+                                .heightIn(max = coverMaxHeight)
                                 .clip(coverShape),
                         ) {
                             coverArt(Modifier.fillMaxWidth(), false)
@@ -361,11 +368,12 @@ private fun PortraitLayout(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
                     ) {
-                        // Cover art centered
+                        // Cover art centered. #1097 — bumped from 250 dp
+                        // for a more cinematic hero on portrait viewports.
                         val coverShape = RoundedCornerShape(SpSpacing.CardCornerRadius)
                         Box(
                             modifier = Modifier
-                                .widthIn(max = 250.dp)
+                                .widthIn(max = 340.dp)
                                 .shadow(12.dp, coverShape)
                                 .clip(coverShape)
                                 .border(2.dp, Color.White.copy(alpha = 0.15f), coverShape),

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -201,7 +201,7 @@ export function GameHero({
 
       {/* Content — in-flow so it sizes the wrapper. Dropdowns aren't
           clipped because no ancestor has overflow-hidden. */}
-      <div className="relative z-10 flex flex-col items-center md:flex-row md:items-end min-h-[320px] md:min-h-[400px] p-6 md:p-8 gap-6 md:gap-8">
+      <div className="relative z-10 flex flex-col items-center md:flex-row md:items-end min-h-[440px] md:min-h-[560px] p-6 md:p-10 gap-6 md:gap-8">
         {/* Cover art */}
           <div className="flex-shrink-0 self-center md:self-end">
             <div className="rounded-xl overflow-hidden bg-surface-900/80 border border-white/10 shadow-2xl backdrop-blur-sm">
@@ -209,14 +209,14 @@ export function GameHero({
                 <AreaSizedImage
                   src={game.coverUrl}
                   alt={game.title}
-                  targetArea={55000}
-                  maxHeight={360}
-                  maxWidth={320}
-                  minHeight={160}
+                  targetArea={120000}
+                  maxHeight={520}
+                  maxWidth={420}
+                  minHeight={220}
                   className="rounded-xl"
                 />
               ) : (
-                <div className="w-48 flex items-center justify-center bg-surface-800" style={{ aspectRatio: "3/4" }}>
+                <div className="w-64 flex items-center justify-center bg-surface-800" style={{ aspectRatio: "3/4" }}>
                   <span className="text-3xl font-bold text-surface-600">{game.title.charAt(0).toUpperCase()}</span>
                 </div>
               )}


### PR DESCRIPTION
## Summary
- Web hero: banner min-h 320/400 → 440/560 px; cover via `AreaSizedImage` 320×360 → 420×520, targetArea 55 000 → 120 000, padding `p-6 md:p-8` → `p-6 md:p-10`; missing-cover placeholder `w-48` → `w-64`.
- Player landscape: cover 200/256 → 280/380 dp, height 200 → 280/360 dp, banner 200 → 360 dp. AYN Thor (`isSmallLandscape`) keeps the conservative branch.
- Player portrait: cover max width 250 → 340 dp (banner remains content-driven).
- `GameDetailSkeleton` consumes `GameDetailLayout` so the new dimensions apply automatically; the existing 0×0 cover-slot shimmer stays unchanged so there's still no layout shift on data load.

Implements #1097.

## Test plan
- [x] Web vitest — 1600 tests, all green.
- [x] Player desktop suite — pending (running locally; will block merge if it fails).
- [ ] Manual smoke — web at 1920 px (verify cover ~420 px wide), web at <`md` (column stack still readable), player desktop landscape (380 dp cover sits next to title block), player portrait (340 dp cover centered above title block).
- [ ] Manual on AYN Thor — confirm `isSmallLandscape` branch keeps the 280 dp cover and the bottom shelves still fit on screen.