### PR TITLE
security: 2026-05 audit — fix all 20 findings (#1115-#1134)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,202 +1,309 @@
 # Security
 
-This document is for self-hosting administrators. It explains Spela's threat
-model, what the backend does well, what known issues exist (with links to
-tracking issues), and how to harden a deployment.
+This document is the operational security baseline for **administrators
+self-hosting Spela**. It explains the threat model the backend was
+designed against, the protections that are in place today, the known
+gaps that have been audited and fixed, and the deployment settings that
+turn a default install into a hardened one.
 
 > **Last full audit:** 2026-05-08 — every Go file under `server/` was
 > reviewed across authentication, authorization, file handling, SQL/input
-> validation, and crypto/transport. The findings below reflect that audit;
-> open issues are tracked on GitHub and SECURITY.md is updated as they are
-> resolved.
+> validation, crypto/transport, and patcher safety.
+>
+> **Status:** All 20 audit findings (1 critical, 3 high, 11 medium,
+> 5 low) have been addressed; see _Resolved findings_ for issue and
+> commit references. The audit will be repeated and this document
+> refreshed at every release with significant security-relevant
+> changes.
 
 ## Threat model
 
 Spela is designed to be **self-hosted** by a single operator (or a small
-trusted team), serving game-emulation features to a private group of users —
-typically family, friends, or a small community. The audit assumed:
+trusted team), serving game-emulation features to a private group of
+users — typically family, friends, or a small community. The audit
+assumed:
 
 - The server is reachable from the public Internet, behind a reverse
   proxy with TLS (e.g. Caddy, nginx, Traefik).
-- New-account registration may be open or closed at the operator's choice.
+- New-account registration may be open or closed at the operator's
+  choice.
 - Authenticated users are not assumed trustworthy. They may try to read
   other users' data, escalate privileges, or attack the host.
-- Administrators are assumed mostly trustworthy but can be phished or have
-  their accounts compromised; defense-in-depth against rogue admins is a
-  goal where reasonable.
-- The deployment host is not actively compromised at the OS level. Spela
-  cannot defend the host from itself.
+- Administrators are assumed mostly trustworthy but can be phished or
+  have their accounts compromised; defense-in-depth against rogue
+  admins is a goal where reasonable.
+- The deployment host is not actively compromised at the OS level.
+  Spela cannot defend the host from itself.
 
-Out of scope: DoS protection beyond basic rate limiting; defending against a
-malicious operator with shell access; and attacks requiring physical access
-to the database file.
+**Out of scope** for the audit: DoS protection beyond basic rate
+limiting; defending against a malicious operator with shell access; and
+attacks requiring physical access to the database file.
 
 ## Reporting a vulnerability
 
-Please **do not file a public issue** for an unpatched vulnerability. Email
-the maintainer at the address in the project README, or use GitHub's
-[private security advisory](https://github.com/mattias800/spela/security/advisories/new)
+Please **do not file a public issue** for an unpatched vulnerability.
+Email the maintainer at the address in the project README, or use
+GitHub's [private security advisory](https://github.com/mattias800/spela/security/advisories/new)
 flow. Coordinated disclosure is preferred. Public issues are appropriate
 once a fix is merged or for low-severity hardening recommendations.
 
 ## What the backend does well
 
-These are the protections in place today; admins reading this should know
-they exist before scrutinizing the findings list.
+These are the protections in place today; admins reading this should
+know they exist before scrutinizing the changelog.
 
 ### Authentication & session
 
-- **JWT secret is enforced**: at startup the server refuses to run with
+- **JWT secret enforcement**: at startup the server refuses to run with
   the default placeholder or a secret shorter than 32 characters
-  (`cmd/server/main.go:86-95`).
-- **bcrypt cost 12** with a startup-generated dummy hash so that timing
-  for a non-existent username matches a real password check
-  (`internal/auth/auth.go:38`, `internal/api/auth_handler.go:43-55`).
-- **Login lockout** escalates 15 → 30 → 60 → 120 minutes per failure tier
-  and is per-account (hashed username) to prevent the lockout table from
-  storing raw usernames (`internal/api/auth_handler.go:66-127`).
-- **Refresh tokens** are 32 random bytes from `crypto/rand`, stored only
-  as SHA-256 hashes, and use **token families with replay detection** —
-  presenting a consumed token revokes the entire family
-  (`internal/api/huma_auth_handlers.go:498-583`).
-- **Token version** on the user row is checked on every request, so role
-  change, password change, or `disabled=true` immediately invalidates all
-  outstanding access tokens (`internal/api/middleware.go:111-145`).
+  (`cmd/server/main.go`).
+- **bcrypt cost 12** with a startup-generated dummy hash so that the
+  timing for a non-existent username matches a real password check
+  (`internal/auth/auth.go`, `internal/api/auth_handler.go`).
+- **Login lockout** escalates 15 → 30 → 60 → 120 minutes per failure
+  tier and is per-account (hashed username) so the lockout table never
+  stores raw usernames. A successful login fully clears the lockout
+  row, so a slow attacker can't keep the escalation tier armed across
+  days.
+- **Common-password blocklist** rejects ~50 of the most-leaked / most-
+  sprayed passwords on registration and password change. Static and
+  offline — no DNS leak.
+- **Refresh tokens** are 32 random bytes from `crypto/rand`, stored
+  only as SHA-256 hashes, and use **token families with replay
+  detection** — presenting a consumed token revokes the entire family.
+- **Token version** on the user row is checked on every request, so
+  role change, password change, email change, or `disabled=true`
+  immediately invalidates all outstanding access tokens.
 - **JWT alg confusion is blocked**: only HMAC signing methods are
-  accepted; `alg: none` and asymmetric-key confusion are rejected
-  (`internal/auth/auth.go:87-89`).
+  accepted; `alg: none` and asymmetric-key confusion are rejected.
 - **Logout** blacklists the access token (SHA-256 hash, indexed) and
-  deletes every refresh token belonging to the user
-  (`internal/api/huma_auth_handlers.go:692-714`).
+  deletes every refresh token belonging to the user. The blacklist
+  also catches tokens delivered via the legacy `?token=` query param
+  on download routes.
+- **`?token=` query fallback** is restricted to a small allowlist of
+  download / WebSocket / asset routes where browsers genuinely cannot
+  set Authorization headers. Every JSON-API endpoint requires a Bearer
+  header, keeping access tokens out of reverse-proxy logs.
+
+### Authorization
+
+- **Owner > admin > user** role hierarchy. Only owner can mutate or
+  delete other admins, change another admin's password, or change
+  another admin's email — a single compromised admin account cannot
+  lock the rest out.
+- **Per-route admin gate** on every `/api/admin/*` endpoint plus
+  defense-in-depth admin checks inside handlers that traverse
+  privileged data.
+- **Per-user file ACLs** on save screenshots and shared session saves;
+  download endpoints re-validate ownership before streaming bytes.
+- **Profile visibility** (`public` default, `private` opt-in) gates
+  exposure of play time, recent games, top-played games, currentGame,
+  and online status on the public profile endpoint.
+- **Block model** filters search, profile, and invite endpoints
+  symmetrically — neither the blocker nor the blocked party shows up
+  in the other's results.
+- **Shared-session turn enforcement** on every save-upload handler
+  (slot, auto-save, dir-bundle). The session owner cannot overwrite
+  saves while a co-op partner holds the turn.
 
 ### Crypto & transport
 
-- **AES-GCM** for at-rest encryption of admin secrets (scraper API keys,
-  RA tokens). Random per-message nonce; key sizes validated to
-  16/24/32 bytes (`internal/auth/encrypt.go`).
+- **AES-GCM** for at-rest encryption of admin secrets (scraper API
+  keys, RA tokens). Random per-message nonce; key sizes validated to
+  16/24/32 bytes.
 - **Separate encryption key required in release mode**
-  (`SPELA_ENCRYPTION_KEY`); falls back to JWT-secret-derived key only in
-  development (`cmd/server/main.go:97-113`).
+  (`SPELA_ENCRYPTION_KEY`); falls back to JWT-secret-derived key only
+  in development.
 - **Outbound HTTP**: every scraper client pins its base URL to a known
-  constant (igdb.com, libretro.com, steamgriddb.com, pouet.net). No
-  `InsecureSkipVerify` anywhere in the tree.
-- **Trusted proxies** restricted to RFC 1918 + loopback so admins behind
-  public CDNs don't get spoofable `X-Forwarded-For`
-  (`internal/api/router.go:55`).
+  constant. The hardened `safehttp` client adds private-IP rejection
+  on every redirect hop, scheme allowlisting (http/https only),
+  response-body size capping, and Content-Type gating for image
+  fetches. No `InsecureSkipVerify` anywhere in the tree.
+- **Trusted proxies** restricted to RFC 1918 + loopback so admins
+  behind public CDNs don't get spoofable `X-Forwarded-For`.
 - **pprof bound to `127.0.0.1` only** — heap dumps and stack traces
-  cannot be reached from the network (`cmd/server/main.go:37-43`).
+  cannot be reached from the network.
 - **Security headers**: COOP same-origin, COEP credentialless,
   X-Content-Type-Options nosniff, X-Frame-Options SAMEORIGIN, HSTS,
-  Referrer-Policy strict-origin-when-cross-origin, Permissions-Policy
-  (`internal/api/router.go:58-77`).
+  Referrer-Policy strict-origin-when-cross-origin, Permissions-Policy.
 - **CSP** scoped for EmulatorJS needs but tight everywhere else.
 - **CORS** defaults to same-origin (no headers sent); explicit origins
-  honored; `*` automatically disables `AllowCredentials`.
-
-### File handling
-
-- **Containment checks** on every write/read into save/image/BIOS dirs
-  via `filepath.Abs` + prefix verification
-  (`internal/storage/storage.go`).
-- **Symlink-aware path resolution** in `ImageHandler.ServeImage` via
-  `filepath.EvalSymlinks` (`internal/api/router.go:503-519`).
-- **Filename sanitization** strips path separators with `filepath.Base`.
-- **Save/BIOS dirs** use `0700` permissions; image/core dirs `0755`.
-- **ROM paths** validated against allowed game directories with
-  symlink resolution (`internal/storage/storage.go:754-779`).
-- **ZIP extraction**: BIOS bundle extractor explicitly checks
-  `filepath.IsAbs`, `..` substrings, and absolute prefix; skips
-  symlinks (`internal/bios/downloader.go:380-456`).
-- **Zip-bomb protection**: file count cap (10 000), declared total
-  uncompressed size cap (50 GB), and per-extraction `io.LimitReader`
-  budget that decrements as extraction progresses.
-- **Patcher output bounded** to 256 MB for IPS / IPS32 / UPS / BPS.
-- **Save screenshot ACL**: `/api/images/save-screenshots/` is auth-gated
-  with ownership check and full token-blacklist/disabled/token-version
-  re-validation (`internal/api/router.go:521-600`).
+  honored; `*` automatically disables `AllowCredentials` on HTTP.
+- **WebSocket origin checks** refuse cross-origin upgrades that
+  authenticate via `?token=` even under a `*` policy — the wildcard
+  is treated as "no credentials" only.
+- **WebSocket recipient filter** delivers private events (invites,
+  shared-session turn changes) only to the connected clients those
+  events are addressed to, instead of broadcasting them to every
+  authenticated WS subscriber.
 
 ### Input validation
 
 - **Body size limit** of 1 MB on all JSON endpoints (multipart excluded
-  and uses its own limits) (`internal/api/middleware.go:170-181`).
-- **GORM placeholders** used universally for user input — no
-  string-concatenated WHERE clauses against user-controlled values were
-  found (with the structural exception flagged in the findings).
+  and uses its own limits).
+- **GORM placeholders** used universally for user input. Every numeric
+  path parameter carries a `pattern:"^[0-9]+$"` schema constraint
+  enforced at the API edge by huma — non-numeric IDs are rejected with
+  422 before any DB call. A unit test in the `api` package fails the
+  build if a future endpoint forgets the pattern.
 - **`escapeLikePattern`** is used consistently with `ESCAPE '\'` in
   LIKE queries.
 - **Admin settings PUT** enforces a strict allowlist of keys; secret
-  values cannot be overwritten with the masked placeholder
-  (`internal/api/admin_handler_settings.go:14-23`).
+  values cannot be overwritten with the masked placeholder.
 - **`os/exec`** is used in only one place (`xdelta3`), with argv form
-  and server-generated temp filenames — no shell, no command injection.
-- **SSRF guard** for user-set avatar URLs via a robust `isPrivateURL`
-  covering RFC 1918, 169.254/16 cloud metadata, IPv6 ULA/link-local, and
-  IPv4-mapped IPv6 (`internal/api/user_handler.go:170-221`).
+  and server-generated temp filenames — no shell, no command
+  injection. The child process runs under a 30-second context timeout
+  to bound damage from any future xdelta3 parser CVE.
+- **SSRF guard** (`internal/safehttp`) covers RFC 1918, 169.254/16
+  cloud metadata, IPv6 ULA/link-local, IPv4-mapped IPv6, and applies
+  to user avatars, admin "set hero art", and every scraper image
+  fetch. CheckRedirect re-validates each hop's IP so a public host
+  cannot bounce us to a private one.
 
-## Open findings
+### File handling
 
-Each finding links to a GitHub issue. Mark as **Resolved** when the
-referenced PR is merged.
+- **Containment checks** on every write/read into save/image/BIOS
+  dirs via `filepath.Abs` + prefix verification.
+- **Symlink-aware path resolution** in `ImageHandler.ServeImage` via
+  `filepath.EvalSymlinks`.
+- **`ResolveGamePath`** rejects empty / absolute / `..`-prefixed
+  paths and verifies the resolved path stays inside the game dir
+  before stat. Any caller that ever forgets to follow up with
+  `ValidateROMPath` is still safe.
+- **Cue/GDI companion paths** are bounded to the disc's directory:
+  the parser refuses absolute paths, refuses `..` segments, and
+  re-resolves the joined path against the disc dir. Defense in
+  depth: the tar/zip stream writer refuses non-regular files, so a
+  planted symlink under the disc dir cannot escape via re-resolution.
+- **SPA static fallback** containment-checks every resolved path
+  against the absolute frontend dir before serving — the previous
+  Stat-vs-FileServer two-path inconsistency is gone.
+- **Filename sanitization** strips path separators with
+  `filepath.Base`.
+- **Save/BIOS dirs** use `0700` permissions; image/core dirs `0755`.
+- **ZIP extraction**: BIOS bundle extractor explicitly checks
+  `filepath.IsAbs`, `..` substrings, and absolute prefix; skips
+  symlinks. File count cap (10 000), declared total uncompressed
+  size cap (50 GB), and per-extraction `io.LimitReader` budget
+  that decrements as extraction progresses.
+- **Patcher**:
+  - 30-second `xdelta3` timeout (no sandbox yet — see _Limitations_).
+  - Output bounded to 256 MB for IPS / IPS32 / UPS / BPS.
+  - Input bounded to 256 MB at the rom-hack endpoint so the in-memory
+    peak matches the patcher's contract.
+  - VLQ decoder returns `(value, n, ok)`; truncated input surfaces a
+    clean parser error instead of a panic recovered into 500.
+- **BIOS uploads**: MD5 mismatch deletes the upload and returns 400
+  with the expected hash — invalid bytes never sit on disk waiting
+  for a permissive core to load them.
+- **BIOS auto-download**:
+  - **Default OFF**. Operators opt in explicitly via the
+    `bios_auto_download` server setting.
+  - Refuses to fetch any registry entry that lacks an MD5 checksum
+    (the upstream is a third-party GitHub account, not Spela's own
+    source tree, so an empty checksum is untrustworthy).
+- **Save screenshot ACL**: `/api/images/save-screenshots/` is
+  auth-gated with ownership check and full token-blacklist /
+  disabled / token-version re-validation.
 
-### Critical
+### Setup safety
 
-| # | Finding | Issue |
-|---|---|---|
-| 1 | GORM string-WHERE SQL injection on user-reachable endpoints (any authenticated user can perform blind boolean SQLi to exfiltrate password hashes / secrets) | [#1115](https://github.com/mattias800/spela/issues/1115) |
-
-### High
-
-| # | Finding | Issue |
-|---|---|---|
-| 2 | Cue/GDI companion-file path traversal — malicious `.cue` lets a download include arbitrary host files in the response tar | [#1116](https://github.com/mattias800/spela/issues/1116) |
-| 3 | `?token=` query fallback applies to every protected route — JWTs leak into proxy logs and aren't blacklisted on logout-via-query | [#1117](https://github.com/mattias800/spela/issues/1117) |
-| 4 | SPA static fallback file server lacks containment check (defense-in-depth — relies on Gin's URL normalization today) | [#1118](https://github.com/mattias800/spela/issues/1118) |
-
-### Medium
-
-| # | Finding | Issue |
-|---|---|---|
-| 5 | WebSocket hub broadcasts every event to every connected client — cross-tenant leak of invites, turn changes, activity feed | [#1119](https://github.com/mattias800/spela/issues/1119) |
-| 6 | SSRF via admin "set hero art" URL fetch + unvalidated scraper image downloads | [#1120](https://github.com/mattias800/spela/issues/1120) |
-| 7 | Public profile endpoint exposes activity/play data to all authenticated users; no privacy or block model | [#1121](https://github.com/mattias800/spela/issues/1121) |
-| 8 | Non-owner admins can demote, disable, and hard-delete other admins | [#1122](https://github.com/mattias800/spela/issues/1122) |
-| 9 | Admin email change has no uniqueness check or owner protection | [#1123](https://github.com/mattias800/spela/issues/1123) |
-| 10 | BIOS upload kept on disk after MD5 mismatch + auto-downloader trusts third-party GitHub repo with weak hashing | [#1124](https://github.com/mattias800/spela/issues/1124) |
-| 11 | `ResolveGamePath` does not bound resolved path to game dirs; rom-hack endpoint skips validation | [#1125](https://github.com/mattias800/spela/issues/1125) |
-| 12 | WebSocket Origin `*` wildcard + `?token=` permits authenticated cross-origin WS | [#1126](https://github.com/mattias800/spela/issues/1126) |
-| 13 | Project-wide: numeric path-param IDs accepted as strings without `pattern` validation (structural cause of #1115) | [#1127](https://github.com/mattias800/spela/issues/1127) |
-| 14 | Slot-save upload skips shared-session turn check | [#1128](https://github.com/mattias800/spela/issues/1128) |
-| 15 | `xdelta3` invoked with attacker-controlled patch input, no sandboxing or timeout | [#1129](https://github.com/mattias800/spela/issues/1129) |
-
-### Low
-
-| # | Finding | Issue |
-|---|---|---|
-| 16 | Re-setup possible if `users` table is truncated out-of-band | [#1130](https://github.com/mattias800/spela/issues/1130) |
-| 17 | Auth hardening: no breached-password / strength check; lockout escalation tier never decays on success | [#1131](https://github.com/mattias800/spela/issues/1131) |
-| 18 | Username/email enumeration on registration via 409 disambiguation | [#1132](https://github.com/mattias800/spela/issues/1132) |
-| 19 | Email change in `PUT /api/user/profile` does not bump `TokenVersion` | [#1133](https://github.com/mattias800/spela/issues/1133) |
-| 20 | Patcher reads full base ROM into memory; BPS VLQ decoder lacks bounds check | [#1134](https://github.com/mattias800/spela/issues/1134) |
+- The first-run `/api/auth/setup` endpoint persists a
+  `setup_completed` row to `server_settings` after the owner is
+  created. Subsequent setup calls are refused regardless of users-
+  table state, so an out-of-band table truncation cannot re-open the
+  endpoint to whoever races to it first.
 
 ## Resolved findings
 
-_None yet — this section will be populated as the issues above are
-fixed. Each entry should record the issue number, the finding title, the
-fixing PR / commit, and the date of the fix._
+The 2026-05-08 audit surfaced 20 issues; every one is fixed in the
+2026-05 security PR. Each entry below records the original severity,
+title, GitHub issue, and the fixing commit.
 
-## Deployment guidance for self-hosting admins
+### Critical
 
-The settings below give you a hardened baseline beyond Spela's defaults.
+| # | Finding | Issue | Fix |
+|---|---|---|---|
+| 1 | GORM string-WHERE SQL injection on user-reachable endpoints | [#1115](https://github.com/mattias800/spela/issues/1115) | `5de02860` |
 
-### Required (will refuse to start without them)
+### High
 
-- `SPELA_JWT_SECRET` — at least 32 random characters. Refuses to run on
-  `change-me-in-production` or any value shorter than 32 chars. Generate
-  with `openssl rand -base64 48`.
-- In release mode (`GIN_MODE=release`): `SPELA_ENCRYPTION_KEY` — exactly
-  16, 24, or 32 bytes. Use a different value from the JWT secret so you
-  can rotate one without re-encrypting stored data. Generate with
-  `openssl rand 32 | base64`.
+| # | Finding | Issue | Fix |
+|---|---|---|---|
+| 2 | Cue/GDI companion-file path traversal | [#1116](https://github.com/mattias800/spela/issues/1116) | `3c0e07e9` |
+| 3 | `?token=` query fallback applied to every protected route | [#1117](https://github.com/mattias800/spela/issues/1117) | `58e8ed26` |
+| 4 | SPA static fallback file server lacked containment check | [#1118](https://github.com/mattias800/spela/issues/1118) | `250abe4e` |
+
+### Medium
+
+| # | Finding | Issue | Fix |
+|---|---|---|---|
+| 5 | WebSocket hub broadcast every event to every client | [#1119](https://github.com/mattias800/spela/issues/1119) | `4a78b661` |
+| 6 | SSRF via admin "set hero art" + unvalidated scraper image fetch | [#1120](https://github.com/mattias800/spela/issues/1120) | `4e133c36` |
+| 7 | Public profile / search exposed activity to all authenticated users | [#1121](https://github.com/mattias800/spela/issues/1121) | `ffad90a6` |
+| 8 | Non-owner admins could demote/disable/delete other admins | [#1122](https://github.com/mattias800/spela/issues/1122) | `1df39959` |
+| 9 | Admin email change had no uniqueness or owner protection | [#1123](https://github.com/mattias800/spela/issues/1123) | `1df39959` |
+| 10 | BIOS upload mismatch + auto-downloader trust on third-party GitHub | [#1124](https://github.com/mattias800/spela/issues/1124) | `15efb126` |
+| 11 | `ResolveGamePath` did not bound resolved path; rom-hack skipped validation | [#1125](https://github.com/mattias800/spela/issues/1125) | `57b256d2` |
+| 12 | WebSocket Origin `*` wildcard allowed credentialed cross-origin | [#1126](https://github.com/mattias800/spela/issues/1126) | `7ae29615` |
+| 13 | Numeric path-param IDs accepted as strings without `pattern` validation | [#1127](https://github.com/mattias800/spela/issues/1127) | `03e0baad` |
+| 14 | Slot-save upload skipped shared-session turn check | [#1128](https://github.com/mattias800/spela/issues/1128) | `483d802f` |
+| 15 | `xdelta3` invoked without sandbox or timeout | [#1129](https://github.com/mattias800/spela/issues/1129) | `228ee5e4` |
+
+### Low
+
+| # | Finding | Issue | Fix |
+|---|---|---|---|
+| 16 | Re-setup possible if `users` table was truncated out-of-band | [#1130](https://github.com/mattias800/spela/issues/1130) | `bf5dd16f` |
+| 17 | No common-password blocklist; lockout escalation never decayed on success | [#1131](https://github.com/mattias800/spela/issues/1131) | `4bc1783b` |
+| 18 | Username/email enumeration on registration via 409 disambiguation | [#1132](https://github.com/mattias800/spela/issues/1132) | `2e89089a` |
+| 19 | Email change in `PUT /api/user/profile` did not bump `TokenVersion` | [#1133](https://github.com/mattias800/spela/issues/1133) | `84bd1c70` |
+| 20 | Patcher in-memory ROM cap; BPS VLQ decoder lacked bounds check | [#1134](https://github.com/mattias800/spela/issues/1134) | `6ca7b551` |
+
+## Limitations & known residual risk
+
+The audit found no further defects above the "low" severity bar that
+had not been fixed at the time of the PR. Some accepted residual risks
+worth noting up front:
+
+- **`xdelta3` runs under a timeout but not a sandbox.** A
+  memory-corruption CVE in the host's installed `xdelta3` binary
+  would still execute as the spela server user. The long-term fix is
+  an in-process Go VCDIFF implementation; the short-term mitigation
+  is the 30-second timeout (#1129) and running spela under a
+  least-privilege OS account.
+- **Open registration leaks email existence via timing.** With
+  registration enabled, an attacker can in principle distinguish a
+  valid email from an invalid one because the password-hash branch
+  is taken on conflict. Self-hosted instances that care about this
+  should disable open registration and provision users via the admin
+  panel.
+- **Email-based password reset is not implemented.** If/when it
+  ships, the email-change → TokenVersion bump (#1133) becomes the
+  hardening that stops a transient password thief from pivoting
+  recovery to their own address.
+- **Activity feed events are broadcast to every WS subscriber today.**
+  Per-user filtering will land alongside the wider profile-visibility
+  surface; for now, hide your activity by setting
+  `profile_visibility = "private"` (which gates the public profile
+  endpoint).
+
+## Hardening checklist for self-hosting admins
+
+The settings below give you a hardened baseline beyond Spela's
+defaults. Items marked **Required** are enforced at startup; items
+marked **Strongly recommended** are not, but every non-trivial
+deployment should set them.
+
+### Required (the server refuses to start without them)
+
+- `SPELA_JWT_SECRET` — at least 32 random characters. Refuses to run
+  on `change-me-in-production` or any value shorter than 32 chars.
+  Generate with `openssl rand -base64 48`.
+- In release mode (`GIN_MODE=release`): `SPELA_ENCRYPTION_KEY` —
+  exactly 16, 24, or 32 bytes. Use a different value from the JWT
+  secret so you can rotate one without re-encrypting stored data.
+  Generate with `openssl rand 32 | base64`.
 
 ### Strongly recommended
 
@@ -204,38 +311,49 @@ The settings below give you a hardened baseline beyond Spela's defaults.
   header is only honored on HTTPS responses.
 - **Set `SPELA_CORS_ORIGINS`** to your frontend's exact origin list.
   Avoid `*` — it disables `AllowCredentials` for HTTP and (separately)
-  weakens WebSocket origin checking; see #1126.
+  weakens WebSocket origin checking. Even after #1126's tightening,
+  enumerating origins is the safer choice.
 - **Set `SPELA_WS_ORIGINS`** explicitly if you need it different from
-  CORS. By default it inherits CORS origins, which is the safer default.
-- **Don't expose `/api/auth/setup` to the public** until the first owner
-  has been created. Once created, the endpoint refuses further setup —
-  but see #1130 for the corner case that requires DB access to trigger.
+  CORS. By default it inherits CORS origins, which is the safer
+  default.
+- **Don't expose `/api/auth/setup` to the public** until the first
+  owner has been created. Once setup completes, the server persists a
+  `setup_completed` marker that prevents re-bootstrap (#1130) — but
+  the cleanest posture is to firewall the endpoint until you've
+  created your owner account.
 - **Disable open registration** if your user list is closed. Admin →
-  Settings → "Allow new registrations" off (or set `registration_enabled=false`
-  in `server_settings`).
-- **Strip `?token=` from your reverse-proxy access logs** to reduce
-  token-leakage exposure. nginx example:
+  Settings → "Allow new registrations" off (or set
+  `registration_enabled=false` in `server_settings`).
+- **Strip `?token=` from your reverse-proxy access logs** even though
+  the new fallback is restricted (#1117), to reduce token-leakage
+  exposure on the routes that still legitimately use it. nginx
+  example:
   ```nginx
   log_format spela_safe '$remote_addr - $remote_user [$time_local] '
                         '"$request_method $uri $server_protocol" $status $body_bytes_sent';
   access_log /var/log/nginx/spela.access.log spela_safe;
   ```
-  This avoids capturing the query string entirely. See #1117.
-- **Back up `spela.db`** with care: it contains bcrypt password hashes,
-  refresh-token hashes, and AES-GCM ciphertext of admin secrets. The
-  encryption key is **not** in the DB — losing it means the encrypted
-  admin secrets become unrecoverable.
-- **Disable BIOS auto-download** if you can supply BIOS files manually:
-  Admin → BIOS → "Auto-download" off. The default-on setting fetches
-  from a third-party GitHub account; see #1124.
+  This avoids capturing the query string entirely.
+- **Back up `spela.db`** with care: it contains bcrypt password
+  hashes, refresh-token hashes, and AES-GCM ciphertext of admin
+  secrets. The encryption key is **not** in the DB — losing it means
+  the encrypted admin secrets become unrecoverable.
+- **BIOS auto-download is OFF by default** (#1124). If you enable it,
+  understand that the upstream is a third-party GitHub account
+  (`Abdess/retrobios`); a compromised commit there could ship
+  malicious BIOS bytes that libretro cores will execute. Prefer
+  uploading BIOS files manually and verify their MD5 against a
+  source you trust.
 - **Run with the smallest privileges that work**. Non-root, dedicated
-  user; only the configured directories writable. The `0700` save and
-  BIOS dirs assume the spela user is the only one reading them.
+  user; only the configured directories writable. The `0700` save
+  and BIOS dirs assume the spela user is the only one reading them.
 
 ### Optional
 
-- `SPELA_MAX_SAVE_UPLOAD_MB` (default 256): per-upload save-state cap.
-- `SPELA_MAX_SAVE_STORAGE_MB` (default 1024): per-user storage quota.
+- `SPELA_MAX_SAVE_UPLOAD_MB` (default 256): per-upload save-state
+  cap.
+- `SPELA_MAX_SAVE_STORAGE_MB` (default 1024): per-user storage
+  quota.
 - `SPELA_CHALLENGE_RATE_LIMIT_SEC` (default 30): minimum seconds
   between challenge attempt submissions.
 
@@ -247,7 +365,7 @@ The settings below give you a hardened baseline beyond Spela's defaults.
 | `127.0.0.1:6060` | Localhost only | pprof. Never expose. |
 | `/api/test/reset` | Only when `SPELA_TEST_MODE=true` | Don't enable in production. |
 | `/api/openapi`, `/api/docs` | Public, unauthenticated | OpenAPI spec + Swagger UI. Read-only metadata about the route surface. |
-| `/api/auth/setup-status` | Public, unauthenticated | Leaks `needsSetup` and `gameCount`. |
+| `/api/auth/setup-status` | Public, unauthenticated | Returns `needsSetup` and `gameCount`. `needsSetup` is true only when there are no users AND the `setup_completed` marker is absent (#1130). |
 
 ## Audit methodology
 
@@ -256,7 +374,18 @@ running targeted `grep` patterns for risky constructs (`Raw`, `Exec`,
 dynamic `Order`, `os/exec`, `math/rand`, `InsecureSkipVerify`, query
 construction in handlers, multipart filename handling, and so on).
 Findings are reproducible from the codebase as it stood at commit
-`64a4e6ab` (master tip on 2026-05-08). When an issue is fixed, update
-this file's "Open findings" table, move the entry to "Resolved
-findings" with the fixing PR/commit and date, and close the linked
-issue.
+`64a4e6ab` (master tip on 2026-05-08).
+
+The fix PR includes:
+
+- 24 commits, one per finding plus targeted test fixups.
+- New regression-style tests in the `api`, `scanner`, `storage`,
+  `safehttp`, `bios`, `patcher`, and `websocket` packages covering
+  each fix.
+- A structural lint (`server/internal/api/path_param_pattern_test.go`)
+  that runs in CI and fails any future PR that adds a `path:"..."`
+  tag without a `pattern:` constraint, preventing regression of the
+  SQLi-class issues.
+
+When future audits surface findings, list them at the top of this
+file and link the fix commit on resolution.

--- a/server/internal/api/admin_user_validation_test.go
+++ b/server/internal/api/admin_user_validation_test.go
@@ -44,7 +44,7 @@ func TestAdminCreateUser_ValidationBounds(t *testing.T) {
 			body: map[string]string{
 				"username": "valid_user_01",
 				"email":    "valid@example.com",
-				"password": "password123",
+				"password": "SecureTestPass!2024",
 				"role":     "user",
 			},
 			expect: http.StatusCreated,
@@ -54,7 +54,7 @@ func TestAdminCreateUser_ValidationBounds(t *testing.T) {
 			body: map[string]string{
 				"username": "ab",
 				"email":    "x@example.com",
-				"password": "password123",
+				"password": "SecureTestPass!2024",
 				"role":     "user",
 			},
 			expect: http.StatusUnprocessableEntity,
@@ -64,7 +64,7 @@ func TestAdminCreateUser_ValidationBounds(t *testing.T) {
 			body: map[string]string{
 				"username": "a234567890123456789012345678901234567890123456789012345678901234X",
 				"email":    "x@example.com",
-				"password": "password123",
+				"password": "SecureTestPass!2024",
 				"role":     "user",
 			},
 			expect: http.StatusUnprocessableEntity,
@@ -84,7 +84,7 @@ func TestAdminCreateUser_ValidationBounds(t *testing.T) {
 			body: map[string]string{
 				"username": "new_user_em",
 				"email":    "",
-				"password": "password123",
+				"password": "SecureTestPass!2024",
 				"role":     "user",
 			},
 			expect: http.StatusUnprocessableEntity,
@@ -94,7 +94,7 @@ func TestAdminCreateUser_ValidationBounds(t *testing.T) {
 			body: map[string]string{
 				"username": "migrated_user_123",
 				"email":    "migrated@example.com",
-				"password": "password123",
+				"password": "SecureTestPass!2024",
 				"role":     "user",
 			},
 			expect: http.StatusCreated,

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -138,7 +138,7 @@ func TestRegisterAndLogin(t *testing.T) {
 	body, _ := json.Marshal(map[string]string{
 		"username": "testuser",
 		"email":    "test@example.com",
-		"password": "password123",
+		"password": "SecureTestPass!2024",
 	})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
@@ -159,7 +159,7 @@ func TestRegisterAndLogin(t *testing.T) {
 	// Login
 	body, _ = json.Marshal(map[string]string{
 		"username": "testuser",
-		"password": "password123",
+		"password": "SecureTestPass!2024",
 	})
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest("POST", "/api/auth/login", bytes.NewReader(body))
@@ -181,7 +181,7 @@ func TestRegister_DuplicateUsername(t *testing.T) {
 	body, _ := json.Marshal(map[string]string{
 		"username": "dupeuser",
 		"email":    "dupe1@example.com",
-		"password": "password123",
+		"password": "SecureTestPass!2024",
 	})
 
 	// First registration
@@ -195,7 +195,7 @@ func TestRegister_DuplicateUsername(t *testing.T) {
 	body, _ = json.Marshal(map[string]string{
 		"username": "dupeuser",
 		"email":    "dupe2@example.com",
-		"password": "password123",
+		"password": "SecureTestPass!2024",
 	})
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
@@ -229,7 +229,7 @@ func TestRefreshToken(t *testing.T) {
 	body, _ := json.Marshal(map[string]string{
 		"username": "refreshuser",
 		"email":    "refresh@example.com",
-		"password": "password123",
+		"password": "SecureTestPass!2024",
 	})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
@@ -398,7 +398,7 @@ func TestUpdateProfile(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]string{
 		"email":           "updated@example.com",
-		"currentPassword": "password123",
+		"currentPassword": "SecureTestPass!2024",
 	})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/user/profile", bytes.NewReader(body))
@@ -469,7 +469,7 @@ func TestAdminEndpoint_NonAdmin(t *testing.T) {
 	ownerToken := registerAndGetToken(t, router)
 
 	// Register second user (will be regular user)
-	userToken := createNonOwnerUser(t, router, ownerToken, "regularuser", "regular@example.com", "password123")
+	userToken := createNonOwnerUser(t, router, ownerToken, "regularuser", "regular@example.com", "SecureTestPass!2024")
 
 	// Verify user is not admin
 	var user db.User
@@ -1324,7 +1324,7 @@ func TestGetPublicProfile_EmptyStats(t *testing.T) {
 	token := registerAndGetToken(t, router)
 
 	// Register a second user with no activity
-	createNonOwnerUser(t, router, token, "emptyuser", "empty@example.com", "password123")
+	createNonOwnerUser(t, router, token, "emptyuser", "empty@example.com", "SecureTestPass!2024")
 
 	database := cfg.DB
 	var user db.User
@@ -2209,7 +2209,7 @@ func TestDeleteSharedSave_NotOwner(t *testing.T) {
 	saveID := createResp["id"].(string)
 
 	// Register a second user
-	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "password123")
+	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "SecureTestPass!2024")
 
 	// Try to delete as other user - should fail
 	w = httptest.NewRecorder()
@@ -2277,7 +2277,7 @@ func TestSearchUsers(t *testing.T) {
 
 	// Register additional users
 	for _, name := range []string{"alice", "alex", "bob", "charlie"} {
-		createNonOwnerUser(t, router, token, name, name+"@example.com", "password123")
+		createNonOwnerUser(t, router, token, name, name+"@example.com", "SecureTestPass!2024")
 	}
 
 	// Helper to extract []map[string]interface{} from PaginatedResponse.Data
@@ -2364,7 +2364,7 @@ func TestGetPendingInviteCount(t *testing.T) {
 	token := registerAndGetToken(t, router)
 
 	// Register a second user
-	inviteeToken := createNonOwnerUser(t, router, token, "invitee", "invitee@example.com", "password123")
+	inviteeToken := createNonOwnerUser(t, router, token, "invitee", "invitee@example.com", "SecureTestPass!2024")
 
 	t.Run("returns zero when no invites", func(t *testing.T) {
 		w := httptest.NewRecorder()
@@ -2459,7 +2459,7 @@ func TestUpdateVerificationTag_NonAdmin_Forbidden(t *testing.T) {
 	ownerToken := registerAndGetToken(t, router)
 
 	// Register second user (regular user)
-	userToken := createNonOwnerUser(t, router, ownerToken, "regularuser", "regular@example.com", "password123")
+	userToken := createNonOwnerUser(t, router, ownerToken, "regularuser", "regular@example.com", "SecureTestPass!2024")
 
 	// Create a test game
 	var console db.Console
@@ -2550,7 +2550,7 @@ func TestScrapeStatus_NonAdmin(t *testing.T) {
 	ownerToken := registerAndGetToken(t, router)
 
 	// Register second user (will be regular user)
-	userToken := createNonOwnerUser(t, router, ownerToken, "regularuser2", "regular2@example.com", "password123")
+	userToken := createNonOwnerUser(t, router, ownerToken, "regularuser2", "regular2@example.com", "SecureTestPass!2024")
 
 	// Verify user is not admin
 	var user db.User
@@ -2571,7 +2571,7 @@ func registerAndGetToken(t *testing.T, router http.Handler) string {
 	body, _ := json.Marshal(map[string]string{
 		"username": "apitest",
 		"email":    "apitest@example.com",
-		"password": "password123",
+		"password": "SecureTestPass!2024",
 	})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -95,6 +95,7 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.GameAgeRating{},
 		&db.ScrapeJob{},
 		&db.ScrapeQueueItem{},
+		&db.Block{},
 	)
 	require.NoError(t, err)
 	err = db.SeedConsoles(database)

--- a/server/internal/api/auth_handler.go
+++ b/server/internal/api/auth_handler.go
@@ -127,10 +127,17 @@ func (h *AuthHandler) recordFailedLogin(username string) {
 	})
 }
 
-// clearFailedLogins resets the failed login counter on successful login.
+// clearFailedLogins fully resets the lockout state for an account on
+// successful login. Issue #1131(B): just clearing failed_count left the
+// LoginAttempt row in place, so a slow attacker who quietly failed one
+// attempt every 23h kept refreshing UpdatedAt — the 24h auto-reset in
+// isLockedOut never fired, and the escalation tier kept climbing across
+// days. Deleting the row outright ensures every legitimate successful
+// login restarts the escalation from zero, matching the recommendation
+// in #1131.
 func (h *AuthHandler) clearFailedLogins(username string) {
 	hashed := hashUsername(username)
-	h.DB.Where("username = ?", hashed).Updates(map[string]interface{}{"failed_count": 0, "locked_until": time.Time{}})
+	h.DB.Where("username = ?", hashed).Delete(&db.LoginAttempt{})
 }
 
 // AuthHandler handles authentication endpoints.

--- a/server/internal/api/bios_handler_test.go
+++ b/server/internal/api/bios_handler_test.go
@@ -401,26 +401,18 @@ func uploadBiosFile(t *testing.T, router *gin.Engine, token string, filename str
 	return w
 }
 
-func TestUploadBiosFile_Success_KnownFile(t *testing.T) {
+// TestUploadBiosFile_KnownFile_MismatchedMD5 verifies issue #1124(A):
+// uploading bytes that match a registry filename but mismatch the
+// expected MD5 returns 400 (so the upload is REJECTED) rather than the
+// pre-fix 200 with status="invalid" that left the bad bytes on disk.
+func TestUploadBiosFile_KnownFile_MismatchedMD5(t *testing.T) {
 	_, database, router := setupBiosTestEnv(t)
 	adminToken := createBiosTestUser(t, database, "admin")
 
 	content := []byte("fake psx bios content")
 	w := uploadBiosFile(t, router, adminToken, "scph5501.bin", content)
 
-	assert.Equal(t, http.StatusOK, w.Code)
-
-	var resp BiosFileResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-
-	assert.Equal(t, "scph5501.bin", resp.Name)
-	assert.Equal(t, int64(len(content)), resp.Size)
-	assert.Equal(t, md5sum(content), resp.MD5)
-	assert.NotNil(t, resp.ConsoleID)
-	assert.Equal(t, "psx", *resp.ConsoleID)
-	assert.True(t, resp.Required)
-	// Content MD5 won't match registry, so status should be "invalid"
-	assert.Equal(t, "invalid", resp.Status)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
 }
 
 func TestUploadBiosFile_Success_UnknownFile(t *testing.T) {

--- a/server/internal/api/blocks_test.go
+++ b/server/internal/api/blocks_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlockRoutes_BasicLifecycle covers issue #1121: a user can block
+// another, the block list reflects the relationship, the blocked user no
+// longer appears in search results, and the block can be removed.
+func TestBlockRoutes_BasicLifecycle(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	tokenA := registerAndGetToken(t, router)
+
+	// Create a second user directly via the DB (bypassing register, which
+	// uses fixed credentials in registerAndGetToken).
+	target := db.User{Username: "harasser", Email: "harasser@example.com", PasswordHash: "x"}
+	require.NoError(t, database.Create(&target).Error)
+	targetID := fmt.Sprintf("%d", target.ID)
+
+	// Search returns the target before any block.
+	t.Run("visible before block", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/users/search?q=harasser", nil)
+		req.Header.Set("Authorization", "Bearer "+tokenA)
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Contains(t, w.Body.String(), "harasser")
+	})
+
+	// POST a block.
+	t.Run("create block", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/user/blocks/"+targetID, bytes.NewReader([]byte{}))
+		req.Header.Set("Authorization", "Bearer "+tokenA)
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+	})
+
+	// GET the block list.
+	t.Run("list reflects block", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/user/blocks", nil)
+		req.Header.Set("Authorization", "Bearer "+tokenA)
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		var resp ListBlocksResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Len(t, resp.Blocked, 1)
+		assert.Equal(t, "harasser", resp.Blocked[0].Username)
+	})
+
+	// Search no longer returns the blocked user.
+	t.Run("hidden after block", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/users/search?q=harasser", nil)
+		req.Header.Set("Authorization", "Bearer "+tokenA)
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.NotContains(t, w.Body.String(), "harasser")
+	})
+
+	// Profile lookup returns 404 instead of leaking existence.
+	t.Run("profile 404 after block", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/users/"+targetID+"/profile", nil)
+		req.Header.Set("Authorization", "Bearer "+tokenA)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
+	})
+
+	// DELETE removes the block.
+	t.Run("delete block", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("DELETE", "/api/user/blocks/"+targetID, nil)
+		req.Header.Set("Authorization", "Bearer "+tokenA)
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	})
+}

--- a/server/internal/api/challenge_handler_test.go
+++ b/server/internal/api/challenge_handler_test.go
@@ -51,7 +51,7 @@ func setupChallengeTestWithRateLimit(t *testing.T, rateLimitSec int) *challengeT
 	body, _ := json.Marshal(map[string]string{
 		"username": "challenger1",
 		"email":    "challenger1@test.com",
-		"password": "password123",
+		"password": "SecureTestPass!2024",
 	})
 	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -66,7 +66,7 @@ func setupChallengeTestWithRateLimit(t *testing.T, rateLimitSec int) *challengeT
 	require.NoError(t, err)
 
 	// Create user 2
-	token2 := createNonOwnerUser(t, router, token1, "challenger2", "challenger2@test.com", "password123")
+	token2 := createNonOwnerUser(t, router, token1, "challenger2", "challenger2@test.com", "SecureTestPass!2024")
 
 	claims2, err := auth.ValidateAccessToken(token2, testJWTSecret)
 	require.NoError(t, err)
@@ -802,7 +802,7 @@ func TestLazyExpiration(t *testing.T) {
 		body, _ := json.Marshal(map[string]string{
 			"username": "expuser",
 			"email":    "expuser@test.com",
-			"password": "password123",
+			"password": "SecureTestPass!2024",
 		})
 		rw := httptest.NewRecorder()
 		req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))

--- a/server/internal/api/collection_handler_test.go
+++ b/server/internal/api/collection_handler_test.go
@@ -273,7 +273,7 @@ func TestGetCollection_PrivateNotAccessibleByOthers(t *testing.T) {
 	colID := createResp["id"].(string)
 
 	// Register a second user
-	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "password123")
+	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "SecureTestPass!2024")
 
 	// Other user tries to access private collection
 	w = httptest.NewRecorder()
@@ -303,7 +303,7 @@ func TestGetCollection_PublicAccessibleByOthers(t *testing.T) {
 	colID := createResp["id"].(string)
 
 	// Register a second user
-	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "password123")
+	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "SecureTestPass!2024")
 
 	// Other user can access public collection
 	w = httptest.NewRecorder()
@@ -376,7 +376,7 @@ func TestUpdateCollection_NotOwner(t *testing.T) {
 	colID := createResp["id"].(string)
 
 	// Register a second user
-	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "password123")
+	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "SecureTestPass!2024")
 
 	// Other user tries to update
 	body, _ = json.Marshal(map[string]interface{}{"name": "Hacked Name"})
@@ -460,7 +460,7 @@ func TestDeleteCollection_NotOwner(t *testing.T) {
 	colID := createResp["id"].(string)
 
 	// Register second user
-	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "password123")
+	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "SecureTestPass!2024")
 
 	// Other user tries to delete
 	w = httptest.NewRecorder()
@@ -601,7 +601,7 @@ func TestAddGame_NotOwner(t *testing.T) {
 	colID := createResp["id"].(string)
 
 	// Register second user
-	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "password123")
+	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "SecureTestPass!2024")
 
 	// Other user tries to add game
 	body, _ = json.Marshal(map[string]interface{}{"gameId": game.ID})

--- a/server/internal/api/console_handler_test.go
+++ b/server/internal/api/console_handler_test.go
@@ -39,7 +39,7 @@ func consoleAuthToken(t *testing.T, router http.Handler) string {
 	body, _ := json.Marshal(map[string]string{
 		"username": "consoletest",
 		"email":    "consoletest@example.com",
-		"password": "password123",
+		"password": "SecureTestPass!2024",
 	})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))

--- a/server/internal/api/core_compatibility_test.go
+++ b/server/internal/api/core_compatibility_test.go
@@ -17,7 +17,7 @@ func TestGetCoreCompatibility_AdminOnly(t *testing.T) {
 	ownerToken := registerAndGetToken(t, router)
 
 	// Non-admin user should be rejected
-	userToken := createNonOwnerUser(t, router, ownerToken, "regular", "regular@test.com", "password123")
+	userToken := createNonOwnerUser(t, router, ownerToken, "regular", "regular@test.com", "SecureTestPass!2024")
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/admin/core-compatibility", nil)

--- a/server/internal/api/device_handler_test.go
+++ b/server/internal/api/device_handler_test.go
@@ -521,7 +521,7 @@ func TestAdminGetUserDevices_NonAdmin(t *testing.T) {
 	ownerToken := registerAndGetToken(t, router)
 
 	// Register second user (regular user)
-	userToken := createNonOwnerUser(t, router, ownerToken, "regular", "regular@example.com", "password123")
+	userToken := createNonOwnerUser(t, router, ownerToken, "regular", "regular@example.com", "SecureTestPass!2024")
 
 	var adminUser db.User
 	database.Where("username = ?", "apitest").First(&adminUser)

--- a/server/internal/api/enrichment_handler_test.go
+++ b/server/internal/api/enrichment_handler_test.go
@@ -138,7 +138,11 @@ func TestListThemeGames_InvalidID(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/themes/abc/games", nil)
 	req.Header.Set("Authorization", "Bearer "+env.token)
 	env.router.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	// Pattern validation in huma rejects with 422 at the API edge (#1127);
+	// before that, the handler parsed the string and returned 400. Either
+	// is acceptable so long as the request never reaches the DB.
+	assert.True(t, w.Code == http.StatusBadRequest || w.Code == http.StatusUnprocessableEntity,
+		"expected 400 or 422, got %d", w.Code)
 }
 
 // --- Keyword endpoint tests ---
@@ -857,7 +861,8 @@ func TestGetGameSeries_InvalidID(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/games/abc/series", nil)
 	req.Header.Set("Authorization", "Bearer "+env.token)
 	env.router.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.True(t, w.Code == http.StatusBadRequest || w.Code == http.StatusUnprocessableEntity,
+		"expected 400 or 422, got %d", w.Code)
 }
 
 func TestGetGameSeries_MultipleSeries(t *testing.T) {
@@ -949,7 +954,8 @@ func TestGetGameFranchises_InvalidID(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/games/abc/franchises", nil)
 	req.Header.Set("Authorization", "Bearer "+env.token)
 	env.router.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.True(t, w.Code == http.StatusBadRequest || w.Code == http.StatusUnprocessableEntity,
+		"expected 400 or 422, got %d", w.Code)
 }
 
 func TestGetGameFranchises_MultipleFranchises(t *testing.T) {

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -3218,7 +3218,8 @@ func TestGetBestOfYear_InvalidYear(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+env.token)
 	env.router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.True(t, w.Code == http.StatusBadRequest || w.Code == http.StatusUnprocessableEntity,
+		"expected 400 or 422, got %d", w.Code)
 }
 
 func TestGetBestOfYear_NoGames(t *testing.T) {

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -497,7 +497,7 @@ func TestGetExploreRows_MostPlayed_AggregatesAcrossUsers(t *testing.T) {
 
 	// Create a second user
 	ownerToken := env.token
-	user2Token := createNonOwnerUser(t, env.router, ownerToken, "player2", "player2@example.com", "password123")
+	user2Token := createNonOwnerUser(t, env.router, ownerToken, "player2", "player2@example.com", "SecureTestPass!2024")
 	_ = user2Token
 	var user2 db.User
 	require.NoError(t, env.database.Where("username = ?", "player2").First(&user2).Error)
@@ -1857,7 +1857,7 @@ func TestGetPlayersLikeYou(t *testing.T) {
 	env.database.Create(&db.Favorite{UserID: user.ID, GameID: game2.ID}) // Zelda
 
 	// Create similar user2: favorites Mario, Zelda, Metroid (overlap: 2)
-	user2Token := createNonOwnerUser(t, env.router, env.token, "user2", "user2@test.com", "password123")
+	user2Token := createNonOwnerUser(t, env.router, env.token, "user2", "user2@test.com", "SecureTestPass!2024")
 	_ = user2Token
 	var user2 db.User
 	require.NoError(t, env.database.Where("username = ?", "user2").First(&user2).Error)
@@ -1866,7 +1866,7 @@ func TestGetPlayersLikeYou(t *testing.T) {
 	env.database.Create(&db.Favorite{UserID: user2.ID, GameID: game3.ID}) // Metroid
 
 	// Create user3: favorites Mario, Castlevania, Mega Man (overlap: 1)
-	user3Token := createNonOwnerUser(t, env.router, env.token, "user3", "user3@test.com", "password123")
+	user3Token := createNonOwnerUser(t, env.router, env.token, "user3", "user3@test.com", "SecureTestPass!2024")
 	_ = user3Token
 	var user3 db.User
 	require.NoError(t, env.database.Where("username = ?", "user3").First(&user3).Error)
@@ -2847,7 +2847,7 @@ func TestGetTrending_ReturnsGamesByPlayerCount(t *testing.T) {
 	var user1 db.User
 	require.NoError(t, env.database.First(&user1).Error)
 
-	user2Token := createNonOwnerUser(t, env.router, env.token, "trending_player", "trending@example.com", "password123")
+	user2Token := createNonOwnerUser(t, env.router, env.token, "trending_player", "trending@example.com", "SecureTestPass!2024")
 	_ = user2Token
 	var user2 db.User
 	require.NoError(t, env.database.Where("username = ?", "trending_player").First(&user2).Error)
@@ -2938,7 +2938,7 @@ func TestGetCommunityTop_ReturnsRankedGames(t *testing.T) {
 
 	var user1 db.User
 	require.NoError(t, env.database.First(&user1).Error)
-	user2Token := createNonOwnerUser(t, env.router, env.token, "rater2", "rater2@example.com", "password123")
+	user2Token := createNonOwnerUser(t, env.router, env.token, "rater2", "rater2@example.com", "SecureTestPass!2024")
 	_ = user2Token
 	var user2 db.User
 	require.NoError(t, env.database.Where("username = ?", "rater2").First(&user2).Error)
@@ -2974,7 +2974,7 @@ func TestGetCultClassics_ReturnsHighCommunityLowIGDB(t *testing.T) {
 
 	var user1 db.User
 	require.NoError(t, env.database.First(&user1).Error)
-	user2Token := createNonOwnerUser(t, env.router, env.token, "cult_rater", "cult@example.com", "password123")
+	user2Token := createNonOwnerUser(t, env.router, env.token, "cult_rater", "cult@example.com", "SecureTestPass!2024")
 	_ = user2Token
 	var user2 db.User
 	require.NoError(t, env.database.Where("username = ?", "cult_rater").First(&user2).Error)
@@ -3025,7 +3025,7 @@ func TestGetRecentlyReviewed_ReturnsReviewsWithText(t *testing.T) {
 	env.database.Create(&db.GameRating{UserID: user.ID, GameID: game.ID, Rating: 4, Review: "Great classic RPG!"})
 	// Rating without review text — should NOT appear
 	game2 := createExploreGame(t, env.database, "NES", "No Review Game", 70.0)
-	user2Token := createNonOwnerUser(t, env.router, env.token, "reviewer2", "reviewer2@example.com", "password123")
+	user2Token := createNonOwnerUser(t, env.router, env.token, "reviewer2", "reviewer2@example.com", "SecureTestPass!2024")
 	_ = user2Token
 	var user2 db.User
 	require.NoError(t, env.database.Where("username = ?", "reviewer2").First(&user2).Error)
@@ -3661,7 +3661,7 @@ func TestGetHardestGames_WithData(t *testing.T) {
 	require.NoError(t, env.database.First(&user1).Error)
 
 	// Create a second user
-	user2Token := createNonOwnerUser(t, env.router, env.token, "hardplayer", "hard@example.com", "password123")
+	user2Token := createNonOwnerUser(t, env.router, env.token, "hardplayer", "hard@example.com", "SecureTestPass!2024")
 	_ = user2Token
 	var user2 db.User
 	require.NoError(t, env.database.Where("username = ?", "hardplayer").First(&user2).Error)

--- a/server/internal/api/game_discovery_handler_test.go
+++ b/server/internal/api/game_discovery_handler_test.go
@@ -20,7 +20,7 @@ func discoveryAuthToken(t *testing.T, router http.Handler) string {
 	body, _ := json.Marshal(map[string]string{
 		"username": "discoverytest",
 		"email":    "discoverytest@example.com",
-		"password": "password123",
+		"password": "SecureTestPass!2024",
 	})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -27,14 +27,21 @@ type GameHandler struct {
 }
 
 // serveTar streams files as an uncompressed tar archive.
+//
+// Issue #1116: refuse symlinks. The cue/gdi parser already containment-checks
+// resolved paths inside the disc dir, but if a symlink were planted under
+// the disc dir it could still point outside. Lstat + IsRegular catches that.
 func serveTar(w io.Writer, filePaths []string) error {
 	tw := tar.NewWriter(w)
 	defer tw.Close()
 
 	for _, path := range filePaths {
-		info, err := os.Stat(path)
+		info, err := os.Lstat(path)
 		if err != nil {
 			return fmt.Errorf("stat file %s: %w", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("refusing non-regular file in archive: %s", path)
 		}
 
 		header := &tar.Header{
@@ -62,14 +69,19 @@ func serveTar(w io.Writer, filePaths []string) error {
 
 // serveZip streams files as a zip archive. Used by EmulatorJS which supports
 // zip extraction but not tar.
+//
+// Issue #1116: refuse symlinks (see serveTar comment).
 func serveZip(w io.Writer, filePaths []string) error {
 	zw := zip.NewWriter(w)
 	defer zw.Close()
 
 	for _, path := range filePaths {
-		info, err := os.Stat(path)
+		info, err := os.Lstat(path)
 		if err != nil {
 			return fmt.Errorf("stat file %s: %w", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("refusing non-regular file in archive: %s", path)
 		}
 
 		header, err := zip.FileInfoHeader(info)

--- a/server/internal/api/game_keymapping_handler_test.go
+++ b/server/internal/api/game_keymapping_handler_test.go
@@ -286,7 +286,7 @@ func TestGameKeyMapping_IsolatedPerUser(t *testing.T) {
 	token1 := registerAndGetToken(t, router)
 
 	// Register second user
-	token2 := createNonOwnerUser(t, router, token1, "user2", "user2@example.com", "password123")
+	token2 := createNonOwnerUser(t, router, token1, "user2", "user2@example.com", "SecureTestPass!2024")
 
 	// Create a game
 	game := db.Game{ConsoleID: 1, Title: "Test Game", FileName: "test.nes", FilePath: "/roms/test.nes"}

--- a/server/internal/api/huma_achievements.go
+++ b/server/internal/api/huma_achievements.go
@@ -38,7 +38,7 @@ type UpdateShowcaseOutput struct {
 
 // GetPublicShowcaseInput is the input for GET /api/users/{id}/achievements/showcase.
 type GetPublicShowcaseInput struct {
-	ID string `path:"id" doc:"User ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"User ID."`
 }
 
 // GetPublicShowcaseOutput wraps the public showcase response.
@@ -48,7 +48,7 @@ type GetPublicShowcaseOutput struct {
 
 // GetGameAchievementsInput is the input for GET /api/games/{id}/achievements.
 type GetGameAchievementsInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GameAchievementsResponse is the wire format for GET /api/games/{id}/achievements.

--- a/server/internal/api/huma_admin.go
+++ b/server/internal/api/huma_admin.go
@@ -77,7 +77,7 @@ type AdminCreateUserOutput struct {
 
 // AdminUpdateUserInput is the input for PUT /api/admin/users/{id}.
 type AdminUpdateUserInput struct {
-	ID   string `path:"id" doc:"User ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"User ID."`
 	Body AdminUpdateUserRequest
 }
 
@@ -88,7 +88,7 @@ type AdminUpdateUserOutput struct {
 
 // AdminDeleteUserInput is the input for DELETE /api/admin/users/{id}.
 type AdminDeleteUserInput struct {
-	ID string `path:"id" doc:"User ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"User ID."`
 }
 
 // AdminDeleteUserOutput wraps the delete success message.

--- a/server/internal/api/huma_admin.go
+++ b/server/internal/api/huma_admin.go
@@ -307,6 +307,19 @@ func (h *AdminHandler) HumaAdminUpdateUser(ctx context.Context, in *AdminUpdateU
 	req := in.Body
 	currentUserID := UserIDFromContext(ctx)
 
+	// Issue #1122: only owner can mutate other admins. Otherwise a
+	// single compromised admin account can demote/disable/lock out
+	// every other admin and become the sole non-owner administrator.
+	// The owner is exempt from this rule (they have ultimate control)
+	// and the existing checks below cover owner-as-target.
+	var caller db.User
+	if err := h.DB.Select("id", "role").First(&caller, currentUserID).Error; err != nil {
+		return nil, huma.Error500InternalServerError("failed to load caller")
+	}
+	if user.Role == db.RoleAdmin && caller.Role != db.RoleOwner && caller.ID != user.ID {
+		return nil, huma.Error403Forbidden("only the owner can modify other admins")
+	}
+
 	if user.Role == db.RoleOwner && req.Role != "" {
 		return nil, huma.Error403Forbidden("cannot change the owner's role")
 	}
@@ -324,11 +337,23 @@ func (h *AdminHandler) HumaAdminUpdateUser(ctx context.Context, in *AdminUpdateU
 		user.Role = req.Role
 	}
 	if req.Email != "" {
+		// Issue #1123: prevent collisions and overwrite of owner email.
+		if user.Role == db.RoleOwner && caller.Role != db.RoleOwner {
+			return nil, huma.Error403Forbidden("cannot change the owner's email")
+		}
+		var conflict db.User
+		if err := h.DB.Where("email = ? AND id != ?", req.Email, user.ID).First(&conflict).Error; err == nil {
+			return nil, huma.Error409Conflict("email already in use")
+		}
 		user.Email = req.Email
 	}
 	if req.Password != "" {
 		if user.Role == db.RoleOwner {
 			return nil, huma.Error403Forbidden("cannot change the owner's password")
+		}
+		// Issue #1123: only owner may change another admin's password.
+		if user.Role == db.RoleAdmin && caller.Role != db.RoleOwner && caller.ID != user.ID {
+			return nil, huma.Error403Forbidden("only the owner can change another admin's password")
 		}
 		if len(req.Password) < 8 {
 			return nil, huma.Error400BadRequest("password must be at least 8 characters")
@@ -378,6 +403,15 @@ func (h *AdminHandler) HumaAdminDeleteUser(ctx context.Context, in *AdminDeleteU
 	currentUserID := UserIDFromContext(ctx)
 	if currentUserID == user.ID {
 		return nil, huma.Error400BadRequest("cannot delete yourself")
+	}
+
+	// Issue #1122: only owner can soft-delete another admin.
+	var caller db.User
+	if err := h.DB.Select("id", "role").First(&caller, currentUserID).Error; err != nil {
+		return nil, huma.Error500InternalServerError("failed to load caller")
+	}
+	if user.Role == db.RoleAdmin && caller.Role != db.RoleOwner {
+		return nil, huma.Error403Forbidden("only the owner can delete other admins")
 	}
 
 	err := h.DB.Transaction(func(tx *gorm.DB) error {

--- a/server/internal/api/huma_admin_games.go
+++ b/server/internal/api/huma_admin_games.go
@@ -22,7 +22,7 @@ import (
 
 // UpdateGameMetadataInput is the input for POST /api/admin/games/{id}/metadata.
 type UpdateGameMetadataInput struct {
-	ID   string `path:"id" doc:"Game ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Body UpdateGameMetadataRequest
 }
 
@@ -33,7 +33,7 @@ type UpdateGameMetadataOutput struct {
 
 // UpdateVerificationTagInput is the input for PUT /api/admin/games/{id}/verification-tag.
 type UpdateVerificationTagInput struct {
-	ID   string `path:"id" doc:"Game ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Body UpdateVerificationTagRequest
 }
 
@@ -51,7 +51,7 @@ type UpdateVerificationTagOutput struct {
 
 // GetGameCoversInput is the input for GET /api/admin/games/{id}/covers.
 type GetGameCoversInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GameCoversResponse is the wire format for the game covers response.
@@ -67,7 +67,7 @@ type GetGameCoversOutput struct {
 
 // SetGameCoverInput is the input for PUT /api/admin/games/{id}/covers.
 type SetGameCoverInput struct {
-	ID   string `path:"id" doc:"Game ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Body SetGameCoverRequest
 }
 
@@ -78,7 +78,7 @@ type SetGameCoverOutput struct {
 
 // GetGameHeroesInput is the input for GET /api/admin/games/{id}/heroes.
 type GetGameHeroesInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GameHeroesResponse is the wire format for the hero options response.
@@ -94,7 +94,7 @@ type GetGameHeroesOutput struct {
 
 // SetGameHeroInput is the input for PUT /api/admin/games/{id}/heroes.
 type SetGameHeroInput struct {
-	ID   string `path:"id" doc:"Game ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Body SetGameHeroRequest
 }
 
@@ -107,7 +107,7 @@ type SetGameHeroOutput struct {
 
 // SearchIGDBInput is the input for GET /api/admin/games/{id}/igdb-search.
 type SearchIGDBInput struct {
-	ID    string `path:"id" doc:"Game ID."`
+	ID    string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Query string `query:"q" doc:"Search query."`
 }
 
@@ -118,7 +118,7 @@ type SearchIGDBOutput struct {
 
 // ApplyIGDBMatchInput is the input for POST /api/admin/games/{id}/igdb-match.
 type ApplyIGDBMatchInput struct {
-	ID   string `path:"id" doc:"Game ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Body ApplyIGDBMatchRequest
 }
 
@@ -180,7 +180,7 @@ type ListDeletedUsersOutput struct {
 
 // HardDeleteUserInput is the input for DELETE /api/admin/users/{id}/permanent.
 type HardDeleteUserInput struct {
-	ID string `path:"id" doc:"User ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"User ID."`
 }
 
 // HardDeleteUserOutput wraps the hard-delete success message.

--- a/server/internal/api/huma_admin_games.go
+++ b/server/internal/api/huma_admin_games.go
@@ -978,6 +978,16 @@ func (h *AdminHandler) HumaHardDeleteUser(ctx context.Context, in *HardDeleteUse
 		return nil, huma.Error403Forbidden("cannot permanently delete the owner")
 	}
 
+	// Issue #1122: only owner can hard-delete another admin row.
+	currentUserID := UserIDFromContext(ctx)
+	var caller db.User
+	if err := h.DB.Select("id", "role").First(&caller, currentUserID).Error; err != nil {
+		return nil, huma.Error500InternalServerError("failed to load caller")
+	}
+	if user.Role == db.RoleAdmin && caller.Role != db.RoleOwner {
+		return nil, huma.Error403Forbidden("only the owner can permanently delete other admins")
+	}
+
 	err := h.DB.Transaction(func(tx *gorm.DB) error {
 		uid := user.ID
 
@@ -1072,7 +1082,6 @@ func (h *AdminHandler) HumaHardDeleteUser(ctx context.Context, in *HardDeleteUse
 		return nil, huma.Error500InternalServerError("failed to permanently delete user")
 	}
 
-	currentUserID := UserIDFromContext(ctx)
 	slog.Info("audit: admin permanently deleted user", "admin_id", currentUserID, "target_user", user.Username)
 	return &HardDeleteUserOutput{Body: MessageResponse{Message: "user permanently deleted"}}, nil
 }

--- a/server/internal/api/huma_admin_games.go
+++ b/server/internal/api/huma_admin_games.go
@@ -12,6 +12,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/igdb"
+	"github.com/spela/server/internal/safehttp"
 	"github.com/spela/server/internal/scanner"
 	"github.com/spela/server/internal/scraper"
 	ws "github.com/spela/server/internal/websocket"
@@ -665,6 +666,14 @@ func (h *AdminHandler) HumaSetGameHero(ctx context.Context, in *SetGameHeroInput
 	req := in.Body
 	if req.URL == "" {
 		return nil, huma.Error400BadRequest("invalid request body")
+	}
+	// Issue #1120: gate the URL against private/internal IPs and
+	// non-http(s) schemes BEFORE handing it to the scraper, otherwise
+	// a rogue admin could point us at the AWS metadata endpoint or
+	// internal services. Defense in depth: NewClient also re-checks
+	// every redirect hop.
+	if err := safehttp.CheckURL(req.URL); err != nil {
+		return nil, huma.Error400BadRequest("invalid hero URL: " + err.Error())
 	}
 
 	if h.Scraper == nil {

--- a/server/internal/api/huma_admin_multipart.go
+++ b/server/internal/api/huma_admin_multipart.go
@@ -495,6 +495,13 @@ func (h *RomHackHandler) HumaCreateRomHack(_ context.Context, in *AdminCreateRom
 	if err != nil {
 		return nil, huma.NewError(http.StatusInternalServerError, "base game ROM file not found on disk")
 	}
+	// Issue #1125: defense in depth. ResolveGamePath now refuses
+	// traversal, but ValidateROMPath here matches the pattern used by
+	// HumaDownloadGame / HumaReplaceROM so any future regression in
+	// ResolveGamePath doesn't immediately turn into arbitrary file read.
+	if !storage.ValidateROMPath(romAbsPath, h.GameDirs) {
+		return nil, huma.NewError(http.StatusForbidden, "base game ROM path is outside configured game dirs")
+	}
 
 	romData, err := os.ReadFile(romAbsPath)
 	if err != nil {

--- a/server/internal/api/huma_admin_multipart.go
+++ b/server/internal/api/huma_admin_multipart.go
@@ -280,8 +280,12 @@ func (h *BiosHandler) HumaUploadBiosFile(_ context.Context, in *AdminUploadBiosI
 		case fileMD5 == match.MD5:
 			resp.Status = "valid"
 		default:
-			resp.Status = "invalid"
-			resp.ExpectedMD5 = match.MD5
+			// Issue #1124(A): hash mismatch — delete the upload so a
+			// libretro core that doesn't strictly check BIOS hash at
+			// load time cannot boot with attacker-supplied bytes.
+			_ = os.Remove(safePath)
+			return nil, huma.Error400BadRequest(fmt.Sprintf("BIOS file hash mismatch (expected %s, got %s); upload discarded",
+				match.MD5, fileMD5))
 		}
 	}
 

--- a/server/internal/api/huma_admin_multipart.go
+++ b/server/internal/api/huma_admin_multipart.go
@@ -503,6 +503,19 @@ func (h *RomHackHandler) HumaCreateRomHack(_ context.Context, in *AdminCreateRom
 		return nil, huma.NewError(http.StatusForbidden, "base game ROM path is outside configured game dirs")
 	}
 
+	// Issue #1134(A): refuse to apply a patch to a multi-GB base ROM.
+	// os.ReadFile loads the full file into memory before patching, and
+	// the patcher's MaxOutputSize is 256 MB — patching a 4 GB ISO peaks
+	// at ~4 GB+ and OOM-kills small hosts. Reject up front using the
+	// patcher's own MaxOutputSize as the ceiling so the in-memory
+	// behaviour is consistent end-to-end.
+	if info, err := os.Stat(romAbsPath); err == nil {
+		if info.Size() > patcher.MaxOutputSize {
+			return nil, huma.NewError(http.StatusRequestEntityTooLarge,
+				fmt.Sprintf("base ROM is %d bytes; patcher refuses inputs larger than %d bytes (issue #1134)", info.Size(), patcher.MaxOutputSize))
+		}
+	}
+
 	romData, err := os.ReadFile(romAbsPath)
 	if err != nil {
 		slog.Warn("failed to read base ROM", "path", romAbsPath, "error", err)

--- a/server/internal/api/huma_admin_multipart.go
+++ b/server/internal/api/huma_admin_multipart.go
@@ -49,7 +49,7 @@ type AdminReplaceROMBody struct {
 
 // AdminReplaceROMInput wraps the path parameter and multipart body.
 type AdminReplaceROMInput struct {
-	ID      string `path:"id" doc:"Numeric game ID."`
+	ID      string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Numeric game ID."`
 	RawBody huma.MultipartFormFiles[AdminReplaceROMBody]
 }
 

--- a/server/internal/api/huma_artwork.go
+++ b/server/internal/api/huma_artwork.go
@@ -11,7 +11,7 @@ import (
 
 // GetGameArtworkInput is the input for GET /api/games/{id}/artwork.
 type GetGameArtworkInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GetGameArtworkOutput wraps the SteamGridDB artwork URLs for the huma

--- a/server/internal/api/huma_auth_handlers.go
+++ b/server/internal/api/huma_auth_handlers.go
@@ -582,10 +582,26 @@ func (h *AuthHandler) HumaRefresh(_ context.Context, in *AuthRefreshInput) (*Aut
 	}}, nil
 }
 
+// setupCompletedKey is the server_settings key written after a successful
+// initial setup. Issue #1130: gating HumaSetup on userCount alone means
+// an out-of-band truncation of the users table re-opens the endpoint to
+// whoever races to /api/auth/setup first. The marker survives such a
+// truncation (it lives in server_settings) and prevents re-bootstrap.
+const setupCompletedKey = "setup_completed"
+
 // HumaSetup is the huma implementation of POST /api/auth/setup. Creates the
 // initial owner account; fails with 403 if a user already exists.
 func (h *AuthHandler) HumaSetup(_ context.Context, in *AuthSetupInput) (*AuthSetupOutput, error) {
 	req := in.Body
+
+	// Issue #1130: refuse setup outright if a previous successful setup
+	// left a marker, even if the users table is currently empty. An
+	// admin who needs to truly re-bootstrap a server must remove this
+	// row from server_settings deliberately.
+	var marker db.ServerSetting
+	if err := h.DB.Where("key = ?", setupCompletedKey).First(&marker).Error; err == nil {
+		return nil, huma.NewError(http.StatusForbidden, "Setup has already been completed.")
+	}
 
 	hash, err := auth.HashPassword(req.Password)
 	if err != nil {
@@ -609,6 +625,12 @@ func (h *AuthHandler) HumaSetup(_ context.Context, in *AuthSetupInput) (*AuthSet
 			Role:         db.RoleOwner,
 		}
 		if err := tx.Create(&user).Error; err != nil {
+			txErr = huma.NewError(http.StatusInternalServerError, "Setup failed. Please try again.")
+			return err
+		}
+		// Persist the setup-completed marker inside the same
+		// transaction so the row only appears on a successful setup.
+		if err := tx.Create(&db.ServerSetting{Key: setupCompletedKey, Value: "true"}).Error; err != nil {
 			txErr = huma.NewError(http.StatusInternalServerError, "Setup failed. Please try again.")
 			return err
 		}
@@ -651,6 +673,12 @@ func (h *AuthHandler) HumaSetupStatus(_ context.Context, _ *SetupStatusInput) (*
 	var userCount int64
 	h.DB.Model(&db.User{}).Count(&userCount)
 
+	// Issue #1130: needsSetup is true only when there are no users AND
+	// the setup-completed marker is absent. Without the marker check, an
+	// out-of-band truncation of users would silently re-open setup.
+	var marker db.ServerSetting
+	hasMarker := h.DB.Where("key = ?", setupCompletedKey).First(&marker).Error == nil
+
 	var gameCount int64
 	h.DB.Model(&db.Game{}).Count(&gameCount)
 
@@ -661,7 +689,7 @@ func (h *AuthHandler) HumaSetupStatus(_ context.Context, _ *SetupStatusInput) (*
 	}
 
 	return &SetupStatusOutput{Body: SetupStatusResponse{
-		NeedsSetup:          userCount == 0,
+		NeedsSetup:          userCount == 0 && !hasMarker,
 		RegistrationEnabled: registrationEnabled,
 		GameCount:           gameCount,
 	}}, nil

--- a/server/internal/api/huma_auth_handlers.go
+++ b/server/internal/api/huma_auth_handlers.go
@@ -393,6 +393,12 @@ func (h *AuthHandler) HumaLogin(ctx context.Context, in *AuthLoginInput) (*AuthL
 func (h *AuthHandler) HumaRegister(ctx context.Context, in *AuthRegisterInput) (*AuthRegisterOutput, error) {
 	req := in.Body
 
+	// Issue #1131(A): refuse the most-common / most-leaked passwords.
+	// Length already enforced via the schema tag.
+	if isCommonPassword(req.Password) {
+		return nil, huma.NewError(http.StatusBadRequest, "That password is on a known-common-password list. Please choose something else.")
+	}
+
 	hash, err := auth.HashPassword(req.Password)
 	if err != nil {
 		return nil, huma.NewError(http.StatusInternalServerError, "Registration failed. Please try again.")

--- a/server/internal/api/huma_auth_handlers.go
+++ b/server/internal/api/huma_auth_handlers.go
@@ -698,6 +698,18 @@ func (h *AuthHandler) HumaLogout(ctx context.Context, in *AuthLogoutInput) (*Aut
 		}
 	}
 
+	// Issue #1117: a client that authenticated this request via the
+	// query-token fallback (still allowed on a small allowlist of
+	// download/WS routes) won't have an Authorization header. Fall back
+	// to the gin context query so its access token still gets
+	// blacklisted on logout — otherwise the leaked token remains valid
+	// for its remaining TTL even after the user explicitly logged out.
+	if token == "" {
+		if g := ginContextFromCtx(ctx); g != nil {
+			token = g.Query("token")
+		}
+	}
+
 	if token != "" {
 		if claims, err := auth.ValidateAccessToken(token, h.JWTSecret); err == nil && claims.ExpiresAt != nil {
 			hash := sha256.Sum256([]byte(token))

--- a/server/internal/api/huma_auth_handlers.go
+++ b/server/internal/api/huma_auth_handlers.go
@@ -418,7 +418,11 @@ func (h *AuthHandler) HumaRegister(ctx context.Context, in *AuthRegisterInput) (
 		var count int64
 		tx.Model(&db.User{}).Where("username = ? OR email = ?", req.Username, req.Email).Count(&count)
 		if count > 0 {
-			txErr = huma.NewError(http.StatusConflict, "That username or email is already taken.")
+			// Issue #1132: keep the response indistinguishable from
+			// any other unprocessable-registration error so an
+			// attacker can't probe whether a specific email is
+			// registered by submitting a junk username with it.
+			txErr = huma.NewError(http.StatusConflict, "Registration could not be completed.")
 			return fmt.Errorf("duplicate")
 		}
 

--- a/server/internal/api/huma_bios.go
+++ b/server/internal/api/huma_bios.go
@@ -25,7 +25,7 @@ type ListBiosFilesOutput struct {
 
 // DeleteBiosFileInput is the input for DELETE /api/admin/bios/{filename}.
 type DeleteBiosFileInput struct {
-	Filename string `path:"filename" doc:"BIOS file name."`
+	Filename string `path:"filename" pattern:"^[A-Za-z0-9._()\\[\\] +-]+$" maxLength:"128" doc:"BIOS file name."`
 }
 
 // DeleteBiosFileOutput wraps the delete success message.

--- a/server/internal/api/huma_blocks.go
+++ b/server/internal/api/huma_blocks.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// --- Block list endpoints (issue #1121) ---
+//
+// Blocks are one-way ("user A blocked user B") but searches/profiles/
+// invites filter symmetrically: if either side has a block on the other,
+// they don't appear in each other's results. This protects the harassed
+// party from continuing exposure even if they neglected to block back.
+
+// ListBlocksInput is the input for GET /api/user/blocks.
+type ListBlocksInput struct{}
+
+// BlockedUserResponse is the wire format of a single block list entry.
+type BlockedUserResponse struct {
+	UserID    string `json:"userId"`
+	Username  string `json:"username"`
+	AvatarURL string `json:"avatarUrl"`
+}
+
+// ListBlocksResponse wraps the caller's block list.
+type ListBlocksResponse struct {
+	Blocked []BlockedUserResponse `json:"blocked"`
+}
+
+// ListBlocksOutput wraps the block list body.
+type ListBlocksOutput struct {
+	Body ListBlocksResponse
+}
+
+// CreateBlockInput is the input for POST /api/user/blocks/{userId}.
+type CreateBlockInput struct {
+	UserID string `path:"userId" pattern:"^[0-9]+$" maxLength:"20" doc:"User ID to block."`
+}
+
+// CreateBlockOutput wraps the created-block confirmation.
+type CreateBlockOutput struct {
+	Body MessageResponse
+}
+
+// DeleteBlockInput is the input for DELETE /api/user/blocks/{userId}.
+type DeleteBlockInput struct {
+	UserID string `path:"userId" pattern:"^[0-9]+$" maxLength:"20" doc:"User ID to unblock."`
+}
+
+// DeleteBlockOutput wraps the unblock confirmation.
+type DeleteBlockOutput struct {
+	Body MessageResponse
+}
+
+// RegisterBlockRoutes wires the block-list endpoints into the huma API.
+func RegisterBlockRoutes(api huma.API, h *SocialHandler, jwtSecret string, database *gorm.DB, userLimiter *RateLimiter) {
+	requireAuth := RequireAuth(jwtSecret, database)
+	rateLimit := UserRateLimitMiddleware(userLimiter)
+	mw := huma.Middlewares{requireAuth, rateLimit}
+	sec := []map[string][]string{{"bearer": {}}}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "listBlocks",
+		Method:      http.MethodGet,
+		Path:        "/api/user/blocks",
+		Summary:     "List the caller's blocked users",
+		Description: "Returns the users the authenticated caller has blocked.",
+		Tags:        []string{"social"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaListBlocks)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "createBlock",
+		Method:        http.MethodPost,
+		Path:          "/api/user/blocks/{userId}",
+		Summary:       "Block another user",
+		Description:   "Adds the specified user to the caller's block list. The relationship is enforced symmetrically — neither party will see the other in search/profile/invite endpoints.",
+		DefaultStatus: http.StatusCreated,
+		Tags:          []string{"social"},
+		Middlewares:   mw,
+		Security:      sec,
+	}, h.HumaCreateBlock)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "deleteBlock",
+		Method:      http.MethodDelete,
+		Path:        "/api/user/blocks/{userId}",
+		Summary:     "Unblock another user",
+		Description: "Removes the specified user from the caller's block list.",
+		Tags:        []string{"social"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaDeleteBlock)
+}
+
+// HumaListBlocks is the huma handler for GET /api/user/blocks.
+func (h *SocialHandler) HumaListBlocks(ctx context.Context, _ *ListBlocksInput) (*ListBlocksOutput, error) {
+	uid := UserIDFromContext(ctx)
+	var rows []db.Block
+	if err := h.DB.Where("user_id = ?", uid).Preload("BlockedUser").Find(&rows).Error; err != nil {
+		return nil, huma.Error500InternalServerError("failed to fetch block list")
+	}
+	out := make([]BlockedUserResponse, 0, len(rows))
+	for _, b := range rows {
+		if b.BlockedUser.ID == 0 {
+			continue
+		}
+		out = append(out, BlockedUserResponse{
+			UserID:    strconv.FormatUint(uint64(b.BlockedUser.ID), 10),
+			Username:  b.BlockedUser.Username,
+			AvatarURL: b.BlockedUser.AvatarURL,
+		})
+	}
+	return &ListBlocksOutput{Body: ListBlocksResponse{Blocked: out}}, nil
+}
+
+// HumaCreateBlock is the huma handler for POST /api/user/blocks/{userId}.
+func (h *SocialHandler) HumaCreateBlock(ctx context.Context, in *CreateBlockInput) (*CreateBlockOutput, error) {
+	uid := UserIDFromContext(ctx)
+	parsed, err := strconv.ParseUint(in.UserID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid user ID")
+	}
+	target := uint(parsed)
+	if target == uid {
+		return nil, huma.Error400BadRequest("cannot block yourself")
+	}
+	var existing db.User
+	if err := h.DB.Select("id").First(&existing, target).Error; err != nil {
+		return nil, huma.Error404NotFound("user not found")
+	}
+	block := db.Block{UserID: uid, BlockedUserID: target}
+	// Idempotent: unique index on (user_id, blocked_user_id) makes a
+	// duplicate insert fail, which we treat as already-blocked success.
+	if err := h.DB.Create(&block).Error; err != nil {
+		return &CreateBlockOutput{Body: MessageResponse{Message: "already blocked"}}, nil
+	}
+	return &CreateBlockOutput{Body: MessageResponse{Message: "user blocked"}}, nil
+}
+
+// HumaDeleteBlock is the huma handler for DELETE /api/user/blocks/{userId}.
+func (h *SocialHandler) HumaDeleteBlock(ctx context.Context, in *DeleteBlockInput) (*DeleteBlockOutput, error) {
+	uid := UserIDFromContext(ctx)
+	parsed, err := strconv.ParseUint(in.UserID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid user ID")
+	}
+	target := uint(parsed)
+	result := h.DB.Where("user_id = ? AND blocked_user_id = ?", uid, target).Delete(&db.Block{})
+	if result.RowsAffected == 0 {
+		return nil, huma.Error404NotFound("block not found")
+	}
+	return &DeleteBlockOutput{Body: MessageResponse{Message: "user unblocked"}}, nil
+}

--- a/server/internal/api/huma_challenges.go
+++ b/server/internal/api/huma_challenges.go
@@ -37,7 +37,7 @@ type ListChallengesOutput struct {
 
 // GetChallengeInput is the input for GET /api/challenges/{id}.
 type GetChallengeInput struct {
-	ID string `path:"id" doc:"Challenge ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Challenge ID."`
 }
 
 // GetChallengeOutput wraps a single challenge response.
@@ -47,7 +47,7 @@ type GetChallengeOutput struct {
 
 // UpdateChallengeInput is the input for PUT /api/challenges/{id}.
 type UpdateChallengeInput struct {
-	ID   string `path:"id" doc:"Challenge ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Challenge ID."`
 	Body UpdateChallengeRequest
 }
 
@@ -58,7 +58,7 @@ type UpdateChallengeOutput struct {
 
 // DeleteChallengeInput is the input for DELETE /api/challenges/{id}.
 type DeleteChallengeInput struct {
-	ID string `path:"id" doc:"Challenge ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Challenge ID."`
 }
 
 // DeleteChallengeOutput wraps the delete success message.
@@ -68,7 +68,7 @@ type DeleteChallengeOutput struct {
 
 // StartChallengeAttemptInput is the input for POST /api/challenges/{id}/attempts/start.
 type StartChallengeAttemptInput struct {
-	ID string `path:"id" doc:"Challenge ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Challenge ID."`
 }
 
 // StartChallengeAttemptOutput wraps the created attempt response (201 Created).
@@ -78,8 +78,8 @@ type StartChallengeAttemptOutput struct {
 
 // CompleteChallengeAttemptInput is the input for POST /api/challenges/{id}/attempts/{aid}/complete.
 type CompleteChallengeAttemptInput struct {
-	ID  string `path:"id" doc:"Challenge ID."`
-	AID string `path:"aid" doc:"Attempt ID."`
+	ID  string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Challenge ID."`
+	AID string `path:"aid" pattern:"^[0-9]+$" maxLength:"20" doc:"Attempt ID."`
 }
 
 // CompleteChallengeAttemptOutput wraps the completed attempt response.
@@ -89,8 +89,8 @@ type CompleteChallengeAttemptOutput struct {
 
 // AbandonChallengeAttemptInput is the input for POST /api/challenges/{id}/attempts/{aid}/abandon.
 type AbandonChallengeAttemptInput struct {
-	ID  string `path:"id" doc:"Challenge ID."`
-	AID string `path:"aid" doc:"Attempt ID."`
+	ID  string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Challenge ID."`
+	AID string `path:"aid" pattern:"^[0-9]+$" maxLength:"20" doc:"Attempt ID."`
 }
 
 // AbandonChallengeAttemptOutput wraps the abandoned attempt response.
@@ -100,7 +100,7 @@ type AbandonChallengeAttemptOutput struct {
 
 // ListMyChallengeAttemptsInput is the input for GET /api/challenges/{id}/attempts/mine.
 type ListMyChallengeAttemptsInput struct {
-	ID string `path:"id" doc:"Challenge ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Challenge ID."`
 }
 
 // ListMyChallengeAttemptsOutput wraps the attempts list.
@@ -110,7 +110,7 @@ type ListMyChallengeAttemptsOutput struct {
 
 // GetChallengeLeaderboardInput is the input for GET /api/challenges/{id}/leaderboard.
 type GetChallengeLeaderboardInput struct {
-	ID       string `path:"id" doc:"Challenge ID."`
+	ID       string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Challenge ID."`
 	Page     int    `query:"page" doc:"1-based page number (defaults to 1)."`
 	PageSize int    `query:"pageSize" doc:"Page size (defaults to 50, clamped to 1-100)."`
 }
@@ -122,7 +122,7 @@ type GetChallengeLeaderboardOutput struct {
 
 // ListGameChallengesInput is the input for GET /api/games/{id}/challenges.
 type ListGameChallengesInput struct {
-	ID       string `path:"id" doc:"Game ID."`
+	ID       string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Page     int    `query:"page" doc:"1-based page number (defaults to 1)."`
 	PageSize int    `query:"pageSize" doc:"Page size (defaults to 20, clamped to 1-100)."`
 }

--- a/server/internal/api/huma_collections.go
+++ b/server/internal/api/huma_collections.go
@@ -36,7 +36,7 @@ type ListCollectionsOutput struct {
 
 // GetCollectionInput is the input for GET /api/collections/{id}.
 type GetCollectionInput struct {
-	ID string `path:"id" doc:"Collection ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Collection ID."`
 }
 
 // GetCollectionOutput wraps the collection detail response.
@@ -46,7 +46,7 @@ type GetCollectionOutput struct {
 
 // UpdateCollectionInput is the input for PUT /api/collections/{id}.
 type UpdateCollectionInput struct {
-	ID   string `path:"id" doc:"Collection ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Collection ID."`
 	Body UpdateCollectionRequest
 }
 
@@ -57,7 +57,7 @@ type UpdateCollectionOutput struct {
 
 // DeleteCollectionInput is the input for DELETE /api/collections/{id}.
 type DeleteCollectionInput struct {
-	ID string `path:"id" doc:"Collection ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Collection ID."`
 }
 
 // DeleteCollectionOutput wraps the delete success message.
@@ -67,7 +67,7 @@ type DeleteCollectionOutput struct {
 
 // AddGameToCollectionInput is the input for POST /api/collections/{id}/games.
 type AddGameToCollectionInput struct {
-	ID   string `path:"id" doc:"Collection ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Collection ID."`
 	Body AddGameToCollectionRequest
 }
 
@@ -78,8 +78,8 @@ type AddGameToCollectionOutput struct {
 
 // RemoveGameFromCollectionInput is the input for DELETE /api/collections/{id}/games/{gameId}.
 type RemoveGameFromCollectionInput struct {
-	ID     string `path:"id" doc:"Collection ID."`
-	GameID string `path:"gameId" doc:"Game ID."`
+	ID     string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Collection ID."`
+	GameID string `path:"gameId" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // RemoveGameFromCollectionOutput wraps the remove-game success message.

--- a/server/internal/api/huma_console.go
+++ b/server/internal/api/huma_console.go
@@ -24,7 +24,7 @@ type ListConsolesOutput struct {
 
 // ListConsoleGamesInput is the input for GET /api/consoles/{id}/games.
 type ListConsoleGamesInput struct {
-	ID             string `path:"id" doc:"Console abbreviation (e.g. 'snes') or code."`
+	ID             string `path:"id" pattern:"^[a-zA-Z0-9_-]+$" maxLength:"32" doc:"Console abbreviation (e.g. 'snes') or code."`
 	Page           int    `query:"page" default:"1" minimum:"1" doc:"1-based page number."`
 	PageSize       int    `query:"pageSize" default:"50" minimum:"1" maximum:"200" doc:"Page size."`
 	SortBy         string `query:"sortBy" default:"title" enum:"title,created_at,file_size,rating" doc:"Sort column."`
@@ -43,7 +43,7 @@ type ListConsoleGamesOutput struct {
 
 // GetTopRatedInput is the input for GET /api/consoles/{id}/top-rated.
 type GetTopRatedInput struct {
-	ID string `path:"id" doc:"Console abbreviation (e.g. 'snes') or code."`
+	ID string `path:"id" pattern:"^[a-zA-Z0-9_-]+$" maxLength:"32" doc:"Console abbreviation (e.g. 'snes') or code."`
 }
 
 // TopRatedListOutput wraps the top-rated game list for the huma response envelope.
@@ -57,7 +57,7 @@ type GetTopRatedGlobalInput struct{}
 // TopListInput is the input for /api/consoles/{id}/top-lists/* endpoints that
 // are scoped to a single console.
 type TopListInput struct {
-	ID string `path:"id" doc:"Console abbreviation (e.g. 'snes') or code."`
+	ID string `path:"id" pattern:"^[a-zA-Z0-9_-]+$" maxLength:"32" doc:"Console abbreviation (e.g. 'snes') or code."`
 }
 
 // TopListGlobalInput is the input for the global /api/top-lists/* endpoints.

--- a/server/internal/api/huma_core.go
+++ b/server/internal/api/huma_core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -23,7 +24,7 @@ type ListCoresOutput struct {
 
 // CoreManifestInput is the input for GET /api/cores/{id}/manifest.
 type CoreManifestInput struct {
-	ID uint `path:"id" doc:"Core row ID (not core name)."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Core row ID (not core name)."`
 }
 
 // CoreManifestResponse is the lightweight fingerprint payload players fetch
@@ -44,7 +45,7 @@ type CoreManifestOutput struct {
 
 // RefreshCoreInput is the input for POST /api/cores/{id}/refresh.
 type RefreshCoreInput struct {
-	ID       uint   `path:"id" doc:"Core row ID (not core name)."`
+	ID       string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Core row ID (not core name)."`
 	Platform string `query:"platform" required:"false" doc:"Platform whose on-disk binary to re-hash (linux|macos|windows|android). Defaults to linux — the default server host platform."`
 }
 
@@ -121,8 +122,12 @@ func (h *CoreHandler) HumaListCores(_ context.Context, _ *ListCoresInput) (*List
 
 // HumaGetCoreManifest is the huma handler for GET /api/cores/{id}/manifest.
 func (h *CoreHandler) HumaGetCoreManifest(_ context.Context, in *CoreManifestInput) (*CoreManifestOutput, error) {
+	parsedID, err := strconv.ParseUint(in.ID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid core ID")
+	}
 	var core db.Core
-	if err := h.DB.First(&core, in.ID).Error; err != nil {
+	if err := h.DB.First(&core, uint(parsedID)).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, huma.Error404NotFound("core not found")
 		}
@@ -140,8 +145,12 @@ func (h *CoreHandler) HumaGetCoreManifest(_ context.Context, in *CoreManifestInp
 // Admin-only. Re-hashes the on-disk binary, updates the DB row, and
 // emits an audit event when the sha256 changed.
 func (h *CoreHandler) HumaRefreshCore(_ context.Context, in *RefreshCoreInput) (*RefreshCoreOutput, error) {
+	parsedID, err := strconv.ParseUint(in.ID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid core ID")
+	}
 	var core db.Core
-	if err := h.DB.First(&core, in.ID).Error; err != nil {
+	if err := h.DB.First(&core, uint(parsedID)).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, huma.Error404NotFound("core not found")
 		}

--- a/server/internal/api/huma_devices.go
+++ b/server/internal/api/huma_devices.go
@@ -32,7 +32,7 @@ type ListDevicesOutput struct {
 
 // UpdateDeviceInput is the input for PUT /api/user/devices/{id}.
 type UpdateDeviceInput struct {
-	ID   string `path:"id" doc:"Device ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Device ID."`
 	Body UpdateDeviceRequest
 }
 
@@ -43,7 +43,7 @@ type UpdateDeviceOutput struct {
 
 // DeleteDeviceInput is the input for DELETE /api/user/devices/{id}.
 type DeleteDeviceInput struct {
-	ID string `path:"id" doc:"Device ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Device ID."`
 }
 
 // DeleteDeviceOutput wraps the delete success message.
@@ -53,7 +53,7 @@ type DeleteDeviceOutput struct {
 
 // GetDevicePreferencesInput is the input for GET /api/user/devices/{id}/preferences.
 type GetDevicePreferencesInput struct {
-	ID string `path:"id" doc:"Device ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Device ID."`
 }
 
 // DevicePreferencesResponse is the wire format for device preferences.
@@ -68,7 +68,7 @@ type GetDevicePreferencesOutput struct {
 
 // UpdateDevicePreferencesInput is the input for PUT /api/user/devices/{id}/preferences.
 type UpdateDevicePreferencesInput struct {
-	ID   string `path:"id" doc:"Device ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Device ID."`
 	Body UpdateDevicePreferencesRequest
 }
 
@@ -79,7 +79,7 @@ type UpdateDevicePreferencesOutput struct {
 
 // AdminGetUserDevicesInput is the input for GET /api/admin/users/{id}/devices.
 type AdminGetUserDevicesInput struct {
-	ID string `path:"id" doc:"User ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"User ID."`
 }
 
 // AdminGetUserDevicesOutput wraps the list of devices for a user (admin view).

--- a/server/internal/api/huma_discovery.go
+++ b/server/internal/api/huma_discovery.go
@@ -15,7 +15,7 @@ import (
 
 // GetSimilarGamesInput is the input for GET /api/games/{id}/similar.
 type GetSimilarGamesInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GetSimilarGamesOutput wraps the similar-games list for the huma response envelope.
@@ -25,7 +25,7 @@ type GetSimilarGamesOutput struct {
 
 // GetDeveloperGamesInput is the input for GET /api/games/{id}/developer-games.
 type GetDeveloperGamesInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GetDeveloperGamesOutput wraps the developer-games list for the huma response envelope.

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -136,14 +136,14 @@ func streamBytesInline(data []byte, contentType string) *huma.StreamResponse {
 
 // CoreDownloadInput is the input for GET /api/cores/{id}/download.
 type CoreDownloadInput struct {
-	ID       string `path:"id" doc:"Core ID."`
+	ID       string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Core ID."`
 	Platform string `query:"platform" required:"false" default:"linux" doc:"Target platform: linux, macos, windows, android."`
 	Sha256   string `query:"sha256" required:"false" doc:"Optional hex sha256 of a historical core binary. When set, serves that specific version from the history snapshot; returns 404 if it's been pruned. Defaults to serving the current binary."`
 }
 
 // BiosDownloadInput is the input for GET /api/bios/{filename}.
 type BiosDownloadInput struct {
-	Filename string `path:"filename" doc:"BIOS file name."`
+	Filename string `path:"filename" pattern:"^[A-Za-z0-9._()\\[\\] +-]+$" maxLength:"128" doc:"BIOS file name."`
 }
 
 // BiosArchiveDownloadInput is the input for GET /api/bios/archive/{filename}.
@@ -151,61 +151,61 @@ type BiosDownloadInput struct {
 // server returns a zip of `<biosDir>/<SubDir>/` so the client can extract
 // the directory tree on the device.
 type BiosArchiveDownloadInput struct {
-	Filename string `path:"filename" doc:"Sentinel filename of the bundle entry (matches registry FileName)."`
+	Filename string `path:"filename" pattern:"^[A-Za-z0-9._()\\[\\] +-]+$" maxLength:"128" doc:"Sentinel filename of the bundle entry (matches registry FileName)."`
 }
 
 // SessionSaveDownloadInput is the input for GET /api/sessions/{id}/saves/{saveId}.
 type SessionSaveDownloadInput struct {
-	ID     string `path:"id" doc:"Session ID."`
-	SaveID string `path:"saveId" doc:"Save state ID."`
+	ID     string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
+	SaveID string `path:"saveId" pattern:"^[0-9]+$" maxLength:"20" doc:"Save state ID."`
 }
 
 // SessionAutoSaveDownloadInput is the input for GET /api/sessions/{id}/saves/auto.
 type SessionAutoSaveDownloadInput struct {
-	ID string `path:"id" doc:"Session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 }
 
 // SessionSlotSaveDownloadInput is the input for GET /api/sessions/{id}/saves/slot/{slot}.
 type SessionSlotSaveDownloadInput struct {
-	ID   string `path:"id" doc:"Session ID."`
-	Slot string `path:"slot" doc:"Save slot number 1-10."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
+	Slot string `path:"slot" pattern:"^[0-9]+$" maxLength:"20" doc:"Save slot number 1-10."`
 }
 
 // SessionSaveDirBundleDownloadInput is the input for GET /api/sessions/{id}/save-dir.
 // Returns the previously-uploaded tarball or 404 if the session has no bundle.
 type SessionSaveDirBundleDownloadInput struct {
-	ID string `path:"id" doc:"Session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 }
 
 // SessionSRAMDownloadInput is the input for GET /api/sessions/{id}/sram.
 type SessionSRAMDownloadInput struct {
-	ID string `path:"id" doc:"Session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 }
 
 // SharedSaveDownloadInput is the input for GET /api/games/{id}/shared-saves/{saveId}/download.
 type SharedSaveDownloadInput struct {
-	ID     string `path:"id" doc:"Game ID."`
-	SaveID string `path:"saveId" doc:"Shared save state ID."`
+	ID     string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
+	SaveID string `path:"saveId" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared save state ID."`
 }
 
 // SharedSessionSaveDownloadInput is the input for
 // GET /api/shared-sessions/{id}/saves/{saveId}.
 type SharedSessionSaveDownloadInput struct {
-	ID     string `path:"id" doc:"Shared session ID."`
-	SaveID string `path:"saveId" doc:"Shared session save ID."`
+	ID     string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
+	SaveID string `path:"saveId" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session save ID."`
 }
 
 // SharedSessionAutoSaveDownloadInput is the input for
 // GET /api/shared-sessions/{id}/saves/auto.
 type SharedSessionAutoSaveDownloadInput struct {
-	ID string `path:"id" doc:"Shared session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
 }
 
 // ConsoleAssetInput is the input for the public console-image endpoints
 // (icon / logo / logo.png / preview-screenshot). The id resolves a console
 // by abbreviation or code.
 type ConsoleAssetInput struct {
-	ID string `path:"id" doc:"Console abbreviation or code."`
+	ID string `path:"id" pattern:"^[a-zA-Z0-9_-]+$" maxLength:"32" doc:"Console abbreviation or code."`
 }
 
 // BrandingLogoInput is the empty input for GET /api/branding/logo.
@@ -215,22 +215,22 @@ type BrandingLogoInput struct{}
 // The filename is captured but unused — it lets the client request the file
 // under a download-friendly name without changing the served bytes.
 type GameDownloadInput struct {
-	ID       string `path:"id" doc:"Game ID."`
-	Filename string `path:"filename" required:"false" doc:"Optional download filename — server ignores it; lets clients control the saved filename."`
+	ID       string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
+	Filename string `path:"filename" required:"false" pattern:"^[A-Za-z0-9._()\\[\\] +-]+$" maxLength:"128" doc:"Optional download filename — server ignores it; lets clients control the saved filename."`
 	Format   string `query:"format" required:"false" doc:"'zip' to force ZIP packaging for multi-file disc games. Default is .tar (or single-file passthrough)."`
 }
 
 // GameDiscDownloadInput is the input for GET
 // /api/games/{id}/discs/{discNumber}/download.
 type GameDiscDownloadInput struct {
-	ID         string `path:"id" doc:"Game ID."`
-	DiscNumber string `path:"discNumber" doc:"Disc number (1-based)."`
+	ID         string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
+	DiscNumber string `path:"discNumber" pattern:"^[0-9]+$" maxLength:"20" doc:"Disc number (1-based)."`
 	Format     string `query:"format" required:"false" doc:"'zip' for ZIP packaging (used by EmulatorJS), default is .tar."`
 }
 
 // ChallengeAssetInput is the input for the two challenge download endpoints.
 type ChallengeAssetInput struct {
-	ID string `path:"id" doc:"Challenge ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Challenge ID."`
 }
 
 // --- Registration ------------------------------------------------------------
@@ -496,8 +496,12 @@ func RegisterDownloadRoutes(
 
 // HumaDownloadCore is the huma implementation of GET /api/cores/{id}/download.
 func (h *CoreHandler) HumaDownloadCore(_ context.Context, in *CoreDownloadInput) (*huma.StreamResponse, error) {
+	parsedID, err := strconv.ParseUint(in.ID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid core ID")
+	}
 	var core db.Core
-	if err := h.DB.First(&core, in.ID).Error; err != nil {
+	if err := h.DB.First(&core, uint(parsedID)).Error; err != nil {
 		return nil, huma.Error404NotFound("core not found")
 	}
 

--- a/server/internal/api/huma_enrichment.go
+++ b/server/internal/api/huma_enrichment.go
@@ -68,7 +68,7 @@ type ListSeriesOutput struct {
 
 // GetSeriesDetailInput is the input for GET /api/series/{id}.
 type GetSeriesDetailInput struct {
-	ID string `path:"id" doc:"Series ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Series ID."`
 }
 
 // GetSeriesDetailOutput wraps the series detail body.
@@ -86,7 +86,7 @@ type ListFranchisesOutput struct {
 
 // GetFranchiseDetailInput is the input for GET /api/franchises/{id}.
 type GetFranchiseDetailInput struct {
-	ID string `path:"id" doc:"Franchise group ID, or IGDB franchise ID as fallback."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Franchise group ID, or IGDB franchise ID as fallback."`
 }
 
 // GetFranchiseDetailOutput wraps the franchise detail body.
@@ -526,8 +526,12 @@ func (h *EnrichmentHandler) HumaListSeries(_ context.Context, _ *ListSeriesInput
 
 // HumaGetSeriesDetail is the huma handler for GET /api/series/{id}.
 func (h *EnrichmentHandler) HumaGetSeriesDetail(_ context.Context, in *GetSeriesDetailInput) (*GetSeriesDetailOutput, error) {
+	parsedID, err := strconv.ParseUint(in.ID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid series ID")
+	}
 	var series db.GameSeries
-	if err := h.DB.Preload("Entries").First(&series, in.ID).Error; err != nil {
+	if err := h.DB.Preload("Entries").First(&series, uint(parsedID)).Error; err != nil {
 		return nil, huma.Error404NotFound("series not found")
 	}
 
@@ -669,7 +673,11 @@ func (h *EnrichmentHandler) HumaListFranchises(_ context.Context, _ *ListFranchi
 
 // HumaGetFranchiseDetail is the huma handler for GET /api/franchises/{id}.
 func (h *EnrichmentHandler) HumaGetFranchiseDetail(_ context.Context, in *GetFranchiseDetailInput) (*GetFranchiseDetailOutput, error) {
-	id := in.ID
+	parsedID, err := strconv.ParseUint(in.ID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid franchise ID")
+	}
+	id := uint(parsedID)
 	var franchise db.GameFranchiseGroup
 	if err := h.DB.Preload("Entries").First(&franchise, id).Error; err != nil {
 		if err2 := h.DB.Preload("Entries").Where("igdb_franchise_id = ?", id).First(&franchise).Error; err2 != nil {

--- a/server/internal/api/huma_enrichment.go
+++ b/server/internal/api/huma_enrichment.go
@@ -26,7 +26,7 @@ type ListThemesOutput struct {
 
 // ListThemeGamesInput is the input for GET /api/themes/{id}/games.
 type ListThemeGamesInput struct {
-	ID       string `path:"id" doc:"IGDB theme ID."`
+	ID       string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"IGDB theme ID."`
 	Page     int    `query:"page" doc:"1-based page number (defaults to 1)."`
 	PageSize int    `query:"pageSize" doc:"Page size (defaults to 20, clamped to 1-100)."`
 }
@@ -48,7 +48,7 @@ type ListKeywordsOutput struct {
 
 // ListKeywordGamesInput is the input for GET /api/keywords/{id}/games.
 type ListKeywordGamesInput struct {
-	ID       string `path:"id" doc:"IGDB keyword ID."`
+	ID       string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"IGDB keyword ID."`
 	Page     int    `query:"page" doc:"1-based page number."`
 	PageSize int    `query:"pageSize" doc:"Page size."`
 }
@@ -96,7 +96,7 @@ type GetFranchiseDetailOutput struct {
 
 // ListFranchiseGamesInput is the input for GET /api/franchises/{id}/games.
 type ListFranchiseGamesInput struct {
-	ID       string `path:"id" doc:"IGDB franchise ID."`
+	ID       string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"IGDB franchise ID."`
 	Page     int    `query:"page" doc:"1-based page number."`
 	PageSize int    `query:"pageSize" doc:"Page size."`
 }
@@ -108,7 +108,7 @@ type ListFranchiseGamesOutput struct {
 
 // GetGameSeriesInput is the input for GET /api/games/{id}/series.
 type GetGameSeriesInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GetGameSeriesOutput wraps the game series list body.
@@ -118,7 +118,7 @@ type GetGameSeriesOutput struct {
 
 // GetGameFranchisesInput is the input for GET /api/games/{id}/franchises.
 type GetGameFranchisesInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GetGameFranchisesOutput wraps the game franchises list body.

--- a/server/internal/api/huma_explore_console.go
+++ b/server/internal/api/huma_explore_console.go
@@ -16,7 +16,7 @@ import (
 
 // GetConsoleShowcaseInput is the input for GET /api/explore/consoles/{id}/showcase.
 type GetConsoleShowcaseInput struct {
-	ID string `path:"id" doc:"Console abbreviation (e.g. 'snes')."`
+	ID string `path:"id" pattern:"^[a-zA-Z0-9_-]+$" maxLength:"32" doc:"Console abbreviation (e.g. 'snes')."`
 }
 
 // GetConsoleShowcaseOutput wraps the console showcase response.

--- a/server/internal/api/huma_explore_developer.go
+++ b/server/internal/api/huma_explore_developer.go
@@ -35,7 +35,7 @@ type GetDeveloperSpotlightOutput struct {
 
 // GetDeveloperDetailInput is the input for GET /api/explore/developers/{name}.
 type GetDeveloperDetailInput struct {
-	Name string `path:"name" doc:"Developer name (URL-decoded)."`
+	Name string `path:"name" pattern:"^[^/\\\\]+$" maxLength:"128" doc:"Developer name (URL-decoded)."`
 }
 
 // GetDeveloperDetailOutput wraps the developer detail response.
@@ -46,7 +46,7 @@ type GetDeveloperDetailOutput struct {
 
 // GetPublisherDetailInput is the input for GET /api/explore/publishers/{name}.
 type GetPublisherDetailInput struct {
-	Name string `path:"name" doc:"Publisher name (URL-decoded)."`
+	Name string `path:"name" pattern:"^[^/\\\\]+$" maxLength:"128" doc:"Publisher name (URL-decoded)."`
 }
 
 // GetPublisherDetailOutput wraps the publisher detail response.

--- a/server/internal/api/huma_explore_featured.go
+++ b/server/internal/api/huma_explore_featured.go
@@ -52,7 +52,7 @@ type GetExploreMoodsOutput struct {
 
 // GetMoodGamesInput is the input for GET /api/explore/mood/{mood}.
 type GetMoodGamesInput struct {
-	Mood string `path:"mood" doc:"Mood identifier, e.g. 'chill', 'challenge'."`
+	Mood string `path:"mood" pattern:"^[a-z][a-z0-9_-]{0,31}$" maxLength:"32" doc:"Mood identifier, e.g. 'chill', 'challenge'."`
 }
 
 // GetMoodGamesOutput wraps the games list for a mood.

--- a/server/internal/api/huma_explore_temporal.go
+++ b/server/internal/api/huma_explore_temporal.go
@@ -28,7 +28,7 @@ type GetOnThisDayOutput struct {
 
 // GetBestOfYearInput is the input for GET /api/explore/best-of-year/{year}.
 type GetBestOfYearInput struct {
-	Year string `path:"year" doc:"Release year (1970-2100)."`
+	Year string `path:"year" pattern:"^(19|20|21)[0-9]{2}$" maxLength:"4" doc:"Release year (1970-2100)."`
 }
 
 // GetBestOfYearOutput wraps the best-of-year response.
@@ -48,7 +48,7 @@ type GetYourAnniversariesOutput struct {
 
 // GetDecadesInput is the input for GET /api/explore/decades/{decade}.
 type GetDecadesInput struct {
-	Decade string `path:"decade" doc:"Decade identifier: '80s', '90s', or '00s'."`
+	Decade string `path:"decade" pattern:"^[0-9]{2}s$" maxLength:"3" doc:"Decade identifier: '80s', '90s', or '00s'."`
 }
 
 // GetDecadesOutput wraps the decades response.

--- a/server/internal/api/huma_favorites_play_later.go
+++ b/server/internal/api/huma_favorites_play_later.go
@@ -22,7 +22,7 @@ type ListFavoritesOutput struct {
 
 // AddFavoriteInput is the input for POST /api/user/favorites/{gameId}.
 type AddFavoriteInput struct {
-	GameID string `path:"gameId" doc:"Game ID."`
+	GameID string `path:"gameId" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // AddFavoriteOutput wraps the create-favorite success message (201 Created).
@@ -32,7 +32,7 @@ type AddFavoriteOutput struct {
 
 // RemoveFavoriteInput is the input for DELETE /api/user/favorites/{gameId}.
 type RemoveFavoriteInput struct {
-	GameID string `path:"gameId" doc:"Game ID."`
+	GameID string `path:"gameId" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // RemoveFavoriteOutput wraps the delete-favorite success message.
@@ -215,8 +215,13 @@ func (h *UserHandler) HumaListFavorites(ctx context.Context, _ *ListFavoritesInp
 func (h *UserHandler) HumaAddFavorite(ctx context.Context, in *AddFavoriteInput) (*AddFavoriteOutput, error) {
 	uid := UserIDFromContext(ctx)
 
+	parsedID, err := strconv.ParseUint(in.GameID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid game ID")
+	}
+
 	var game db.Game
-	if err := h.DB.First(&game, in.GameID).Error; err != nil {
+	if err := h.DB.First(&game, uint(parsedID)).Error; err != nil {
 		return nil, huma.Error404NotFound("game not found")
 	}
 

--- a/server/internal/api/huma_favorites_play_later.go
+++ b/server/internal/api/huma_favorites_play_later.go
@@ -52,7 +52,7 @@ type ListPlayLaterOutput struct {
 
 // AddToPlayLaterInput is the input for POST /api/user/play-later/{gameId}.
 type AddToPlayLaterInput struct {
-	GameID string `path:"gameId" doc:"Game ID."`
+	GameID string `path:"gameId" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // AddToPlayLaterOutput uses a dynamic status code — 201 when we added a new
@@ -65,7 +65,7 @@ type AddToPlayLaterOutput struct {
 
 // RemoveFromPlayLaterInput is the input for DELETE /api/user/play-later/{gameId}.
 type RemoveFromPlayLaterInput struct {
-	GameID string `path:"gameId" doc:"Game ID."`
+	GameID string `path:"gameId" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // RemoveFromPlayLaterOutput wraps the delete-from-play-later success message.

--- a/server/internal/api/huma_game.go
+++ b/server/internal/api/huma_game.go
@@ -60,7 +60,7 @@ type ListGamesOutput struct {
 
 // GetGameInput is the input for GET /api/games/{id}.
 type GetGameInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GetGameOutput wraps a single game response.
@@ -85,7 +85,7 @@ type GetRecommendedCoreOutput struct {
 
 // ScrapeIfNeededInput is the input for POST /api/games/{id}/scrape-if-needed.
 type ScrapeIfNeededInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // StatusMessageResponse is the {status: ...} wire format used by the scrape /
@@ -105,7 +105,7 @@ type ScrapeIfNeededOutput struct {
 
 // UpdateGamePlayTimeInput is the input for POST /api/games/{id}/play-time.
 type UpdateGamePlayTimeInput struct {
-	ID   string `path:"id" doc:"Game ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Body UpdateGamePlayTimeRequest
 }
 
@@ -122,7 +122,7 @@ type UpdateGamePlayTimeOutput struct {
 
 // StopPlayingInput is the input for DELETE /api/games/{id}/play-time.
 type StopPlayingInput struct {
-	ID string `path:"id" doc:"Game ID (path placeholder; not used server-side)."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID (path placeholder; not used server-side)."`
 }
 
 // StopPlayingOutput wraps the stop-playing status.

--- a/server/internal/api/huma_maker.go
+++ b/server/internal/api/huma_maker.go
@@ -19,7 +19,7 @@ type ListMakersOutput struct {
 
 // GetMakerInput is the input for GET /api/makers/{code}.
 type GetMakerInput struct {
-	Code string `path:"code" doc:"Hardware maker code, e.g. 'nintendo'." example:"nintendo"`
+	Code string `path:"code" pattern:"^[a-z0-9_-]+$" maxLength:"32" doc:"Hardware maker code, e.g. 'nintendo'." example:"nintendo"`
 }
 
 // GetMakerOutput wraps the single-maker body for the huma response envelope.

--- a/server/internal/api/huma_misc.go
+++ b/server/internal/api/huma_misc.go
@@ -67,7 +67,7 @@ type ListSavedSearchesOutput struct {
 
 // DeleteSavedSearchInput is the input for DELETE /api/user/saved-searches/{id}.
 type DeleteSavedSearchInput struct {
-	ID string `path:"id" doc:"Saved search ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Saved search ID."`
 }
 
 // DeletedStatusResponse is the wire format for delete responses that return a status.
@@ -116,7 +116,7 @@ type GetCoreCompatibilityOutput struct {
 
 // GetUserRateLimitInput is the input for GET /api/admin/users/{id}/rate-limit.
 type GetUserRateLimitInput struct {
-	ID string `path:"id" doc:"User ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"User ID."`
 }
 
 // GetUserRateLimitOutput wraps the rate-limit response.
@@ -126,7 +126,7 @@ type GetUserRateLimitOutput struct {
 
 // ResetUserRateLimitInput is the input for DELETE /api/admin/users/{id}/rate-limit.
 type ResetUserRateLimitInput struct {
-	ID string `path:"id" doc:"User ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"User ID."`
 }
 
 // ResetUserRateLimitOutput wraps the rate-limit reset response.

--- a/server/internal/api/huma_netplay.go
+++ b/server/internal/api/huma_netplay.go
@@ -50,7 +50,7 @@ type ListNetplaySessionsOutput struct {
 
 // GetNetplaySessionInput is the input for GET /api/netplay/sessions/{id}.
 type GetNetplaySessionInput struct {
-	ID string `path:"id" doc:"Netplay session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Netplay session ID."`
 }
 
 // GetNetplaySessionOutput wraps the session response.
@@ -60,7 +60,7 @@ type GetNetplaySessionOutput struct {
 
 // DeleteNetplaySessionInput is the input for DELETE /api/netplay/sessions/{id}.
 type DeleteNetplaySessionInput struct {
-	ID string `path:"id" doc:"Netplay session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Netplay session ID."`
 }
 
 // DeleteNetplaySessionOutput wraps the delete success message.
@@ -70,7 +70,7 @@ type DeleteNetplaySessionOutput struct {
 
 // LeaveNetplaySessionInput is the input for POST /api/netplay/sessions/{id}/leave.
 type LeaveNetplaySessionInput struct {
-	ID string `path:"id" doc:"Netplay session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Netplay session ID."`
 }
 
 // LeaveNetplaySessionResponse is the wire format for the leave endpoint.
@@ -86,7 +86,7 @@ type LeaveNetplaySessionOutput struct {
 
 // UpdateNetplaySettingsInput is the input for PUT /api/netplay/sessions/{id}/settings.
 type UpdateNetplaySettingsInput struct {
-	ID   string `path:"id" doc:"Netplay session ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Netplay session ID."`
 	Body UpdateNetplaySettingsRequest
 }
 
@@ -97,7 +97,7 @@ type UpdateNetplaySettingsOutput struct {
 
 // NetplayInviteUserInput is the input for POST /api/netplay/sessions/{id}/invites.
 type NetplayInviteUserInput struct {
-	ID   string `path:"id" doc:"Netplay session ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Netplay session ID."`
 	Body NetplayInviteUserRequest
 }
 
@@ -110,7 +110,7 @@ type NetplayInviteUserOutput struct {
 // The path parameter is the numeric invite ID (kept at its historical
 // inviteId name to preserve wire compatibility with existing clients).
 type AcceptNetplayInviteByCodeInput struct {
-	Code string `path:"inviteId" doc:"Invite ID."`
+	Code string `path:"inviteId" pattern:"^[0-9]+$" maxLength:"20" doc:"Invite ID."`
 }
 
 // AcceptNetplayInviteByCodeOutput wraps the accepted invite response.
@@ -120,7 +120,7 @@ type AcceptNetplayInviteByCodeOutput struct {
 
 // DeclineNetplayInviteByCodeInput is the input for POST /api/netplay/invites/{inviteId}/decline.
 type DeclineNetplayInviteByCodeInput struct {
-	Code string `path:"inviteId" doc:"Invite ID."`
+	Code string `path:"inviteId" pattern:"^[0-9]+$" maxLength:"20" doc:"Invite ID."`
 }
 
 // DeclineNetplayInviteByCodeOutput wraps the decline success message.
@@ -130,7 +130,7 @@ type DeclineNetplayInviteByCodeOutput struct {
 
 // ListNetplaySessionInvitesInput is the input for GET /api/netplay/sessions/{id}/invites.
 type ListNetplaySessionInvitesInput struct {
-	ID string `path:"id" doc:"Netplay session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Netplay session ID."`
 }
 
 // ListNetplaySessionInvitesOutput wraps the session invites list.

--- a/server/internal/api/huma_netplay.go
+++ b/server/internal/api/huma_netplay.go
@@ -700,7 +700,12 @@ func (h *NetplayHandler) HumaNetplayInviteUser(ctx context.Context, in *NetplayI
 	resp := h.toNetplayInviteResponse(invite)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: ws.EventNetplayInviteSent, Payload: resp})
+		// Issue #1119: deliver only to the inviter and invitee.
+		h.Hub.Broadcast(ws.Event{
+			Type:             ws.EventNetplayInviteSent,
+			Payload:          resp,
+			RecipientUserIDs: []uint{invite.InviterID, invite.InviteeID},
+		})
 	}
 
 	return &NetplayInviteUserOutput{Body: resp}, nil

--- a/server/internal/api/huma_ra.go
+++ b/server/internal/api/huma_ra.go
@@ -83,7 +83,7 @@ type GetRATokenOutput struct {
 
 // GetAchievementProgressInput is the input for GET /api/games/{id}/achievements/progress.
 type GetAchievementProgressInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GameAchievementProgressResponse is the wire format for per-game user progress.
@@ -99,7 +99,7 @@ type GetAchievementProgressOutput struct {
 
 // GetAchievementTimelineInput is the input for GET /api/games/{id}/achievements/timeline.
 type GetAchievementTimelineInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // AchievementTimelineResponse is the wire format for the timeline response.
@@ -121,7 +121,7 @@ type GetAchievementTimelineOutput struct {
 
 // GetAchievementLeaderboardInput is the input for GET /api/games/{id}/achievements/leaderboard.
 type GetAchievementLeaderboardInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // AchievementLeaderboardResponse is the wire format for the leaderboard response.

--- a/server/internal/api/huma_ratings.go
+++ b/server/internal/api/huma_ratings.go
@@ -13,7 +13,7 @@ import (
 
 // CreateOrUpdateRatingInput is the input for POST /api/games/{id}/ratings.
 type CreateOrUpdateRatingInput struct {
-	ID   string `path:"id" doc:"Game ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Body CreateOrUpdateRatingRequest
 }
 
@@ -29,7 +29,7 @@ type CreateOrUpdateRatingOutput struct {
 // page/pageSize are enforced in the handler so out-of-range values fall back
 // to defaults instead of returning huma's 422 "validation failed".
 type GetRatingsInput struct {
-	ID       string `path:"id" doc:"Game ID."`
+	ID       string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Page     int    `query:"page" doc:"1-based page number (defaults to 1)."`
 	PageSize int    `query:"pageSize" doc:"Page size (defaults to 20, clamped to 1-100)."`
 }
@@ -41,7 +41,7 @@ type GetRatingsOutput struct {
 
 // GetRatingSummaryInput is the input for GET /api/games/{id}/ratings/summary.
 type GetRatingSummaryInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GetRatingSummaryOutput wraps the rating-summary response.
@@ -51,7 +51,7 @@ type GetRatingSummaryOutput struct {
 
 // GetMyRatingInput is the input for GET /api/games/{id}/ratings/mine.
 type GetMyRatingInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GetMyRatingOutput wraps the current user's rating response.
@@ -61,7 +61,7 @@ type GetMyRatingOutput struct {
 
 // DeleteRatingInput is the input for DELETE /api/games/{id}/ratings.
 type DeleteRatingInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // DeleteRatingOutput wraps the delete-rating success message.

--- a/server/internal/api/huma_scraper.go
+++ b/server/internal/api/huma_scraper.go
@@ -84,7 +84,7 @@ type ScrapeStatusCountsOutput struct {
 
 // ScrapeGameInput is the input for POST /api/admin/games/{id}/scrape.
 type ScrapeGameInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // ScrapeGameResponse is the wire format for scrape-game responses.
@@ -100,7 +100,7 @@ type ScrapeGameOutput struct {
 
 // RefreshAchievementsInput is the input for POST /api/admin/games/{id}/achievements/refresh.
 type RefreshAchievementsInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // RefreshAchievementsResponse is the wire format for refresh responses.

--- a/server/internal/api/huma_search_social.go
+++ b/server/internal/api/huma_search_social.go
@@ -167,6 +167,16 @@ func (h *SocialHandler) HumaSearchUsers(ctx context.Context, in *SearchUsersInpu
 		base = base.Where("username LIKE ? ESCAPE '\\'", escapeLikePattern(query)+"%")
 	}
 
+	// Issue #1121: exclude users the caller has blocked AND users
+	// who have blocked the caller. The harasser shouldn't be able to
+	// see the harassed user pop up in their search results either.
+	if uid != 0 {
+		base = base.Where(
+			"id NOT IN (SELECT blocked_user_id FROM blocks WHERE user_id = ? AND deleted_at IS NULL) AND "+
+				"id NOT IN (SELECT user_id FROM blocks WHERE blocked_user_id = ? AND deleted_at IS NULL)",
+			uid, uid)
+	}
+
 	var total int64
 	base.Model(&db.User{}).Count(&total)
 

--- a/server/internal/api/huma_session_uploads.go
+++ b/server/internal/api/huma_session_uploads.go
@@ -344,6 +344,14 @@ func (h *SessionHandler) HumaUpsertSlotSave(ctx context.Context, in *SessionSlot
 	if err != nil {
 		return nil, err
 	}
+	// Issue #1128: parity with HumaUploadSessionSave / HumaUploadAutoSave
+	// — if a shared session backs this game session, the caller must
+	// hold the turn before they can write a slot. Without this gate, the
+	// session owner could overwrite slots while a co-op partner held the
+	// turn, polluting the shared playthrough save bank.
+	if err := h.humaCheckSharedSessionTurn(session.ID, uid); err != nil {
+		return nil, err
+	}
 
 	slotNum, err := strconv.Atoi(in.Slot)
 	if err != nil || slotNum < 1 || slotNum > 10 {

--- a/server/internal/api/huma_session_uploads.go
+++ b/server/internal/api/huma_session_uploads.go
@@ -36,7 +36,7 @@ type SessionSaveUploadBody struct {
 // SessionSaveUploadInput wraps the path parameter and multipart body for
 // POST /api/sessions/{id}/saves.
 type SessionSaveUploadInput struct {
-	ID      string `path:"id" doc:"Session ID."`
+	ID      string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 	RawBody huma.MultipartFormFiles[SessionSaveUploadBody]
 }
 
@@ -49,15 +49,15 @@ type SessionSaveUploadOutput struct {
 // SessionAutoSaveUploadInput is the multipart body for POST
 // /api/sessions/{id}/saves/auto. Same shape as a manual save.
 type SessionAutoSaveUploadInput struct {
-	ID      string `path:"id" doc:"Session ID."`
+	ID      string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 	RawBody huma.MultipartFormFiles[SessionSaveUploadBody]
 }
 
 // SessionSlotSaveUploadInput is the multipart body for PUT
 // /api/sessions/{id}/saves/slot/{slot}. Slot saves don't have a name.
 type SessionSlotSaveUploadInput struct {
-	ID      string `path:"id" doc:"Session ID."`
-	Slot    string `path:"slot" doc:"Slot number 1-10."`
+	ID      string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
+	Slot    string `path:"slot" pattern:"^[0-9]+$" maxLength:"20" doc:"Slot number 1-10."`
 	RawBody huma.MultipartFormFiles[SessionSaveUploadBody]
 }
 
@@ -68,7 +68,7 @@ type SessionSRAMUploadBody struct {
 
 // SessionSRAMUploadInput wraps the path parameter and multipart body.
 type SessionSRAMUploadInput struct {
-	ID      string `path:"id" doc:"Session ID."`
+	ID      string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 	RawBody huma.MultipartFormFiles[SessionSRAMUploadBody]
 }
 
@@ -89,7 +89,7 @@ type SessionSaveDirBundleUploadBody struct {
 
 // SessionSaveDirBundleUploadInput wraps the path parameter and multipart body.
 type SessionSaveDirBundleUploadInput struct {
-	ID      string `path:"id" doc:"Session ID."`
+	ID      string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 	RawBody huma.MultipartFormFiles[SessionSaveDirBundleUploadBody]
 }
 

--- a/server/internal/api/huma_sessions.go
+++ b/server/internal/api/huma_sessions.go
@@ -25,7 +25,7 @@ func humaFilepathBase(p string) string {
 
 // ListGameSessionsInput is the input for GET /api/games/{id}/sessions.
 type ListGameSessionsInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // ListGameSessionsOutput wraps the list response.
@@ -35,7 +35,7 @@ type ListGameSessionsOutput struct {
 
 // GetSessionInput is the input for GET /api/sessions/{id}.
 type GetSessionInput struct {
-	ID string `path:"id" doc:"Session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 }
 
 // GetSessionOutput wraps a single session response.
@@ -45,7 +45,7 @@ type GetSessionOutput struct {
 
 // CreateSessionInput is the input for POST /api/games/{id}/sessions.
 type CreateSessionInput struct {
-	ID   string `path:"id" doc:"Game ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Body CreateSessionRequest
 }
 
@@ -57,8 +57,8 @@ type CreateSessionOutput struct {
 // CreateSessionFromSharedSaveInput is the input for POST
 // /api/games/{id}/sessions/from-shared-save/{saveId}.
 type CreateSessionFromSharedSaveInput struct {
-	ID     string `path:"id" doc:"Game ID."`
-	SaveID string `path:"saveId" doc:"Shared save ID to seed the new session from."`
+	ID     string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
+	SaveID string `path:"saveId" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared save ID to seed the new session from."`
 }
 
 // CreateSessionFromSharedSaveOutput wraps the created session response (201).
@@ -68,7 +68,7 @@ type CreateSessionFromSharedSaveOutput struct {
 
 // UpdateSessionInput is the input for PUT /api/sessions/{id}.
 type UpdateSessionInput struct {
-	ID   string `path:"id" doc:"Session ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 	Body UpdateSessionRequest
 }
 
@@ -79,7 +79,7 @@ type UpdateSessionOutput struct {
 
 // DeleteSessionInput is the input for DELETE /api/sessions/{id}.
 type DeleteSessionInput struct {
-	ID string `path:"id" doc:"Session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 }
 
 // DeleteSessionOutput wraps the delete success message.
@@ -94,7 +94,7 @@ type DeleteSessionOutput struct {
 // specific save instead of the most recent; 0 (the default for a missing
 // query param) means "use the most-recent save".
 type DuplicateSessionInput struct {
-	ID     string `path:"id" doc:"Session ID to clone."`
+	ID     string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID to clone."`
 	SaveID uint   `query:"saveId" required:"false" doc:"Optional save ID to clone from. Defaults to the most recent save when omitted or zero."`
 	Body   *DuplicateSessionRequest
 }
@@ -106,7 +106,7 @@ type DuplicateSessionOutput struct {
 
 // ListSessionSavesInput is the input for GET /api/sessions/{id}/saves and the slot variant.
 type ListSessionSavesInput struct {
-	ID string `path:"id" doc:"Session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 }
 
 // ListSessionSavesOutput wraps the saves list.
@@ -116,8 +116,8 @@ type ListSessionSavesOutput struct {
 
 // DeleteSessionSaveInput is the input for DELETE /api/sessions/{id}/saves/{saveId}.
 type DeleteSessionSaveInput struct {
-	ID     string `path:"id" doc:"Session ID."`
-	SaveID string `path:"saveId" doc:"Save ID."`
+	ID     string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
+	SaveID string `path:"saveId" pattern:"^[0-9]+$" maxLength:"20" doc:"Save ID."`
 }
 
 // DeleteSessionSaveOutput wraps the delete success message.
@@ -127,8 +127,8 @@ type DeleteSessionSaveOutput struct {
 
 // UpdateSessionSaveInput is the input for PUT /api/sessions/{id}/saves/{saveId}.
 type UpdateSessionSaveInput struct {
-	ID     string `path:"id" doc:"Session ID."`
-	SaveID string `path:"saveId" doc:"Save ID."`
+	ID     string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
+	SaveID string `path:"saveId" pattern:"^[0-9]+$" maxLength:"20" doc:"Save ID."`
 	Body   UpdateSessionSaveRequest
 }
 
@@ -139,7 +139,7 @@ type UpdateSessionSaveOutput struct {
 
 // BulkDeleteSessionSavesInput is the input for DELETE /api/sessions/{id}/saves.
 type BulkDeleteSessionSavesInput struct {
-	ID string `path:"id" doc:"Session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 }
 
 // BulkDeleteSessionSavesResponse mirrors the raw gin handler body.
@@ -155,7 +155,7 @@ type BulkDeleteSessionSavesOutput struct {
 
 // UpdateSessionPlayTimeInput is the input for POST /api/sessions/{id}/play-time.
 type UpdateSessionPlayTimeInput struct {
-	ID   string `path:"id" doc:"Session ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 	Body UpdateSessionPlayTimeRequest
 }
 
@@ -166,7 +166,7 @@ type UpdateSessionPlayTimeOutput struct {
 
 // StopPlayingSessionInput is the input for DELETE /api/sessions/{id}/play-time.
 type StopPlayingSessionInput struct {
-	ID string `path:"id" doc:"Session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 }
 
 // StopPlayingSessionOutput wraps the stop-playing success message.
@@ -182,7 +182,7 @@ type SessionCheatsResponse struct {
 
 // GetSessionCheatsInput is the input for GET /api/sessions/{id}/cheats.
 type GetSessionCheatsInput struct {
-	ID string `path:"id" doc:"Session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 }
 
 // GetSessionCheatsOutput wraps the cheats response.
@@ -192,7 +192,7 @@ type GetSessionCheatsOutput struct {
 
 // UpdateSessionCheatsInput is the input for PUT /api/sessions/{id}/cheats.
 type UpdateSessionCheatsInput struct {
-	ID   string `path:"id" doc:"Session ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Session ID."`
 	Body UpdateSessionCheatsRequest
 }
 

--- a/server/internal/api/huma_shared.go
+++ b/server/internal/api/huma_shared.go
@@ -19,7 +19,7 @@ import (
 
 // ListSharedSavesInput is the input for GET /api/games/{id}/shared-saves.
 type ListSharedSavesInput struct {
-	ID       string `path:"id" doc:"Game ID."`
+	ID       string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Page     int    `query:"page" doc:"1-based page number (defaults to 1)."`
 	PageSize int    `query:"pageSize" doc:"Page size (defaults to 20, clamped to 1-100)."`
 }
@@ -31,8 +31,8 @@ type ListSharedSavesOutput struct {
 
 // DeleteSharedSaveInput is the input for DELETE /api/games/{id}/shared-saves/{saveId}.
 type DeleteSharedSaveInput struct {
-	ID     string `path:"id" doc:"Game ID."`
-	SaveID string `path:"saveId" doc:"Shared save ID."`
+	ID     string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
+	SaveID string `path:"saveId" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared save ID."`
 }
 
 // DeleteSharedSaveOutput wraps the delete success message.
@@ -52,7 +52,7 @@ type CreateSharedSessionOutput struct {
 
 // GetSharedSessionInput is the input for GET /api/shared-sessions/{id}.
 type GetSharedSessionInput struct {
-	ID string `path:"id" doc:"Shared session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
 }
 
 // GetSharedSessionOutput wraps the shared session detail response.
@@ -62,7 +62,7 @@ type GetSharedSessionOutput struct {
 
 // UpdateSharedSessionInput is the input for PUT /api/shared-sessions/{id}.
 type UpdateSharedSessionInput struct {
-	ID   string `path:"id" doc:"Shared session ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
 	Body UpdateSharedSessionRequest
 }
 
@@ -73,7 +73,7 @@ type UpdateSharedSessionOutput struct {
 
 // DeleteSharedSessionInput is the input for DELETE /api/shared-sessions/{id}.
 type DeleteSharedSessionInput struct {
-	ID string `path:"id" doc:"Shared session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
 }
 
 // DeleteSharedSessionOutput wraps the delete success message.
@@ -83,7 +83,7 @@ type DeleteSharedSessionOutput struct {
 
 // ListGameSharedSessionsInput is the input for GET /api/games/{id}/shared-sessions.
 type ListGameSharedSessionsInput struct {
-	ID string `path:"id" doc:"Game ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // ListGameSharedSessionsOutput wraps the game shared sessions list.
@@ -101,7 +101,7 @@ type ListMySharedSessionsOutput struct {
 
 // InviteToSharedSessionInput is the input for POST /api/shared-sessions/{id}/invites.
 type InviteToSharedSessionInput struct {
-	ID   string `path:"id" doc:"Shared session ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
 	Body InviteToSharedSessionRequest
 }
 
@@ -112,7 +112,7 @@ type InviteToSharedSessionOutput struct {
 
 // LeaveSharedSessionInput is the input for POST /api/shared-sessions/{id}/leave.
 type LeaveSharedSessionInput struct {
-	ID string `path:"id" doc:"Shared session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
 }
 
 // LeaveSharedSessionOutput wraps the leave success message.
@@ -122,8 +122,8 @@ type LeaveSharedSessionOutput struct {
 
 // RemoveSharedSessionMemberInput is the input for DELETE /api/shared-sessions/{id}/members/{userId}.
 type RemoveSharedSessionMemberInput struct {
-	ID     string `path:"id" doc:"Shared session ID."`
-	UserID string `path:"userId" doc:"User ID to remove."`
+	ID     string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
+	UserID string `path:"userId" pattern:"^[0-9]+$" maxLength:"20" doc:"User ID to remove."`
 }
 
 // RemoveSharedSessionMemberOutput wraps the remove-member success message.
@@ -133,7 +133,7 @@ type RemoveSharedSessionMemberOutput struct {
 
 // SharedSessionTurnInput is the input for POST /api/shared-sessions/{id}/take-turn and release-turn.
 type SharedSessionTurnInput struct {
-	ID string `path:"id" doc:"Shared session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
 }
 
 // SharedSessionTakeTurnResponse is the wire format for take-turn.
@@ -165,7 +165,7 @@ type SharedSessionHeartbeatOutput struct {
 
 // ListSharedSessionSavesInput is the input for GET /api/shared-sessions/{id}/saves.
 type ListSharedSessionSavesInput struct {
-	ID string `path:"id" doc:"Shared session ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
 }
 
 // ListSharedSessionSavesOutput wraps the saves list.
@@ -175,8 +175,8 @@ type ListSharedSessionSavesOutput struct {
 
 // DeleteSharedSessionSaveInput is the input for DELETE /api/shared-sessions/{id}/saves/{saveId}.
 type DeleteSharedSessionSaveInput struct {
-	ID     string `path:"id" doc:"Shared session ID."`
-	SaveID string `path:"saveId" doc:"Save ID."`
+	ID     string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
+	SaveID string `path:"saveId" pattern:"^[0-9]+$" maxLength:"20" doc:"Save ID."`
 }
 
 // DeleteSharedSessionSaveOutput wraps the delete success message.
@@ -193,8 +193,8 @@ type RenameSharedSessionSaveRequest struct {
 
 // RenameSharedSessionSaveInput is the input for PUT /api/shared-sessions/{id}/saves/{saveId}/rename.
 type RenameSharedSessionSaveInput struct {
-	ID     string `path:"id" doc:"Shared session ID."`
-	SaveID string `path:"saveId" doc:"Save ID."`
+	ID     string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
+	SaveID string `path:"saveId" pattern:"^[0-9]+$" maxLength:"20" doc:"Save ID."`
 	Body   RenameSharedSessionSaveRequest
 }
 
@@ -226,7 +226,7 @@ type SharedSessionInviteCountOutput struct {
 
 // AcceptSharedSessionInviteInput is the input for POST /api/user/shared-session-invites/{id}/accept.
 type AcceptSharedSessionInviteInput struct {
-	ID string `path:"id" doc:"Invite ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Invite ID."`
 }
 
 // AcceptSharedSessionInviteOutput wraps the accept success message.
@@ -236,7 +236,7 @@ type AcceptSharedSessionInviteOutput struct {
 
 // DeclineSharedSessionInviteInput is the input for POST /api/user/shared-session-invites/{id}/decline.
 type DeclineSharedSessionInviteInput struct {
-	ID string `path:"id" doc:"Invite ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Invite ID."`
 }
 
 // DeclineSharedSessionInviteOutput wraps the decline success message.

--- a/server/internal/api/huma_shared.go
+++ b/server/internal/api/huma_shared.go
@@ -861,7 +861,14 @@ func (h *SharedSessionHandler) HumaInviteToSharedSession(ctx context.Context, in
 	h.DB.Preload("Inviter").Preload("Invitee").Preload("SharedSession").Preload("SharedSession.Game").First(&invite, invite.ID)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionInviteSent, Payload: h.toSharedSessionInviteResponse(invite)})
+		// Issue #1119: deliver only to inviter and invitee — invite
+		// state is private and was previously broadcast to every
+		// connected client.
+		h.Hub.Broadcast(ws.Event{
+			Type:             ws.EventSharedSessionInviteSent,
+			Payload:          h.toSharedSessionInviteResponse(invite),
+			RecipientUserIDs: []uint{invite.InviterID, invite.InviteeID},
+		})
 	}
 
 	return &InviteToSharedSessionOutput{Body: h.toSharedSessionInviteResponse(invite)}, nil
@@ -997,22 +1004,34 @@ func (h *SharedSessionHandler) HumaSharedSessionTakeTurn(ctx context.Context, in
 		return nil, huma.Error500InternalServerError("failed to acquire turn")
 	}
 
+	// Issue #1119: turn events are private to session members. Build the
+	// recipient list once for both the expired and acquired broadcasts.
+	memberIDs := h.sharedSessionMemberIDs(ss.ID)
+
 	if previousUserID != nil && h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionTurnExpired, Payload: ws.SharedSessionTurnExpiredPayload{
-			SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
-			PreviousUserID:  strconv.FormatUint(uint64(*previousUserID), 10),
-		}})
+		h.Hub.Broadcast(ws.Event{
+			Type: ws.EventSharedSessionTurnExpired,
+			Payload: ws.SharedSessionTurnExpiredPayload{
+				SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
+				PreviousUserID:  strconv.FormatUint(uint64(*previousUserID), 10),
+			},
+			RecipientUserIDs: memberIDs,
+		})
 	}
 
 	var user db.User
 	h.DB.First(&user, uid)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionTurnAcquired, Payload: ws.SharedSessionTurnAcquiredPayload{
-			SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
-			UserID:          strconv.FormatUint(uint64(uid), 10),
-			Username:        user.Username,
-		}})
+		h.Hub.Broadcast(ws.Event{
+			Type: ws.EventSharedSessionTurnAcquired,
+			Payload: ws.SharedSessionTurnAcquiredPayload{
+				SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
+				UserID:          strconv.FormatUint(uint64(uid), 10),
+				Username:        user.Username,
+			},
+			RecipientUserIDs: memberIDs,
+		})
 	}
 
 	return &SharedSessionTakeTurnOutput{Body: SharedSessionTakeTurnResponse{
@@ -1040,13 +1059,37 @@ func (h *SharedSessionHandler) HumaSharedSessionReleaseTurn(ctx context.Context,
 	})
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionTurnReleased, Payload: ws.SharedSessionTurnReleasedPayload{
-			SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
-			UserID:          strconv.FormatUint(uint64(uid), 10),
-		}})
+		// Issue #1119: scope to session members.
+		h.Hub.Broadcast(ws.Event{
+			Type: ws.EventSharedSessionTurnReleased,
+			Payload: ws.SharedSessionTurnReleasedPayload{
+				SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
+				UserID:          strconv.FormatUint(uint64(uid), 10),
+			},
+			RecipientUserIDs: h.sharedSessionMemberIDs(ss.ID),
+		})
 	}
 
 	return &SharedSessionReleaseTurnOutput{Body: MessageResponse{Message: "turn released"}}, nil
+}
+
+// sharedSessionMemberIDs returns the user IDs of all members of a shared
+// session. Used to scope private events (invites, turn changes) to the
+// recipients who are part of the session, rather than broadcasting to
+// every connected client (issue #1119).
+func (h *SharedSessionHandler) sharedSessionMemberIDs(sharedSessionID uint) []uint {
+	var rows []db.SharedSessionMember
+	if err := h.DB.Where("shared_session_id = ?", sharedSessionID).Find(&rows).Error; err != nil {
+		// Falling back to nil = unfiltered would re-introduce the
+		// information leak. Empty list = nobody, which is safer (the
+		// event still hits the hub but never delivers).
+		return []uint{}
+	}
+	ids := make([]uint, 0, len(rows))
+	for _, m := range rows {
+		ids = append(ids, m.UserID)
+	}
+	return ids
 }
 
 // HumaSharedSessionHeartbeat is the huma handler for POST /api/shared-sessions/{id}/heartbeat.

--- a/server/internal/api/huma_shared_from_session_test.go
+++ b/server/internal/api/huma_shared_from_session_test.go
@@ -129,7 +129,7 @@ func TestCreateSharedSession_FromSession_RejectsCrossUser(t *testing.T) {
 	// Two users.
 	tokenA := registerAndGetToken(t, router)
 	bodyB, _ := json.Marshal(map[string]string{
-		"username": "otheruser", "email": "other@example.com", "password": "password123",
+		"username": "otheruser", "email": "other@example.com", "password": "SecureTestPass!2024",
 	})
 	wB := httptest.NewRecorder()
 	reqB := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(bodyB))

--- a/server/internal/api/huma_shared_uploads.go
+++ b/server/internal/api/huma_shared_uploads.go
@@ -26,7 +26,7 @@ type SharedSaveUploadBody struct {
 
 // SharedSaveUploadInput is the input for POST /api/games/{id}/shared-saves.
 type SharedSaveUploadInput struct {
-	ID      string `path:"id" doc:"Game ID."`
+	ID      string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	RawBody huma.MultipartFormFiles[SharedSaveUploadBody]
 }
 
@@ -48,7 +48,7 @@ type SharedSessionUploadSaveBody struct {
 // SharedSessionUploadSaveInput wraps the path parameter and multipart body
 // plus the X-Turn-Token header that authorises the upload.
 type SharedSessionUploadSaveInput struct {
-	ID        string `path:"id" doc:"Shared session ID."`
+	ID        string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Shared session ID."`
 	TurnToken string `header:"X-Turn-Token" required:"false" doc:"Token proving the caller currently holds the turn (returned by joinSharedSession / takeTurn)."`
 	RawBody   huma.MultipartFormFiles[SharedSessionUploadSaveBody]
 }

--- a/server/internal/api/huma_social.go
+++ b/server/internal/api/huma_social.go
@@ -283,7 +283,7 @@ func (h *SocialHandler) HumaGetRecentPartners(ctx context.Context, _ *GetRecentP
 }
 
 // HumaGetPublicProfile is the huma handler for GET /api/users/{id}/profile.
-func (h *SocialHandler) HumaGetPublicProfile(_ context.Context, in *GetPublicProfileInput) (*GetPublicProfileOutput, error) {
+func (h *SocialHandler) HumaGetPublicProfile(ctx context.Context, in *GetPublicProfileInput) (*GetPublicProfileOutput, error) {
 	parsedID, err := strconv.ParseUint(in.ID, 10, 64)
 	if err != nil {
 		return nil, huma.Error400BadRequest("invalid user ID")
@@ -294,85 +294,98 @@ func (h *SocialHandler) HumaGetPublicProfile(_ context.Context, in *GetPublicPro
 	}
 
 	uid := user.ID
+	callerID := UserIDFromContext(ctx)
+
+	// Issue #1121: respect block relationships in BOTH directions and
+	// the target's profile_visibility setting. If either user has
+	// blocked the other, surface the same 404 we'd return for a
+	// nonexistent user — don't leak existence.
+	if callerID != 0 && callerID != uid && isBlockedEitherWay(h.DB, callerID, uid) {
+		return nil, huma.Error404NotFound("user not found")
+	}
+
+	// Treat anything other than "public" as private. The caller can
+	// still see their own profile in full.
+	visible := user.ProfileVisibility == "" || user.ProfileVisibility == "public" || callerID == uid
 
 	var agg struct {
 		TotalPlayTime int64
 		GamesPlayed   int64
 	}
-	h.DB.Model(&db.PlayHistory{}).
-		Where("user_id = ?", uid).
-		Select("COALESCE(SUM(play_time), 0) as total_play_time, COUNT(*) as games_played").
-		Scan(&agg)
-
-	var favorites []db.Favorite
-	h.DB.Where("user_id = ?", uid).
-		Preload("Game").Preload("Game.Console").
-		Limit(6).
-		Find(&favorites)
-
-	favGames := make([]PublicProfileGame, 0, len(favorites))
-	for _, f := range favorites {
-		if f.Game.ID == 0 {
-			continue
-		}
-		favGames = append(favGames, toPublicProfileGame(f.Game, 0))
-	}
-
-	var recentHistory []db.PlayHistory
-	h.DB.Where("user_id = ?", uid).
-		Preload("Game").Preload("Game.Console").
-		Order("last_played DESC").
-		Limit(6).
-		Find(&recentHistory)
-
-	recentGames := make([]PublicProfileGame, 0, len(recentHistory))
-	for _, ph := range recentHistory {
-		if ph.Game.ID == 0 {
-			continue
-		}
-		recentGames = append(recentGames, toPublicProfileGame(ph.Game, ph.PlayTime))
-	}
-
-	var topHistory []db.PlayHistory
-	h.DB.Where("user_id = ?", uid).
-		Preload("Game").Preload("Game.Console").
-		Order("play_time DESC").
-		Limit(6).
-		Find(&topHistory)
-
-	topGames := make([]PublicProfileGame, 0, len(topHistory))
-	for _, ph := range topHistory {
-		if ph.Game.ID == 0 {
-			continue
-		}
-		topGames = append(topGames, toPublicProfileGame(ph.Game, ph.PlayTime))
-	}
-
+	favGames := []PublicProfileGame{}
+	recentGames := []PublicProfileGame{}
+	topGames := []PublicProfileGame{}
 	isOnline := false
 	var currentGame *OnlineUserGameResponse
-	for _, oid := range h.Hub.GetOnlineUserIDs() {
-		if oid == uid {
-			isOnline = true
-			break
+
+	if visible {
+		h.DB.Model(&db.PlayHistory{}).
+			Where("user_id = ?", uid).
+			Select("COALESCE(SUM(play_time), 0) as total_play_time, COUNT(*) as games_played").
+			Scan(&agg)
+
+		var favorites []db.Favorite
+		h.DB.Where("user_id = ?", uid).
+			Preload("Game").Preload("Game.Console").
+			Limit(6).
+			Find(&favorites)
+		for _, f := range favorites {
+			if f.Game.ID == 0 {
+				continue
+			}
+			favGames = append(favGames, toPublicProfileGame(f.Game, 0))
 		}
-	}
-	if isOnline {
-		if gameID := h.Hub.GetUserGame(uid); gameID != 0 {
-			var game db.Game
-			if err := h.DB.Preload("Console").First(&game, gameID).Error; err == nil {
-				coverURL := game.CoverURL
-				if coverURL != "" && !strings.HasPrefix(coverURL, "http") {
-					coverURL = "/api/images/" + coverURL
-				}
-				consoleName := ""
-				if game.Console.ID != 0 {
-					consoleName = game.Console.Name
-				}
-				currentGame = &OnlineUserGameResponse{
-					ID:          strconv.FormatUint(uint64(game.ID), 10),
-					Title:       game.Title,
-					CoverURL:    coverURL,
-					ConsoleName: consoleName,
+
+		var recentHistory []db.PlayHistory
+		h.DB.Where("user_id = ?", uid).
+			Preload("Game").Preload("Game.Console").
+			Order("last_played DESC").
+			Limit(6).
+			Find(&recentHistory)
+		for _, ph := range recentHistory {
+			if ph.Game.ID == 0 {
+				continue
+			}
+			recentGames = append(recentGames, toPublicProfileGame(ph.Game, ph.PlayTime))
+		}
+
+		var topHistory []db.PlayHistory
+		h.DB.Where("user_id = ?", uid).
+			Preload("Game").Preload("Game.Console").
+			Order("play_time DESC").
+			Limit(6).
+			Find(&topHistory)
+		for _, ph := range topHistory {
+			if ph.Game.ID == 0 {
+				continue
+			}
+			topGames = append(topGames, toPublicProfileGame(ph.Game, ph.PlayTime))
+		}
+
+		for _, oid := range h.Hub.GetOnlineUserIDs() {
+			if oid == uid {
+				isOnline = true
+				break
+			}
+		}
+		if isOnline {
+			if gameID := h.Hub.GetUserGame(uid); gameID != 0 {
+				var game db.Game
+				if err := h.DB.Preload("Console").First(&game, gameID).Error; err == nil {
+					coverURL := game.CoverURL
+					if coverURL != "" && !strings.HasPrefix(coverURL, "http") {
+						coverURL = "/api/images/" + coverURL
+					}
+					consoleName := ""
+					if game.Console.ID != 0 {
+						consoleName = game.Console.Name
+					}
+					currentGame = &OnlineUserGameResponse{
+						ID:          strconv.FormatUint(uint64(game.ID), 10),
+						Title:       game.Title,
+						CoverURL:    coverURL,
+						ConsoleName: consoleName,
+					}
 				}
 			}
 		}
@@ -391,4 +404,15 @@ func (h *SocialHandler) HumaGetPublicProfile(_ context.Context, in *GetPublicPro
 		RecentGames:   recentGames,
 		TopGames:      topGames,
 	}}, nil
+}
+
+// isBlockedEitherWay returns true if a or b has blocked the other.
+// Issue #1121: lookups respect blocks symmetrically — a blocked user
+// shouldn't be able to scrape the blocker either.
+func isBlockedEitherWay(database *gorm.DB, a, b uint) bool {
+	var count int64
+	database.Model(&db.Block{}).
+		Where("(user_id = ? AND blocked_user_id = ?) OR (user_id = ? AND blocked_user_id = ?)", a, b, b, a).
+		Count(&count)
+	return count > 0
 }

--- a/server/internal/api/huma_social.go
+++ b/server/internal/api/huma_social.go
@@ -41,7 +41,7 @@ type GetRecentPartnersOutput struct {
 
 // GetPublicProfileInput is the input for GET /api/users/{id}/profile.
 type GetPublicProfileInput struct {
-	ID string `path:"id" doc:"User ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"User ID."`
 }
 
 // GetPublicProfileOutput wraps the public profile response.
@@ -284,8 +284,12 @@ func (h *SocialHandler) HumaGetRecentPartners(ctx context.Context, _ *GetRecentP
 
 // HumaGetPublicProfile is the huma handler for GET /api/users/{id}/profile.
 func (h *SocialHandler) HumaGetPublicProfile(_ context.Context, in *GetPublicProfileInput) (*GetPublicProfileOutput, error) {
+	parsedID, err := strconv.ParseUint(in.ID, 10, 64)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid user ID")
+	}
 	var user db.User
-	if err := h.DB.First(&user, in.ID).Error; err != nil {
+	if err := h.DB.First(&user, uint(parsedID)).Error; err != nil {
 		return nil, huma.Error404NotFound("user not found")
 	}
 

--- a/server/internal/api/huma_system_events.go
+++ b/server/internal/api/huma_system_events.go
@@ -32,7 +32,7 @@ type ListSystemEventsOutput struct {
 
 // GetSystemEventInput is the input for GET /api/admin/system-events/{id}.
 type GetSystemEventInput struct {
-	ID string `path:"id" doc:"System event ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"System event ID."`
 }
 
 // GetSystemEventOutput wraps a single system event response.
@@ -58,7 +58,7 @@ type GetSystemEventCategoriesOutput struct {
 
 // DismissSystemEventInput is the input for PUT /api/admin/system-events/{id}/dismiss.
 type DismissSystemEventInput struct {
-	ID string `path:"id" doc:"System event ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"System event ID."`
 }
 
 // DismissedResponse is the wire format for the dismiss endpoint.

--- a/server/internal/api/huma_uploads.go
+++ b/server/internal/api/huma_uploads.go
@@ -38,7 +38,7 @@ type ListUploadsOutput struct {
 
 // SetUploadConsoleInput is the input for POST /api/admin/uploads/{id}/console.
 type SetUploadConsoleInput struct {
-	ID   string `path:"id" doc:"Staged upload ID."`
+	ID   string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Staged upload ID."`
 	Body SetUploadConsoleRequest
 }
 
@@ -49,7 +49,7 @@ type SetUploadConsoleOutput struct {
 
 // ScrapeUploadInput is the input for POST /api/admin/uploads/{id}/scrape.
 type ScrapeUploadInput struct {
-	ID string `path:"id" doc:"Staged upload ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Staged upload ID."`
 }
 
 // ScrapeUploadOutput wraps the scraped upload response.
@@ -67,7 +67,7 @@ type ScrapeAllUploadsOutput struct {
 
 // AcceptUploadInput is the input for POST /api/admin/uploads/{id}/accept.
 type AcceptUploadInput struct {
-	ID string `path:"id" doc:"Staged upload ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Staged upload ID."`
 }
 
 // AcceptUploadOutput wraps the accepted game response.
@@ -77,7 +77,7 @@ type AcceptUploadOutput struct {
 
 // RejectUploadInput is the input for POST /api/admin/uploads/{id}/reject.
 type RejectUploadInput struct {
-	ID string `path:"id" doc:"Staged upload ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Staged upload ID."`
 }
 
 // RejectUploadOutput wraps the reject success message.

--- a/server/internal/api/huma_user_extra.go
+++ b/server/internal/api/huma_user_extra.go
@@ -24,7 +24,7 @@ type GetPlayHeatmapOutput struct {
 
 // GetPublicPlayHeatmapInput is the input for GET /api/users/{id}/play-heatmap.
 type GetPublicPlayHeatmapInput struct {
-	ID string `path:"id" doc:"User ID."`
+	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"User ID."`
 }
 
 // GetPublicPlayHeatmapOutput wraps the public heatmap list.
@@ -73,7 +73,7 @@ type ReportEmulatorErrorOutput struct {
 
 // GetGameKeyMappingInput is the input for GET /api/user/games/{gameId}/keymapping.
 type GetGameKeyMappingInput struct {
-	GameID string `path:"gameId" doc:"Game ID."`
+	GameID string `path:"gameId" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // GetGameKeyMappingOutput wraps the key-mapping response.
@@ -83,7 +83,7 @@ type GetGameKeyMappingOutput struct {
 
 // UpdateGameKeyMappingInput is the input for PUT /api/user/games/{gameId}/keymapping.
 type UpdateGameKeyMappingInput struct {
-	GameID string `path:"gameId" doc:"Game ID."`
+	GameID string `path:"gameId" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 	Body   UpdateGameKeyMappingRequest
 }
 
@@ -94,7 +94,7 @@ type UpdateGameKeyMappingOutput struct {
 
 // DeleteGameKeyMappingInput is the input for DELETE /api/user/games/{gameId}/keymapping.
 type DeleteGameKeyMappingInput struct {
-	GameID string `path:"gameId" doc:"Game ID."`
+	GameID string `path:"gameId" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
 }
 
 // DeleteGameKeyMappingOutput wraps the delete success message.

--- a/server/internal/api/huma_user_mutations.go
+++ b/server/internal/api/huma_user_mutations.go
@@ -132,6 +132,7 @@ func (h *UserHandler) HumaUpdateProfile(ctx context.Context, in *UpdateProfileIn
 
 	req := in.Body
 
+	emailChanged := false
 	if req.Email != "" {
 		if req.CurrentPassword == "" {
 			return nil, huma.Error400BadRequest("current password is required to change email")
@@ -146,6 +147,9 @@ func (h *UserHandler) HumaUpdateProfile(ctx context.Context, in *UpdateProfileIn
 			// registered by issuing PUT /api/user/profile against
 			// a long list of candidates.
 			return nil, huma.Error409Conflict("could not update profile")
+		}
+		if user.Email != req.Email {
+			emailChanged = true
 		}
 		user.Email = req.Email
 	}
@@ -163,8 +167,23 @@ func (h *UserHandler) HumaUpdateProfile(ctx context.Context, in *UpdateProfileIn
 		user.AvatarURL = req.AvatarURL
 	}
 
+	// Issue #1133: a successful email change is recovery-channel-class
+	// state — bump TokenVersion (invalidating other access tokens) and
+	// revoke all refresh tokens, mirroring HumaChangePassword. Without
+	// this, a thief who briefly held the password (now rotated by the
+	// real owner) could keep a stolen access token alive for its full
+	// TTL while pivoting recovery to their own email if email-based
+	// password reset ships later.
+	if emailChanged {
+		user.TokenVersion++
+	}
+
 	if err := h.DB.Save(&user).Error; err != nil {
 		return nil, huma.Error500InternalServerError("failed to update profile")
+	}
+
+	if emailChanged {
+		h.DB.Where("user_id = ?", user.ID).Delete(&db.RefreshToken{})
 	}
 
 	return &UpdateProfileOutput{Body: ToUserResponse(user)}, nil

--- a/server/internal/api/huma_user_mutations.go
+++ b/server/internal/api/huma_user_mutations.go
@@ -415,6 +415,11 @@ func (h *UserHandler) HumaChangePassword(ctx context.Context, in *ChangePassword
 		return nil, huma.Error401Unauthorized("incorrect current password")
 	}
 
+	// Issue #1131(A): refuse common passwords on change too.
+	if isCommonPassword(req.NewPassword) {
+		return nil, huma.Error400BadRequest("that password is on a known-common-password list; please choose something else")
+	}
+
 	hash, err := auth.HashPassword(req.NewPassword)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("failed to hash password")

--- a/server/internal/api/huma_user_mutations.go
+++ b/server/internal/api/huma_user_mutations.go
@@ -141,7 +141,11 @@ func (h *UserHandler) HumaUpdateProfile(ctx context.Context, in *UpdateProfileIn
 		}
 		var existing db.User
 		if err := h.DB.Where("email = ? AND id != ?", req.Email, user.ID).First(&existing).Error; err == nil {
-			return nil, huma.Error409Conflict("email already in use")
+			// Issue #1132: vague message so an authenticated
+			// attacker can't probe whether a specific email is
+			// registered by issuing PUT /api/user/profile against
+			// a long list of candidates.
+			return nil, huma.Error409Conflict("could not update profile")
 		}
 		user.Email = req.Email
 	}

--- a/server/internal/api/middleware.go
+++ b/server/internal/api/middleware.go
@@ -66,6 +66,44 @@ func checkStorageQuota(database *gorm.DB, userID uint, additionalBytes int64) er
 	return nil
 }
 
+// pathAllowsQueryToken reports whether a request path is allowed to fall
+// back to `?token=<jwt>` for authentication. Issue #1117: applying the
+// query-token fallback to every protected route leaks JWTs into reverse-
+// proxy logs, browser history, Referer headers, etc. The fallback is only
+// needed where browsers cannot set Authorization headers — WebSocket
+// upgrades and asset URLs loaded by <img>/<audio>/<video>.
+func pathAllowsQueryToken(path string) bool {
+	switch {
+	case path == "/api/ws":
+		return true
+	case strings.HasPrefix(path, "/api/netplay/sessions/") && strings.HasSuffix(path, "/ws"):
+		return true
+	case strings.HasPrefix(path, "/api/images/save-screenshots/"):
+		return true
+	case strings.HasPrefix(path, "/api/bios/"):
+		return true
+	case strings.HasPrefix(path, "/api/cores/") && strings.Contains(path, "/download"):
+		return true
+	case strings.HasPrefix(path, "/api/games/") && strings.Contains(path, "/download"):
+		return true
+	case strings.HasPrefix(path, "/api/games/") && strings.Contains(path, "/discs/") && strings.HasSuffix(path, "/download"):
+		return true
+	case strings.HasPrefix(path, "/api/games/") && strings.Contains(path, "/shared-saves/") && strings.HasSuffix(path, "/download"):
+		return true
+	case strings.HasPrefix(path, "/api/sessions/") && strings.Contains(path, "/saves"):
+		return true
+	case strings.HasPrefix(path, "/api/sessions/") && strings.HasSuffix(path, "/sram"):
+		return true
+	case strings.HasPrefix(path, "/api/sessions/") && strings.HasSuffix(path, "/save-dir"):
+		return true
+	case strings.HasPrefix(path, "/api/shared-sessions/") && strings.Contains(path, "/saves"):
+		return true
+	case strings.HasPrefix(path, "/api/challenges/") && (strings.HasSuffix(path, "/save/download") || strings.HasSuffix(path, "/screenshot")):
+		return true
+	}
+	return false
+}
+
 // AuthMiddleware validates JWT tokens on protected routes and rejects disabled users.
 func AuthMiddleware(jwtSecret string, database *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -78,10 +116,12 @@ func AuthMiddleware(jwtSecret string, database *gorm.DB) gin.HandlerFunc {
 			}
 		}
 
-		// Fall back to query parameter for WebSocket upgrades and file
-		// downloads (EmulatorJS, <img>/<audio>/<video> tags cannot set
-		// Authorization headers when loading resources by URL).
-		if token == "" {
+		// Fall back to query parameter only on routes where browsers
+		// genuinely can't set the Authorization header (WS upgrades,
+		// asset URLs loaded by <img>/<audio>/<video>, file downloads).
+		// Restricting the fallback prevents JWTs leaking into proxy
+		// access logs / Referer headers from JSON endpoints (#1117).
+		if token == "" && pathAllowsQueryToken(c.Request.URL.Path) {
 			token = c.Query("token")
 		}
 

--- a/server/internal/api/netplay_test.go
+++ b/server/internal/api/netplay_test.go
@@ -17,7 +17,7 @@ import (
 // ownerToken must be a valid admin/owner token.
 func registerUserAndGetToken(t *testing.T, router http.Handler, ownerToken, username, email string) string {
 	t.Helper()
-	return createNonOwnerUser(t, router, ownerToken, username, email, "password123")
+	return createNonOwnerUser(t, router, ownerToken, username, email, "SecureTestPass!2024")
 }
 
 // netplayTestCtx holds shared state for netplay tests.

--- a/server/internal/api/password_policy.go
+++ b/server/internal/api/password_policy.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"strings"
+)
+
+// commonPasswords is a static, offline blocklist of the most common /
+// most-leaked passwords. Issue #1131(A): registration and password change
+// previously enforced only minLength:8 maxLength:72; combined with the
+// username enumeration in #1132, an attacker who identified a valid
+// username could password-spray "Password1" / "qwerty12" / "summer2025"
+// against many accounts without ever tripping the per-account lockout.
+//
+// The list is intentionally small and offline — no network call to a
+// breach API. It catches the password-spray hit-list without imposing
+// HIBP latency or making a DNS lookup that could leak password hashes.
+// Operators wanting stricter enforcement can layer a HIBP k-anonymity
+// integration on top.
+var commonPasswords = func() map[string]struct{} {
+	list := []string{
+		"password", "password1", "password12", "password123",
+		"qwerty", "qwerty1", "qwerty12", "qwerty123",
+		"123456", "1234567", "12345678", "123456789", "1234567890",
+		"letmein", "welcome", "welcome1", "admin", "admin123", "administrator",
+		"changeme", "change-me", "default", "iloveyou", "monkey",
+		"dragon", "master", "abc12345", "abcdef", "abc123",
+		"football", "baseball", "trustno1", "sunshine", "princess",
+		"superman", "batman", "michael", "jennifer", "michelle",
+		"summer2024", "summer2025", "spring2024", "winter2024", "autumn2024",
+		"passw0rd", "p@ssword", "p@ssw0rd",
+		"00000000", "11111111", "22222222", "88888888", "99999999",
+		"qwertyuiop", "asdfghjkl", "zxcvbnm", "qazwsx", "qwer1234",
+	}
+	out := make(map[string]struct{}, len(list))
+	for _, p := range list {
+		out[strings.ToLower(p)] = struct{}{}
+	}
+	return out
+}()
+
+// isCommonPassword reports whether a password is on the static
+// common-password blocklist (case-insensitive). Length and other
+// schema-level rules are enforced elsewhere — this catches passwords
+// that pass the length check but are still trivial to spray.
+func isCommonPassword(password string) bool {
+	_, ok := commonPasswords[strings.ToLower(password)]
+	return ok
+}

--- a/server/internal/api/path_param_pattern_test.go
+++ b/server/internal/api/path_param_pattern_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestAllPathParamsHavePattern is a structural lint that prevents new handlers
+// from regressing on issue #1127 (project-wide numeric path-param IDs accepted
+// as strings without pattern validation, which gave rise to the SQLi class
+// in #1115).
+//
+// Every `path:"<name>"` struct tag in this package must also carry a
+// `pattern:` constraint so huma rejects malformed input at the API edge
+// before it can reach a GORM expression-fallback path or any other parser.
+func TestAllPathParamsHavePattern(t *testing.T) {
+	pathTagRE := regexp.MustCompile(`path:"[^"]+"`)
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+
+	var offenders []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		body, err := os.ReadFile(filepath.Join(".", name))
+		if err != nil {
+			t.Fatalf("ReadFile %s: %v", name, err)
+		}
+
+		for i, line := range strings.Split(string(body), "\n") {
+			if !pathTagRE.MatchString(line) {
+				continue
+			}
+			if strings.Contains(line, "pattern:") {
+				continue
+			}
+			offenders = append(offenders, fmt.Sprintf("%s:%d: %s", name, i+1, strings.TrimSpace(line)))
+		}
+	}
+
+	if len(offenders) > 0 {
+		t.Fatalf("path-param tags without `pattern:` constraint (issue #1127):\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/server/internal/api/play_later_handler_test.go
+++ b/server/internal/api/play_later_handler_test.go
@@ -518,7 +518,7 @@ func TestPlayLater_PerUserIsolation(t *testing.T) {
 	token1 := registerAndGetToken(t, router)
 
 	// Register second user
-	token2 := createNonOwnerUser(t, router, token1, "otheruser", "other@example.com", "password123")
+	token2 := createNonOwnerUser(t, router, token1, "otheruser", "other@example.com", "SecureTestPass!2024")
 
 	var console db.Console
 	database.First(&console)

--- a/server/internal/api/query_token_fallback_test.go
+++ b/server/internal/api/query_token_fallback_test.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestQueryTokenFallback_DeniedOnJSONRoutes verifies that issue #1117 is
+// fixed: the `?token=<jwt>` fallback no longer applies to JSON-API routes
+// (only to file-download / WS / asset routes where browsers genuinely can
+// not set Authorization headers). Authentication via query string on any
+// JSON endpoint must return 401 even when the token is otherwise valid.
+func TestQueryTokenFallback_DeniedOnJSONRoutes(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	token := registerAndGetToken(t, router)
+
+	// JSON endpoints that previously honored ?token= and must not now.
+	jsonPaths := []string{
+		"/api/user/profile",
+		"/api/user/preferences",
+		"/api/social/activity",
+		"/api/admin/users",
+	}
+
+	for _, p := range jsonPaths {
+		t.Run("denies "+p, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, p+"?token="+token, nil)
+			router.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusUnauthorized, w.Code,
+				"%s with ?token= should be 401 (query fallback restricted), got %d body=%s",
+				p, w.Code, w.Body.String())
+		})
+	}
+
+	// Header still works on those same endpoints.
+	t.Run("header path still works", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/user/profile", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	})
+}
+
+// TestQueryTokenFallback_AllowedOnDownloadRoutes verifies the fallback
+// still works on the small allowlist of routes that legitimately need it
+// (here: BIOS asset routes; they may 404/403 depending on test fixture
+// state, but they must NOT be 401 — meaning auth via query did succeed).
+func TestQueryTokenFallback_AllowedOnDownloadRoutes(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	token := registerAndGetToken(t, router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/bios/nonexistent.bin?token="+token, nil)
+	router.ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusUnauthorized, w.Code,
+		"BIOS download via ?token= should still authenticate (got 401, body=%s)", w.Body.String())
+}

--- a/server/internal/api/requests.go
+++ b/server/internal/api/requests.go
@@ -69,7 +69,7 @@ type UpdateGameKeyMappingRequest struct {
 // and reserved-name allocation. Length and password strength still apply.
 type AdminCreateUserRequest struct {
 	Username string      `json:"username" minLength:"3" maxLength:"64" doc:"New account username (3-64 characters)."`
-	Email    string      `json:"email" minLength:"1" maxLength:"254" doc:"New account email (RFC 5321 cap)."`
+	Email    string      `json:"email" format:"email" minLength:"1" maxLength:"254" doc:"New account email (RFC 5321 cap)."`
 	Password string      `json:"password" minLength:"8" maxLength:"72" doc:"New account password (8-72 characters)."`
 	Role     db.UserRole `json:"role,omitempty"`
 }
@@ -77,7 +77,7 @@ type AdminCreateUserRequest struct {
 // AdminUpdateUserRequest is the body for PUT /api/admin/users/:id.
 type AdminUpdateUserRequest struct {
 	Role            db.UserRole `json:"role,omitempty"`
-	Email           string      `json:"email,omitempty" maxLength:"254"`
+	Email           string      `json:"email,omitempty" format:"email" maxLength:"254"`
 	Password        string      `json:"password,omitempty" maxLength:"72"`
 	Disabled        *bool       `json:"disabled,omitempty"`
 	PendingApproval *bool       `json:"pendingApproval,omitempty"`

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -450,6 +450,15 @@ func serveFrontend(frontendDir string) gin.HandlerFunc {
 	fs := http.Dir(frontendDir)
 	fileServer := http.FileServer(fs)
 
+	// Issue #1118: lock the SPA file server to a containment-checked
+	// resolution of frontendDir. filepath.Clean does not strip `..` from a
+	// relative path, and the previous code stat'd one path while
+	// http.FileServer resolved a different one — Gin's URL normalisation
+	// happened to keep them in sync, but a routing or middleware change
+	// could break the only barrier. Resolve once, prefix-check, refuse if
+	// it escapes.
+	absRoot, _ := filepath.Abs(frontendDir)
+
 	return func(c *gin.Context) {
 		reqPath := c.Request.URL.Path
 
@@ -461,6 +470,13 @@ func serveFrontend(frontendDir string) gin.HandlerFunc {
 
 		// Try to serve the file directly
 		filePath := filepath.Join(frontendDir, filepath.Clean(reqPath))
+		absPath, absErr := filepath.Abs(filePath)
+		if absErr != nil || (absPath != absRoot && !strings.HasPrefix(absPath, absRoot+string(filepath.Separator))) {
+			// Resolved path escaped frontendDir — refuse outright,
+			// don't fall through to SPA index.
+			c.Status(http.StatusNotFound)
+			return
+		}
 		if info, err := os.Stat(filePath); err == nil && !info.IsDir() {
 			// Hashed assets get immutable cache headers
 			if strings.HasPrefix(reqPath, "/assets/") {

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -263,6 +263,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterUploadAdminRoutes(humaAPI, uploadHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterAdminMultipartRoutes(humaAPI, biosHandler, gameHandler, romHackHandler, uploadHandler, cfg.JWTSecret, cfg.DB, userLimiter, uploadLimiter)
 	RegisterSocialExtraRoutes(humaAPI, socialHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterBlockRoutes(humaAPI, socialHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterProfileRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreFeaturedRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreForYouRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)

--- a/server/internal/api/saved_search_handler_test.go
+++ b/server/internal/api/saved_search_handler_test.go
@@ -169,7 +169,7 @@ func TestDeleteSavedSearch_NotOwned(t *testing.T) {
 	searchID := resp["id"].(string)
 
 	// Create a second user
-	token2 := createNonOwnerUser(t, router, token, "user2", "user2@example.com", "password123")
+	token2 := createNonOwnerUser(t, router, token, "user2", "user2@example.com", "SecureTestPass!2024")
 	_ = database // suppress unused
 
 	// Try to delete user1's search as user2

--- a/server/internal/api/search_handler_test.go
+++ b/server/internal/api/search_handler_test.go
@@ -264,7 +264,7 @@ func TestSearch_Collections_PublicAndOwnPrivate(t *testing.T) {
 	require.NoError(t, database.First(&owner).Error)
 
 	// Create a second user
-	token2 := createNonOwnerUser(t, router, token, "user2", "user2@test.com", "password123")
+	token2 := createNonOwnerUser(t, router, token, "user2", "user2@test.com", "SecureTestPass!2024")
 	var user2 db.User
 	require.NoError(t, database.Where("username = ?", "user2").First(&user2).Error)
 

--- a/server/internal/api/serve_frontend_test.go
+++ b/server/internal/api/serve_frontend_test.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServeFrontend_RejectsTraversal verifies issue #1118: the SPA
+// fallback file server containment-checks resolved paths against
+// frontendDir and refuses anything that escapes, even if the request
+// path normalised through filepath.Clean wouldn't strip the traversal
+// (relative `..` segments are preserved by Clean).
+func TestServeFrontend_RejectsTraversal(t *testing.T) {
+	tmp := t.TempDir()
+	frontend := filepath.Join(tmp, "dist")
+	require.NoError(t, os.MkdirAll(frontend, 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(frontend, "index.html"), []byte("<html/>"), 0o644))
+
+	// Plant a "secret" outside the dist root.
+	secret := filepath.Join(tmp, "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("PWNED"), 0o644))
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.NoRoute(serveFrontend(frontend))
+
+	cases := []string{
+		"/../secret.txt",
+		"/../../secret.txt",
+		"/foo/../../secret.txt",
+	}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, p, nil)
+			r.ServeHTTP(w, req)
+
+			body := w.Body.String()
+			assert.NotContains(t, body, "PWNED",
+				"path %s leaked secret content; status=%d body=%s", p, w.Code, body)
+		})
+	}
+
+	t.Run("legitimate file still served", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(filepath.Join(frontend, "robots.txt"), []byte("User-agent: *\n"), 0o644))
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/robots.txt", nil)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "User-agent")
+	})
+}

--- a/server/internal/api/session_clone_test.go
+++ b/server/internal/api/session_clone_test.go
@@ -167,7 +167,7 @@ func TestCloneSession_SharedSessionMemberAllowed(t *testing.T) {
 	defer cleanup()
 
 	token1 := registerAndGetToken(t, router)
-	token2 := createNonOwnerUser(t, router, token1, "cloner", "cloner@example.com", "password123")
+	token2 := createNonOwnerUser(t, router, token1, "cloner", "cloner@example.com", "SecureTestPass!2024")
 
 	var console db.Console
 	database.First(&console)

--- a/server/internal/api/session_handler_test.go
+++ b/server/internal/api/session_handler_test.go
@@ -746,7 +746,13 @@ func TestSessionSlotSave_InvalidSlot(t *testing.T) {
 			req.Header.Set("Authorization", "Bearer "+env.token)
 			req.Header.Set("Content-Type", writer.FormDataContentType())
 			env.router.ServeHTTP(w, req)
-			assert.Equal(t, http.StatusBadRequest, w.Code)
+			// Pattern validation rejects non-digit slots ("-1", "abc") at
+			// the API edge with 422; out-of-range numeric slots ("0",
+			// "11") still parse and the handler returns 400. Either is
+			// acceptable so long as the upload is rejected.
+			assert.True(t,
+				w.Code == http.StatusBadRequest || w.Code == http.StatusUnprocessableEntity,
+				"slot %q: expected 400 or 422, got %d", tc.slot, w.Code)
 		})
 	}
 }
@@ -1166,7 +1172,8 @@ func TestCreateFromSharedSave_InvalidGameID(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/games/abc/sessions/from-shared-save/1", nil)
 	req.Header.Set("Authorization", "Bearer "+env.token)
 	env.router.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.True(t, w.Code == http.StatusBadRequest || w.Code == http.StatusUnprocessableEntity,
+		"expected 400 or 422, got %d", w.Code)
 }
 
 func TestCreateFromSharedSave_InvalidSaveID(t *testing.T) {
@@ -1176,7 +1183,8 @@ func TestCreateFromSharedSave_InvalidSaveID(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/games/"+env.gameID+"/sessions/from-shared-save/abc", nil)
 	req.Header.Set("Authorization", "Bearer "+env.token)
 	env.router.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.True(t, w.Code == http.StatusBadRequest || w.Code == http.StatusUnprocessableEntity,
+		"expected 400 or 422, got %d", w.Code)
 }
 
 func TestCreateFromSharedSave_GameNotFound(t *testing.T) {

--- a/server/internal/api/session_handler_test.go
+++ b/server/internal/api/session_handler_test.go
@@ -37,7 +37,7 @@ func setupSessionTestEnv(t *testing.T) *sessionTestEnv {
 	token := registerAndGetToken(t, router)
 
 	// Register second user
-	token2 := createNonOwnerUser(t, router, token, "user2", "user2@example.com", "password123")
+	token2 := createNonOwnerUser(t, router, token, "user2", "user2@example.com", "SecureTestPass!2024")
 
 	// Create a test game
 	var console db.Console
@@ -1462,7 +1462,7 @@ func TestDuplicateSession_SharedSessionMember(t *testing.T) {
 	defer cleanup()
 
 	token1 := registerAndGetToken(t, router)
-	token2 := createNonOwnerUser(t, router, token1, "user2", "user2@example.com", "password123")
+	token2 := createNonOwnerUser(t, router, token1, "user2", "user2@example.com", "SecureTestPass!2024")
 
 	var console db.Console
 	database.First(&console)

--- a/server/internal/api/shared_session_handler_test.go
+++ b/server/internal/api/shared_session_handler_test.go
@@ -20,13 +20,13 @@ import (
 // registerSecondUser registers a second user and returns their access token.
 func registerSecondUser(t *testing.T, router http.Handler, ownerToken string) string {
 	t.Helper()
-	return createNonOwnerUser(t, router, ownerToken, "player2", "player2@example.com", "password123")
+	return createNonOwnerUser(t, router, ownerToken, "player2", "player2@example.com", "SecureTestPass!2024")
 }
 
 // registerNamedUser registers a user with the given username and returns their access token.
 func registerNamedUser(t *testing.T, router http.Handler, ownerToken, username string) string {
 	t.Helper()
-	return createNonOwnerUser(t, router, ownerToken, username, username+"@example.com", "password123")
+	return createNonOwnerUser(t, router, ownerToken, username, username+"@example.com", "SecureTestPass!2024")
 }
 
 // createSharedSession creates a shared session via API and returns the response map.

--- a/server/internal/api/social_search_test.go
+++ b/server/internal/api/social_search_test.go
@@ -22,8 +22,8 @@ func TestSearchUsers_EmptyQuery_ReturnsAllUsers(t *testing.T) {
 	ownerToken := registerAndGetToken(t, router) // creates "apitest" user
 
 	// Create additional users
-	createNonOwnerUser(t, router, ownerToken, "alice", "alice@test.com", "password123")
-	createNonOwnerUser(t, router, ownerToken, "bob", "bob@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "alice", "alice@test.com", "SecureTestPass!2024")
+	createNonOwnerUser(t, router, ownerToken, "bob", "bob@test.com", "SecureTestPass!2024")
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/users/search", nil)
@@ -67,9 +67,9 @@ func TestSearchUsers_WithQuery_MatchesByPrefix(t *testing.T) {
 	defer cleanup()
 	ownerToken := registerAndGetToken(t, router)
 
-	createNonOwnerUser(t, router, ownerToken, "alice", "alice@test.com", "password123")
-	createNonOwnerUser(t, router, ownerToken, "bob", "bob@test.com", "password123")
-	createNonOwnerUser(t, router, ownerToken, "alex", "alex@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "alice", "alice@test.com", "SecureTestPass!2024")
+	createNonOwnerUser(t, router, ownerToken, "bob", "bob@test.com", "SecureTestPass!2024")
+	createNonOwnerUser(t, router, ownerToken, "alex", "alex@test.com", "SecureTestPass!2024")
 
 	// Search with single character
 	w := httptest.NewRecorder()
@@ -106,7 +106,7 @@ func TestSearchUsers_Pagination(t *testing.T) {
 		createNonOwnerUser(t, router, ownerToken,
 			fmt.Sprintf("user%02d", i),
 			fmt.Sprintf("user%02d@test.com", i),
-			"password123",
+			"SecureTestPass!2024",
 		)
 	}
 
@@ -232,8 +232,8 @@ func TestRecentPartners_NetplayPartners(t *testing.T) {
 	ownerToken := registerAndGetToken(t, router)
 
 	// Create users
-	createNonOwnerUser(t, router, ownerToken, "alice", "alice@test.com", "password123")
-	createNonOwnerUser(t, router, ownerToken, "bob", "bob@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "alice", "alice@test.com", "SecureTestPass!2024")
+	createNonOwnerUser(t, router, ownerToken, "bob", "bob@test.com", "SecureTestPass!2024")
 
 	var owner, alice, bob db.User
 	database.Where("username = ?", "apitest").First(&owner)
@@ -293,7 +293,7 @@ func TestRecentPartners_SharedSessionPartners(t *testing.T) {
 	defer cleanup()
 	ownerToken := registerAndGetToken(t, router)
 
-	createNonOwnerUser(t, router, ownerToken, "carol", "carol@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "carol", "carol@test.com", "SecureTestPass!2024")
 
 	var owner, carol db.User
 	database.Where("username = ?", "apitest").First(&owner)
@@ -345,7 +345,7 @@ func TestRecentPartners_ExcludesDisabledUsers(t *testing.T) {
 	defer cleanup()
 	ownerToken := registerAndGetToken(t, router)
 
-	createNonOwnerUser(t, router, ownerToken, "disabled_user", "disabled@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "disabled_user", "disabled@test.com", "SecureTestPass!2024")
 
 	var owner, disabled db.User
 	database.Where("username = ?", "apitest").First(&owner)
@@ -387,7 +387,7 @@ func TestRecentPartners_ExcludesOldSessions(t *testing.T) {
 	defer cleanup()
 	ownerToken := registerAndGetToken(t, router)
 
-	createNonOwnerUser(t, router, ownerToken, "old_partner", "old@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "old_partner", "old@test.com", "SecureTestPass!2024")
 
 	var owner, oldPartner db.User
 	database.Where("username = ?", "apitest").First(&owner)
@@ -431,8 +431,8 @@ func TestRecentPartners_SortedByMostRecent(t *testing.T) {
 	defer cleanup()
 	ownerToken := registerAndGetToken(t, router)
 
-	createNonOwnerUser(t, router, ownerToken, "first", "first@test.com", "password123")
-	createNonOwnerUser(t, router, ownerToken, "second", "second@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "first", "first@test.com", "SecureTestPass!2024")
+	createNonOwnerUser(t, router, ownerToken, "second", "second@test.com", "SecureTestPass!2024")
 
 	var owner, first, second db.User
 	database.Where("username = ?", "apitest").First(&owner)
@@ -541,7 +541,7 @@ func TestRecentPartners_MaxTenResults(t *testing.T) {
 	// Create 12 partners via netplay
 	for i := 0; i < 12; i++ {
 		username := fmt.Sprintf("partner%02d", i)
-		createNonOwnerUser(t, router, ownerToken, username, fmt.Sprintf("%s@test.com", username), "password123")
+		createNonOwnerUser(t, router, ownerToken, username, fmt.Sprintf("%s@test.com", username), "SecureTestPass!2024")
 
 		var partner db.User
 		database.Where("username = ?", username).First(&partner)
@@ -575,8 +575,8 @@ func TestRecentPartners_CombinesNetplayAndSharedSessions(t *testing.T) {
 	defer cleanup()
 	ownerToken := registerAndGetToken(t, router)
 
-	createNonOwnerUser(t, router, ownerToken, "netplay_friend", "nf@test.com", "password123")
-	createNonOwnerUser(t, router, ownerToken, "shared_friend", "sf@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "netplay_friend", "nf@test.com", "SecureTestPass!2024")
+	createNonOwnerUser(t, router, ownerToken, "shared_friend", "sf@test.com", "SecureTestPass!2024")
 
 	var owner, netplayFriend, sharedFriend db.User
 	database.Where("username = ?", "apitest").First(&owner)

--- a/server/internal/api/sqli_path_param_test.go
+++ b/server/internal/api/sqli_path_param_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPathParamRejectsSQLInjection verifies that user-reachable handlers which
+// previously passed `path:"id"` strings directly to GORM's First() — and
+// therefore inherited GORM's expression-fallback for non-numeric strings
+// (CVE-class SQLi, issue #1115) — now reject any non-numeric ID at the API
+// edge with 4xx, never reaching the DB layer.
+func TestPathParamRejectsSQLInjection(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	token := registerAndGetToken(t, router)
+
+	// Each of these paths used to allow GORM's string-WHERE expression branch.
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"public profile", "/api/users/" + url.PathEscape("1 OR 1=1") + "/profile"},
+		{"add favorite", "/api/user/favorites/" + url.PathEscape("1 OR 1=1")},
+		{"remove favorite", "/api/user/favorites/" + url.PathEscape("1 OR 1=1")},
+		{"series detail", "/api/series/" + url.PathEscape("1 OR 1=1")},
+		{"franchise detail", "/api/franchises/" + url.PathEscape("1 OR 1=1")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			method := http.MethodGet
+			if tc.name == "add favorite" {
+				method = http.MethodPost
+			} else if tc.name == "remove favorite" {
+				method = http.MethodDelete
+			}
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(method, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			router.ServeHTTP(w, req)
+			// Pattern validation in huma rejects with 422 (Unprocessable
+			// Entity); some routes may also surface 400 if the handler
+			// itself parses. Either way, never 200.
+			assert.True(t,
+				w.Code == http.StatusBadRequest ||
+					w.Code == http.StatusUnprocessableEntity,
+				"%s: expected 400/422, got %d body=%s",
+				tc.name, w.Code, w.Body.String())
+		})
+	}
+}

--- a/server/internal/auth/auth_test.go
+++ b/server/internal/auth/auth_test.go
@@ -38,14 +38,14 @@ func TestHashPasswordUsesBcryptCost(t *testing.T) {
 }
 
 func TestHashPassword(t *testing.T) {
-	hash, err := HashPassword("testpassword123")
+	hash, err := HashPassword("testSecureTestPass!2024")
 	require.NoError(t, err)
 	assert.NotEmpty(t, hash)
-	assert.NotEqual(t, "testpassword123", hash)
+	assert.NotEqual(t, "testSecureTestPass!2024", hash)
 }
 
 func TestCheckPassword(t *testing.T) {
-	hash, err := HashPassword("testpassword123")
+	hash, err := HashPassword("testSecureTestPass!2024")
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -53,7 +53,7 @@ func TestCheckPassword(t *testing.T) {
 		password string
 		want     bool
 	}{
-		{"correct password", "testpassword123", true},
+		{"correct password", "testSecureTestPass!2024", true},
 		{"wrong password", "wrongpassword", false},
 		{"empty password", "", false},
 	}

--- a/server/internal/bios/downloader.go
+++ b/server/internal/bios/downloader.go
@@ -79,6 +79,13 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 		// Re-download if the file is suspiciously small (< 1KB, likely a
 		// placeholder from a failed earlier download) or if it fails MD5
 		// validation when a checksum is available.
+		//
+		// Bundle entries: the sentinel file on disk is just one member
+		// of the extracted archive, not the archive itself. The MD5
+		// stored in the registry is the archive's hash, so we can't
+		// validate the sentinel directly. Fall back to size-only check
+		// for bundles; the archive MD5 still gates the actual download
+		// path further down.
 		destPath := entry.FilePath(biosDir)
 		if info, err := os.Stat(destPath); err == nil {
 			needsRedownload := false
@@ -86,7 +93,7 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 				slog.Warn("BIOS file too small, re-downloading",
 					"file", entry.FileName, "size", info.Size())
 				needsRedownload = true
-			} else if entry.MD5 != "" {
+			} else if entry.MD5 != "" && !entry.Bundle {
 				if f, err := os.Open(destPath); err == nil {
 					h := md5.New()
 					io.Copy(h, f)
@@ -109,6 +116,30 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 				}
 				continue
 			}
+		}
+
+		// Issue #1124(B): refuse to fetch entries lacking a registry
+		// checksum. The downloader pulls from a third-party GitHub
+		// account (Abdess/retrobios); without an MD5 we have no way
+		// to detect a malicious commit or cache poisoning, and the
+		// bytes are passed verbatim to the emulated CPU by libretro
+		// cores. Files already on disk are still served (operator
+		// uploaded them manually) — this only blocks the network
+		// fetch path.
+		if entry.MD5 == "" {
+			progress.Status = "failed"
+			progress.Error = "registry entry has no MD5 checksum; refusing untrusted auto-download (issue #1124)"
+			result.Failed++
+			result.Errors = append(result.Errors, DownloadError{
+				FileName:  entry.FileName,
+				ConsoleID: entry.ConsoleID,
+				URL:       "",
+				Error:     progress.Error,
+			})
+			if onProgress != nil {
+				onProgress(progress)
+			}
+			continue
 		}
 
 		// Use OverrideURL if set, otherwise build from repo base URL
@@ -324,13 +355,22 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 
 // StartAutoDownload checks the bios_auto_download setting and, if enabled,
 // spawns a goroutine that downloads missing BIOS files at startup.
+//
+// Issue #1124: defaults to OFF. Auto-download trusts a third-party GitHub
+// account (Abdess/retrobios) and BIOS bytes are passed verbatim to the
+// emulated CPU by libretro cores; admins should opt in explicitly after
+// reviewing the trust model in SECURITY.md.
 func StartAutoDownload(biosDir string, database *gorm.DB) {
-	// Read the setting; default to "true" if not set
+	// Read the setting; default to OFF unless an admin has explicitly
+	// enabled auto-download. Pre-existing deployments that relied on
+	// the old default-on behaviour will not silently start fetching
+	// after this change — they need to flip the toggle in admin
+	// settings.
 	var setting db.ServerSetting
-	enabled := true
+	enabled := false
 	if err := database.Where("key = ?", "bios_auto_download").First(&setting).Error; err == nil {
-		if setting.Value == "false" {
-			enabled = false
+		if setting.Value == "true" {
+			enabled = true
 		}
 	}
 

--- a/server/internal/bios/downloader_test.go
+++ b/server/internal/bios/downloader_test.go
@@ -152,12 +152,16 @@ func TestDownloadMissing_ServerError(t *testing.T) {
 	assert.Equal(t, "missing_remote.bin: HTTP 404", result.Errors[0].String())
 }
 
-func TestDownloadMissing_EmptyMD5Accepted(t *testing.T) {
+// TestDownloadMissing_EmptyMD5Rejected verifies issue #1124(B): the
+// auto-downloader refuses entries that lack a registry checksum.
+// Previously empty-MD5 entries were silently trusted, which let a
+// compromised third-party repo (Abdess/retrobios) ship arbitrary BIOS
+// bytes to every Spela instance.
+func TestDownloadMissing_EmptyMD5Rejected(t *testing.T) {
 	biosDir := t.TempDir()
-	fileContent := []byte("sega cd bios")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(fileContent)
+		t.Errorf("network should not be reached for empty-MD5 entry")
 	}))
 	defer server.Close()
 
@@ -170,13 +174,12 @@ func TestDownloadMissing_EmptyMD5Accepted(t *testing.T) {
 
 	result := DownloadMissing(biosDir, server.URL, nil)
 
-	assert.Equal(t, 1, result.Downloaded)
-	assert.Equal(t, 0, result.Failed)
+	assert.Equal(t, 0, result.Downloaded)
+	assert.Equal(t, 1, result.Failed)
 
-	// File should exist
-	data, err := os.ReadFile(filepath.Join(biosDir, "bios_CD_U.bin"))
-	require.NoError(t, err)
-	assert.Equal(t, fileContent, data)
+	// File should NOT exist on disk.
+	_, err := os.Stat(filepath.Join(biosDir, "bios_CD_U.bin"))
+	assert.True(t, os.IsNotExist(err), "rejected entry must not be written to disk")
 }
 
 func TestDownloadMissing_OverrideURL(t *testing.T) {
@@ -199,7 +202,7 @@ func TestDownloadMissing_OverrideURL(t *testing.T) {
 	origRegistry := make([]Entry, len(registry))
 	copy(origRegistry, registry)
 	registry = []Entry{
-		{ConsoleID: "neogeo", FileName: "neogeo.zip", Description: "Neo Geo BIOS", MD5: "", Required: true, OverrideURL: overrideServer.URL + "/neogeo.zip"},
+		{ConsoleID: "neogeo", FileName: "neogeo.zip", Description: "Neo Geo BIOS", MD5: md5hex(fileContent), Required: true, OverrideURL: overrideServer.URL + "/neogeo.zip"},
 	}
 	defer func() { registry = origRegistry }()
 
@@ -218,14 +221,14 @@ func TestDownloadMissing_NilProgressCallback(t *testing.T) {
 
 	origRegistry := make([]Entry, len(registry))
 	copy(origRegistry, registry)
-	registry = []Entry{
-		{ConsoleID: "psx", FileName: "skip_me.bin", Description: "Skip", MD5: "", Required: false},
-	}
-	defer func() { registry = origRegistry }()
-
 	// Pre-create with enough data to pass minimum size check
 	skipContent := make([]byte, 2048)
 	os.WriteFile(filepath.Join(biosDir, "skip_me.bin"), skipContent, 0644)
+
+	registry = []Entry{
+		{ConsoleID: "psx", FileName: "skip_me.bin", Description: "Skip", MD5: md5hex(skipContent), Required: false},
+	}
+	defer func() { registry = origRegistry }()
 
 	// Should not panic with nil callback
 	result := DownloadMissing(biosDir, "http://unused", nil)
@@ -273,6 +276,7 @@ func TestDownloadMissing_BundleExtracts(t *testing.T) {
 			ConsoleID:   "psp",
 			FileName:    "flash0/font/jpn0.pgf",
 			Description: "PPSSPP system bundle (test)",
+			MD5:         md5hex(zipBytes),
 			Required:    true,
 			OverrideURL: server.URL,
 			SubDir:      "PPSSPP",
@@ -368,6 +372,7 @@ func TestDownloadMissing_BundleStripsArchivePrefix(t *testing.T) {
 			ConsoleID:   "psp",
 			FileName:    "ppge_atlas.zim",
 			Description: "PPSSPP bundle (StripPrefix)",
+			MD5:         md5hex(zipBytes),
 			Required:    true,
 			SubDir:      "PPSSPP",
 			OverrideURL: server.URL,
@@ -426,6 +431,7 @@ func TestDownloadMissing_BundleStripPrefixSkipsNonMatching(t *testing.T) {
 			ConsoleID:   "psp",
 			FileName:    "ppge_atlas.zim",
 			Description: "PPSSPP bundle",
+			MD5:         md5hex(zipBytes),
 			Required:    true,
 			SubDir:      "PPSSPP",
 			OverrideURL: server.URL,
@@ -469,6 +475,7 @@ func TestDownloadMissing_BundleRefusesZipSlip(t *testing.T) {
 			ConsoleID:   "test",
 			FileName:    "ok.txt",
 			Description: "Slippy bundle",
+			MD5:         md5hex(zipBytes),
 			Required:    true,
 			OverrideURL: server.URL,
 			SubDir:      "test",

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -227,6 +227,8 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		// Persistent scrape queue
 		&ScrapeJob{},
 		&ScrapeQueueItem{},
+		// Privacy: per-user block list (issue #1121)
+		&Block{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running migrations: %w", err)

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -57,6 +57,28 @@ type User struct {
 	CustomKeyMapping         string         `gorm:"type:text" json:"customKeyMapping"` // JSON: {"0":"z","1":"x",...}
 	DefaultSecondScreenPage string         `gorm:"size:64;default:art" json:"defaultSecondScreenPage"`
 	PreferredRegions         string         `gorm:"size:255" json:"preferredRegions"` // comma-separated ordered list, e.g. "USA,Europe,World"
+	// ProfileVisibility controls whether the user's public profile
+	// exposes detailed activity (current game, recent games, top
+	// played, play time). Issue #1121: previously every authenticated
+	// user could scrape every other user's gaming habits in real time.
+	// Values: "public" (default), "private". The "friends" tier is
+	// reserved for a future friend graph.
+	ProfileVisibility       string         `gorm:"size:16;default:public" json:"profileVisibility"`
+}
+
+// Block represents a one-way "I do not want to interact with this user"
+// relationship (issue #1121). Filtered in both directions on profile,
+// search, and invite endpoints. The unique constraint on the pair
+// prevents duplicates without a separate idempotency key.
+type Block struct {
+	ID            uint           `gorm:"primarykey" json:"id"`
+	CreatedAt     time.Time      `json:"createdAt"`
+	UpdatedAt     time.Time      `json:"updatedAt"`
+	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
+	UserID        uint           `gorm:"uniqueIndex:idx_block_user_blocked;not null" json:"userId"`
+	User          User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
+	BlockedUserID uint           `gorm:"uniqueIndex:idx_block_user_blocked;not null" json:"blockedUserId"`
+	BlockedUser   User           `gorm:"foreignKey:BlockedUserID;constraint:OnDelete:CASCADE" json:"-"`
 }
 
 // LoginAttempt tracks failed login attempts per username for account lockout.

--- a/server/internal/patcher/bps.go
+++ b/server/internal/patcher/bps.go
@@ -44,7 +44,10 @@ func ApplyBPS(romData, patchData []byte) ([]byte, error) {
 	pos := 4
 
 	// Read source size
-	sourceSize, n := decodeVLQ(patchData[pos:])
+	sourceSize, n, ok := decodeVLQ(patchData[pos:])
+	if !ok {
+		return nil, fmt.Errorf("BPS patch truncated reading source size")
+	}
 	pos += n
 
 	// Verify source size matches
@@ -53,12 +56,21 @@ func ApplyBPS(romData, patchData []byte) ([]byte, error) {
 	}
 
 	// Read target size
-	targetSize, n := decodeVLQ(patchData[pos:])
+	targetSize, n, ok := decodeVLQ(patchData[pos:])
+	if !ok {
+		return nil, fmt.Errorf("BPS patch truncated reading target size")
+	}
 	pos += n
 
 	// Read and skip metadata
-	metadataSize, n := decodeVLQ(patchData[pos:])
+	metadataSize, n, ok := decodeVLQ(patchData[pos:])
+	if !ok {
+		return nil, fmt.Errorf("BPS patch truncated reading metadata size")
+	}
 	pos += n
+	if pos+int(metadataSize) > len(patchData) {
+		return nil, fmt.Errorf("BPS metadata size %d overruns patch buffer", metadataSize)
+	}
 	pos += int(metadataSize)
 
 	// Verify source CRC32
@@ -83,7 +95,10 @@ func ApplyBPS(romData, patchData []byte) ([]byte, error) {
 	// Process actions (stop 12 bytes before end = 3 CRC32 values)
 	endPos := len(patchData) - 12
 	for pos < endPos {
-		data, n := decodeVLQ(patchData[pos:])
+		data, n, ok := decodeVLQ(patchData[pos:])
+		if !ok {
+			return nil, fmt.Errorf("BPS patch truncated reading action header at offset %d", pos)
+		}
 		pos += n
 
 		actionType := data & 3
@@ -110,7 +125,10 @@ func ApplyBPS(romData, patchData []byte) ([]byte, error) {
 			targetPos += length
 
 		case 2: // SourceCopy
-			offset, n := decodeSignedVLQ(patchData[pos:])
+			offset, n, ok := decodeSignedVLQ(patchData[pos:])
+			if !ok {
+				return nil, fmt.Errorf("BPS patch truncated reading SourceCopy offset at %d", pos)
+			}
 			pos += n
 			sourceRelOffset += offset
 			for i := 0; i < length; i++ {
@@ -122,7 +140,10 @@ func ApplyBPS(romData, patchData []byte) ([]byte, error) {
 			}
 
 		case 3: // TargetCopy
-			offset, n := decodeSignedVLQ(patchData[pos:])
+			offset, n, ok := decodeSignedVLQ(patchData[pos:])
+			if !ok {
+				return nil, fmt.Errorf("BPS patch truncated reading TargetCopy offset at %d", pos)
+			}
 			pos += n
 			targetRelOffset += offset
 			for i := 0; i < length; i++ {
@@ -146,29 +167,37 @@ func ApplyBPS(romData, patchData []byte) ([]byte, error) {
 }
 
 // decodeVLQ decodes a variable-length quantity from BPS/UPS format.
-// Returns the value and the number of bytes consumed.
-func decodeVLQ(data []byte) (uint64, int) {
+// Returns the value, the number of bytes consumed, and ok=false if the
+// input is truncated (no terminator byte found).
+//
+// Issue #1134(B): the previous (value, n) signature returned len(data)
+// as the consumed-byte count when no terminator was present, leaving
+// the caller's `pos += n` legitimately past end-of-buffer. The next
+// indexed read panicked with index-out-of-range; huma's middleware
+// recovered that into a 500. Switching to (value, n, ok) lets callers
+// surface a clean parser error and avoids any panic-recovery branch.
+func decodeVLQ(data []byte) (uint64, int, bool) {
 	var value uint64
 	shift := uint(0)
 	for i, b := range data {
 		value += uint64(b&0x7F) << shift
 		if b&0x80 != 0 {
-			return value, i + 1
+			return value, i + 1, true
 		}
 		value += 1 << (shift + 7)
 		shift += 7
 	}
-	return value, len(data)
+	return value, len(data), false
 }
 
 // decodeSignedVLQ decodes a signed variable-length quantity.
 // The lowest bit indicates sign (1 = negative).
-func decodeSignedVLQ(data []byte) (int, int) {
-	value, n := decodeVLQ(data)
+func decodeSignedVLQ(data []byte) (int, int, bool) {
+	value, n, ok := decodeVLQ(data)
 	if value&1 != 0 {
-		return -int(value >> 1) - 1, n
+		return -int(value >> 1) - 1, n, ok
 	}
-	return int(value >> 1), n
+	return int(value >> 1), n, ok
 }
 
 // readLE32 reads a 32-bit little-endian value.

--- a/server/internal/patcher/bps_test.go
+++ b/server/internal/patcher/bps_test.go
@@ -162,7 +162,8 @@ func TestVLQRoundtrip(t *testing.T) {
 	tests := []uint64{0, 1, 127, 128, 255, 256, 1000, 65535, 16777215}
 	for _, v := range tests {
 		encoded := encodeVLQ(v)
-		decoded, n := decodeVLQ(encoded)
+		decoded, n, ok := decodeVLQ(encoded)
+		assert.True(t, ok, "value %d", v)
 		assert.Equal(t, v, decoded, "value %d", v)
 		assert.Equal(t, len(encoded), n, "bytes consumed for value %d", v)
 	}
@@ -172,8 +173,23 @@ func TestSignedVLQRoundtrip(t *testing.T) {
 	tests := []int{0, 1, -1, 127, -128, 1000, -1000}
 	for _, v := range tests {
 		encoded := encodeSignedVLQ(v)
-		decoded, n := decodeSignedVLQ(encoded)
+		decoded, n, ok := decodeSignedVLQ(encoded)
+		assert.True(t, ok, "value %d", v)
 		assert.Equal(t, v, decoded, "value %d", v)
 		assert.Equal(t, len(encoded), n, "bytes consumed for value %d", v)
 	}
+}
+
+// TestVLQTruncated covers issue #1134(B): decodeVLQ on a truncated
+// (no-terminator) input must return ok=false rather than the
+// (consumed=len(data)) value that previously caused index-out-of-range
+// panics in callers' next read.
+func TestVLQTruncated(t *testing.T) {
+	// Three continuation bytes (high bit clear), no terminator.
+	bad := []byte{0x00, 0x00, 0x00}
+	_, _, ok := decodeVLQ(bad)
+	assert.False(t, ok, "truncated VLQ must report ok=false")
+
+	_, _, ok = decodeSignedVLQ(bad)
+	assert.False(t, ok, "truncated signed VLQ must report ok=false")
 }

--- a/server/internal/patcher/ups.go
+++ b/server/internal/patcher/ups.go
@@ -40,7 +40,10 @@ func ApplyUPS(romData, patchData []byte) ([]byte, error) {
 	pos := 4
 
 	// Read source size
-	sourceSize, n := decodeVLQ(patchData[pos:])
+	sourceSize, n, ok := decodeVLQ(patchData[pos:])
+	if !ok {
+		return nil, fmt.Errorf("UPS patch truncated reading source size")
+	}
 	pos += n
 
 	if int(sourceSize) != len(romData) {
@@ -48,7 +51,10 @@ func ApplyUPS(romData, patchData []byte) ([]byte, error) {
 	}
 
 	// Read target size
-	targetSize, n := decodeVLQ(patchData[pos:])
+	targetSize, n, ok := decodeVLQ(patchData[pos:])
+	if !ok {
+		return nil, fmt.Errorf("UPS patch truncated reading target size")
+	}
 	pos += n
 
 	// Verify source CRC32
@@ -73,7 +79,10 @@ func ApplyUPS(romData, patchData []byte) ([]byte, error) {
 
 	for pos < endPos {
 		// Read relative offset to next change
-		relOffset, n := decodeVLQ(patchData[pos:])
+		relOffset, n, ok := decodeVLQ(patchData[pos:])
+		if !ok {
+			return nil, fmt.Errorf("UPS patch truncated reading relative offset at %d", pos)
+		}
 		pos += n
 		targetPos += int(relOffset)
 

--- a/server/internal/patcher/xdelta.go
+++ b/server/internal/patcher/xdelta.go
@@ -1,10 +1,20 @@
 package patcher
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
+	"time"
 )
+
+// xdeltaTimeout caps how long the xdelta3 child process is allowed to run.
+// xdelta3 is a complex C parser of attacker-supplied patch bytes
+// (issue #1129); a malformed patch could trigger an infinite loop or
+// runaway memory growth in older versions of the binary. 30 seconds is
+// generous for legitimate ROM hacks (which decode in milliseconds) and
+// short enough to bound DoS impact.
+const xdeltaTimeout = 30 * time.Second
 
 // ApplyXDelta applies an xdelta/VCDIFF patch by shelling out to xdelta3.
 // This requires xdelta3 to be installed on the system.
@@ -48,9 +58,18 @@ func ApplyXDelta(romData, patchData []byte) ([]byte, error) {
 	defer os.Remove(outFile.Name())
 	outFile.Close()
 
-	// Run xdelta3
-	cmd := exec.Command(xdeltaPath, "-d", "-s", srcFile.Name(), patchFile.Name(), outFile.Name())
+	// Run xdelta3 under a timeout (issue #1129). The argv form already
+	// makes shell metacharacters inert so command injection isn't a
+	// concern; the remaining attack surface is the C parser inside
+	// xdelta3 itself, which we bound with the context deadline so a
+	// hostile patch can't pin the server's CPU/memory indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), xdeltaTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, xdeltaPath, "-d", "-s", srcFile.Name(), patchFile.Name(), outFile.Name())
 	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, fmt.Errorf("xdelta3 timed out after %s: patch may be malformed", xdeltaTimeout)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("xdelta3 failed: %s: %w", string(output), err)
 	}

--- a/server/internal/safehttp/safehttp.go
+++ b/server/internal/safehttp/safehttp.go
@@ -46,11 +46,36 @@ var privateNetworks = func() []*net.IPNet {
 	return nets
 }()
 
+// allowPrivateForTest, when true, makes IsPrivateURL return false for
+// private addresses. Used only by tests that spin up httptest servers
+// bound to 127.0.0.1 — production code never flips this. Set via
+// SetAllowPrivateForTest from a _test.go file.
+var allowPrivateForTest bool
+
+// SetAllowPrivateForTest is a test-only escape hatch that bypasses the
+// private-IP block list for the duration of a test. Production code
+// must not call this.
+func SetAllowPrivateForTest(v bool) { allowPrivateForTest = v }
+
 // IsPrivateURL reports whether rawURL points at a private/internal IP. A
 // scheme other than http/https, an unparseable URL, or an unresolvable host
 // is treated as private (fail-closed). Returns the parsed URL on success
 // for callers that want to do additional checks.
 func IsPrivateURL(rawURL string) bool {
+	if allowPrivateForTest {
+		// Still keep scheme + host validation so test code is exercised
+		// against the real shape of the function.
+		if u, err := url.Parse(rawURL); err == nil {
+			if u.Scheme != "http" && u.Scheme != "https" {
+				return true
+			}
+			if u.Hostname() == "" {
+				return true
+			}
+			return false
+		}
+		return true
+	}
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return true

--- a/server/internal/safehttp/safehttp.go
+++ b/server/internal/safehttp/safehttp.go
@@ -1,0 +1,132 @@
+// Package safehttp provides SSRF-hardened HTTP fetching primitives shared by
+// any code that fetches attacker-controlled or upstream-controlled URLs
+// (e.g. user avatars, admin "set hero art", scraper images returned by
+// IGDB/SteamGridDB/Pouet).
+//
+// Issue #1120: the previous scraper.DownloadExternalImage used a default
+// http.Client with no scheme allowlist, no private-IP filter, no redirect
+// validation, and no size cap. A rogue admin (or compromised upstream
+// service) could point it at internal services or large response bodies.
+package safehttp
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// privateNetworks is the deny list of CIDR ranges that must never be
+// reached by outbound URL fetches. Mirrors api.privateNetworks.
+var privateNetworks = func() []*net.IPNet {
+	cidrs := []string{
+		"0.0.0.0/8",      // Current network
+		"10.0.0.0/8",     // Private (RFC 1918)
+		"100.64.0.0/10",  // Carrier-grade NAT (RFC 6598)
+		"127.0.0.0/8",    // Loopback
+		"169.254.0.0/16", // Link-local (incl. AWS instance metadata 169.254.169.254)
+		"172.16.0.0/12",  // Private (RFC 1918)
+		"192.0.0.0/24",   // IETF protocol assignments
+		"192.168.0.0/16", // Private (RFC 1918)
+		"198.18.0.0/15",  // Benchmarking (RFC 2544)
+		"::1/128",        // IPv6 loopback
+		"fc00::/7",       // IPv6 unique local
+		"fe80::/10",      // IPv6 link-local
+	}
+	var nets []*net.IPNet
+	for _, cidr := range cidrs {
+		_, n, err := net.ParseCIDR(cidr)
+		if err == nil {
+			nets = append(nets, n)
+		}
+	}
+	return nets
+}()
+
+// IsPrivateURL reports whether rawURL points at a private/internal IP. A
+// scheme other than http/https, an unparseable URL, or an unresolvable host
+// is treated as private (fail-closed). Returns the parsed URL on success
+// for callers that want to do additional checks.
+func IsPrivateURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return true
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return true
+	}
+	host := u.Hostname()
+	if host == "" {
+		return true
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return true
+	}
+	for _, ip := range ips {
+		if v4 := ip.To4(); v4 != nil {
+			ip = v4
+		}
+		for _, n := range privateNetworks {
+			if n.Contains(ip) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ErrPrivateURL is returned when an outbound fetch is rejected because the
+// URL targets a private IP (initial host or redirect target).
+var ErrPrivateURL = errors.New("safehttp: URL targets a private/internal IP")
+
+// ErrUnsupportedScheme is returned when an outbound fetch is rejected
+// because the scheme is not http or https.
+var ErrUnsupportedScheme = errors.New("safehttp: only http/https are allowed")
+
+// NewClient returns a hardened *http.Client with:
+//   - http/https scheme enforcement
+//   - private-IP rejection on the initial request and on every redirect hop
+//   - configurable per-request timeout
+//   - a redirect cap of 10 (matches Go's default) to bound chains
+//
+// Body size limits are caller-side — the client cannot enforce them since
+// it doesn't read the body.
+func NewClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("safehttp: redirect chain exceeds 10 hops")
+			}
+			if IsPrivateURL(req.URL.String()) {
+				return fmt.Errorf("redirect to %s: %w", req.URL.Host, ErrPrivateURL)
+			}
+			return nil
+		},
+	}
+}
+
+// CheckURL is a convenience that runs the same checks as NewClient applies
+// before issuing a request — useful for callers that want to gate a URL
+// before passing it to an existing http.Client (where redirect validation
+// alone is not enough).
+func CheckURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("safehttp: parse URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return ErrUnsupportedScheme
+	}
+	if IsPrivateURL(rawURL) {
+		return ErrPrivateURL
+	}
+	return nil
+}

--- a/server/internal/safehttp/safehttp_test.go
+++ b/server/internal/safehttp/safehttp_test.go
@@ -1,0 +1,73 @@
+package safehttp
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPrivateURL(t *testing.T) {
+	cases := []struct {
+		url     string
+		private bool
+	}{
+		{"http://127.0.0.1/foo", true},
+		{"http://localhost/foo", true},
+		{"http://169.254.169.254/latest/meta-data/", true}, // AWS metadata
+		{"http://10.0.0.1/", true},
+		{"http://172.16.0.5/", true},
+		{"http://192.168.1.1/", true},
+		{"file:///etc/passwd", true}, // wrong scheme — fail closed
+		{"javascript:alert(1)", true},
+		{"http://[::1]/", true},
+		{"https://1.1.1.1/", false},
+		{"https://example.com/", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.url, func(t *testing.T) {
+			assert.Equal(t, tc.private, IsPrivateURL(tc.url))
+		})
+	}
+}
+
+func TestCheckURL_RejectsNonHTTPSchemes(t *testing.T) {
+	for _, u := range []string{
+		"ftp://example.com/",
+		"gopher://example.com/",
+		"javascript:alert(1)",
+		"data:text/html,<script>",
+	} {
+		err := CheckURL(u)
+		assert.Error(t, err, "expected error for scheme in %q", u)
+	}
+}
+
+// TestNewClient_RedirectToPrivateRejected verifies that a 302 redirect to a
+// private IP is refused mid-flight, defeating the classic SSRF
+// "public-host -> redirect to 127.0.0.1" trick.
+func TestNewClient_RedirectToPrivateRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://127.0.0.1:1/", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	cli := NewClient(5 * time.Second)
+	resp, err := cli.Get(srv.URL)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("expected error from redirect to private IP")
+	}
+
+	// errors.Is may not match because http.Client wraps in *url.Error.
+	// Accept either the sentinel or a message reference.
+	if !errors.Is(err, ErrPrivateURL) && !strings.Contains(err.Error(), "private") {
+		t.Fatalf("expected ErrPrivateURL, got: %v", err)
+	}
+}

--- a/server/internal/scanner/disc_traversal_test.go
+++ b/server/internal/scanner/disc_traversal_test.go
@@ -1,0 +1,72 @@
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDiscCompanionFiles_RejectsTraversal verifies that a malicious .cue
+// file referencing files outside the disc directory has those entries
+// silently dropped rather than included in the companion list (issue #1116).
+func TestDiscCompanionFiles_RejectsTraversal(t *testing.T) {
+	tmp := t.TempDir()
+
+	discDir := filepath.Join(tmp, "psx")
+	if err := os.MkdirAll(discDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Plant a sibling that legitimately should be included.
+	if err := os.WriteFile(filepath.Join(discDir, "game.bin"), []byte("disc data"), 0o644); err != nil {
+		t.Fatalf("write game.bin: %v", err)
+	}
+	// Plant a "secret" outside the disc dir to ensure it never appears.
+	secret := filepath.Join(tmp, "secret.txt")
+	if err := os.WriteFile(secret, []byte("PWNED"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	cuePath := filepath.Join(discDir, "game.cue")
+	cue := strings.Join([]string{
+		// Legitimate entry — should be included.
+		`FILE "game.bin" BINARY`,
+		`  TRACK 01 MODE2/2352`,
+		`    INDEX 01 00:00:00`,
+		// Traversal entry — must be dropped.
+		`FILE "../secret.txt" BINARY`,
+		`  TRACK 02 AUDIO`,
+		`    INDEX 01 00:00:00`,
+		// Absolute-path entry — must be dropped.
+		`FILE "/etc/passwd" BINARY`,
+		`  TRACK 03 AUDIO`,
+		`    INDEX 01 00:00:00`,
+		// Backslash-prefixed absolute (Windows-style) — must be dropped.
+		`FILE "\Windows\System32\config\SAM" BINARY`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(cuePath, []byte(cue), 0o644); err != nil {
+		t.Fatalf("write cue: %v", err)
+	}
+
+	files, _, err := DiscCompanionFiles(cuePath)
+	if err != nil {
+		t.Fatalf("DiscCompanionFiles: %v", err)
+	}
+
+	for _, f := range files {
+		if strings.Contains(f, "secret.txt") {
+			t.Fatalf("traversal entry leaked into result: %s\n  full: %v", f, files)
+		}
+		if strings.Contains(f, "passwd") || strings.Contains(f, "SAM") {
+			t.Fatalf("absolute-path entry leaked into result: %s\n  full: %v", f, files)
+		}
+		if !strings.HasPrefix(f, discDir) {
+			t.Fatalf("entry escapes disc dir: %s\n  full: %v", f, files)
+		}
+	}
+
+	// We should still have the disc + the legitimate companion (game.bin).
+	if len(files) != 2 {
+		t.Fatalf("expected 2 entries (cue + game.bin), got %d: %v", len(files), files)
+	}
+}

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -568,6 +568,11 @@ func parseM3U(m3uPath string, allowedDirs []string) ([]string, error) {
 // DiscCompanionFiles returns all file paths and total size for a disc entry.
 // For .cue files, it parses FILE directives to find companion .bin files.
 // For .iso/.chd/.pbp, it returns just the file itself.
+//
+// Companion paths are bounded to the disc's directory (issue #1116): a
+// malicious .cue/.gdi can otherwise reference `../../etc/passwd` and the
+// download path will read it back. Absolute paths and `..` segments are
+// rejected outright; resolved paths must remain inside the disc directory.
 func DiscCompanionFiles(discEntryPath string) ([]string, int64, error) {
 	ext := strings.ToLower(filepath.Ext(discEntryPath))
 	if ext != ".cue" && ext != ".gdi" {
@@ -580,6 +585,10 @@ func DiscCompanionFiles(discEntryPath string) ([]string, int64, error) {
 	}
 
 	dir := filepath.Dir(discEntryPath)
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, 0, fmt.Errorf("resolving disc directory: %w", err)
+	}
 	files := []string{discEntryPath}
 	var totalSize int64
 
@@ -594,6 +603,39 @@ func DiscCompanionFiles(discEntryPath string) ([]string, int64, error) {
 		return nil, 0, fmt.Errorf("opening %s file: %w", ext, err)
 	}
 	defer f.Close()
+
+	resolveCompanion := func(name string) (string, bool) {
+		if name == "" {
+			return "", false
+		}
+		// Reject absolute paths outright — companions must be sibling
+		// files. .cue/.gdi sources sometimes carry forward-slash paths
+		// even on Windows, so check both separators.
+		if filepath.IsAbs(name) || strings.HasPrefix(name, "/") || strings.HasPrefix(name, "\\") {
+			slog.Warn("disc companion: absolute path rejected", "disc", discEntryPath, "entry", name)
+			return "", false
+		}
+		// Reject explicit traversal segments before resolving.
+		cleaned := filepath.Clean(name)
+		for _, seg := range strings.Split(filepath.ToSlash(cleaned), "/") {
+			if seg == ".." {
+				slog.Warn("disc companion: traversal rejected", "disc", discEntryPath, "entry", name)
+				return "", false
+			}
+		}
+		joined := filepath.Join(dir, cleaned)
+		abs, err := filepath.Abs(joined)
+		if err != nil {
+			slog.Warn("disc companion: abs resolve failed", "disc", discEntryPath, "entry", name, "error", err)
+			return "", false
+		}
+		// Must stay strictly inside the disc directory.
+		if abs != absDir && !strings.HasPrefix(abs, absDir+string(filepath.Separator)) {
+			slog.Warn("disc companion: escapes disc dir", "disc", discEntryPath, "entry", name, "resolved", abs)
+			return "", false
+		}
+		return joined, true
+	}
 
 	if ext == ".gdi" {
 		// GDI format: first line is track count, subsequent lines are
@@ -616,11 +658,10 @@ func DiscCompanionFiles(discEntryPath string) ([]string, int64, error) {
 				continue
 			}
 			trackFile := strings.Trim(fields[4], "\"")
-			trackPath := trackFile
-			if !filepath.IsAbs(trackPath) {
-				trackPath = filepath.Join(dir, trackPath)
+			trackPath, ok := resolveCompanion(trackFile)
+			if !ok {
+				continue
 			}
-			trackPath = filepath.Clean(trackPath)
 			files = append(files, trackPath)
 			if trackInfo, err := os.Stat(trackPath); err == nil {
 				totalSize += trackInfo.Size()
@@ -635,12 +676,10 @@ func DiscCompanionFiles(discEntryPath string) ([]string, int64, error) {
 			if matches == nil {
 				continue
 			}
-			binName := matches[1]
-			binPath := binName
-			if !filepath.IsAbs(binPath) {
-				binPath = filepath.Join(dir, binPath)
+			binPath, ok := resolveCompanion(matches[1])
+			if !ok {
+				continue
 			}
-			binPath = filepath.Clean(binPath)
 			files = append(files, binPath)
 			if binInfo, err := os.Stat(binPath); err == nil {
 				totalSize += binInfo.Size()

--- a/server/internal/scraper/main_test.go
+++ b/server/internal/scraper/main_test.go
@@ -1,0 +1,19 @@
+package scraper
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spela/server/internal/safehttp"
+)
+
+// TestMain unlocks the safehttp private-IP block for the duration of
+// the scraper test suite. Many of these tests spin up `httptest.Server`
+// instances which bind to 127.0.0.1; without the override, every
+// scraper image fetch (#1120 hardening) would refuse the test URL.
+// Production code never flips this — see safehttp.SetAllowPrivateForTest.
+func TestMain(m *testing.M) {
+	safehttp.SetAllowPrivateForTest(true)
+	defer safehttp.SetAllowPrivateForTest(false)
+	os.Exit(m.Run())
+}

--- a/server/internal/scraper/scraper_batch.go
+++ b/server/internal/scraper/scraper_batch.go
@@ -2,12 +2,15 @@ package scraper
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/safehttp"
 	"gorm.io/gorm"
 )
 
@@ -132,23 +135,53 @@ func (s *Scraper) EnrichAll(mode string, onProgress func(EnrichProgress)) (int, 
 	return successes, total, nil
 }
 
-// DownloadExternalImage downloads an image from an external URL and saves it locally.
-// Returns the relative path for DB storage, or "" on failure.
+// maxExternalImageBytes caps the size of a single image we'll pull from a
+// third-party URL. Issue #1120: without a cap, an attacker-controlled
+// upstream (or a rogue admin pointing at an internal service) can stream
+// gigabytes into the scraper image directory.
+const maxExternalImageBytes = 32 << 20 // 32 MB — covers full-resolution hero art
+
+// safeImageClient is a SSRF-hardened http.Client used by
+// DownloadExternalImage: scheme allowlist, private-IP rejection on every
+// redirect hop, and a per-request timeout. The Scraper's general
+// HTTPClient is kept for non-image fetches (which target known scraper
+// hosts and benefit from a different timeout / retry posture).
+var safeImageClient = safehttp.NewClient(30 * time.Second)
+
+// DownloadExternalImage downloads an image from an external URL and saves
+// it locally. Returns the relative path for DB storage, or "" on failure.
+//
+// Issue #1120: the URL is validated up front (http/https only, no private
+// IPs), the response is wrapped in an io.LimitReader, and the
+// Content-Type must look like an image. The HTTP client re-checks every
+// redirect hop against the private-IP block list to defeat
+// attacker-controlled `302 → http://169.254.169.254/...` chains.
 func (s *Scraper) DownloadExternalImage(imageURL, subpath string) string {
-	resp, err := s.HTTPClient.Get(imageURL)
+	if err := safehttp.CheckURL(imageURL); err != nil {
+		slog.Debug("rejecting external image URL", "url", imageURL, "error", err)
+		return ""
+	}
+
+	resp, err := safeImageClient.Get(imageURL)
 	if err != nil {
 		slog.Debug("failed to fetch external image", "url", imageURL, "error", err)
 		return ""
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
 		slog.Debug("external image not found", "url", imageURL, "status", resp.StatusCode)
 		return ""
 	}
 
-	savedPath, err := s.Storage.WriteImage(subpath, resp.Body)
-	resp.Body.Close()
+	ct := resp.Header.Get("Content-Type")
+	if ct != "" && !strings.HasPrefix(strings.ToLower(ct), "image/") {
+		slog.Debug("rejecting non-image content type", "url", imageURL, "contentType", ct)
+		return ""
+	}
+
+	limited := io.LimitReader(resp.Body, maxExternalImageBytes+1)
+	savedPath, err := s.Storage.WriteImage(subpath, limited)
 	if err != nil {
 		slog.Warn("failed to save external image", "subpath", subpath, "error", err)
 		return ""

--- a/server/internal/storage/resolve_traversal_test.go
+++ b/server/internal/storage/resolve_traversal_test.go
@@ -1,0 +1,59 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveGamePath_RejectsTraversal verifies issue #1125: a stored
+// Game.FilePath containing `..` segments or absolute paths is rejected
+// before stat, so callers that don't follow up with ValidateROMPath
+// (e.g. HumaCreateRomHack pre-fix) cannot read arbitrary host files.
+func TestResolveGamePath_RejectsTraversal(t *testing.T) {
+	tmp := t.TempDir()
+	gameDir := filepath.Join(tmp, "games")
+	if err := os.MkdirAll(filepath.Join(gameDir, "nes"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gameDir, "nes", "smb.nes"), []byte("rom"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// "Secret" outside the gameDir.
+	if err := os.WriteFile(filepath.Join(tmp, "secret.txt"), []byte("PWNED"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		path    string
+		wantErr string
+	}{
+		{"absolute", "/etc/passwd", "must be relative"},
+		{"backslash", "\\etc\\passwd", "must be relative"},
+		{"traversal segment", "../secret.txt", "traversal"},
+		{"deep traversal", "nes/../../secret.txt", "traversal"},
+		{"empty", "", "empty"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ResolveGamePath(tc.path, []string{gameDir})
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", tc.path)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not mention %q", err, tc.wantErr)
+			}
+		})
+	}
+
+	// Sanity: a legitimate relative path still resolves.
+	got, err := ResolveGamePath("nes/smb.nes", []string{gameDir})
+	if err != nil {
+		t.Fatalf("legit path: %v", err)
+	}
+	if !strings.HasSuffix(got, filepath.Join("nes", "smb.nes")) {
+		t.Fatalf("unexpected resolved path: %s", got)
+	}
+}

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -701,9 +701,41 @@ func (s *Storage) DeleteSessionDir(sessionID uint) error {
 // ResolveGamePath resolves a relative game path (e.g. "nes/Mario.nes") to an
 // absolute filesystem path by joining it with each gameDir and returning the
 // first that exists on disk. Returns an error if no match is found.
+//
+// Issue #1125: rejects relPaths that contain `..` segments or are
+// absolute, and verifies the resolved path stays inside the gameDir it
+// was joined onto. Without this, a Game.FilePath value of
+// "../../etc/spela.env" — introducible via any caller that ever writes
+// FilePath without scrubbing — joined+cleaned through filepath.Join
+// could land outside gameDirs, and callers that don't follow up with
+// ValidateROMPath (e.g. HumaCreateRomHack) leak arbitrary host files.
 func ResolveGamePath(relPath string, gameDirs []string) (string, error) {
+	if relPath == "" {
+		return "", fmt.Errorf("game path is empty")
+	}
+	if filepath.IsAbs(relPath) || strings.HasPrefix(relPath, "/") || strings.HasPrefix(relPath, "\\") {
+		return "", fmt.Errorf("game path must be relative: %s", relPath)
+	}
+	cleaned := filepath.Clean(relPath)
+	for _, seg := range strings.Split(filepath.ToSlash(cleaned), "/") {
+		if seg == ".." {
+			return "", fmt.Errorf("game path contains traversal segment: %s", relPath)
+		}
+	}
 	for _, dir := range gameDirs {
-		full := filepath.Join(dir, relPath)
+		full := filepath.Join(dir, cleaned)
+		absFull, err := filepath.Abs(full)
+		if err != nil {
+			continue
+		}
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+		if absFull != absDir && !strings.HasPrefix(absFull, absDir+string(filepath.Separator)) {
+			// Joined path escapes the gameDir — try the next one.
+			continue
+		}
 		if _, err := os.Stat(full); err == nil {
 			return full, nil
 		}

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -14,9 +14,20 @@ import (
 )
 
 // Event represents a real-time event sent to clients.
+//
+// RecipientUserIDs filters delivery to a specific subset of connected
+// clients (issue #1119). When non-nil and non-empty, the broadcast loop
+// only delivers to clients whose UserID is in the list. nil/empty means
+// "deliver to everyone" — preserving the historical fan-out semantics
+// for genuinely server-wide events (scrape progress, BIOS download
+// progress, library scan progress, online-status broadcasts).
+//
+// The recipient list is intentionally not serialised to clients —
+// `json:"-"` keeps it out of the wire payload.
 type Event struct {
-	Type    string      `json:"type"`
-	Payload interface{} `json:"payload"`
+	Type             string      `json:"type"`
+	Payload          interface{} `json:"payload"`
+	RecipientUserIDs []uint      `json:"-"`
 }
 
 // OnlineUser represents a user currently connected via WebSocket.
@@ -154,8 +165,22 @@ func (h *Hub) Run() {
 				slog.Error("failed to marshal websocket event", "error", err)
 				continue
 			}
+			// Build a recipient set if the event is targeted; otherwise
+			// fan out to every connected client (issue #1119).
+			var recipientSet map[uint]struct{}
+			if len(event.RecipientUserIDs) > 0 {
+				recipientSet = make(map[uint]struct{}, len(event.RecipientUserIDs))
+				for _, uid := range event.RecipientUserIDs {
+					recipientSet[uid] = struct{}{}
+				}
+			}
 			h.mu.Lock()
 			for client := range h.clients {
+				if recipientSet != nil {
+					if _, ok := recipientSet[client.UserID]; !ok {
+						continue
+					}
+				}
 				select {
 				case client.Send <- data:
 				default:

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -94,6 +94,16 @@ func NewHub(allowedOrigins []string) *Hub {
 
 // checkOrigin returns an origin checker for WebSocket upgrades. An empty
 // allowedOrigins list only allows same-origin requests (secure default).
+//
+// Issue #1126: a `*` entry in allowedOrigins used to bless any cross-origin
+// upgrade, including those carrying ?token=<jwt>. Combined with the
+// query-token fallback (#1117), an attacker who got hold of a token
+// could open an authenticated WS from any origin. Any request that looks
+// credentialed (Origin header present + ?token= query param) now ignores
+// the wildcard and falls back to a strict same-origin check; operators
+// who genuinely want "open" must enumerate origins explicitly. Plain
+// HTTP-style wildcard (no credentials) still works for unauthenticated
+// upgrades.
 func checkOrigin(allowedOrigins []string) func(*http.Request) bool {
 	return func(r *http.Request) bool {
 		origin := r.Header.Get("Origin")
@@ -102,6 +112,8 @@ func checkOrigin(allowedOrigins []string) func(*http.Request) bool {
 		if origin == "" {
 			return true
 		}
+
+		isCredentialed := r.URL != nil && r.URL.Query().Get("token") != ""
 
 		// No configured origins: fall back to gorilla/websocket's default
 		// behaviour — allow only if the Origin host matches the request Host.
@@ -114,7 +126,23 @@ func checkOrigin(allowedOrigins []string) func(*http.Request) bool {
 		}
 
 		for _, allowed := range allowedOrigins {
-			if allowed == "*" || allowed == origin {
+			if allowed == "*" {
+				// Refuse cross-origin upgrades that authenticate via
+				// the query token under a wildcard policy. Plain
+				// (header-authed or unauthenticated) upgrades still
+				// honour the wildcard.
+				if isCredentialed {
+					u, err := url.Parse(origin)
+					if err != nil {
+						return false
+					}
+					if !strings.EqualFold(u.Host, r.Host) {
+						return false
+					}
+				}
+				return true
+			}
+			if allowed == origin {
 				return true
 			}
 		}

--- a/server/internal/websocket/hub_test.go
+++ b/server/internal/websocket/hub_test.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -55,6 +56,42 @@ func TestCheckOrigin_ExplicitList_Rejected(t *testing.T) {
 func TestCheckOrigin_Wildcard(t *testing.T) {
 	check := checkOrigin([]string{"*"})
 	assert.True(t, check(makeRequest("https://anything.com", "server:8080")))
+}
+
+// TestCheckOrigin_WildcardRejectsCredentialed covers issue #1126:
+// when allowedOrigins is "*", a request that authenticates via the
+// query-token fallback (i.e. `?token=<jwt>`) and originates from a
+// cross-origin host is refused regardless of the wildcard. Operators
+// who truly need cross-origin authenticated WS must enumerate origins.
+func TestCheckOrigin_WildcardRejectsCredentialed(t *testing.T) {
+	check := checkOrigin([]string{"*"})
+
+	credentialed := &http.Request{
+		Header: make(http.Header),
+		Host:   "spela.example.com",
+		URL:    mustParse("/api/ws?token=abc"),
+	}
+	credentialed.Header.Set("Origin", "https://evil.example")
+	assert.False(t, check(credentialed),
+		"credentialed cross-origin WS must be refused under wildcard")
+
+	// Same-origin credentialed upgrade still allowed.
+	sameOrigin := &http.Request{
+		Header: make(http.Header),
+		Host:   "spela.example.com",
+		URL:    mustParse("/api/ws?token=abc"),
+	}
+	sameOrigin.Header.Set("Origin", "https://spela.example.com")
+	assert.True(t, check(sameOrigin),
+		"same-origin credentialed WS must still work")
+}
+
+func mustParse(rawURL string) *url.URL {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		panic(err)
+	}
+	return u
 }
 
 func TestCheckOrigin_InvalidOriginURL(t *testing.T) {

--- a/server/internal/websocket/recipient_filter_test.go
+++ b/server/internal/websocket/recipient_filter_test.go
@@ -1,0 +1,103 @@
+package websocket
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBroadcast_RecipientFilter verifies issue #1119: an Event with a
+// non-empty RecipientUserIDs is delivered only to clients whose UserID
+// matches, leaving the existing fan-out unchanged for events without
+// recipients.
+func TestBroadcast_RecipientFilter(t *testing.T) {
+	hub := NewHub(nil)
+	go hub.Run()
+	defer hub.Close()
+
+	make := func(uid uint) *Client {
+		return &Client{
+			Hub:    hub,
+			Send:   make(chan []byte, 4),
+			UserID: uid,
+		}
+	}
+
+	a := make(1)
+	b := make(2)
+	c := make(3)
+
+	hub.register <- a
+	hub.register <- b
+	hub.register <- c
+
+	// Wait briefly for register to settle and for the implicit
+	// online-status broadcast to drain.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		hub.mu.Lock()
+		registered := len(hub.clients)
+		hub.mu.Unlock()
+		if registered == 3 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	for _, cli := range []*Client{a, b, c} {
+	drain:
+		for {
+			select {
+			case <-cli.Send:
+			default:
+				break drain
+			}
+		}
+	}
+
+	// Targeted event — only users 1 and 3 should receive it.
+	hub.Broadcast(Event{
+		Type:             "private_test",
+		Payload:          map[string]string{"hello": "world"},
+		RecipientUserIDs: []uint{1, 3},
+	})
+
+	collect := func(cli *Client) []string {
+		var got []string
+		t := time.NewTimer(100 * time.Millisecond)
+		defer t.Stop()
+	loop:
+		for {
+			select {
+			case msg := <-cli.Send:
+				got = append(got, string(msg))
+			case <-t.C:
+				break loop
+			}
+		}
+		return got
+	}
+
+	aMsgs := collect(a)
+	bMsgs := collect(b)
+	cMsgs := collect(c)
+
+	assert.Len(t, aMsgs, 1, "user 1 should receive the targeted event")
+	assert.Empty(t, bMsgs, "user 2 should NOT receive the targeted event")
+	assert.Len(t, cMsgs, 1, "user 3 should receive the targeted event")
+
+	// Sanity: the recipient list is not serialised to clients.
+	for _, msgs := range [][]string{aMsgs, cMsgs} {
+		if len(msgs) == 0 {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(msgs[0]), &m); err == nil {
+			_, hasRecipients := m["recipientUserIds"]
+			_, hasGoFieldName := m["RecipientUserIDs"]
+			assert.False(t, hasRecipients, "wire payload must not include recipientUserIds")
+			assert.False(t, hasGoFieldName, "wire payload must not include RecipientUserIDs")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR resolves every finding from the 2026-05-08 security audit logged
in issues #1115 – #1134. One commit per issue (with two test-fixup
commits), one consolidated review surface.

| Severity | Count | Issues |
|---|---|---|
| Critical | 1 | #1115 |
| High | 3 | #1116, #1117, #1118 |
| Medium | 11 | #1119, #1120, #1121, #1122, #1123, #1124, #1125, #1126, #1127, #1128, #1129 |
| Low | 5 | #1130, #1131, #1132, #1133, #1134 |

`SECURITY.md` is rewritten as an admin-facing security overview that
reflects the post-PR state of the backend, lists the 20 resolved
findings with their fix commits, and documents the residual risks that
remain accepted.

## What changed (highlights)

- **SQLi class closed at the framework edge** (#1115, #1127) — every
  numeric `path:"..."` tag carries `pattern:"^[0-9]+$"`; a unit lint in
  `internal/api` fails the build if a future PR forgets to add the
  pattern.
- **Path-traversal hardening** in disc-companion parsing (#1116),
  `ResolveGamePath` (#1125), and the SPA static fallback (#1118).
- **`?token=` query fallback restricted** to the small set of
  download / WS / asset routes that genuinely need it (#1117); JSON-API
  endpoints now require Authorization headers.
- **WebSocket hub recipient filter** so private events (invites, turn
  changes) only reach members of the relevant session (#1119).
- **SSRF guard** (`internal/safehttp`) wraps every outbound URL fetch:
  scheme allowlist, private-IP block list, redirect-hop validation,
  body-size and Content-Type caps (#1120).
- **Privacy controls**: `User.ProfileVisibility` plus a new `Block`
  model with symmetric enforcement on profile / search (#1121).
- **Admin -> admin defense in depth**: only owner can mutate or delete
  other admins; admin email change runs the same uniqueness +
  format checks the self-update path uses (#1122, #1123).
- **BIOS supply chain**: MD5 mismatch on upload deletes the bytes;
  auto-downloader refuses entries lacking a registry checksum and
  defaults to OFF (#1124).
- **WS Origin wildcard tightened**: cross-origin upgrades that
  authenticate via `?token=` are refused even under a `*` policy (#1126).
- **Slot-save honors shared-session turn** (#1128), `xdelta3` runs
  under a 30s context timeout (#1129), patcher refuses ROMs
  larger than `MaxOutputSize` and surfaces clean parser errors on
  truncated VLQ input (#1134).
- **Setup completion is persistent**: a marker row in
  `server_settings` survives an out-of-band `users` truncation (#1130).
- **Auth hardening**: ~50-entry common-password blocklist on
  registration / change-password, full lockout-row delete on success
  so a slow attacker cannot keep the escalation tier armed (#1131).
- **Enumeration tightened** on registration / profile-update (#1132);
  email change now bumps `TokenVersion` and revokes refresh tokens
  (#1133).

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./...` clean across all 14 packages
  (api / auth / bios / cheats / db / igdb / patcher / pouet /
  retroachievements / safehttp / scanner / scraper / storage /
  websocket).
- [x] New regression tests cover each fix:
  - `internal/api/sqli_path_param_test.go` — #1115
  - `internal/api/path_param_pattern_test.go` — #1127 structural lint
  - `internal/scanner/disc_traversal_test.go` — #1116
  - `internal/api/query_token_fallback_test.go` — #1117
  - `internal/api/serve_frontend_test.go` — #1118
  - `internal/websocket/recipient_filter_test.go` — #1119
  - `internal/safehttp/safehttp_test.go` — #1120
  - `internal/api/blocks_test.go` — #1121
  - `internal/storage/resolve_traversal_test.go` — #1125
  - `internal/websocket/hub_test.go` (new wildcard cases) — #1126
  - `internal/bios/downloader_test.go` (rewritten EmptyMD5 case) — #1124
  - `internal/patcher/bps_test.go` (truncated VLQ) — #1134
- [x] Existing tests touched only where the new behaviour required it
  (huma 422 vs 400 on invalid path params; password fixture renamed
  off the common-password list; BIOS upload mismatch test inverted to
  assert 400 + bytes deleted).

## Out of scope (called out in `SECURITY.md` _Limitations_)

- `xdelta3` is timeout-bounded but not yet sandboxed (the long-term
  fix is an in-process Go VCDIFF implementation).
- Activity-feed events still broadcast; per-user filtering follows the
  profile-visibility surface in a future PR.
- Email-based password reset is not implemented; the email-change ->
  TokenVersion bump (#1133) is the hardening that future work will
  rely on.
- Open registration retains an inherent timing channel via the
  password-hash branch on conflict; operators who care should disable
  open registration.

Closes #1115, #1116, #1117, #1118, #1119, #1120, #1121, #1122, #1123,
#1124, #1125, #1126, #1127, #1128, #1129, #1130, #1131, #1132, #1133,
#1134.