### PR TITLE
fix(player): restore Android text input styling + IME UX

### DIFF
--- a/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/components/PlatformTextFieldCore.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/components/PlatformTextFieldCore.android.kt
@@ -1,18 +1,24 @@
 package com.spela.player.presentation.ui.components
 
+import android.content.Context
 import android.graphics.drawable.GradientDrawable
-import android.graphics.Color as AndroidColor
 import android.text.InputType
 import android.text.method.PasswordTransformationMethod
 import android.view.Gravity
+import android.view.View
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.input.ImeAction
@@ -30,24 +37,84 @@ import androidx.compose.ui.viewinterop.AndroidView
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
-import com.spela.player.presentation.ui.theme.spelaBrandGradient
 
 /**
- * Android implementation of [PlatformTextFieldCore].
+ * Android actual for [PlatformTextFieldCore].
  *
- * Wraps a standard `EditText` via `AndroidView` so we can set
- * `EditorInfo.IME_FLAG_NO_EXTRACT_UI | IME_FLAG_NO_FULLSCREEN` on
- * its `imeOptions`. Compose Multiplatform 1.10's `KeyboardOptions`
- * exposes only `privateImeOptions` (a free-form string hint that
- * Gboard ignores), so dropping to the view system is the only
- * reliable way to keep the IME from going fullscreen on landscape
- * Android handhelds (AYN Thor and similar). See
- * `PlatformTextFieldCore.kt` in commonMain for the rationale.
+ * ## Architecture
  *
- * Visual goal: match `OutlinedTextField`'s appearance closely
- * enough that the existing screens look right. Not pixel-perfect.
- * The wrapper in `SpTextField` already supplies the focus glow
- * and rounded outline; we just render the inner editor.
+ * ```
+ *  Column (Modifier.fillMaxWidth)                  <- our wrapper for label + field
+ *    ├── Text(label)                               <- static label, when label.isNotEmpty()
+ *    └── Row (modifier from SpTextField wrapper)   <- the field "edge"
+ *          ├── leadingIcon (optional)
+ *          ├── Box.weight(1f)
+ *          │     └── AndroidView { EditText }      <- the focusable text editor
+ *          └── trailingIcon (optional)
+ * ```
+ *
+ * The Row receives the modifier passed in from [SpTextField], so the
+ * wrapper's focus glow + brand-gradient ring (when focused) trace
+ * around the *field row only*, not the label above. We add our own
+ * static border + container fill onto the same Row.
+ *
+ * The `EditText` itself is bare — `background = null`, no drawable —
+ * because every visual treatment happens in Compose at the Row level.
+ * This avoids the rendering glitches that arise when a Drawable border
+ * and a Compose `Modifier.border` both try to paint at the same edge.
+ *
+ * ## Why an EditText instead of OutlinedTextField
+ *
+ * To set `EditorInfo.IME_FLAG_NO_EXTRACT_UI | IME_FLAG_NO_FULLSCREEN`.
+ * Compose Multiplatform 1.10 exposes only `privateImeOptions` (a free-
+ * form String) on Android via `PlatformImeOptions`, and Gboard / OEM
+ * keyboards ignore string hints when deciding whether to enter
+ * fullscreen extract mode. Without those int flags, the IME takes
+ * over the entire screen on short-height landscape windows — the
+ * AYN Thor, the second screen of dual-screen handhelds, secondary
+ * displays — and the UI behind is hidden. See
+ * `PlatformTextFieldCore.kt` (commonMain) for the upstream rationale.
+ *
+ * If a future Compose version exposes the int flags directly through
+ * `KeyboardOptions` / `PlatformImeOptions`, this entire file can be
+ * deleted and the Android target can fall back to `OutlinedTextField`
+ * the same way desktop does. Until then: this is the workaround.
+ *
+ * ## Visual treatment
+ *
+ * | State           | Border                 | Background          | Outer ring (wrapper)              |
+ * |-----------------|------------------------|---------------------|-----------------------------------|
+ * | Idle            | white @ 40%, 1.5dp     | white @ 4%          | none                              |
+ * | Focused         | accent-purple, 2.5dp   | accent-purple @ 10% | brand-gradient ring + soft glow   |
+ * | Error           | error red, 1.5dp       | white @ 4%          | none (error replaces focus glow)  |
+ * | Disabled        | white @ 40%, 1.5dp     | white @ 4%          | none                              |
+ *
+ * Idle vs focused for the *static* part is computed locally in this
+ * file (see [fieldFocused]). The wrapper's ring/glow is computed in
+ * [SpTextField] from a *different* focus-state flag. Both flags read
+ * the same source-of-truth (the EditText's focus event surfaced
+ * through Compose), via `Modifier.onFocusChanged { it.hasFocus }`.
+ * Note `hasFocus`, not `isFocused`: the focusable target is the
+ * EditText buried inside AndroidView, several levels below the
+ * modifier owner — `isFocused` would never fire.
+ *
+ * ## IME action handling
+ *
+ * The soft-keyboard action key — and Enter on a single-line field,
+ * which TextView routes through onEditorAction — invokes
+ * [handleImeAction]. The mapping:
+ *   • `Done / Go / Search / Send` → run screen callback, dismiss IME,
+ *     clear focus.
+ *   • `Next / Previous`           → run screen callback, advance focus
+ *     via Android's `focusSearch`. Keyboard stays up.
+ *   • `None`                      → run screen callback, no UI side-effect.
+ *
+ * We have to perform every side-effect manually because returning
+ * `true` from `setOnEditorActionListener` consumes the event and
+ * suppresses Android's defaults. Returning `false` from the listener
+ * to let Android handle defaults is unreliable inside Compose's
+ * focus tree (focusSearch doesn't always find the next field across
+ * AndroidView boundaries), so we keep the listener fully responsible.
  */
 @Composable
 actual fun PlatformTextFieldCore(
@@ -68,50 +135,108 @@ actual fun PlatformTextFieldCore(
     leadingIcon: (@Composable () -> Unit)?,
     trailingIcon: (@Composable () -> Unit)?,
 ) {
-    val borderColor = when {
-        isError -> SpColor.Error
-        else -> Color.White.copy(alpha = 0.15f)
-    }
+    // Pre-resolve theme colours into ARGB ints for the EditText (which
+    // doesn't accept Compose Color directly). Re-resolved on every
+    // recomposition so theme/enabled changes take effect.
     val textColorArgb = if (enabled) SpColor.OnBackground.toArgb()
     else SpColor.OnBackgroundTertiary.toArgb()
     val hintColorArgb = SpColor.OnBackgroundTertiary.toArgb()
     val cursorColorArgb = SpColor.AccentPurple.toArgb()
 
-    Row(
-        modifier = modifier
-            .clip(RoundedCornerShape(SpSpacing.RadiusLarge))
-            .heightIn(min = 56.dp)
-            .padding(horizontal = SpSpacing.Default),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        if (leadingIcon != null) {
-            Box(modifier = Modifier.padding(end = SpSpacing.Small)) { leadingIcon() }
-        }
+    // Static-border focus tracking. Independent from SpTextField's
+    // (which drives the brand-gradient ring on top); see file-level
+    // KDoc for why we maintain two separate flags. `hasFocus` because
+    // the EditText is several levels below this modifier owner.
+    var fieldFocused by remember { mutableStateOf(false) }
+    val borderColor = when {
+        isError -> SpColor.Error
+        fieldFocused -> SpColor.AccentPurple
+        else -> Color.White.copy(alpha = 0.40f)
+    }
+    val borderWidth = if (fieldFocused && !isError) 2.5.dp else 1.5.dp
+    val containerColor = if (fieldFocused && !isError) {
+        SpColor.AccentPurple.copy(alpha = 0.10f)
+    } else {
+        Color.White.copy(alpha = 0.04f)
+    }
+    val containerShape = RoundedCornerShape(SpSpacing.RadiusLarge)
 
-        Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
-            AndroidView(
-                modifier = Modifier.fillMaxWidth(),
-                factory = { ctx ->
-                    EditText(ctx).apply {
-                        // Background outline + transparent fill — Compose
-                        // wrapper draws the focus glow / error tint, so a
-                        // simple thin border is enough here.
-                        background = GradientDrawable().apply {
-                            cornerRadius = SpSpacing.RadiusLarge.value * resources.displayMetrics.density
-                            setStroke(
-                                (1 * resources.displayMetrics.density).toInt(),
-                                borderColor.toArgb(),
-                            )
-                            setColor(AndroidColor.TRANSPARENT)
-                        }
+    // Outer Column: holds the static label above the field. Note this
+    // Column does NOT receive the SpTextField wrapper modifier — that
+    // goes on the inner Row, so the wrapper's focus glow / brand ring
+    // traces the field edge, not the label area.
+    Column(modifier = Modifier.fillMaxWidth()) {
+        if (label.isNotEmpty()) {
+            Text(
+                text = label,
+                style = SpTypography.LabelMedium,
+                color = if (enabled) SpColor.OnBackgroundSecondary
+                else SpColor.OnBackgroundTertiary,
+                // Tiny start indent so the label optically aligns with
+                // the editor text (the Row's horizontal padding pushes
+                // the editor in by SpSpacing.Default).
+                modifier = Modifier.padding(
+                    start = SpSpacing.XSmall,
+                    bottom = SpSpacing.XSmall,
+                ),
+            )
+        }
+        Row(
+            // Modifier order matters here.
+            //
+            //   modifier (from SpTextField wrapper):
+            //     fillMaxWidth → onFocusChanged → drawBehind glow (focus)
+            //                  → Modifier.border(brand gradient) (focus)
+            //   .onFocusChanged { fieldFocused = ... }     ← our local focus mirror
+            //   .background(containerColor, containerShape) ← container fill
+            //   .border(borderWidth, borderColor, ..)       ← static border
+            //   .clip(containerShape)                       ← clip child content
+            //   .heightIn(min = 56.dp)                      ← MD3-equivalent min height
+            //   .padding(horizontal = SpSpacing.Default)    ← inner gutter
+            //
+            // The wrapper's brand-gradient `Modifier.border` runs first
+            // in the chain (i.e. drawn underneath); our static border
+            // runs later and draws on top. When the field is focused the
+            // wrapper's gradient and our solid accent-purple coexist —
+            // the gradient peeks out at the corners, the solid line
+            // dominates the straight edges. That's the intended look.
+            modifier = modifier
+                // `hasFocus`, not `isFocused` — see file-level KDoc.
+                .onFocusChanged { fieldFocused = it.hasFocus }
+                .background(containerColor, containerShape)
+                .border(borderWidth, borderColor, containerShape)
+                .clip(containerShape)
+                .heightIn(min = 56.dp)
+                .padding(horizontal = SpSpacing.Default),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (leadingIcon != null) {
+                Box(modifier = Modifier.padding(end = SpSpacing.Small)) { leadingIcon() }
+            }
+
+            Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                AndroidView(
+                    modifier = Modifier.fillMaxWidth(),
+                    // factory: one-time setup. Things that DON'T change
+                    // across recompositions (listeners, cursor drawable,
+                    // padding, gravity) live here. State that the screen
+                    // can change (text value, hint, isError, imeAction,
+                    // inputType) is re-applied in the `update` block
+                    // below — never trust a closure to capture the
+                    // latest value, since the factory runs only once.
+                    factory = { ctx ->
+                        EditText(ctx).apply {
+                        // Bare editor: container fill + border are drawn
+                        // at the Row level in Compose, not here.
+                        background = null
                         setTextColor(textColorArgb)
                         setHintTextColor(hintColorArgb)
                         textSize = 16f
                         gravity = Gravity.CENTER_VERTICAL or Gravity.START
-                        // Single-line vs multi-line input. Disambiguate
-                        // the function-parameter `minLines` / `maxLines`
-                        // from the EditText properties via `setMinLines` /
-                        // `setMaxLines`.
+                        // `setMinLines` / `setMaxLines` (not the
+                        // function parameters) — the EditText properties
+                        // are shadowed in this scope by the @Composable
+                        // params of the same name.
                         isSingleLine = singleLine
                         if (singleLine) {
                             setMaxLines(1)
@@ -119,10 +244,6 @@ actual fun PlatformTextFieldCore(
                             setMinLines(minLines)
                             setMaxLines(maxLines)
                         }
-                        // Input type — password / email / numeric / text.
-                        // Re-evaluated on every recomposition via the
-                        // update block below so toggling isPassword
-                        // mid-life works.
                         inputType = computeAndroidInputType(
                             isPassword,
                             keyboardType,
@@ -131,20 +252,21 @@ actual fun PlatformTextFieldCore(
                         if (isPassword) {
                             transformationMethod = PasswordTransformationMethod.getInstance()
                         }
-                        // The actual fix: set the standard Android IME
-                        // flags so Gboard / OEM keyboards skip
-                        // fullscreen extract mode in landscape. This is
-                        // why we're wrapping a plain EditText instead
-                        // of using Compose's TextField.
+                        // The whole reason this file exists: set the
+                        // standard `EditorInfo` int flags so Gboard / OEM
+                        // keyboards skip fullscreen extract mode. See
+                        // file-level KDoc.
                         imeOptions = imeActionToEditorInfo(imeAction) or
                             EditorInfo.IME_FLAG_NO_EXTRACT_UI or
                             EditorInfo.IME_FLAG_NO_FULLSCREEN
-                        // Padding inside the field (left, top, right, bottom)
-                        val pad = (SpSpacing.Default.value * resources.displayMetrics.density).toInt()
-                        setPadding(pad, pad / 2, pad, pad / 2)
-                        // Reflect the cursor accent.
-                        // textCursorDrawable requires API 29+, fallback
-                        // is the system default cursor.
+                        // Row supplies horizontal gutter; vertical pad
+                        // here keeps text off the top/bottom edges. No
+                        // horizontal pad → text aligns with the label
+                        // start indent above.
+                        val verticalPad = (SpSpacing.Small.value * resources.displayMetrics.density).toInt()
+                        setPadding(0, verticalPad, 0, verticalPad)
+                        // Accent-coloured cursor (API 29+). Pre-Q falls
+                        // back to the system default.
                         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
                             textCursorDrawable = GradientDrawable().apply {
                                 shape = GradientDrawable.RECTANGLE
@@ -152,35 +274,50 @@ actual fun PlatformTextFieldCore(
                                 setColor(cursorColorArgb)
                             }
                         }
-                        // Hint text (placeholder).
-                        hint = placeholder.ifEmpty { label }
-                        // Forward IME action to the Compose callback.
+                        // Hint = placeholder. The label sits above the
+                        // field as a separate Text composable, since we
+                        // don't get Material 3's floating-label animation
+                        // around a raw EditText.
+                        hint = placeholder
+                        // Routes the action key (and Enter on single-line
+                        // fields, which TextView converts to an editor
+                        // action) through `handleImeAction`. We always
+                        // return `true` to fully take ownership of the
+                        // side-effect; see file-level KDoc.
                         setOnEditorActionListener { _, actionId, _ ->
-                            // Honour the action that matches our imeAction
-                            // mapping; ignore others (autofill / etc.).
                             if (actionId == imeActionToEditorInfo(imeAction) ||
                                 actionId == EditorInfo.IME_ACTION_DONE) {
-                                onImeAction()
+                                handleImeAction(this, imeAction, onImeAction)
                                 true
                             } else false
                         }
-                        // Wire change events back to Compose state.
+                        // Surface text changes back to Compose state.
+                        // Guarded inside the watcher (newText != value)
+                        // so we don't loop when our own update block
+                        // calls setText below.
                         addTextChangedListener(SimpleTextWatcher { newText ->
                             if (newText != value) onValueChange(newText)
                         })
                     }
                 },
+                // update: runs on every recomposition. Only mutate
+                // properties that can change AT ALL across the field's
+                // life — and gate the mutations behind equality checks
+                // so we don't bounce the cursor / IME composition on
+                // every keystroke (Compose recomposes after each value
+                // update, which would otherwise re-set the text and
+                // re-trigger the change watcher).
                 update = { editText ->
-                    // Sync state back from Compose. Guard with a
-                    // non-equality check so Android doesn't bounce the
-                    // cursor / IME composition on every recomposition.
                     if (editText.text.toString() != value) {
                         val cursor = editText.selectionStart
                         editText.setText(value)
                         editText.setSelection(cursor.coerceIn(0, value.length))
                     }
                     editText.isEnabled = enabled
-                    editText.hint = placeholder.ifEmpty { label }
+                    editText.hint = placeholder
+                    // imeOptions is cheap to set — re-applied each frame
+                    // because the action might change as the screen
+                    // re-renders for some reason.
                     editText.imeOptions = imeActionToEditorInfo(imeAction) or
                         EditorInfo.IME_FLAG_NO_EXTRACT_UI or
                         EditorInfo.IME_FLAG_NO_FULLSCREEN
@@ -196,25 +333,22 @@ actual fun PlatformTextFieldCore(
                                 PasswordTransformationMethod.getInstance()
                         }
                     }
-                    val targetBorder = (if (isError) SpColor.Error
-                    else Color.White.copy(alpha = 0.15f)).toArgb()
-                    val bg = editText.background
-                    if (bg is GradientDrawable) {
-                        bg.setStroke(
-                            (1 * editText.resources.displayMetrics.density).toInt(),
-                            targetBorder,
-                        )
-                    }
                 },
             )
         }
 
-        if (trailingIcon != null) {
-            Box(modifier = Modifier.padding(start = SpSpacing.Small)) { trailingIcon() }
+            if (trailingIcon != null) {
+                Box(modifier = Modifier.padding(start = SpSpacing.Small)) { trailingIcon() }
+            }
         }
     }
 }
 
+/**
+ * `TextWatcher` that only forwards the final post-edit text and
+ * ignores the verbose before/on intermediate callbacks. Used to bridge
+ * EditText text changes back into Compose state via `onValueChange`.
+ */
 private class SimpleTextWatcher(
     private val onChange: (String) -> Unit,
 ) : android.text.TextWatcher {
@@ -225,7 +359,14 @@ private class SimpleTextWatcher(
     }
 }
 
-/** Map Compose [ImeAction] to Android's [EditorInfo] action constant. */
+/**
+ * Map a Compose [ImeAction] to the corresponding Android
+ * [EditorInfo] action constant — what we put in the EditText's
+ * `imeOptions` so the soft keyboard renders the right action key
+ * (Done check / Search magnifier / Next arrow / etc.).
+ *
+ * Unknown / future Compose actions fall back to `IME_ACTION_DONE`.
+ */
 private fun imeActionToEditorInfo(imeAction: ImeAction): Int = when (imeAction) {
     ImeAction.Default, ImeAction.Done -> EditorInfo.IME_ACTION_DONE
     ImeAction.Go -> EditorInfo.IME_ACTION_GO
@@ -237,7 +378,66 @@ private fun imeActionToEditorInfo(imeAction: ImeAction): Int = when (imeAction) 
     else -> EditorInfo.IME_ACTION_DONE
 }
 
-/** Map Compose [KeyboardType] to Android [InputType] flags. */
+/**
+ * Side-effect handler for an IME-action trigger. Called from the
+ * EditText's `OnEditorActionListener` for both soft-keyboard action
+ * key taps and hardware Enter on single-line fields.
+ *
+ * Routing:
+ *   • `Done / Go / Search / Send` — invoke the screen's [onImeAction],
+ *     then clear focus + hide the IME via `InputMethodManager`. The
+ *     screen typically handles submit / search inside [onImeAction];
+ *     dismissing the keyboard afterwards is automatic.
+ *   • `Next` — invoke [onImeAction], then forward-focus via
+ *     `focusSearch(FOCUS_FORWARD)`. Keyboard intentionally stays up
+ *     because the next field needs it.
+ *   • `Previous` — symmetric to Next, backward.
+ *   • `None` — invoke [onImeAction], no UI side-effect.
+ *
+ * Why we own every side-effect: the listener must return `true` to
+ * tell EditText the event is handled. That in turn suppresses
+ * Android's default dismiss / focus-traverse behaviour, which we
+ * deliberately replace with the Compose-aware version above.
+ *
+ * @param view The EditText whose action key was triggered. Used as
+ *   the anchor for `focusSearch` and `hideSoftInputFromWindow`.
+ */
+private fun handleImeAction(
+    view: EditText,
+    imeAction: ImeAction,
+    onImeAction: () -> Unit,
+) {
+    onImeAction()
+    when (imeAction) {
+        ImeAction.Next -> view.focusSearch(View.FOCUS_FORWARD)
+            ?.requestFocus(View.FOCUS_FORWARD)
+        ImeAction.Previous -> view.focusSearch(View.FOCUS_BACKWARD)
+            ?.requestFocus(View.FOCUS_BACKWARD)
+        ImeAction.None -> { /* screen callback only */ }
+        else -> {
+            // Done / Go / Search / Send: terminal actions — dismiss IME.
+            val imm = view.context
+                .getSystemService(Context.INPUT_METHOD_SERVICE)
+                as? InputMethodManager
+            view.clearFocus()
+            imm?.hideSoftInputFromWindow(view.windowToken, 0)
+        }
+    }
+}
+
+/**
+ * Translate a Compose [KeyboardType] to the bitmask of Android
+ * [InputType] flags an EditText expects.
+ *
+ * Influences both the soft keyboard layout (numeric pad, email
+ * keyboard with @ key, etc.) and what characters the EditText will
+ * accept. `TYPE_TEXT_FLAG_MULTI_LINE` is OR-ed in for non-single-line
+ * fields so the editor accepts newlines.
+ *
+ * Password fields are special-cased to ensure the bullet/dot mask
+ * shows up regardless of [keyboardType] — the
+ * `TYPE_TEXT_VARIATION_PASSWORD` flag is what triggers masking.
+ */
 private fun computeAndroidInputType(
     isPassword: Boolean,
     keyboardType: KeyboardType,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/PlatformTextFieldCore.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/PlatformTextFieldCore.kt
@@ -6,23 +6,76 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 
 /**
- * Inner text-input widget used by [SpTextField]. Split out as
- * `expect`/`actual` so Android can render an `AndroidView`-wrapped
- * `EditText` with `IME_FLAG_NO_EXTRACT_UI | IME_FLAG_NO_FULLSCREEN`
- * set on its `imeOptions` — the only reliable way to keep the
- * keyboard from going fullscreen on landscape Android handhelds
- * (AYN Thor and similar).
+ * The platform-specific inner editor used by [SpTextField]. Don't call
+ * this directly from screens — go through [SpTextField] so the wrapper's
+ * focus glow, error message, and shared visual contract apply.
  *
- * Compose Multiplatform 1.10's `PlatformImeOptions` only exposes
- * `privateImeOptions` (a free-form string). Gboard and most OEM
- * keyboards ignore string hints for fullscreen behaviour — they only
- * honour the standard `EditorInfo.imeOptions` int flags. Compose
- * doesn't expose those flags through its public Kotlin API, so we
- * have to drop down to the Android view system on Android only.
+ * ## Why this is `expect`/`actual`
  *
- * Desktop and other targets keep using `OutlinedTextField` with no
- * behaviour change — fullscreen IME is a landscape-Android-handheld
- * problem only.
+ * Android needs to wrap a real `EditText` via `AndroidView` so it can
+ * set the standard `EditorInfo.imeOptions` int flags
+ * (`IME_FLAG_NO_EXTRACT_UI | IME_FLAG_NO_FULLSCREEN`) on the input
+ * connection. Compose Multiplatform 1.10's `PlatformImeOptions` only
+ * exposes `privateImeOptions` (a free-form string hint), and Gboard
+ * plus most OEM keyboards ignore string hints for the fullscreen
+ * extract-mode decision — they only look at the int flags.
+ *
+ * Without those flags, when a Compose `BasicTextField` / `OutlinedTextField`
+ * gains focus on a short-height landscape window (gaming handhelds
+ * like the AYN Thor, secondary displays, etc.), the IME goes fullscreen
+ * and renders its own giant text box on top of the entire UI — making
+ * the field unusable, and also masking everything from UiAutomator-
+ * based instrumentation tests.
+ *
+ * Desktop and other non-Android targets don't have this problem (no
+ * concept of fullscreen extract mode), so the desktop actual just
+ * delegates to Material 3 `OutlinedTextField` with the wrapper's focus
+ * styling overlaid.
+ *
+ * ## Per-platform responsibilities
+ *
+ * Both implementations:
+ *   • Render the actual editor (text input area).
+ *   • Map `keyboardType` and `imeAction` to the platform-native type
+ *     and action constants.
+ *   • Invoke `onImeAction` when the user taps the soft-keyboard's
+ *     action key (Done / Next / Search / etc.) or presses Enter on a
+ *     single-line field.
+ *   • Honour `enabled`, `isPassword`, `singleLine`, `minLines`,
+ *     `maxLines`, `leadingIcon`, `trailingIcon` exactly as documented
+ *     on [SpTextField].
+ *
+ * Android-specific extras (because the wrapper's Material-3-shaped
+ * primitives don't apply to a raw EditText):
+ *   • Render the [label] as static `Text` above the input row (no
+ *     floating-label animation — recreating Material 3's measurement
+ *     and animation precisely around an EditText would be a lot of
+ *     code for marginal value).
+ *   • Draw a static unfocused border and subtle container fill so
+ *     the field reads as a contained surface even when the wrapper's
+ *     focus glow isn't active. Switches to accent-purple on focus to
+ *     give a clear focused state.
+ *   • For `ImeAction.Done / Go / Search / Send`, dismiss the IME and
+ *     clear focus. For `Next / Previous`, advance focus via Android's
+ *     focus-traverse — the keyboard stays up because the next field
+ *     immediately needs it.
+ *
+ * Desktop-specific extras:
+ *   • Use OutlinedTextField's built-in floating-label animation —
+ *     it's free and idiomatic on desktop.
+ *   • Set `focusedBorderColor = Transparent` so the wrapper's
+ *     brand-gradient border is the only ring visible on focus.
+ *
+ * @param modifier The modifier from [SpTextField] — already includes
+ *   `fillMaxWidth`, focus tracking, and the conditional focus glow +
+ *   gradient ring. The platform implementation should apply this to
+ *   the *editor row*, not the outer label-plus-field column, so the
+ *   gradient ring traces the field rather than the label too.
+ * @param label See [SpTextField.label]. Empty string means "no label".
+ * @param onImeAction Invoked unconditionally for every action firing,
+ *   *before* the platform layer performs dismiss / focus-traverse.
+ *   Screens use this to trigger submit / search / etc. — and the
+ *   side-effect (dismiss / next field) is automatic.
  */
 @Composable
 expect fun PlatformTextFieldCore(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpScreen.kt
@@ -2,6 +2,7 @@ package com.spela.player.presentation.ui.components
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -19,6 +20,9 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.spScreenBackground
 
@@ -61,10 +65,32 @@ fun SpScreen(
         Modifier.spScreenBackground()
     }
 
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
     Box(
         modifier = modifier
             .fillMaxSize()
-            .then(backgroundModifier),
+            .then(backgroundModifier)
+            // Tap-outside-to-dismiss handler. `detectTapGestures` runs in
+            // the bubble phase (PointerEventPass.Main), so any tap that
+            // hits an inner `Modifier.clickable` / interactive composable
+            // is consumed before reaching us — this only fires for taps
+            // on bare screen background. The two effects together give
+            // every screen the "click anywhere outside the form to
+            // dismiss the keyboard" behaviour without per-screen wiring:
+            //
+            //   1. `keyboardController?.hide()` — Compose's cross-platform
+            //      "hide IME" call (no-op on platforms without an IME).
+            //   2. `focusManager.clearFocus()` — drops focus from the
+            //      currently focused text field so it visibly de-focuses
+            //      and the AndroidView+EditText path stops requesting
+            //      input.
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = {
+                    keyboardController?.hide()
+                    focusManager.clearFocus()
+                })
+            },
         content = content,
     )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTextField.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTextField.kt
@@ -26,6 +26,105 @@ import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.ui.theme.spelaBrandGradient
 
+// ─── Text-field architecture ──────────────────────────────────────────────
+//
+// Every text field in the player app goes through three layers:
+//
+//   SpTextField (this file, commonMain)
+//     └── PlatformTextFieldCore (expect, commonMain)
+//           ├── PlatformTextFieldCore.desktop.kt — Material 3 OutlinedTextField
+//           └── PlatformTextFieldCore.android.kt — AndroidView { EditText }
+//
+// SpTextField is the public, cross-platform composable used by every
+// screen. It owns:
+//   • the optional error message rendered below the field,
+//   • the focus-state visual treatment that's shared across platforms:
+//     a soft multi-colour glow drawn behind the field, plus a 1.5dp
+//     brand-gradient border on its edge.
+//
+// PlatformTextFieldCore is `expect`/`actual` because the inner editor
+// itself has to differ between platforms — Android needs to wrap a real
+// `EditText` via `AndroidView` to access standard `EditorInfo` int flags
+// (`IME_FLAG_NO_EXTRACT_UI`, `IME_FLAG_NO_FULLSCREEN`) that Compose
+// Multiplatform 1.10's KeyboardOptions does not expose. Without those
+// flags Gboard and most OEM keyboards take over the entire screen in
+// landscape on short-height windows (gaming handhelds like the AYN
+// Thor) and the rest of the UI is unusable. See
+// `PlatformTextFieldCore.kt` for the full rationale.
+//
+// The Android implementation also draws the *static* unfocused border,
+// the subtle container fill, and the label — Material 3's floating-
+// label animation isn't reasonable to recreate around a plain EditText,
+// so the label sits as static `Text` above the field. The desktop
+// implementation keeps the OutlinedTextField floating-label visual.
+//
+// Focus tracking gotcha: this wrapper detects focus via
+// `Modifier.onFocusChanged { it.hasFocus }`, NOT `it.isFocused`. The
+// modifier sits one or two levels above the actual focus target (the
+// EditText inside AndroidView, or the OutlinedTextField on desktop),
+// so `isFocused` would never fire. `hasFocus` is true for self-or-
+// descendant, which gives the same visual result on both platforms.
+
+/**
+ * Spela's branded text input. This is the only text-field composable
+ * screens should use — never reach for Material 3's `OutlinedTextField`
+ * or `BasicTextField` directly, since those bypass the platform-specific
+ * IME-flag handling described in [PlatformTextFieldCore].
+ *
+ * Visual contract:
+ *   • Idle field: subtle outlined surface, label rendered above (Android)
+ *     or as a floating Material 3 label (desktop).
+ *   • Focused field: the multi-colour brand glow + brand-gradient border
+ *     drawn by this wrapper, on top of whatever the platform layer
+ *     contributes (accent-purple solid border on Android, transparent
+ *     border on desktop so the gradient shows cleanly).
+ *   • Error: red border drawn by the platform layer; [errorMessage]
+ *     rendered as small text below the field.
+ *
+ * Behaviour contract:
+ *   • [imeAction] drives the soft-keyboard action key (Done / Next /
+ *     Search / Send / Previous). The platform layer routes the action:
+ *     terminal actions dismiss the IME, Next / Previous traverse focus.
+ *   • [onImeAction] is invoked for every action firing — including
+ *     Next / Previous — for screens that want to react (e.g. trigger
+ *     submit). It runs *before* dismiss / focus traversal.
+ *   • Tapping outside any field on a screen wrapped in `SpScreen`
+ *     clears focus and hides the IME; that behaviour lives in
+ *     [SpScreen], not here.
+ *
+ * @param value Current text value (state-hoisted; no internal state).
+ * @param onValueChange Called for every keystroke. Must update [value]
+ *   from the screen's state holder for the field to feel responsive.
+ * @param modifier Applied to the *outer* Column wrapping the label, the
+ *   input row, and the error text. Use this for testTag / weight /
+ *   fillMaxWidth.
+ * @param label Text rendered above the field on Android, or as the
+ *   floating label on desktop. Empty string hides the label.
+ * @param placeholder Hint text shown when the field is empty.
+ * @param isPassword Mask the input + select a numeric-or-text password
+ *   keyboard variant. Note: also influences the [keyboardType] that
+ *   actually gets sent to the IME — see the platform implementations.
+ * @param isError Render the error border colour. If [errorMessage] is
+ *   non-null this is forced to true even when [isError] is false.
+ * @param errorMessage Optional error text rendered below the field.
+ *   Supplying this also flips the field into the error visual state.
+ * @param enabled Disable interaction; renders text in a dimmer colour.
+ * @param singleLine Single-line fields convert Enter into the
+ *   configured [imeAction]; multiline fields treat Enter as a newline.
+ * @param keyboardType Compose KeyboardType — mapped per-platform to
+ *   the right native input type (number / email / URI / etc.).
+ * @param imeAction Determines the soft-keyboard action key and the
+ *   side-effect when fired. Default is [ImeAction.Next] which matches
+ *   the typical multi-field form pattern. The *last* field in a form
+ *   should use [ImeAction.Done] (or Go / Send / Search) so the last
+ *   Enter dismisses the keyboard.
+ * @param onImeAction Screen callback fired when the IME action key is
+ *   tapped or Enter is pressed on a single-line field.
+ * @param leadingIcon Optional composable rendered inside the field on
+ *   the leading edge (typical use: search-glass icon).
+ * @param trailingIcon Optional composable rendered inside the field on
+ *   the trailing edge (typical use: clear-text or visibility-toggle).
+ */
 @Composable
 fun SpTextField(
     value: String,
@@ -47,20 +146,33 @@ fun SpTextField(
     trailingIcon: (@Composable () -> Unit)? = null,
 ) {
     Column(modifier = modifier) {
+        // Focus state is tracked here (commonMain) to drive the shared
+        // glow + brand-gradient ring. The Android platform layer also
+        // tracks focus locally to swap its static border colour to
+        // accent-purple. Two state machines, same source of truth (the
+        // EditText / OutlinedTextField focus event), but they live in
+        // different modules so neither has to know about the other.
         var isFocused by remember { mutableStateOf(false) }
+        // The glow + gradient border are skipped for error and disabled
+        // states: error gets a solid red border from the platform layer,
+        // and disabled fields shouldn't look interactive.
         val showGlow = isFocused && enabled && !isError && errorMessage == null
 
-        // The actual text-input widget is platform-specific so Android
-        // can fall back to AndroidView+EditText with the right
-        // IME_FLAG_NO_EXTRACT_UI / IME_FLAG_NO_FULLSCREEN flags set
-        // on EditorInfo (Compose Multiplatform doesn't expose those
-        // flags through KeyboardOptions). See PlatformTextFieldCore.
         PlatformTextFieldCore(
             value = value,
             onValueChange = onValueChange,
             modifier = Modifier
                 .fillMaxWidth()
-                .onFocusChanged { isFocused = it.isFocused }
+                // `hasFocus`, not `isFocused`: on Android the focusable node
+                // is the EditText buried inside AndroidView, so the wrapper's
+                // own location never reports `isFocused`. `hasFocus` is true
+                // for self-or-descendant, which is what we want here. On
+                // desktop (OutlinedTextField is the focus target directly)
+                // both flags resolve to the same value. See `feedback_compose_focus_haspower.md`.
+                .onFocusChanged { isFocused = it.hasFocus }
+                // Outer halo (drawn behind the field). Three soft-blue/
+                // purple/pink stops at low alpha render as a faint
+                // ambient glow when focused.
                 .then(if (showGlow) Modifier.drawBehind {
                     val cr = CornerRadius(SpSpacing.RadiusLarge.toPx())
                     val glowBrush = Brush.linearGradient(
@@ -77,11 +189,19 @@ fun SpTextField(
                         style = Stroke(width = 6.dp.toPx()),
                     )
                 } else Modifier)
+                // Brand-gradient ring at the field edge. Drawn at the
+                // same RoundedCornerShape as the platform-layer borders;
+                // since modifier order makes this draw FIRST (chain
+                // outermost), the platform layer's solid accent-purple
+                // border (Android) will draw on top — accentuating the
+                // gradient rather than competing with it.
                 .then(if (showGlow) Modifier.border(
                     1.5.dp, spelaBrandGradient(), RoundedCornerShape(SpSpacing.RadiusLarge)
                 ) else Modifier),
             enabled = enabled,
             isPassword = isPassword,
+            // Force error visual whenever an error message is shown,
+            // even if the caller forgot to also set isError = true.
             isError = isError || errorMessage != null,
             singleLine = singleLine,
             minLines = minLines,
@@ -106,6 +226,15 @@ fun SpTextField(
     }
 }
 
+/**
+ * Convenience wrapper around [SpTextField] preconfigured for "search"
+ * semantics: single-line, [ImeAction.Search] action key, and
+ * [onSearch] is invoked when the user taps the search action key (or
+ * presses Enter on a hardware keyboard).
+ *
+ * No visual differences vs [SpTextField] — this is purely a default-
+ * setting helper for screens that need a search input.
+ */
 @Composable
 fun SpSearchField(
     value: String,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ServerConnectionScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ServerConnectionScreen.kt
@@ -23,8 +23,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ServerConnectionScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ServerConnectionScreen.kt
@@ -18,12 +18,15 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -137,14 +140,16 @@ private fun MobileLayout(
 ) {
     val state by viewModel.state.collectAsState()
 
-    SpGradientBackground(contentAlignment = Alignment.Center) {
+    SpGradientBackground {
         Column(
             modifier = Modifier
-                .widthIn(max = 400.dp)
-                .fillMaxWidth()
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .imePadding()
                 .padding(horizontal = SpSpacing.XLarge),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            Spacer(Modifier.height(SpSpacing.XLarge))
             AppIcon(size = 192.dp, radius = 16.dp)
             Spacer(Modifier.height(SpSpacing.Small))
             Text(
@@ -217,6 +222,8 @@ private fun SplitLayout(
                     modifier = Modifier
                         .widthIn(max = 380.dp)
                         .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .imePadding()
                         .padding(horizontal = SpSpacing.XLarge),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
@@ -247,11 +254,15 @@ private fun ServerListOrForm(
 ) {
     val state by viewModel.state.collectAsState()
 
-    LazyColumn(
+    // Use Column rather than LazyColumn so this composable can be embedded
+    // inside an outer verticalScroll (the layouts wrap us in one to keep the
+    // form visible above the IME). Server lists are always short — handful
+    // of items at most — so eager rendering is fine.
+    Column(
         modifier = if (fullWidth) Modifier.fillMaxWidth() else Modifier,
         verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
     ) {
-        items(state.servers) { server ->
+        state.servers.forEach { server ->
             val gradientBrush = spelaBrandGradient()
             SpActionCard(
                 onClick = {
@@ -311,7 +322,7 @@ private fun ServerListOrForm(
             }
         }
 
-        item {
+        run {
             val animEnabled = com.spela.player.presentation.ui.components.LocalAnimationsEnabled.current
             AnimatedVisibility(
                 visible = state.isAddingServer,

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/presentation/ui/components/PlatformTextFieldCore.desktop.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/presentation/ui/components/PlatformTextFieldCore.desktop.kt
@@ -17,6 +17,29 @@ import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 
+/**
+ * Desktop actual for [PlatformTextFieldCore].
+ *
+ * Desktop has no fullscreen-IME problem — soft keyboards aren't a
+ * thing here in the same way they are on Android — so this is just
+ * a thin styling wrapper around Material 3's `OutlinedTextField`. We
+ * delegate everything (floating label, container, cursor, label
+ * colours, error state, IME action plumbing) to OutlinedTextField
+ * and only override colour tokens to match the design system.
+ *
+ * Border styling on focus: `focusedBorderColor = Color.Transparent`.
+ * That's intentional — when the field is focused, the [SpTextField]
+ * wrapper draws its multi-colour brand-gradient ring on top of this
+ * field. Leaving the OutlinedTextField's own focused border visible
+ * would compete with the gradient, so we hide it and let the wrapper's
+ * ring be the entire focused-edge treatment. Unfocused border is a
+ * subtle low-alpha white that reads as a faint outline on dark
+ * backgrounds.
+ *
+ * If the Android implementation evolves, mirror visual changes here so
+ * desktop and Android stay in lockstep — the screens use [SpTextField]
+ * and shouldn't have to know which platform they're running on.
+ */
 @Composable
 actual fun PlatformTextFieldCore(
     value: String,


### PR DESCRIPTION
Closes #1113.

PR #847 swapped Compose's `OutlinedTextField` for an `AndroidView { EditText }` to fix the AYN Thor fullscreen-IME bug. The replacement was visually unfinished — invisible borders, no label, no focused-state visual — and the IME-action and IME-padding plumbing wasn't wired through. This PR finishes that work.

## Summary

- **Restore visual styling on Android** — label rendered above the field, container fill, accent-purple focused border, the `SpTextField` wrapper's brand-gradient ring + soft glow now actually fire.
- **Fix the focus-tracking bug** — `Modifier.onFocusChanged { it.isFocused }` only fires for self-focus, but the focusable target is the `EditText` buried inside `AndroidView`. Switched to `it.hasFocus` (self-or-descendant) in both the wrapper and the Android `PlatformTextFieldCore`.
- **Wire up IME action handling** — Done / Go / Search / Send dismiss the IME and clear focus; Next / Previous traverse focus via Android's `focusSearch`. Each path runs the screen's `onImeAction` callback first.
- **Tap outside to dismiss IME** — added to `SpScreen` so every screen gets it without per-screen wiring.
- **Keep focused field visible above IME on Server Connect** — added `imePadding` + `verticalScroll` on `ServerConnectionScreen`'s content Columns, mirroring `LoginScreen`. Replaced the inner `LazyColumn` with an eager `Column` to fix the nested-scrollable crash that the outer scroll triggered.
- **Extensive doc comments** — every text-field source file now has a top-level KDoc explaining the architecture, the IME-flag workaround, the focus-tracking gotcha, the visual treatment, and the deletion criteria for when the AndroidView+EditText path can be removed. A future agent should be able to make sound changes from any one file in isolation.

## Why the EditText workaround stays

Compose Multiplatform 1.10 still doesn't expose `EditorInfo.imeOptions` int flags through `KeyboardOptions` / `PlatformImeOptions` — only `privateImeOptions` (a free-form String that Gboard ignores). Until upstream exposes the int flags, dropping to the view system on Android is the only reliable way to set `IME_FLAG_NO_EXTRACT_UI | IME_FLAG_NO_FULLSCREEN` and keep the keyboard from going fullscreen on landscape handhelds (AYN Thor and similar). Desktop is unaffected and continues to use `OutlinedTextField` directly.

## Commits

1. `fix(player): restore Android text input styling and IME action handling (#1113)` — the styling + focus + IME-action work, plus all the doc comments.
2. `feat(player): tap outside text fields to dismiss IME (#1113)` — `SpScreen` change.
3. `fix(player): scroll Server Connect form above IME (#1113)` — `ServerConnectionScreen` `imePadding` + scroll + `LazyColumn` → `Column` conversion.

## Test plan

- [x] AYN Thor (serial 54071896) — verified visually: labels, borders, focus highlight, container fill all render.
- [x] AYN Thor — Enter on Server Name advances focus to Server URL with the form scrolled above the IME; Enter on Server URL submits and dismisses the keyboard.
- [x] AYN Thor — tap on screen background dismisses the keyboard.
- [x] `:shared:desktopTest` — 647 tests, 0 failures.
- [x] `:android:assembleDebug` — green.
- [ ] On-device verification of dialogs that use `SpTextField` (Settings device-name, Save dialog, Challenge create, Collection form, etc.) — visual smoke check across the app.