### PR TITLE
fix: compact Time to Beat card + accent-color section icons (#1110)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTitledSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTitledSection.kt
@@ -73,10 +73,16 @@ fun SpTitledSection(
                 horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
             ) {
                 if (icon != null) {
+                    // #1110 — accent tint to match the docstring contract
+                    // ("icon displayed before the title in accent color").
+                    // Was Color.White.copy(alpha = 0.55f), which read as a
+                    // disabled / muted icon — the parallel of the web bug
+                    // where TitledSection icons mistakenly came through
+                    // uncoloured. Aligns with the web side's `text-brand-400`.
                     Icon(
                         imageVector = icon,
                         contentDescription = null,
-                        tint = Color.White.copy(alpha = 0.55f),
+                        tint = SpColor.Primary,
                         modifier = Modifier.size(SpSpacing.IconDefault),
                     )
                 }

--- a/web/src/features/game-detail/components/__tests__/time-to-beat-card.test.tsx
+++ b/web/src/features/game-detail/components/__tests__/time-to-beat-card.test.tsx
@@ -62,7 +62,19 @@ describe("TimeToBeatCard", () => {
     expect(container.querySelector("[class*='bg-purple-400']")).toBeNull();
   });
 
-  it("converts seconds to hours and shows correct labels", () => {
+  it("renders the Clock header icon in the standard section colour (#1110)", () => {
+    // The Time-to-Beat card pairs visually with UserRating; both use
+    // `text-brand-400` on their lucide header icon. TitledSection
+    // enforces the same colour for sections elsewhere on the page,
+    // so this test pins the convention from outside the component.
+    const game = makeGame({ timeToBeatNormally: hrs(10) });
+    const { container } = render(<TimeToBeatCard game={game} />);
+    const headerIcon = container.querySelector(".lucide-clock");
+    expect(headerIcon).not.toBeNull();
+    expect(headerIcon?.getAttribute("class")).toMatch(/text-brand-400/);
+  });
+
+  it("converts seconds to hours and shows correct labels (#1110: Main / Extras / All, Xh)", () => {
     const game = makeGame({
       timeToBeatHastily: hrs(10),
       timeToBeatNormally: hrs(25),
@@ -70,14 +82,20 @@ describe("TimeToBeatCard", () => {
     });
     render(<TimeToBeatCard game={game} />);
 
-    expect(screen.getByText("Main Story")).toBeInTheDocument();
-    expect(screen.getByText("10 hrs")).toBeInTheDocument();
+    // #1110 — labels shortened so the 3-up grid fits comfortably at 1280 px:
+    //   "Main Story"     → "Main"
+    //   "Main + Extras"  → "Extras"
+    //   "Completionist"  → "All"
+    // Tooltips still carry the full disambiguation ("Time to finish the
+    // main story" etc.) — see the tooltip test below.
+    expect(screen.getByText("Main")).toBeInTheDocument();
+    expect(screen.getByText("10h")).toBeInTheDocument();
 
-    expect(screen.getByText("Main + Extras")).toBeInTheDocument();
-    expect(screen.getByText("25 hrs")).toBeInTheDocument();
+    expect(screen.getByText("Extras")).toBeInTheDocument();
+    expect(screen.getByText("25h")).toBeInTheDocument();
 
-    expect(screen.getByText("Completionist")).toBeInTheDocument();
-    expect(screen.getByText("50 hrs")).toBeInTheDocument();
+    expect(screen.getByText("All")).toBeInTheDocument();
+    expect(screen.getByText("50h")).toBeInTheDocument();
   });
 
   it("renders all three tier labels even when some values are missing (#1099)", () => {
@@ -91,13 +109,13 @@ describe("TimeToBeatCard", () => {
     });
     render(<TimeToBeatCard game={game} />);
 
-    expect(screen.getByText("Main Story")).toBeInTheDocument();
-    expect(screen.getByText("Main + Extras")).toBeInTheDocument();
-    expect(screen.getByText("Completionist")).toBeInTheDocument();
+    expect(screen.getByText("Main")).toBeInTheDocument();
+    expect(screen.getByText("Extras")).toBeInTheDocument();
+    expect(screen.getByText("All")).toBeInTheDocument();
     // Missing tier shows the em-dash placeholder, not a value.
     expect(screen.getByText("—")).toBeInTheDocument();
-    expect(screen.getByText("15 hrs")).toBeInTheDocument();
-    expect(screen.getByText("40 hrs")).toBeInTheDocument();
+    expect(screen.getByText("15h")).toBeInTheDocument();
+    expect(screen.getByText("40h")).toBeInTheDocument();
   });
 
   it("attaches an explanatory tooltip to each tier card (#1099)", () => {
@@ -116,7 +134,7 @@ describe("TimeToBeatCard", () => {
     expect(tierCards[2].getAttribute("title")).toMatch(/100% completion/i);
   });
 
-  it("formats fractional hours correctly", () => {
+  it("formats fractional hours correctly (#1110: 5.5h)", () => {
     // 5.5 hours = 19800 seconds
     const game = makeGame({
       timeToBeatHastily: 19800,
@@ -124,10 +142,10 @@ describe("TimeToBeatCard", () => {
       timeToBeatCompletely: 0,
     });
     render(<TimeToBeatCard game={game} />);
-    expect(screen.getByText("5.5 hrs")).toBeInTheDocument();
+    expect(screen.getByText("5.5h")).toBeInTheDocument();
   });
 
-  it('formats sub-hour values as "<1 hr"', () => {
+  it('formats sub-hour values as "<1h" (#1110)', () => {
     // 30 minutes = 1800 seconds
     const game = makeGame({
       timeToBeatHastily: 1800,
@@ -135,27 +153,27 @@ describe("TimeToBeatCard", () => {
       timeToBeatCompletely: 0,
     });
     render(<TimeToBeatCard game={game} />);
-    expect(screen.getByText("<1 hr")).toBeInTheDocument();
+    expect(screen.getByText("<1h")).toBeInTheDocument();
   });
 
-  it('formats exactly 1 hour as "1 hr"', () => {
+  it('formats exactly 1 hour as "1h" (#1110)', () => {
     const game = makeGame({
       timeToBeatHastily: hrs(1),
       timeToBeatNormally: 0,
       timeToBeatCompletely: 0,
     });
     render(<TimeToBeatCard game={game} />);
-    expect(screen.getByText("1 hr")).toBeInTheDocument();
+    expect(screen.getByText("1h")).toBeInTheDocument();
   });
 
-  it("handles the bug case: 7200 seconds = 2 hrs, not 7200 hrs", () => {
+  it("handles the bug case: 7200 seconds = 2h, not 7200h", () => {
     const game = makeGame({
       timeToBeatHastily: 0,
       timeToBeatNormally: 7200,
       timeToBeatCompletely: 0,
     });
     render(<TimeToBeatCard game={game} />);
-    expect(screen.getByText("2 hrs")).toBeInTheDocument();
-    expect(screen.queryByText("7200 hrs")).not.toBeInTheDocument();
+    expect(screen.getByText("2h")).toBeInTheDocument();
+    expect(screen.queryByText("7200h")).not.toBeInTheDocument();
   });
 });

--- a/web/src/features/game-detail/components/time-to-beat-card.tsx
+++ b/web/src/features/game-detail/components/time-to-beat-card.tsx
@@ -19,9 +19,9 @@ export function TimeToBeatCard({ game }: TimeToBeatCardProps) {
   if (!hastily && !normally && !completely) return null;
 
   const tiers: Tier[] = [
-    { label: "Main Story", hours: hastily, tooltip: "Time to finish the main story" },
-    { label: "Main + Extras", hours: normally, tooltip: "Main story plus side content" },
-    { label: "Completionist", hours: completely, tooltip: "Everything — 100% completion" },
+    { label: "Main", hours: hastily, tooltip: "Time to finish the main story" },
+    { label: "Extras", hours: normally, tooltip: "Main story plus side content" },
+    { label: "All", hours: completely, tooltip: "Everything — 100% completion" },
   ];
 
   return (
@@ -31,7 +31,7 @@ export function TimeToBeatCard({ game }: TimeToBeatCardProps) {
       className="rounded-xl bg-surface-800/30 p-4"
     >
       <div className="flex items-center gap-2.5 mb-3">
-        <Clock className="h-4 w-4 text-surface-500" />
+        <Clock className="h-4 w-4 text-brand-400" />
         <h3 className="text-sm font-semibold text-surface-200">Time to Beat</h3>
       </div>
       <div className="grid grid-cols-3 gap-2">
@@ -59,8 +59,7 @@ export function TimeToBeatCard({ game }: TimeToBeatCardProps) {
 }
 
 function formatHours(hours: number): string {
-  if (hours < 1) return "<1 hr";
-  if (hours === 1) return "1 hr";
-  if (hours === Math.floor(hours)) return `${hours} hrs`;
-  return `${hours.toFixed(1)} hrs`;
+  if (hours < 1) return "<1h";
+  if (hours === Math.floor(hours)) return `${hours}h`;
+  return `${hours.toFixed(1)}h`;
 }


### PR DESCRIPTION
## Summary
Polish on top of #1099 / #1104. Two related fixes about how Time to Beat-style headers render.

### Web — `TimeToBeatCard`
- **Tier labels** shortened so the 3-up grid fits comfortably at 1280 px:
  - Main Story → **Main**
  - Main + Extras → **Extras**
  - Completionist → **All**
  Tooltips still carry the full disambiguation, so no signal lost.
- **Units** compacted: \`X hrs\` / \`X.Y hrs\` / \`1 hr\` / \`<1 hr\` → \`Xh\` / \`X.Yh\` / \`1h\` / \`<1h\`. Longest reasonable value shrinks from 8 chars to 5.
- **Header Clock icon** colour: \`text-surface-500\` → \`text-brand-400\`. UserRating uses \`text-brand-400\` on its Star, and \`TitledSection\` enforces the same convention on its \`icon\` prop — so paired-with-UserRating cards should match.

### Player — `SpTitledSection`
- The icon docstring promised *"icon displayed before the title in accent color"* but the implementation rendered \`Color.White.copy(alpha = 0.55f)\` — same class of bug the web side had on Time to Beat. Fixed at the source: \`tint = SpColor.Primary\`. Every existing call site (the Library section added in #1107, etc.) inherits the fix without per-call edits.

Implements #1110.

## Test plan
- [x] \`time-to-beat-card.test.tsx\` — 13/13 pass, including the new Clock-icon-colour assertion that pins \`text-brand-400\` from outside the component.
- [x] Full web vitest suite — 1611/1611 pass.
- [ ] Player desktop suite (running, will block merge if it fails — only the cosmetic icon change touches shared code).
- [ ] Manual smoke web at 1280 px: Time to Beat reads as **Main / Extras / All** with values like **27h** or **5.5h**; Clock icon is the same colour as UserRating's Star.
- [ ] Manual smoke player: console-detail Library section's icon now shows in accent purple instead of muted white.