### PR TITLE
fix: middle-ground sizing for game-detail box art and hero (#1109)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
@@ -89,11 +89,11 @@ fun GameDetailLayout(
 
         if (isLandscape) {
             val isSmallLandscape = maxHeight < 500.dp
-            // #1097 — bumped from 200/256 dp so the cover reads cinematic
-            // on standard desktop / tablet windows. The compact branch
-            // (AYN Thor in landscape, ~700 dp tall) keeps a smaller
-            // value so vertical real estate isn't eaten by the hero.
-            val coverWidth = if (isSmallLandscape) 280.dp else 380.dp
+            // #1109 — middle ground between #1097's bigger sizes and the
+            // pre-#1097 originals. Closer to original than to #1097.
+            // Compact branch (AYN Thor in landscape, ~700 dp tall) stays
+            // conservative so vertical real estate isn't eaten by the hero.
+            val coverWidth = if (isSmallLandscape) 240.dp else 320.dp
             LandscapeLayout(
                 coverWidth = coverWidth,
                 isCompact = isSmallLandscape,
@@ -136,9 +136,10 @@ private fun LandscapeLayout(
     fullWidthSections: @Composable () -> Unit,
 ) {
     val verticalPad = if (isCompact) SpSpacing.Medium else SpSpacing.XLarge
-    // #1097 — banner sized to host the bigger cover (max-height 280/360 dp
-    // depending on isCompact) plus top/bottom padding.
-    val coverMaxHeight = if (isCompact) 280.dp else 360.dp
+    // #1109 — banner sized to host the cover (max-height 240/300 dp
+    // depending on isCompact) plus top/bottom padding. Middle ground
+    // between #1097 (280/360) and pre-#1097 (200 fixed).
+    val coverMaxHeight = if (isCompact) 240.dp else 300.dp
     val bannerHeight = coverMaxHeight + SpSpacing.TopBarHeight + SpSpacing.Large
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -368,12 +369,14 @@ private fun PortraitLayout(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
                     ) {
-                        // Cover art centered. #1097 — bumped from 250 dp
-                        // for a more cinematic hero on portrait viewports.
+                        // Cover art centered. #1109 — middle ground
+                        // (290 dp) between pre-#1097 (250 dp) and #1097
+                        // (340 dp), closer to the smaller side per user
+                        // feedback that 340 was too dominant.
                         val coverShape = RoundedCornerShape(SpSpacing.CardCornerRadius)
                         Box(
                             modifier = Modifier
-                                .widthIn(max = 340.dp)
+                                .widthIn(max = 290.dp)
                                 .shadow(12.dp, coverShape)
                                 .clip(coverShape)
                                 .border(2.dp, Color.White.copy(alpha = 0.15f), coverShape),

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -201,7 +201,7 @@ export function GameHero({
 
       {/* Content — in-flow so it sizes the wrapper. Dropdowns aren't
           clipped because no ancestor has overflow-hidden. */}
-      <div className="relative z-10 flex flex-col items-center md:flex-row md:items-end min-h-[440px] md:min-h-[560px] p-6 md:p-10 gap-6 md:gap-8">
+      <div className="relative z-10 flex flex-col items-center md:flex-row md:items-end min-h-[360px] md:min-h-[460px] p-6 md:p-8 gap-6 md:gap-8">
         {/* Cover art */}
           <div className="flex-shrink-0 self-center md:self-end">
             <div className="rounded-xl overflow-hidden bg-surface-900/80 border border-white/10 shadow-2xl backdrop-blur-sm">
@@ -209,14 +209,14 @@ export function GameHero({
                 <AreaSizedImage
                   src={game.coverUrl}
                   alt={game.title}
-                  targetArea={120000}
-                  maxHeight={520}
-                  maxWidth={420}
-                  minHeight={220}
+                  targetArea={80000}
+                  maxHeight={420}
+                  maxWidth={360}
+                  minHeight={180}
                   className="rounded-xl"
                 />
               ) : (
-                <div className="w-64 flex items-center justify-center bg-surface-800" style={{ aspectRatio: "3/4" }}>
+                <div className="w-56 flex items-center justify-center bg-surface-800" style={{ aspectRatio: "3/4" }}>
                   <span className="text-3xl font-bold text-surface-600">{game.title.charAt(0).toUpperCase()}</span>
                 </div>
               )}


### PR DESCRIPTION
## Summary

#1097 / #1103 went too far in the "make the cover cinematic" direction — on standard desktop and tablet viewports the box art read as **dominant** rather than prominent. This PR scales back to a middle ground sized **closer to the pre-#1097 originals than to the #1097 values**.

| Surface | Field | Pre-#1097 | #1097 | **#1109** |
|---|---|---|---|---|
| Web | Banner \`min-h\` (sm / md+) | 320 / 400 | 440 / 560 | **360 / 460** |
| Web | Cover \`targetArea\` | 55 000 | 120 000 | **80 000** |
| Web | Cover \`maxWidth\` × \`maxHeight\` | 320 × 360 | 420 × 520 | **360 × 420** |
| Web | Cover \`minHeight\` | 160 | 220 | **180** |
| Web | Padding | \`p-6 md:p-8\` | \`p-6 md:p-10\` | **\`p-6 md:p-8\`** |
| Web | Placeholder \`w-\` | \`w-48\` | \`w-64\` | **\`w-56\`** |
| Player landscape | Cover width (regular / smallLandscape) | 256 / 200 dp | 380 / 280 dp | **320 / 240 dp** |
| Player landscape | Cover \`maxHeight\` | 200 dp | 360 / 280 dp | **300 / 240 dp** |
| Player landscape | Banner height contribution | 200 dp | 360 dp | **300 / 240 dp** |
| Player portrait | Cover \`widthIn(max)\` | 250 dp | 340 dp | **290 dp** |

Cover area: pre-#1097 ~115 200 px², #1097 ~218 400 px², **#1109 ~151 200 px²** — ~30 % bigger than pre-#1097, ~30 % smaller than #1097. AYN Thor (\`isSmallLandscape\`) keeps a conservative 240 dp cover so curated shelves fit on the 720-dp display.

Implements #1109.

## Test plan
- [x] Web vitest — 1611/1611 pass.
- [x] Player desktop suite — 800/800 pass apart from the documented \`GamepadConfigTest.activityIndicatorShowsActiveAfterInput\` flake (passes in isolation; same flake from #1097 / #1101 runs).
- [ ] Manual smoke web at 1280 / 1920 px viewports — cover noticeably smaller than #1103 baseline but still larger than v0.0.232.
- [ ] Manual smoke player desktop landscape — 320 dp cover sits next to title block; banner ~340 dp tall (was 200, then 360).
- [ ] Manual smoke player portrait — 290 dp cover centered above title block.
- [ ] Manual on AYN Thor (small landscape) — 240 dp cover; curated shelves below still fit.