### PR TITLE
feat: console-detail relocate Browse/Scan/Settings out of hero banner

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ConsoleDetailBrowseSectionTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ConsoleDetailBrowseSectionTest.kt
@@ -1,0 +1,191 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.ui.TestTags
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+
+/**
+ * Desktop E2E tests for the console detail screen changes from #1095:
+ * - Terminal "Library" browse section renders for >15-game libraries
+ * - Terminal section is hidden for ≤15-game libraries
+ * - Admin overflow menu (MoreVert) is visible for admin users
+ * - Admin overflow menu is hidden for non-admin users
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ConsoleDetailBrowseSectionTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private fun SpelaTestHarness.setupLargeLibrary(consoleId: String = "nes", gameCount: Int = 20) {
+        val existingConsole = gameRepo.consoles.find { it.id == consoleId }!!
+        gameRepo.consoles = gameRepo.consoles.map {
+            if (it.id == consoleId) it.copy(gameCount = gameCount) else it
+        }
+        gameRepo.games = (1..gameCount).map { index ->
+            Game(
+                id = "large_$index",
+                title = "Game $index",
+                consoleId = consoleId,
+                consoleName = existingConsole.name,
+                developer = "Dev",
+                publisher = "Pub",
+                releaseDate = "2000",
+                genre = "Action",
+                fileSize = 131072,
+                fileName = "game_$index.nes",
+                scrapeAttempts = 1,
+            )
+        }
+    }
+
+    private fun SpelaTestHarness.setupSmallLibrary(consoleId: String = "nes", gameCount: Int = 3) {
+        gameRepo.consoles = gameRepo.consoles.map {
+            if (it.id == consoleId) it.copy(gameCount = gameCount) else it
+        }
+        gameRepo.games = gameRepo.games.filter { it.consoleId == consoleId }.take(gameCount)
+    }
+
+    // ─────────────────────────────────────────────────
+    // Terminal browse section: large library (>15 games)
+    // ─────────────────────────────────────────────────
+
+    @Test
+    fun terminalBrowseSectionVisibleForLargeLibrary() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setupLargeLibrary(gameCount = 20)
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        advance(harness)
+
+        onNodeWithTag(TestTags.CONSOLE_BROWSE_ALL_SECTION).assertIsDisplayed()
+        onNodeWithTag(TestTags.CONSOLE_BROWSE_ALL_CTA).assertIsDisplayed()
+    }
+
+    @Test
+    fun terminalBrowseSectionContainsGameCount() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setupLargeLibrary(gameCount = 20)
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        advance(harness)
+
+        onNodeWithText("Browse all 20", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun terminalBrowseSectionHiddenForSmallLibrary() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setupSmallLibrary(gameCount = 3)
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        advance(harness)
+
+        onAllNodesWithTag(TestTags.CONSOLE_BROWSE_ALL_SECTION).assertCountEquals(0)
+        onAllNodesWithTag(TestTags.CONSOLE_BROWSE_ALL_CTA).assertCountEquals(0)
+    }
+
+    @Test
+    fun terminalBrowseSectionHiddenForExactlyFifteenGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setupLargeLibrary(gameCount = 15)
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        advance(harness)
+
+        onAllNodesWithTag(TestTags.CONSOLE_BROWSE_ALL_SECTION).assertCountEquals(0)
+    }
+
+    @Test
+    fun terminalBrowseSectionVisibleForSixteenGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setupLargeLibrary(gameCount = 16)
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        advance(harness)
+
+        onNodeWithTag(TestTags.CONSOLE_BROWSE_ALL_SECTION).assertIsDisplayed()
+    }
+
+    // ─────────────────────────────────────────────────
+    // Admin overflow menu visibility
+    // ─────────────────────────────────────────────────
+
+    @Test
+    fun adminMenuButtonVisibleForAdminUser() = runComposeUiTest {
+        val harness = createHarness()
+        harness.authRepo.simulateAdminLoggedIn()
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        advanceFully(harness)
+
+        onNodeWithTag(TestTags.CONSOLE_ADMIN_MENU_BUTTON).assertIsDisplayed()
+    }
+
+    @Test
+    fun adminMenuButtonHiddenForNonAdminUser() = runComposeUiTest {
+        val harness = createHarness()
+        // Default FakeAuthRepository returns role "player" — non-admin
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        advanceFully(harness)
+
+        onAllNodesWithTag(TestTags.CONSOLE_ADMIN_MENU_BUTTON).assertCountEquals(0)
+    }
+
+    @Test
+    fun adminMenuOpensWithSettingsItem() = runComposeUiTest {
+        val harness = createHarness()
+        harness.authRepo.simulateAdminLoggedIn()
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        advanceFully(harness)
+
+        onNodeWithTag(TestTags.CONSOLE_ADMIN_MENU_BUTTON).performClick()
+        advanceQuick(harness)
+
+        onNodeWithTag(TestTags.CONSOLE_ADMIN_MENU_SETTINGS).assertIsDisplayed()
+    }
+
+    // ─────────────────────────────────────────────────
+    // Banner is clean — no action buttons
+    // ─────────────────────────────────────────────────
+
+    @Test
+    fun heroBannerHasNoBrowseGamesButton() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setupLargeLibrary(gameCount = 20)
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        advance(harness)
+
+        // The old banner browse button used consoleBrowseGames tag — should be gone
+        onAllNodesWithTag(TestTags.consoleBrowseGames("nes")).assertCountEquals(0)
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -129,6 +129,7 @@ class SpelaTestHarness(
         dispatchers = dispatchers,
         scope = scope,
         biosRepository = biosRepo,
+        authRepository = authRepo,
     )
     val sharedSessionRepo = FakeSharedSessionRepository()
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -170,10 +170,18 @@ class FakeAuthRepository : AuthRepository {
     var shouldFail = false
     var registeredUsers = mutableMapOf("player" to "player123")
     private var tokens: AuthTokens? = null
+    /** Role returned by getCurrentUser(). Set to "admin" or "owner" for admin tests. */
+    var userRole: String = "player"
 
     /** Pre-set tokens so getCurrentUser() returns success without calling login(). */
     fun simulateLoggedIn() {
         tokens = AuthTokens("test-access-token", "test-refresh-token")
+    }
+
+    /** Pre-set tokens and role so admin-only UI elements are visible in tests. */
+    fun simulateAdminLoggedIn() {
+        tokens = AuthTokens("test-access-token", "test-refresh-token")
+        userRole = "admin"
     }
 
     override suspend fun login(
@@ -212,7 +220,7 @@ class FakeAuthRepository : AuthRepository {
 
     override suspend fun getCurrentUser(): Result<User> {
         return if (tokens != null) {
-            Result.success(User("1", "player", "player@test.com", "player"))
+            Result.success(User("1", "player", "player@test.com", userRole))
         } else {
             Result.failure(Exception("Not logged in"))
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameListState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameListState.kt
@@ -13,6 +13,7 @@ enum class ViewMode {
 }
 
 data class GameListState(
+    val isAdmin: Boolean = false,
     val consoles: List<Console> = emptyList(),
     val games: List<Game> = emptyList(),
     val recentGames: List<Game> = emptyList(),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/TestTags.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/TestTags.kt
@@ -62,6 +62,12 @@ object TestTags {
     fun consoleCard(consoleId: String) = "console_card_$consoleId"
     fun consoleBrowseGames(consoleId: String) = "console_browse_games_$consoleId"
 
+    // Console detail — terminal browse section and admin overflow menu
+    const val CONSOLE_BROWSE_ALL_SECTION = "console_browse_all_section"
+    const val CONSOLE_BROWSE_ALL_CTA = "console_browse_all_cta"
+    const val CONSOLE_ADMIN_MENU_BUTTON = "console_admin_menu_button"
+    const val CONSOLE_ADMIN_MENU_SETTINGS = "console_admin_menu_settings"
+
     // Game detail — primary CTA changes label between Play / Resume / Download
     // depending on save + cache state. Tests should target the tag, not the
     // visible label, since a Continue/Resume copy change shouldn't fail tests.

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -35,7 +35,6 @@ import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Language
@@ -410,59 +409,17 @@ internal fun ConsolesSkeletonGrid(
 internal fun ConsoleHeroBanner(
     console: Console,
     modifier: Modifier = Modifier,
-    onBrowseGames: (() -> Unit)? = null,
-    onConsoleSettings: (() -> Unit)? = null,
 ) {
-    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
-        val showButtonsBelow = maxWidth < 700.dp
-        Column {
-            ConsoleHeroBannerContent(
-                console = console,
-                onBrowseGames = onBrowseGames,
-                onConsoleSettings = onConsoleSettings,
-                showButtons = !showButtonsBelow,
-            )
-            if (showButtonsBelow && (onBrowseGames != null || onConsoleSettings != null)) {
-                Spacer(Modifier.height(SpSpacing.Medium))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-                ) {
-                    if (onConsoleSettings != null) {
-                        SpButton(
-                            text = "Settings",
-                            onClick = onConsoleSettings,
-                            style = SpButtonStyle.Outlined,
-                            modifier = Modifier.weight(1f).autoFocus(),
-                            leadingIcon = {
-                                Icon(
-                                    Icons.Filled.Settings,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp),
-                                )
-                            },
-                        )
-                    }
-                    if (onBrowseGames != null) {
-                        SpButton(
-                            text = "Browse",
-                            onClick = onBrowseGames,
-                            style = SpButtonStyle.Secondary,
-                            modifier = Modifier.weight(1f),
-                        )
-                    }
-                }
-            }
-        }
-    }
+    ConsoleHeroBannerContent(
+        console = console,
+        modifier = modifier.fillMaxWidth(),
+    )
 }
 
 @Composable
 private fun ConsoleHeroBannerContent(
     console: Console,
-    onBrowseGames: (() -> Unit)? = null,
-    onConsoleSettings: (() -> Unit)? = null,
-    showButtons: Boolean = true,
+    modifier: Modifier = Modifier,
 ) {
     val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
 
@@ -481,8 +438,7 @@ private fun ConsoleHeroBannerContent(
     )
 
     Box(
-        modifier = Modifier
-            .fillMaxWidth()
+        modifier = modifier
             .height(200.dp)
             .focusGroup()
             .clip(shape)
@@ -654,46 +610,6 @@ private fun ConsoleHeroBannerContent(
                     }
                 }
 
-                // Bottom-right: action buttons (only when parent says so)
-                if (showButtons && (onBrowseGames != null || onConsoleSettings != null)) {
-                    Column(
-                        modifier = Modifier.align(Alignment.BottomEnd),
-                        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-                        horizontalAlignment = Alignment.End,
-                    ) {
-                        // Both banner action buttons use the tinted-on-
-                        // gradient treatment so they read as siblings of
-                        // the hero badges (white tint + thin white border)
-                        // instead of competing with the gradient via the
-                        // brand-gradient + neon glow. See #930.
-                        if (onConsoleSettings != null) {
-                            SpButton(
-                                text = "Console settings",
-                                onClick = onConsoleSettings,
-                                style = SpButtonStyle.Tinted,
-                                modifier = Modifier.autoFocus(),
-                                leadingIcon = {
-                                    Icon(
-                                        Icons.Filled.Settings,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(16.dp),
-                                    )
-                                },
-                            )
-                        }
-                        if (onBrowseGames != null) {
-                            SpButton(
-                                text = "Browse games",
-                                onClick = onBrowseGames,
-                                style = SpButtonStyle.Tinted,
-                                modifier = Modifier.testTag(
-                                    com.spela.player.presentation.ui.TestTags
-                                        .consoleBrowseGames(console.id),
-                                ),
-                            )
-                        }
-                    }
-                }
             }
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -10,19 +10,28 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.LibraryBooks
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
@@ -61,8 +70,11 @@ import androidx.compose.runtime.CompositionLocalProvider
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.rememberFocus
 import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
+import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 import com.spela.player.presentation.viewmodel.GameListViewModel
 
@@ -127,13 +139,9 @@ fun ConsoleScreen(
                 SpScrollableContent {
                     SpScreenTopSpacer()
                     SpMainContentPadding {
-                    // Console hero banner — inside padding
+                    // Console hero banner — pure identity, no action buttons
                     if (console != null) {
-                        ConsoleHeroBanner(
-                            console = console,
-                            onBrowseGames = if (state.games.size > 15) onBrowseAllGames else null,
-                            onConsoleSettings = onNavigateToConsoleSettings,
-                        )
+                        ConsoleHeroBanner(console = console)
                     }
 
                     val focusMemory = rememberFocusMemoryState()
@@ -213,7 +221,6 @@ fun ConsoleScreen(
                     }
 
                     // All Games — inline grid at bottom for small libraries (≤15 games)
-                    // For larger libraries, the "Browse games" button is in the hero banner
                     if (state.games.isNotEmpty() && state.games.size <= 15) {
                         SpTitledSection(
                             title = "All Games",
@@ -233,6 +240,26 @@ fun ConsoleScreen(
                                         )
                                     }
                                 },
+                            )
+                        }
+                    }
+
+                    // Terminal browse section for larger libraries (>15 games)
+                    if (state.games.size > 15) {
+                        SpTitledSection(
+                            title = "Library",
+                            icon = Icons.AutoMirrored.Filled.LibraryBooks,
+                            modifier = Modifier
+                                .rememberFocus("section_library")
+                                .testTag(TestTags.CONSOLE_BROWSE_ALL_SECTION),
+                        ) {
+                            SpButton(
+                                text = "Browse all ${state.games.size} $consoleName games",
+                                onClick = onBrowseAllGames,
+                                style = SpButtonStyle.Secondary,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .testTag(TestTags.CONSOLE_BROWSE_ALL_CTA),
                             )
                         }
                     }
@@ -276,12 +303,43 @@ fun ConsoleScreen(
                     }
                 } else null,
                 actions = {
-                    SpIconButton(
-                        icon = Icons.Filled.Settings,
-                        contentDescription = "Console settings",
-                        onGradient = true,
-                        onClick = onNavigateToConsoleSettings,
-                    )
+                    if (state.isAdmin) {
+                        var adminMenuExpanded by remember { mutableStateOf(false) }
+                        Box {
+                            SpIconButton(
+                                icon = Icons.Filled.MoreVert,
+                                contentDescription = "Console options",
+                                onGradient = true,
+                                onClick = { adminMenuExpanded = true },
+                                modifier = Modifier.testTag(TestTags.CONSOLE_ADMIN_MENU_BUTTON),
+                            )
+                            DropdownMenu(
+                                expanded = adminMenuExpanded,
+                                onDismissRequest = { adminMenuExpanded = false },
+                            ) {
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            text = "Console settings",
+                                            style = SpTypography.BodyMedium,
+                                        )
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = Icons.Filled.Settings,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(20.dp),
+                                        )
+                                    },
+                                    onClick = {
+                                        adminMenuExpanded = false
+                                        onNavigateToConsoleSettings()
+                                    },
+                                    modifier = Modifier.testTag(TestTags.CONSOLE_ADMIN_MENU_SETTINGS),
+                                )
+                            }
+                        }
+                    }
                 },
             )
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -3,6 +3,7 @@ package com.spela.player.presentation.viewmodel
 import com.spela.player.data.remote.ScrapeService
 import com.spela.player.data.repository.BiosRepository
 import com.spela.player.domain.model.Game
+import com.spela.player.domain.repository.AuthRepository
 import com.spela.player.domain.repository.ChallengeRepository
 import com.spela.player.domain.repository.GameRepository
 import com.spela.player.domain.usecase.*
@@ -36,6 +37,7 @@ class GameListViewModel(
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
     private val biosRepository: BiosRepository? = null,
+    private val authRepository: AuthRepository? = null,
 ) {
     private val _state = MutableStateFlow(GameListState())
     val state: StateFlow<GameListState> = _state.asStateFlow()
@@ -45,6 +47,14 @@ class GameListViewModel(
     private var consoleGamesJob: Job? = null
 
     init {
+        // Load admin status once on startup
+        scope.launch(dispatchers.io) {
+            val isAdmin = authRepository?.getCurrentUser()
+                ?.map { it.role == "admin" || it.role == "owner" }
+                ?.getOrDefault(false) ?: false
+            _state.update { it.copy(isAdmin = isAdmin) }
+        }
+
         // Observe scrape completions and update cover art in game lists
         scope.launch(dispatchers.io) {
             scrapeService.scrapedCovers.collect { (gameId, coverUrl) ->

--- a/web/src/components/console-hero-banner.tsx
+++ b/web/src/components/console-hero-banner.tsx
@@ -2,18 +2,15 @@ import { Check, Globe } from "lucide-react";
 import { getConsoleStyle } from "@/lib/console-metadata";
 import { cn } from "@/lib/cn";
 import type { Console } from "@/types/api";
-import type { ReactNode } from "react";
 
 interface ConsoleHeroBannerProps {
   console: Console | undefined;
   gameCount?: number;
-  actions?: ReactNode;
 }
 
 export function ConsoleHeroBanner({
   console: consoleData,
   gameCount,
-  actions,
 }: ConsoleHeroBannerProps) {
   const consoleName = consoleData?.name ?? "Console";
   const consoleAbbr = consoleData?.abbreviation ?? "";
@@ -49,7 +46,7 @@ export function ConsoleHeroBanner({
       <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-white/[0.04] pointer-events-none" />
 
       {/* Content */}
-      <div className="relative px-6 py-10 md:py-12">
+      <div className="relative px-6 py-8 md:py-10">
         <div className="flex flex-col items-center">
         {/* Logo / Title */}
         {consoleData?.logoUrl ? (
@@ -108,13 +105,6 @@ export function ConsoleHeroBanner({
           )}
         </div>
         </div>
-
-        {/* Action buttons — bottom right */}
-        {actions && (
-          <div className="absolute bottom-4 right-4 flex flex-col gap-2 items-end">
-            {actions}
-          </div>
-        )}
       </div>
     </div>
   );

--- a/web/src/pages/__tests__/console-detail-page.test.tsx
+++ b/web/src/pages/__tests__/console-detail-page.test.tsx
@@ -115,12 +115,17 @@ describe("ConsoleDetailPage", () => {
       expect(screen.getByText("100 games")).toBeInTheDocument();
     });
 
-    it("renders browse games link in the banner", () => {
+    it("renders the terminal Browse-all CTA below the curated shelves (#1095)", () => {
+      // Pre-#1095 the Browse link lived in the banner's bottom-right
+      // corner with test ID `banner-browse-games`. The hero banner is
+      // now pure identity; the Browse-all CTA moves to a terminal
+      // "Library" section below the showcase shelves with the new
+      // test ID `browse-all-games-cta`.
       renderPage();
-      const bannerLink = screen.getByTestId("banner-browse-games");
-      expect(bannerLink).toBeInTheDocument();
-      expect(bannerLink).toHaveTextContent("Browse 100 games");
-      expect(bannerLink).toHaveAttribute("href", "/consoles/snes/games");
+      const cta = screen.getByTestId("browse-all-games-cta");
+      expect(cta).toBeInTheDocument();
+      expect(cta).toHaveTextContent("Browse all 100 Super Nintendo games");
+      expect(cta).toHaveAttribute("href", "/consoles/snes/games");
     });
 
     it("does not render inline search input", () => {
@@ -202,7 +207,10 @@ describe("ConsoleDetailPage", () => {
 
     it("does not render browse all games link", () => {
       renderPage();
-      expect(screen.queryByTestId("banner-browse-games")).not.toBeInTheDocument();
+      // #1095: banner is now pure identity, Browse-all CTA only renders
+      // on libraries with >24 games (the small-library / empty branches
+      // stay free of it). New test ID is `browse-all-games-cta`.
+      expect(screen.queryByTestId("browse-all-games-cta")).not.toBeInTheDocument();
     });
 
     it("shows loading skeletons while data is loading", () => {
@@ -279,7 +287,10 @@ describe("ConsoleDetailPage", () => {
 
     it("does not render browse all games link", () => {
       renderPage();
-      expect(screen.queryByTestId("banner-browse-games")).not.toBeInTheDocument();
+      // #1095: banner is now pure identity, Browse-all CTA only renders
+      // on libraries with >24 games (the small-library / empty branches
+      // stay free of it). New test ID is `browse-all-games-cta`.
+      expect(screen.queryByTestId("browse-all-games-cta")).not.toBeInTheDocument();
     });
   });
 });

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import {
   Library,
   FolderSearch,
@@ -12,8 +12,10 @@ import {
   EmptyState,
   GameCardSkeleton,
   SearchInput,
+  ActionsMenu,
+  BackButton,
 } from "@/components/ui";
-import { PageLayout, SectionList } from "@/components/layout";
+import { PageLayout, SectionList, TitledSection } from "@/components/layout";
 import { useConsoles } from "@/hooks/use-consoles";
 import { useGames, useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -33,9 +35,11 @@ import {
 } from "@/features/explore/components/console-showcase-sections";
 
 const SMALL_LIBRARY_THRESHOLD = 24;
+const BROWSE_CTA_THRESHOLD = 15;
 
 export function ConsoleDetailPage() {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const { data: consoles } = useConsoles();
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
@@ -77,36 +81,45 @@ export function ConsoleDetailPage() {
       ?.filter((f) => f.status === "missing" && f.required)
       .map((f) => f.fileName) ?? [];
 
+  const adminMenuItems = isAdmin
+    ? [
+        {
+          label: "Scan for new games",
+          icon: <FolderSearch className="h-4 w-4" />,
+          onClick: () =>
+            scanLibrary.mutate(
+              { console: consoleAbbr },
+              {
+                onSuccess: () =>
+                  toast("info", `Scan started for ${consoleName}.`),
+                onError: (err) =>
+                  toast(
+                    "error",
+                    err instanceof Error ? err.message : "Scan failed",
+                  ),
+              },
+            ),
+          loading: scanLibrary.isPending,
+        },
+      ]
+    : [];
+
   return (
-    <PageLayout backButtonVariant="standard" backTo="/consoles" backLabel="Consoles">
+    <PageLayout>
       <SectionList>
 
-      {/* Console hero banner */}
-      <ConsoleHeroBanner
-        console={console}
-        actions={
-          <>
-            {gameCount > SMALL_LIBRARY_THRESHOLD && (
-              <Link
-                to={`/consoles/${id}/games`}
-                className="inline-flex items-center gap-2 rounded-lg bg-white/10 backdrop-blur-sm px-4 py-2 text-sm font-medium text-white hover:bg-white/20 transition-colors"
-                data-testid="banner-browse-games"
-              >
-                Browse {gameCount} games
-                <ArrowRight className="h-4 w-4" />
-              </Link>
-            )}
-            {isAdmin && (
-              <ScanButton
-                consoleAbbr={consoleAbbr}
-                consoleName={consoleName}
-                scanLibrary={scanLibrary}
-                toast={toast}
-              />
-            )}
-          </>
-        }
-      />
+      {/* Page header: back button + admin overflow menu */}
+      <div className="flex items-center justify-between">
+        <BackButton onClick={() => navigate("/consoles")} data-testid="page-back-button">
+          Consoles
+        </BackButton>
+        {adminMenuItems.length > 0 && (
+          <ActionsMenu items={adminMenuItems} />
+        )}
+      </div>
+
+      {/* Console hero banner — pure identity, no action buttons */}
+      <ConsoleHeroBanner console={console} />
 
       {/* BIOS warning */}
       {showBiosWarning && (
@@ -174,7 +187,7 @@ export function ConsoleDetailPage() {
           )}
         </>
       ) : (
-        /* Large library: showcase sections */
+        /* Large library: showcase sections + terminal browse CTA */
         <>
           <ConsoleRecentlyPlayed consoleId={id!} />
           <ConsoleEssentials consoleId={id!} />
@@ -182,47 +195,24 @@ export function ConsoleDetailPage() {
           <ConsoleHiddenGems consoleId={id!} />
           <ConsoleTopDevelopers consoleId={id!} />
           <ConsoleRecentlyAdded consoleId={id!} />
+          {gameCount > BROWSE_CTA_THRESHOLD && (
+            <TitledSection title="Library" icon={Library}>
+              <Link
+                to={`/consoles/${id}/games`}
+                className="flex items-center justify-between w-full rounded-xl bg-white/[0.03] border border-white/[0.06] px-5 py-4 text-surface-100 hover:bg-white/[0.06] transition-colors group"
+                data-testid="browse-all-games-cta"
+              >
+                <span className="text-base font-medium">
+                  Browse all {gameCount} {consoleName} games
+                </span>
+                <ArrowRight className="h-5 w-5 text-surface-400 group-hover:text-surface-200 transition-colors" />
+              </Link>
+            </TitledSection>
+          )}
         </>
       )}
     </SectionList>
     </PageLayout>
-  );
-}
-
-function ScanButton({
-  consoleAbbr,
-  consoleName,
-  scanLibrary,
-  toast,
-}: {
-  consoleAbbr: string;
-  consoleName: string;
-  scanLibrary: ReturnType<typeof useScanLibrary>;
-  toast: ReturnType<typeof useToast>["toast"];
-}) {
-  return (
-    <button data-comp="ScanButton"
-      className="inline-flex items-center gap-2 rounded-lg bg-white/10 backdrop-blur-sm px-4 py-2 text-sm font-medium text-white hover:bg-white/20 transition-colors disabled:opacity-50"
-      disabled={scanLibrary.isPending}
-      data-testid="scan-button"
-      onClick={() =>
-        scanLibrary.mutate(
-          { console: consoleAbbr },
-          {
-            onSuccess: () =>
-              toast("info", `Scan started for ${consoleName}.`),
-            onError: (err) =>
-              toast(
-                "error",
-                err instanceof Error ? err.message : "Scan failed",
-              ),
-          },
-        )
-      }
-    >
-      <FolderSearch className="h-4 w-4" />
-      Scan for new games
-    </button>
   );
 }
 


### PR DESCRIPTION
Implements #1095.

**Web:** Banner is now pure identity. Admin actions (Scan for new games) moved to overflow menu in page header. Terminal "Library" section with Browse CTA added for >15-game libraries. Banner padding trimmed.

**Player:** Banner buttons removed. Admin-only MoreVert overflow menu in top bar with Console settings. Terminal Library section for >15 games. isAdmin added to GameListState loaded via authRepository.

**Tests:** New ConsoleDetailBrowseSectionTest with 8 desktop E2E tests. FakeAuthRepository gains simulateAdminLoggedIn() helper.

Generated with [Claude Code](https://claude.ai/code)