### PR TITLE
feat(player): group-by toggle on console list (mirror of #1094 web)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadNavigationTest.kt
@@ -116,10 +116,32 @@ class GamepadNavigationTest {
         val nesCard = onNodeWithContentDescription("Nintendo Entertainment System, 3 games")
         nesCard.assertIsFocused()
 
-        // Press Up — nothing above, focus should stay
+        // #1106 — the consoles tab now hosts a By-generation /
+        // By-manufacturer toggle directly above the grid. DPad-up
+        // from the first card may either move focus to the toggle
+        // (new boundary) or stay on the card if spatial navigation
+        // doesn't cross the section header. Either way is acceptable;
+        // what we still must assert is that focus does NOT wrap to
+        // the bottom of the screen (e.g. nav tabs).
+        // #1106 — the consoles tab now hosts a By-generation /
+        // By-manufacturer toggle row directly above the grid. DPad-up
+        // from a card may land on either chip depending on spatial
+        // search; what we still must assert is that focus does NOT
+        // wrap (e.g. into bottom nav tabs) — it stays inside the tab
+        // content. Either NES, the generation chip, or the
+        // manufacturer chip is acceptable.
         nesCard.performKeyInput { pressKey(Key.DirectionUp) }
         advanceQuick(harness)
-        nesCard.assertIsFocused()
+        val nesFocused = try { nesCard.assertIsFocused(); true } catch (_: AssertionError) { false }
+        val genToggleFocused = try {
+            onNodeWithTag("console-grouping-generation").assertIsFocused(); true
+        } catch (_: AssertionError) { false }
+        val mfgToggleFocused = try {
+            onNodeWithTag("console-grouping-manufacturer").assertIsFocused(); true
+        } catch (_: AssertionError) { false }
+        assert(nesFocused || genToggleFocused || mfgToggleFocused) {
+            "Expected focus to stay on NES card or move to either grouping toggle chip"
+        }
     }
 
     @Test

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -110,28 +110,15 @@ internal fun consoleColumnsForWidth(width: androidx.compose.ui.unit.Dp): Int = w
     else             -> 1
 }
 
-private fun generationLabel(generation: Int): String = when (generation) {
-    2 -> "2nd Generation · 1976–1992"
-    3 -> "3rd Generation · 1983–1992"
-    4 -> "4th Generation · 1987–1996"
-    5 -> "5th Generation · 1993–2006"
-    6 -> "6th Generation · 1998–2007"
-    7 -> "7th Generation · 2004–2013"
-    8 -> "8th Generation · 2011–2020"
-    9 -> "9th Generation · 2017–present"
-    100 -> "Home Computers · 1977–1995"
-    101 -> "Arcade · 1971–present"
-    else -> "Other"
-}
-
 @Composable
 internal fun ConsolesGrid(
     consoles: List<Console>,
     onConsoleSelected: (String) -> Unit,
     consolesWithMissingBios: Set<String> = emptySet(),
     columnsPerRow: Int = 2,
+    grouping: ConsoleGrouping = ConsoleGrouping.Generation,
 ) {
-    val grouped = consoles.groupBy { it.generation }.toSortedMap()
+    val sections = groupConsoles(consoles, grouping)
     val focusMemory = rememberFocusMemoryState()
 
     var isFirstCard = true
@@ -141,17 +128,17 @@ internal fun ConsolesGrid(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
     ) {
-        grouped.entries.forEachIndexed { index, (generation, groupConsoles) ->
+        sections.forEachIndexed { index, section ->
             if (index > 0) {
                 Spacer(Modifier.height(SpSpacing.Medium))
             }
             Text(
-                text = generationLabel(generation),
+                text = section.title,
                 style = SpTypography.TitleMedium,
                 fontWeight = FontWeight.SemiBold,
                 color = Color.White.copy(alpha = 0.85f),
             )
-            groupConsoles.chunked(columnsPerRow).forEach { rowConsoles ->
+            section.consoles.chunked(columnsPerRow).forEach { rowConsoles ->
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleGrouping.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleGrouping.kt
@@ -1,0 +1,117 @@
+package com.spela.player.presentation.ui.feature.library
+
+import com.spela.player.domain.model.Console
+
+/**
+ * The two grouping modes the consoles list supports. Mirrors the
+ * web side's `ConsoleGrouping` (`web/src/lib/console-grouping.ts`).
+ */
+enum class ConsoleGrouping { Generation, Manufacturer }
+
+/**
+ * One section in the rendered consoles list. The `kind` discriminator
+ * keeps the [ConsolesGrid] composable type-safe — generation-only
+ * fields (`years`, the "Nth Generation" labelling) live on
+ * [ConsoleGroupSection.Generation], maker-only fields live on
+ * [ConsoleGroupSection.Manufacturer].
+ */
+sealed class ConsoleGroupSection {
+    abstract val key: String
+    abstract val title: String
+    abstract val consoles: List<Console>
+
+    data class Generation(
+        val generation: Int,
+        override val title: String,
+        override val consoles: List<Console>,
+    ) : ConsoleGroupSection() {
+        override val key: String get() = "gen-$generation"
+    }
+
+    data class Manufacturer(
+        val makerCode: String,
+        val makerName: String,
+        override val consoles: List<Console>,
+    ) : ConsoleGroupSection() {
+        override val key: String get() = "maker-$makerCode"
+        override val title: String get() = makerName
+    }
+}
+
+internal const val VARIOUS_MAKER_CODE = "various"
+
+private fun generationLabelInternal(generation: Int): String = when (generation) {
+    2 -> "2nd Generation · 1976–1992"
+    3 -> "3rd Generation · 1983–1992"
+    4 -> "4th Generation · 1987–1996"
+    5 -> "5th Generation · 1993–2006"
+    6 -> "6th Generation · 1998–2007"
+    7 -> "7th Generation · 2004–2013"
+    8 -> "8th Generation · 2011–2020"
+    9 -> "9th Generation · 2017–present"
+    100 -> "Home Computers · 1977–1995"
+    101 -> "Arcade · 1971–present"
+    else -> "Other"
+}
+
+fun groupByGeneration(consoles: List<Console>): List<ConsoleGroupSection.Generation> =
+    consoles
+        .groupBy { it.generation }
+        .toSortedMap()
+        .map { (gen, list) ->
+            ConsoleGroupSection.Generation(
+                generation = gen,
+                title = generationLabelInternal(gen),
+                consoles = list,
+            )
+        }
+
+/**
+ * Groups consoles by `makerCode`. Manufacturers are sorted alphabetically
+ * by `makerName` so users can predict where each row lives. The catch-all
+ * `"various"` bucket (arcade, DOS demos, Amiga demos, ScummVM — see
+ * `seed_metadata.go`) is pinned last regardless of letter.
+ *
+ * Within each manufacturer, consoles are ordered by [Console.releaseYear]
+ * ascending — same chronological intra-group order the generation view
+ * uses. Consoles missing `makerCode` (rare DB orphans pre-dating the
+ * maker column) bucket into `Various` rather than disappearing.
+ */
+fun groupByManufacturer(consoles: List<Console>): List<ConsoleGroupSection.Manufacturer> {
+    val buckets = linkedMapOf<String, MutableList<Console>>()
+    val displayName = mutableMapOf<String, String>()
+    for (c in consoles) {
+        val code = c.makerCode?.takeIf { it.isNotBlank() } ?: VARIOUS_MAKER_CODE
+        val name = c.makerName?.takeIf { it.isNotBlank() } ?: "Various"
+        buckets.getOrPut(code) { mutableListOf() }.add(c)
+        // First occurrence wins — keeps the bucket label stable even
+        // if a later orphan for the same code carries an empty name.
+        if (code !in displayName) {
+            displayName[code] = name
+        }
+    }
+    return buckets.entries
+        .map { (code, list) ->
+            list.sortBy { it.releaseYear ?: 0 }
+            ConsoleGroupSection.Manufacturer(
+                makerCode = code,
+                makerName = displayName[code] ?: "Various",
+                consoles = list,
+            )
+        }
+        .sortedWith(
+            compareBy(
+                // Pin "various" to the end regardless of name.
+                { if (it.makerCode == VARIOUS_MAKER_CODE) 1 else 0 },
+                { it.makerName.lowercase() },
+            ),
+        )
+}
+
+fun groupConsoles(
+    consoles: List<Console>,
+    grouping: ConsoleGrouping,
+): List<ConsoleGroupSection> = when (grouping) {
+    ConsoleGrouping.Generation -> groupByGeneration(consoles)
+    ConsoleGrouping.Manufacturer -> groupByManufacturer(consoles)
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/LibraryConsolesTab.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/LibraryConsolesTab.kt
@@ -1,9 +1,13 @@
 package com.spela.player.presentation.ui.feature.library
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.ui.platform.testTag
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -11,16 +15,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.intent.GameListIntent
+import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpMainContentPadding
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpScreenTopSpacer
 import com.spela.player.presentation.ui.components.SpScrollableContent
 import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.viewmodel.GameListViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -30,6 +39,13 @@ internal fun LibraryConsolesTab(
     onConsoleSelected: (String) -> Unit,
 ) {
     val state by viewModel.state.collectAsState()
+
+    // #1106 — toggle state lives at the tab level so the segmented
+    // control and the grid render from the same source of truth.
+    // `remember` keeps the choice for the lifetime of the tab; cross-
+    // restart persistence (and rotation persistence on Android) is
+    // filed as a follow-up.
+    var grouping by remember { mutableStateOf(ConsoleGrouping.Generation) }
 
     LaunchedEffect(Unit) {
         viewModel.onIntent(GameListIntent.LoadConsoles)
@@ -71,12 +87,18 @@ internal fun LibraryConsolesTab(
                     SpScrollableContent(modifier = Modifier.testTag("consoles-list")) {
                         SpScreenTopSpacer()
                         SpMainContentPadding {
+                            ConsoleGroupingToggle(
+                                grouping = grouping,
+                                onGroupingChange = { grouping = it },
+                            )
+                            Spacer(Modifier.height(SpSpacing.Medium))
                             BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
                                 ConsolesGrid(
                                     consoles = state.consoles,
                                     onConsoleSelected = onConsoleSelected,
                                     consolesWithMissingBios = state.consolesWithMissingBios,
                                     columnsPerRow = consoleColumnsForWidth(maxWidth),
+                                    grouping = grouping,
                                 )
                             }
                         }
@@ -84,5 +106,33 @@ internal fun LibraryConsolesTab(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun ConsoleGroupingToggle(
+    grouping: ConsoleGrouping,
+    onGroupingChange: (ConsoleGrouping) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("console-grouping-toggle"),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+    ) {
+        SpChip(
+            text = "By generation",
+            isSelected = grouping == ConsoleGrouping.Generation,
+            onClick = { onGroupingChange(ConsoleGrouping.Generation) },
+            onGradient = true,
+            modifier = Modifier.testTag("console-grouping-generation"),
+        )
+        SpChip(
+            text = "By manufacturer",
+            isSelected = grouping == ConsoleGrouping.Manufacturer,
+            onClick = { onGroupingChange(ConsoleGrouping.Manufacturer) },
+            onGradient = true,
+            modifier = Modifier.testTag("console-grouping-manufacturer"),
+        )
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleGroupingTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleGroupingTest.kt
@@ -1,0 +1,112 @@
+package com.spela.player.presentation.ui.feature.library
+
+import com.spela.player.domain.model.Console
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * #1106 — Kotlin counterpart of `web/src/lib/__tests__/console-grouping.test.ts`.
+ * The rule set must match: alphabetical by maker name, "Various" pinned
+ * last, releaseYear ascending intra-group, orphan consoles bucketed
+ * into Various.
+ */
+class ConsoleGroupingTest {
+
+    private fun console(
+        id: String,
+        gen: Int = 0,
+        year: Int? = null,
+        code: String? = null,
+        name: String? = null,
+    ) = Console(
+        id = id,
+        name = id,
+        abbreviation = id.uppercase(),
+        gameCount = 0,
+        generation = gen,
+        releaseYear = year,
+        makerCode = code,
+        makerName = name,
+    )
+
+    private val nes = console("nes", gen = 3, year = 1983, code = "nintendo", name = "Nintendo")
+    private val snes = console("snes", gen = 4, year = 1990, code = "nintendo", name = "Nintendo")
+    private val n64 = console("n64", gen = 5, year = 1996, code = "nintendo", name = "Nintendo")
+    private val genesis = console("genesis", gen = 4, year = 1988, code = "sega", name = "Sega")
+    private val atari2600 = console("a2600", gen = 2, year = 1977, code = "atari", name = "Atari")
+    private val arcade = console("arcade", gen = 101, year = null, code = "various", name = "Various")
+    private val scummvm = console("scummvm", gen = 100, year = null, code = "various", name = "Various")
+
+    @Test
+    fun groupByGeneration_ordersGenerationsAscending() {
+        val groups = groupByGeneration(listOf(n64, nes, atari2600, snes))
+        assertEquals(listOf(2, 3, 4, 5), groups.map { it.generation })
+    }
+
+    @Test
+    fun groupByGeneration_homeComputersAndArcadePinAtEnd() {
+        val groups = groupByGeneration(listOf(snes, arcade, atari2600, scummvm))
+        assertEquals(listOf(2, 4, 100, 101), groups.map { it.generation })
+    }
+
+    @Test
+    fun groupByManufacturer_sortsAlphabeticallyByName() {
+        val groups = groupByManufacturer(listOf(n64, genesis, nes, atari2600))
+        assertEquals(listOf("Atari", "Nintendo", "Sega"), groups.map { it.makerName })
+    }
+
+    @Test
+    fun groupByManufacturer_pinsVariousLast() {
+        // Atari < Nintendo < Sega < V alphabetically would put Various
+        // between Sega and ... well, after S. But the rule is Various
+        // pinned LAST, regardless of letter — so even if there's a maker
+        // called "Yamaha" in the list, Various still ends up after it.
+        val groups = groupByManufacturer(listOf(arcade, genesis, nes, atari2600, scummvm))
+        assertEquals(
+            listOf("Atari", "Nintendo", "Sega", "Various"),
+            groups.map { it.makerName },
+        )
+    }
+
+    @Test
+    fun groupByManufacturer_ordersConsolesByReleaseYearAscending() {
+        // NES 1983 → SNES 1990 → N64 1996 inside Nintendo.
+        val groups = groupByManufacturer(listOf(n64, snes, nes))
+        assertEquals("Nintendo", groups[0].makerName)
+        assertEquals(listOf("nes", "snes", "n64"), groups[0].consoles.map { it.id })
+    }
+
+    @Test
+    fun groupByManufacturer_bucketsOrphansIntoVarious() {
+        // Console rows from before the maker column was added carry
+        // null/empty makerCode. They should land in Various rather than
+        // be silently dropped — keeps grouping idempotent across data
+        // states.
+        val orphan = console("orphan", code = null, name = null)
+        val groups = groupByManufacturer(listOf(nes, orphan))
+        val allIds = groups.flatMap { it.consoles.map { c -> c.id } }
+        assertTrue("orphan" in allIds, "orphan must survive grouping")
+        assertTrue("nes" in allIds, "nes must survive grouping")
+        // Nintendo is the only named manufacturer; orphan goes to
+        // Various; ordering: Nintendo, Various.
+        assertEquals(listOf("Nintendo", "Various"), groups.map { it.makerName })
+    }
+
+    @Test
+    fun groupByManufacturer_returnsEmptyForEmptyInput() {
+        assertEquals(emptyList(), groupByManufacturer(emptyList()))
+    }
+
+    @Test
+    fun groupConsoles_dispatchesByGroupingArg() {
+        assertTrue(
+            groupConsoles(listOf(nes, atari2600), ConsoleGrouping.Generation)
+                .all { it is ConsoleGroupSection.Generation },
+        )
+        assertTrue(
+            groupConsoles(listOf(nes, atari2600), ConsoleGrouping.Manufacturer)
+                .all { it is ConsoleGroupSection.Manufacturer },
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Mirrors #1105 on the player app: the consoles tab now hosts a By-generation / By-manufacturer toggle directly above the grid.
- Pure grouper module `ConsoleGrouping.kt` codifies the same rules as the web counterpart — alphabetical by maker name, "Various" pinned last, releaseYear ascending intra-group, orphan consoles bucketed into Various.
- 8 unit tests in `ConsoleGroupingTest` mirror the web side's vitest matrix.
- `ConsolesGrid` parameterized with `grouping: ConsoleGrouping = ConsoleGrouping.Generation` (default keeps existing call sites unchanged).
- `LibraryConsolesTab` hosts the toggle row (two `SpChip` pills) and a `remember` state. **Cross-restart persistence is deliberately deferred** to keep this PR free of a SQLDelight schema migration.

Implements the player half of #1094 — the parity issue tracked as #1106.

Fixes #1106.

## Test plan
- [x] `ConsoleGroupingTest` — 8/8 pass (web parity matrix).
- [x] Full desktop suite — 800/800 pass.
- [x] `GamepadNavigationTest.focusDoesNotWrapOnDirectionUpAtBoundary` updated to acknowledge the new boundary above the cards (DPad-up from NES now spatially reaches a toggle chip; invariant remains "focus stays inside tab content, no wrap").
- [ ] Manual smoke on desktop: toggle pills visible above first row; switching to Manufacturer rebuilds sections with maker names and Various last; gamepad DPad navigation reaches both chips.

## Out of scope (kept tracked on #1106's body)
- SQLDelight key/value entry for cross-restart persistence.
- `rememberSaveable` for Android rotation persistence.

## Related
- #1094 — original cross-stack issue.
- #1105 — web counterpart (merged).