### PR TITLE
refactor(web): compact 3-up Time to Beat card paired under Your Rating (#1099)

### DIFF
--- a/web/src/features/game-detail/components/__tests__/time-to-beat-card.test.tsx
+++ b/web/src/features/game-detail/components/__tests__/time-to-beat-card.test.tsx
@@ -39,12 +39,27 @@ describe("TimeToBeatCard", () => {
     expect(screen.getByTestId("time-to-beat-card")).toBeInTheDocument();
   });
 
-  it('displays "How Long to Beat" heading', () => {
+  it('displays "Time to Beat" heading', () => {
     const game = makeGame({ timeToBeatNormally: hrs(10) });
     render(<TimeToBeatCard game={game} />);
     expect(
-      screen.getByRole("heading", { name: /How Long to Beat/i, level: 3 }),
+      screen.getByRole("heading", { name: /Time to Beat/i, level: 3 }),
     ).toBeInTheDocument();
+  });
+
+  it("does not render progress bars (#1099)", () => {
+    const game = makeGame({
+      timeToBeatHastily: hrs(10),
+      timeToBeatNormally: hrs(25),
+      timeToBeatCompletely: hrs(50),
+    });
+    const { container } = render(<TimeToBeatCard game={game} />);
+    // Pre-#1099: each tier had a bg-brand-400 / bg-amber-400 / bg-purple-400
+    // bar element. The compact redesign drops bars entirely.
+    expect(container.querySelectorAll("progress").length).toBe(0);
+    expect(container.querySelector("[class*='bg-brand-400']")).toBeNull();
+    expect(container.querySelector("[class*='bg-amber-400']")).toBeNull();
+    expect(container.querySelector("[class*='bg-purple-400']")).toBeNull();
   });
 
   it("converts seconds to hours and shows correct labels", () => {
@@ -65,7 +80,10 @@ describe("TimeToBeatCard", () => {
     expect(screen.getByText("50 hrs")).toBeInTheDocument();
   });
 
-  it("only shows tiers with non-zero values", () => {
+  it("renders all three tier labels even when some values are missing (#1099)", () => {
+    // Pre-#1099 tests asserted that zero-tiers were absent from the DOM
+    // (`.filter((t) => t.hours > 0)`). The compact redesign keeps the grid
+    // rhythm by rendering placeholder "—" cards for missing tiers.
     const game = makeGame({
       timeToBeatHastily: 0,
       timeToBeatNormally: hrs(15),
@@ -73,9 +91,29 @@ describe("TimeToBeatCard", () => {
     });
     render(<TimeToBeatCard game={game} />);
 
-    expect(screen.queryByText("Main Story")).not.toBeInTheDocument();
+    expect(screen.getByText("Main Story")).toBeInTheDocument();
     expect(screen.getByText("Main + Extras")).toBeInTheDocument();
     expect(screen.getByText("Completionist")).toBeInTheDocument();
+    // Missing tier shows the em-dash placeholder, not a value.
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("15 hrs")).toBeInTheDocument();
+    expect(screen.getByText("40 hrs")).toBeInTheDocument();
+  });
+
+  it("attaches an explanatory tooltip to each tier card (#1099)", () => {
+    const game = makeGame({
+      timeToBeatHastily: hrs(10),
+      timeToBeatNormally: hrs(25),
+      timeToBeatCompletely: hrs(50),
+    });
+    const { container } = render(<TimeToBeatCard game={game} />);
+    // Per-tier disambiguation moved from inline icons (#1099 dropped them)
+    // to a hover tooltip. Three tiers → three tooltips.
+    const tierCards = container.querySelectorAll("[title]");
+    expect(tierCards.length).toBe(3);
+    expect(tierCards[0].getAttribute("title")).toMatch(/main story/i);
+    expect(tierCards[1].getAttribute("title")).toMatch(/side content/i);
+    expect(tierCards[2].getAttribute("title")).toMatch(/100% completion/i);
   });
 
   it("formats fractional hours correctly", () => {

--- a/web/src/features/game-detail/components/time-to-beat-card.tsx
+++ b/web/src/features/game-detail/components/time-to-beat-card.tsx
@@ -1,80 +1,60 @@
-import { Clock, Zap, Gamepad2, Trophy } from "lucide-react";
-import { Section } from "@/components/ui";
+import { Clock } from "lucide-react";
 import type { Game } from "@/types/api";
 
 interface TimeToBeatCardProps {
   game: Game;
 }
 
+interface Tier {
+  label: string;
+  hours: number;
+  tooltip: string;
+}
+
 export function TimeToBeatCard({ game }: TimeToBeatCardProps) {
-  // Backend stores time-to-beat in seconds (from IGDB API)
   const hastily = (game.timeToBeatHastily ?? 0) / 3600;
   const normally = (game.timeToBeatNormally ?? 0) / 3600;
   const completely = (game.timeToBeatCompletely ?? 0) / 3600;
 
   if (!hastily && !normally && !completely) return null;
 
-  const maxHours = Math.max(hastily, normally, completely);
-
-  const tiers = [
-    {
-      label: "Main Story",
-      hours: hastily,
-      icon: Zap,
-      barClass: "bg-brand-400",
-      iconClass: "text-brand-400",
-      textClass: "text-brand-300",
-    },
-    {
-      label: "Main + Extras",
-      hours: normally,
-      icon: Gamepad2,
-      barClass: "bg-amber-400",
-      iconClass: "text-amber-400",
-      textClass: "text-amber-300",
-    },
-    {
-      label: "Completionist",
-      hours: completely,
-      icon: Trophy,
-      barClass: "bg-purple-400",
-      iconClass: "text-purple-400",
-      textClass: "text-purple-300",
-    },
-  ].filter((t) => t.hours > 0);
+  const tiers: Tier[] = [
+    { label: "Main Story", hours: hastily, tooltip: "Time to finish the main story" },
+    { label: "Main + Extras", hours: normally, tooltip: "Main story plus side content" },
+    { label: "Completionist", hours: completely, tooltip: "Everything — 100% completion" },
+  ];
 
   return (
-    <Section className="p-6" data-testid="time-to-beat-card">
-      <div className="flex items-center gap-2.5 mb-5">
-        <Clock className="h-5 w-5 text-brand-400" />
-        <h3 className="text-lg font-bold text-surface-100">How Long to Beat</h3>
+    <div
+      data-comp="TimeToBeatCard"
+      data-testid="time-to-beat-card"
+      className="rounded-xl bg-surface-800/30 p-4"
+    >
+      <div className="flex items-center gap-2.5 mb-3">
+        <Clock className="h-4 w-4 text-surface-500" />
+        <h3 className="text-sm font-semibold text-surface-200">Time to Beat</h3>
       </div>
-      <div className="space-y-4">
-        {tiers.map((tier) => {
-          const Icon = tier.icon;
-          const pct = maxHours > 0 ? (tier.hours / maxHours) * 100 : 0;
-          return (
-            <div key={tier.label}>
-              <div className="flex items-center justify-between mb-1.5">
-                <div className="flex items-center gap-2">
-                  <Icon className={`h-4 w-4 ${tier.iconClass}`} />
-                  <span className="text-sm font-medium text-surface-200">{tier.label}</span>
-                </div>
-                <span className={`text-sm font-bold tabular-nums ${tier.textClass}`}>
-                  {formatHours(tier.hours)}
-                </span>
-              </div>
-              <div className="h-2 w-full rounded-full bg-surface-800/80 overflow-hidden">
-                <div
-                  className={`h-full rounded-full ${tier.barClass} transition-all duration-700 ease-out`}
-                  style={{ width: `${Math.max(pct, 4)}%`, opacity: 0.85 }}
-                />
-              </div>
+      <div className="grid grid-cols-3 gap-2">
+        {tiers.map((tier) => (
+          <div
+            key={tier.label}
+            className="rounded-lg bg-surface-900/50 px-2.5 py-2"
+            title={tier.tooltip}
+          >
+            <div className="text-[10px] uppercase tracking-wide text-surface-500 truncate">
+              {tier.label}
             </div>
-          );
-        })}
+            <div className="text-base font-semibold text-surface-100 tabular-nums mt-0.5">
+              {tier.hours > 0 ? (
+                formatHours(tier.hours)
+              ) : (
+                <span className="text-surface-600">—</span>
+              )}
+            </div>
+          </div>
+        ))}
       </div>
-    </Section>
+    </div>
   );
 }
 

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -296,8 +296,12 @@ export function GameDetailPage() {
 
       {/* Rating + description + metadata */}
       <div className="flex gap-6">
-        <div className="flex-shrink-0">
+        <div className="flex-shrink-0 space-y-3">
           <UserRating gameId={game.id} />
+          {/* #1099 — paired directly with UserRating; shared chrome
+              (rounded-xl bg-surface-800/30 p-4). Was a sibling block
+              in the page flow far below; now a compact 3-up grid. */}
+          {!isDemo && <TimeToBeatCard game={game} />}
         </div>
         <div className="flex-1 min-w-0 space-y-4">
           {game.description && (
@@ -431,8 +435,6 @@ export function GameDetailPage() {
           ))}
         </div>
       )}
-
-      {!isDemo && <TimeToBeatCard game={game} />}
 
       {!isDemo && <GameSessions gameId={game.id} gameTitle={game.title} />}
 


### PR DESCRIPTION
## Summary
- Replaces the full-width `<Section>` Time to Beat block (~200 px tall) with a compact 3-up grid (~96 px tall) using the same `rounded-xl bg-surface-800/30 p-4` chrome as `UserRating`.
- Mounts as a sibling immediately below `UserRating` in the same `flex-shrink-0` column so the two read as a paired group.
- Drops the per-tier progress bars and per-tier role icons (Zap / Gamepad2 / Trophy). Disambiguation moves to a hover tooltip on each tier card.
- Renders all three tiers always; missing values show a `text-surface-600` em-dash so the grid rhythm stays consistent across games.

Implements #1099.

## Test plan
- [x] `time-to-beat-card.test.tsx` — 12 tests pass, including new assertions that no progress bars or tier-colour classes exist, all three tier labels are present even when values are missing, em-dash placeholder for the missing tier, and tooltip per tier.
- [ ] Manual smoke at 1280 / 1440 / 1920 px viewports — confirm pairing with UserRating, no clipping in `grid-cols-3` cells.
- [ ] Manual: game with all three tiers populated, game with only "Main + Extras" populated (verify em-dashes), game with all-zero (verify component hides).
- [ ] Visual: hover over a tier card → tooltip text appears.

## Out of scope
- Player app parity (no TimeToBeat UI exists in Kotlin today).
- Information-density audit of the rest of the right column.