### PR TITLE
feat(web): group-by toggle on console list (generation / manufacturer) (#1094)

### DIFF
--- a/web/src/lib/__tests__/console-grouping.test.ts
+++ b/web/src/lib/__tests__/console-grouping.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { makeConsole } from "@/test-utils/fixtures";
+import {
+  groupByGeneration,
+  groupByManufacturer,
+  groupConsoles,
+} from "@/lib/console-grouping";
+
+const nes = makeConsole({
+  id: "nes",
+  name: "Nintendo Entertainment System",
+  generation: 3,
+  releaseYear: 1983,
+  maker: { code: "nintendo", name: "Nintendo" },
+});
+const snes = makeConsole({
+  id: "snes",
+  name: "Super Nintendo",
+  generation: 4,
+  releaseYear: 1990,
+  maker: { code: "nintendo", name: "Nintendo" },
+});
+const n64 = makeConsole({
+  id: "n64",
+  name: "Nintendo 64",
+  generation: 5,
+  releaseYear: 1996,
+  maker: { code: "nintendo", name: "Nintendo" },
+});
+const genesis = makeConsole({
+  id: "genesis",
+  name: "Sega Genesis",
+  generation: 4,
+  releaseYear: 1988,
+  maker: { code: "sega", name: "Sega" },
+});
+const atari2600 = makeConsole({
+  id: "a2600",
+  name: "Atari 2600",
+  generation: 2,
+  releaseYear: 1977,
+  maker: { code: "atari", name: "Atari" },
+});
+const arcade = makeConsole({
+  id: "arcade",
+  name: "Arcade",
+  generation: 101,
+  releaseYear: null,
+  maker: { code: "various", name: "Various" },
+});
+const scummvm = makeConsole({
+  id: "scummvm",
+  name: "ScummVM",
+  generation: 100,
+  releaseYear: null,
+  maker: { code: "various", name: "Various" },
+});
+
+describe("groupByGeneration", () => {
+  it("orders generations ascending", () => {
+    const groups = groupByGeneration([n64, nes, atari2600, snes]);
+    expect(groups.map((g) => g.generation)).toEqual([2, 3, 4, 5]);
+  });
+
+  it("renders Home Computers (gen 100) and Arcade (gen 101) at the end", () => {
+    const groups = groupByGeneration([snes, arcade, atari2600, scummvm]);
+    expect(groups.map((g) => g.generation)).toEqual([2, 4, 100, 101]);
+  });
+});
+
+describe("groupByManufacturer", () => {
+  it("groups by maker.code and sorts alphabetically by maker.name", () => {
+    const groups = groupByManufacturer([n64, genesis, nes, atari2600]);
+    // Atari < Nintendo < Sega alphabetically.
+    expect(groups.map((g) => g.makerName)).toEqual([
+      "Atari",
+      "Nintendo",
+      "Sega",
+    ]);
+  });
+
+  it("pins 'Various' to the end regardless of alphabetical order", () => {
+    // "Atari" / "Nintendo" / "Various" / "Sega" — even though "S" < "V"
+    // alphabetically, Various must come last as the catch-all bucket.
+    const groups = groupByManufacturer([
+      arcade,
+      genesis,
+      nes,
+      atari2600,
+      scummvm,
+    ]);
+    expect(groups.map((g) => g.makerName)).toEqual([
+      "Atari",
+      "Nintendo",
+      "Sega",
+      "Various",
+    ]);
+  });
+
+  it("orders consoles within each manufacturer by releaseYear ascending", () => {
+    // NES 1983 → SNES 1990 → N64 1996 — chronological inside Nintendo.
+    const groups = groupByManufacturer([n64, snes, nes]);
+    expect(groups[0].makerName).toBe("Nintendo");
+    expect(groups[0].consoles.map((c) => c.id)).toEqual(["nes", "snes", "n64"]);
+  });
+
+  it("buckets consoles missing maker into Various rather than dropping them", () => {
+    // DB rows from before the maker column existed have an empty
+    // maker { code: '', name: '' } — they should bucket as Various
+    // (the seed value used for arcade/demos/scummvm) so they aren't
+    // silently hidden.
+    const orphan = makeConsole({
+      id: "orphan",
+      name: "Orphan Console",
+      generation: 0,
+      maker: { code: "", name: "" },
+    });
+    const groups = groupByManufacturer([nes, orphan]);
+    // The empty-code orphan and any actual "various" rows share the
+    // same default-name bucket. Two distinct groups are reasonable
+    // here; the test asserts the orphan is *somewhere* (not dropped)
+    // and that Nintendo still leads alphabetically.
+    expect(groups.length).toBeGreaterThanOrEqual(2);
+    const allConsoleIds = groups.flatMap((g) => g.consoles.map((c) => c.id));
+    expect(allConsoleIds).toContain("orphan");
+    expect(allConsoleIds).toContain("nes");
+  });
+
+  it("returns an empty list when given no consoles", () => {
+    expect(groupByManufacturer([])).toEqual([]);
+  });
+});
+
+describe("groupConsoles", () => {
+  it("dispatches to groupByGeneration for grouping='generation'", () => {
+    const groups = groupConsoles([n64, nes], "generation");
+    expect(groups[0].kind).toBe("generation");
+  });
+
+  it("dispatches to groupByManufacturer for grouping='manufacturer'", () => {
+    const groups = groupConsoles([n64, nes], "manufacturer");
+    expect(groups[0].kind).toBe("manufacturer");
+  });
+});

--- a/web/src/lib/console-grouping.ts
+++ b/web/src/lib/console-grouping.ts
@@ -1,0 +1,127 @@
+import type { Console } from "@/types/api";
+
+export type ConsoleGrouping = "generation" | "manufacturer";
+
+export interface GenerationInfo {
+  label: string;
+  years: string;
+}
+
+export interface GenerationGroup {
+  kind: "generation";
+  key: string;
+  generation: number;
+  info: GenerationInfo;
+  consoles: Console[];
+}
+
+export interface ManufacturerGroup {
+  kind: "manufacturer";
+  key: string;
+  makerCode: string;
+  makerName: string;
+  consoles: Console[];
+}
+
+export type ConsoleGroup = GenerationGroup | ManufacturerGroup;
+
+const VARIOUS_MAKER_CODE = "various";
+
+export function generationInfo(generation: number): GenerationInfo {
+  switch (generation) {
+    case 2:
+      return { label: "2nd Generation", years: "1976–1982" };
+    case 3:
+      return { label: "3rd Generation", years: "1983–1987" };
+    case 4:
+      return { label: "4th Generation", years: "1987–1993" };
+    case 5:
+      return { label: "5th Generation", years: "1993–1998" };
+    case 6:
+      return { label: "6th Generation", years: "1998–2005" };
+    case 7:
+      return { label: "7th Generation", years: "2005–2012" };
+    case 8:
+      return { label: "8th Generation", years: "2012–2020" };
+    case 9:
+      return { label: "9th Generation", years: "2020–present" };
+    case 100:
+      return { label: "Home Computers", years: "1977–1995" };
+    case 101:
+      return { label: "Arcade", years: "1971–present" };
+    default:
+      return { label: "Other", years: "" };
+  }
+}
+
+export function groupByGeneration(consoles: Console[]): GenerationGroup[] {
+  const map = new Map<number, Console[]>();
+  for (const c of consoles) {
+    const gen = c.generation || 0;
+    if (!map.has(gen)) map.set(gen, []);
+    map.get(gen)!.push(c);
+  }
+  return Array.from(map.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([gen, items]) => ({
+      kind: "generation",
+      key: `gen-${gen}`,
+      generation: gen,
+      info: generationInfo(gen),
+      consoles: items,
+    }));
+}
+
+/**
+ * Groups consoles by their `maker.code`. Manufacturers are sorted
+ * alphabetically by `maker.name` so the user can predict where each
+ * row lives; the catch-all `"various"` bucket (arcade / DOS demos /
+ * Amiga demos / scummvm — see seed_metadata.go) is pinned last so
+ * the named manufacturers read first.
+ *
+ * Within each manufacturer, consoles are ordered by `releaseYear`
+ * ascending to match the chronological intra-group order used by the
+ * generation view. Consoles missing `maker` (rare, but possible on DB
+ * rows that pre-date the maker column) are bucketed into `Various`
+ * rather than dropped — keeping the grouping idempotent across data
+ * states.
+ */
+export function groupByManufacturer(consoles: Console[]): ManufacturerGroup[] {
+  const buckets = new Map<string, { name: string; consoles: Console[] }>();
+  for (const c of consoles) {
+    const code = c.maker?.code ?? VARIOUS_MAKER_CODE;
+    const name = c.maker?.name ?? "Various";
+    if (!buckets.has(code)) {
+      buckets.set(code, { name, consoles: [] });
+    }
+    buckets.get(code)!.consoles.push(c);
+  }
+  for (const bucket of buckets.values()) {
+    bucket.consoles.sort(
+      (a, b) => (a.releaseYear ?? 0) - (b.releaseYear ?? 0),
+    );
+  }
+  return Array.from(buckets.entries())
+    .sort(([codeA, a], [codeB, b]) => {
+      // Pin "various" to the end regardless of name.
+      if (codeA === VARIOUS_MAKER_CODE) return 1;
+      if (codeB === VARIOUS_MAKER_CODE) return -1;
+      return a.name.localeCompare(b.name);
+    })
+    .map(([code, bucket]) => ({
+      kind: "manufacturer",
+      key: `maker-${code}`,
+      makerCode: code,
+      makerName: bucket.name,
+      consoles: bucket.consoles,
+    }));
+}
+
+export function groupConsoles(
+  consoles: Console[],
+  grouping: ConsoleGrouping,
+): ConsoleGroup[] {
+  return grouping === "manufacturer"
+    ? groupByManufacturer(consoles)
+    : groupByGeneration(consoles);
+}

--- a/web/src/pages/consoles-page.tsx
+++ b/web/src/pages/consoles-page.tsx
@@ -1,68 +1,38 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Gamepad2 } from "lucide-react";
 import { ConsoleCard } from "@/components/console-card";
-import { ConsoleCardSkeleton, EmptyState } from "@/components/ui";
+import { Chip, ConsoleCardSkeleton, EmptyState } from "@/components/ui";
 import { useBiosStatus } from "@/hooks/use-bios";
 import { useConsoles } from "@/hooks/use-consoles";
-import type { Console } from "@/types/api";
 import { PageLayout, SectionList } from "@/components/layout";
+import {
+  type ConsoleGrouping,
+  groupConsoles,
+} from "@/lib/console-grouping";
 
-interface GenerationInfo {
-  label: string;
-  years: string;
-}
+const STORAGE_KEY = "consoleListGrouping";
 
-function generationInfo(generation: number): GenerationInfo {
-  switch (generation) {
-    case 2:
-      return { label: "2nd Generation", years: "1976–1982" };
-    case 3:
-      return { label: "3rd Generation", years: "1983–1987" };
-    case 4:
-      return { label: "4th Generation", years: "1987–1993" };
-    case 5:
-      return { label: "5th Generation", years: "1993–1998" };
-    case 6:
-      return { label: "6th Generation", years: "1998–2005" };
-    case 7:
-      return { label: "7th Generation", years: "2005–2012" };
-    case 8:
-      return { label: "8th Generation", years: "2012–2020" };
-    case 9:
-      return { label: "9th Generation", years: "2020–present" };
-    case 100:
-      return { label: "Home Computers", years: "1977–1995" };
-    case 101:
-      return { label: "Arcade", years: "1971–present" };
-    default:
-      return { label: "Other", years: "" };
-  }
-}
-
-function groupByGeneration(
-  consoles: Console[],
-): { generation: number; info: GenerationInfo; consoles: Console[] }[] {
-  const map = new Map<number, Console[]>();
-  for (const c of consoles) {
-    const gen = c.generation || 0;
-    if (!map.has(gen)) map.set(gen, []);
-    map.get(gen)!.push(c);
-  }
-  return Array.from(map.entries())
-    .sort(([a], [b]) => a - b)
-    .map(([gen, items]) => ({
-      generation: gen,
-      info: generationInfo(gen),
-      consoles: items,
-    }));
+function readGroupingPreference(): ConsoleGrouping {
+  if (typeof window === "undefined") return "generation";
+  const v = window.localStorage.getItem(STORAGE_KEY);
+  return v === "manufacturer" ? "manufacturer" : "generation";
 }
 
 export function ConsolesPage() {
   const { data: consoles, isLoading } = useConsoles();
   const { data: biosData } = useBiosStatus();
+  const [grouping, setGrouping] = useState<ConsoleGrouping>(
+    readGroupingPreference,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(STORAGE_KEY, grouping);
+  }, [grouping]);
+
   const groups = useMemo(
-    () => (consoles ? groupByGeneration(consoles) : []),
-    [consoles],
+    () => (consoles ? groupConsoles(consoles, grouping) : []),
+    [consoles, grouping],
   );
 
   // Set of consoleIds for which a required BIOS file is missing on disk.
@@ -95,13 +65,34 @@ export function ConsolesPage() {
         />
       ) : (
         <div className="space-y-8">
+          <div
+            data-testid="console-grouping-toggle"
+            className="flex items-center gap-2"
+            role="group"
+            aria-label="Console grouping"
+          >
+            <Chip
+              data-testid="console-grouping-generation"
+              selected={grouping === "generation"}
+              onClick={() => setGrouping("generation")}
+            >
+              By generation
+            </Chip>
+            <Chip
+              data-testid="console-grouping-manufacturer"
+              selected={grouping === "manufacturer"}
+              onClick={() => setGrouping("manufacturer")}
+            >
+              By manufacturer
+            </Chip>
+          </div>
           {groups.map((group) => (
-            <section key={group.generation}>
+            <section key={group.key}>
               <div className="flex items-baseline gap-3 mb-4">
                 <h2 className="text-lg font-semibold text-surface-200">
-                  {group.info.label}
+                  {group.kind === "generation" ? group.info.label : group.makerName}
                 </h2>
-                {group.info.years && (
+                {group.kind === "generation" && group.info.years && (
                   <span className="text-sm text-surface-500">
                     {group.info.years}
                   </span>


### PR DESCRIPTION
## Summary
- Adds a top-of-page toggle on the consoles list with two `Chip` pills: **By generation** (default) / **By manufacturer**.
- New pure module `src/lib/console-grouping.ts` exposes `groupByGeneration`, `groupByManufacturer`, and a `groupConsoles(consoles, grouping)` dispatcher. 9 vitest tests cover the alphabetical sort, "Various"-pinned-last, releaseYear-ascending intra-group order, and the orphan-bucketing fallback.
- User's choice is persisted in `localStorage.consoleListGrouping` so it sticks across sessions; defaults to `"generation"` for first-time users.
- No server changes — `ConsoleResponse.maker` is already populated from the seeded `HardwareMaker` table.
- Player-app parity is **out of scope** for this PR (issue acceptance criteria covers both surfaces; the Kotlin side needs a SQLDelight key/value entry for device-local persistence and deserves its own focused PR).

Implements the web half of #1094.

## Test plan
- [x] 9 vitest cases for the grouper:
  - Generations ordered ascending; Home Computers (100) and Arcade (101) at the end.
  - Manufacturers alphabetical by name; Various pinned last regardless of letter.
  - Consoles inside each manufacturer ordered by releaseYear ascending.
  - Orphan consoles (empty maker) survive — bucketed not dropped.
  - `groupConsoles` dispatcher covered for both branches.
- [x] Full web vitest suite — 1611/1611 pass.
- [ ] Manual smoke at 1280 / 1920 px — toggle pills visible, sections re-render with correct headers, choice survives a reload.
- [ ] Manual: clear localStorage → page defaults to "By generation".
- [ ] Playwright E2E (filed as follow-up; deferred per local-only-Playwright policy).

## Follow-up
- Kotlin player-app parity (`LibraryConsolesTab` / `ConsolesGrid` parameterization + SQLDelight key/value persistence). The acceptance criteria item for the player surface stays open until that ships.