### PR TITLE
refactor(player): retire Modifier.autoFocus() in favour of focusRestoreItem

### DIFF
--- a/player/GAMEPAD_NAVIGATION.md
+++ b/player/GAMEPAD_NAVIGATION.md
@@ -345,21 +345,18 @@ focusable elements that don't themselves use `focusRestoreItem` — it
 gives back-nav something to land on (the section's first focusable
 descendant) when no item key matches.
 
-## Default Focus on Forward Entry: `Modifier.autoFocus`
+## Default Focus on Forward Entry
 
-```kotlin
-modifier = Modifier.autoFocus()
-```
+`Modifier.focusRestoreItem(key, isDefault = true)` is the single
+primitive for default-on-entry focus. It saves the focused element's
+key to the enclosing `LocalFocusMemory` scope, restores focus on
+back-nav when the saved key matches, and acts as the screen's default
+on first entry when the saved key is empty.
 
-A legacy single-element modifier. Fires once on forward navigation OR
-tab switch, on screen mount. Use it for a single primary action button
-on screens that don't have a clear "first item" (e.g. the Play button
-on a session-detail screen, the Search input on the Global Search
-screen). Do not combine with `focusRestoreItem(isDefault = true)` on
-the same screen — they will race.
-
-`autoFocus` is no longer gated by gamepad mode (it now fires for
-keyboard users on desktop too).
+The legacy `Modifier.autoFocus()` was retired in #1138. New code must
+use `focusRestoreItem` — `autoFocus` fired on every forward navigation
+but never saved focus, so it didn't compose with the rest of the
+system.
 
 ## What to Do for a New Screen
 
@@ -370,14 +367,17 @@ For most screens, follow the recipe:
    `Modifier.focusRestoreItem(key = "<screen>_<itemId>", isDefault = (item == list.firstOrNull()))`.
 3. **For SpCarousels**, pass `memoryKey` + `itemKey` (and
    `isDefaultFocusGroup = true` on at most one carousel per screen).
-4. **For static-button screens** (no list), use `Modifier.autoFocus()`
+4. **For static-button screens** (no list), use
+   `Modifier.focusRestoreItem(key = "<screen>_<button>", isDefault = true)`
    on the primary action.
 5. Section containers that sit above SpCarousels can keep
    `Modifier.rememberFocus("section_xyz")` as a fallback; new screens
    typically don't need it.
 
-Do **not** combine `autoFocus()` with `focusRestoreItem(isDefault = true)`
-on the same screen. Pick one source of default focus.
+Only **one** element per `LocalFocusMemory` scope should set
+`isDefault = true`. If multiple do, the first to fire claims focus and
+the rest skip — so this is safe but you'll typically want a deliberate
+choice.
 
 ## Testing
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sharedsession/SharedSessionDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sharedsession/SharedSessionDetailComponents.kt
@@ -34,7 +34,7 @@ import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.social.formatRelativeTime
-import com.spela.player.presentation.ui.gamepad.autoFocus
+import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -153,7 +153,10 @@ internal fun SharedSessionHeader(
                 onClick = onTakeTurn,
                 isLoading = isTakingTurn,
                 enabled = !isTakingTurn,
-                modifier = Modifier.autoFocus(),
+                modifier = Modifier.focusRestoreItem(
+                    key = "shared_session_take_turn",
+                    isDefault = true,
+                ),
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.Filled.PlayArrow,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/AutoFocus.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/AutoFocus.kt
@@ -1,59 +1,22 @@
 package com.spela.player.presentation.ui.gamepad
 
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import kotlinx.coroutines.delay
+
+// Historically this file also defined `Modifier.autoFocus()`, the legacy
+// single-element default-focus modifier. Issue #1138 retired that primitive
+// in favour of `Modifier.focusRestoreItem(key, isDefault = true)` (defined
+// in FocusMemory.kt) which is a strict superset — default focus AND
+// back-nav restoration via the same scope. The forward/tab-switch
+// CompositionLocals stay here because they're still consumed by
+// FocusMemory.kt and provided by SpelaApp on every screen mount.
 
 /**
  * Whether the current screen was reached via forward navigation (not back/tab switch).
- * Set by SpelaApp when rendering each screen.
+ * Set by SpelaApp when rendering each screen and consumed by
+ * [Modifier.focusRestoreItem] to decide whether to restore the saved
+ * focus key or fire the default-focus path.
  */
 val LocalIsForwardNavigation = compositionLocalOf { false }
-
-/**
- * Requests focus on this element when it mounts during forward navigation
- * (or a bottom-nav tab switch) in gamepad mode.
- *
- * Apply to the first meaningful focusable element on each screen — the
- * element that should receive initial gamepad focus. Each screen is
- * responsible for placing this modifier; this is the primary mechanism
- * for focus acquisition on navigation.
- *
- * On back navigation, this modifier does nothing — focus-memory
- * restoration in [Modifier.rememberFocus] takes over so the user lands
- * back on the element they last focused.
- *
- * The 500ms delay ensures the AnimatedContent exit transition has
- * completed so focus doesn't land on the outgoing screen.
- */
-fun Modifier.autoFocus(): Modifier = composed {
-    val isForward = LocalIsForwardNavigation.current
-    // Tab-switches via L1/R1 are not forward navigations (no back stack
-    // entry) but also not back navigations. Treat them like forward
-    // navigations for focus purposes — the destination screen has no
-    // focus memory yet, so autoFocus is the only mechanism that can
-    // place initial focus on a useful element.
-    val isTabSwitch = LocalIsTabSwitch.current
-
-    if (isForward || isTabSwitch) {
-        val focusRequester = remember { FocusRequester() }
-        LaunchedEffect(Unit) {
-            // Wait for AnimatedContent exit transition to complete
-            delay(500)
-            try {
-                focusRequester.requestFocus()
-            } catch (_: Exception) {}
-        }
-        this.focusRequester(focusRequester)
-    } else {
-        this
-    }
-}
 
 /**
  * Whether the current screen was reached via a bottom-nav tab switch

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -77,8 +77,9 @@ fun GamepadHandler(
 
     // When focusResetKey changes, ensure the GamepadHandler Box has focus
     // so d-pad key events are received. Individual screens handle their own
-    // focus acquisition via Modifier.autoFocus() on their first focusable
-    // element — this is just a fallback so the Box can receive key events.
+    // focus acquisition via Modifier.focusRestoreItem(isDefault = true) on
+    // their default focusable — this is just a fallback so the Box can
+    // receive key events.
     if (focusResetKey != null) {
         LaunchedEffect(focusResetKey) {
             delay(500)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ChallengeDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ChallengeDetailScreen.kt
@@ -56,9 +56,12 @@ import com.spela.player.presentation.ui.components.challenge.SpChallengeTypeChip
 import com.spela.player.presentation.ui.components.challenge.SpDifficultyChip
 import com.spela.player.presentation.ui.components.challenge.formatDuration
 import com.spela.player.presentation.ui.theme.SpColor
+import androidx.compose.runtime.CompositionLocalProvider
 import com.spela.player.presentation.ui.gamepad.InputMode
+import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.gamepad.autoFocus
+import com.spela.player.presentation.ui.gamepad.focusRestoreItem
+import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.viewmodel.ChallengeDetailViewModel
@@ -94,6 +97,8 @@ fun ChallengeDetailScreen(
     val isGamepad = LocalInputMode.current == InputMode.GAMEPAD
 
     SpScreen {
+        val focusMemory = rememberFocusMemoryState()
+        CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
         Column(
             modifier = Modifier
                 .fillMaxSize(),
@@ -236,7 +241,10 @@ fun ChallengeDetailScreen(
                         text = "Attempt Challenge",
                         onClick = { onAttempt(challenge.id, challenge.gameId) },
                         modifier = Modifier
-                            .autoFocus()
+                            .focusRestoreItem(
+                                key = "challenge_detail_attempt",
+                                isDefault = true,
+                            )
                             .fillMaxWidth()
                             .testTag("attempt_challenge_button"),
                     )
@@ -306,6 +314,7 @@ fun ChallengeDetailScreen(
                 onDismiss = { showDeleteConfirm = false },
             )
         }
+        } // CompositionLocalProvider
     }
 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DeveloperGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DeveloperGamesScreen.kt
@@ -45,9 +45,12 @@ import com.spela.player.presentation.ui.components.SpSearchField
 import com.spela.player.presentation.ui.components.SpScreenTopSpacer
 import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.feature.library.GameGridItem
+import androidx.compose.runtime.CompositionLocalProvider
 import com.spela.player.presentation.ui.gamepad.InputMode
+import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.gamepad.autoFocus
+import com.spela.player.presentation.ui.gamepad.focusRestoreItem
+import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -152,6 +155,8 @@ fun DeveloperGamesScreen(
     val isGamepad = LocalInputMode.current == InputMode.GAMEPAD
 
     SpScreen(modifier = Modifier.testTag("developer_games_screen")) {
+        val focusMemory = rememberFocusMemoryState()
+        CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
         SpLazyVerticalGrid(
             columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
             modifier = Modifier.fillMaxSize().testTag("developer_games_grid"),
@@ -210,7 +215,10 @@ fun DeveloperGamesScreen(
                             icon = Icons.Filled.SwapVert,
                             contentDescription = "Sort games",
                             onClick = { showSortMenu = true },
-                            modifier = Modifier.autoFocus(),
+                            modifier = Modifier.focusRestoreItem(
+                                key = "developer_games_sort",
+                                isDefault = true,
+                            ),
                         )
                         DropdownMenu(
                             expanded = showSortMenu,
@@ -290,5 +298,6 @@ fun DeveloperGamesScreen(
                 },
             )
         }
+        } // CompositionLocalProvider
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DownloadsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DownloadsScreen.kt
@@ -46,7 +46,6 @@ import com.spela.player.presentation.ui.components.SpScreenTopSpacer
 import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.gamepad.autoFocus
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
@@ -127,7 +126,10 @@ fun DownloadsScreen(
                             onClick = { viewModel.onIntent(DownloadsIntent.ClearCache) },
                             isLoading = state.isClearingCache,
                             enabled = !state.isClearingCache && state.cacheSize > 0,
-                            modifier = Modifier.autoFocus(),
+                            modifier = Modifier.focusRestoreItem(
+                                key = "downloads_clear_cache",
+                                isDefault = true,
+                            ),
                         )
                     }
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
@@ -43,7 +43,6 @@ import com.spela.player.presentation.ui.feature.explore.DeveloperTopRatedRow
 import com.spela.player.presentation.ui.feature.explore.DeveloperUserStatsCard
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.gamepad.autoFocus
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
@@ -105,7 +104,7 @@ fun ExploreDeveloperScreen(
                         DeveloperHeroBanner(
                             detail = detail,
                             modifier = Modifier
-                                .autoFocus()
+                                .focusRestoreItem(key = "explore_developer_hero", isDefault = true)
                                 .layout { measurable, constraints ->
                                     val extraWidth = (horizontalPadding * 2).roundToPx()
                                     val newConstraints = constraints.copy(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExplorePublisherScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExplorePublisherScreen.kt
@@ -43,7 +43,6 @@ import com.spela.player.presentation.ui.feature.explore.DeveloperTopRatedRow
 import com.spela.player.presentation.ui.feature.explore.DeveloperUserStatsCard
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.gamepad.autoFocus
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
@@ -104,7 +103,7 @@ fun ExplorePublisherScreen(
                             DeveloperHeroBanner(
                                 detail = detail,
                                 modifier = Modifier
-                                    .autoFocus()
+                                    .focusRestoreItem(key = "explore_publisher_hero", isDefault = true)
                                     .layout { measurable, constraints ->
                                         val extraWidth = (horizontalPadding * 2).roundToPx()
                                         val newConstraints = constraints.copy(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -38,8 +38,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
-import com.spela.player.presentation.ui.gamepad.autoFocus
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
+import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.gamepad.rememberFocus
 import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import androidx.compose.runtime.CompositionLocalProvider
@@ -172,7 +172,7 @@ fun ExploreScreen(
                     SearchBarEntryPoint(
                         onClick = { onGlobalSearchSelected?.invoke() },
                         modifier = Modifier
-                            .autoFocus()
+                            .focusRestoreItem(key = "explore_search_bar", isDefault = true)
                             .testTag("explore_search_bar"),
                     )
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreSearchScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreSearchScreen.kt
@@ -53,7 +53,6 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.feature.explore.GameFilterPanel
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.gamepad.autoFocus
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -118,7 +117,7 @@ fun ExploreSearchScreen(
                     onDeleteSavedSearch = { id -> viewModel.deleteSavedSearch(id) },
                     onApplySavedSearch = { saved -> viewModel.applySavedSearch(saved) },
                     modifier = Modifier
-                        .autoFocus()
+                        .focusRestoreItem(key = "explore_search_filters", isDefault = true)
                         .fillMaxWidth()
                         .padding(horizontal = SpSpacing.ScreenHorizontal),
                 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameAchievementsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameAchievementsScreen.kt
@@ -16,9 +16,12 @@ import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpScreenTopSpacer
 import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.feature.gamedetail.GameAchievementsSection
+import androidx.compose.runtime.CompositionLocalProvider
 import com.spela.player.presentation.ui.gamepad.InputMode
+import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.gamepad.autoFocus
+import com.spela.player.presentation.ui.gamepad.focusRestoreItem
+import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.viewmodel.GameDetailViewModel
 
@@ -39,6 +42,8 @@ fun GameAchievementsScreen(
     val isGamepad = LocalInputMode.current == InputMode.GAMEPAD
 
     SpScreen {
+        val focusMemory = rememberFocusMemoryState()
+        CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
         Column(
             modifier = Modifier
                 .fillMaxSize(),
@@ -60,7 +65,10 @@ fun GameAchievementsScreen(
                 .padding(SpSpacing.Default),
         ) {
             GameAchievementsSection(
-                modifier = Modifier.autoFocus(),
+                modifier = Modifier.focusRestoreItem(
+                    key = "game_achievements_section",
+                    isDefault = true,
+                ),
                 achievements = state.achievements,
                 progress = state.achievementProgress,
                 timeline = state.achievementTimeline,
@@ -74,5 +82,6 @@ fun GameAchievementsScreen(
             )
         }
         }
+        } // CompositionLocalProvider
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/LicensesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/LicensesScreen.kt
@@ -22,9 +22,8 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.gamepad.autoFocus
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
-import com.spela.player.presentation.ui.gamepad.rememberFocus
+import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import androidx.compose.runtime.CompositionLocalProvider
 import com.spela.player.presentation.ui.theme.SpColor
@@ -140,8 +139,10 @@ fun LicensesScreen(
 
             items(credits) { entry ->
                 SpCard(
-                    modifier = (if (entry == credits.firstOrNull()) Modifier.autoFocus() else Modifier)
-                        .rememberFocus(entry.name),
+                    modifier = Modifier.focusRestoreItem(
+                        key = "license_${entry.name}",
+                        isDefault = entry == credits.firstOrNull(),
+                    ),
                 ) {
                     Column(
                         modifier = Modifier

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayListScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayListScreen.kt
@@ -51,7 +51,6 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.gamepad.autoFocus
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
@@ -132,7 +131,10 @@ fun NetplayListScreen(
                                 SpSecondaryButton(
                                     text = "Join by Code",
                                     onClick = { showJoinDialog = true },
-                                    modifier = Modifier.autoFocus(),
+                                    modifier = Modifier.focusRestoreItem(
+                                        key = "netplay_list_join_by_code",
+                                        isDefault = true,
+                                    ),
                                 )
                             }
                             Spacer(Modifier.height(SpSpacing.Default))

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
@@ -53,9 +53,12 @@ import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpScreenTopSpacer
 import com.spela.player.presentation.ui.components.SpTopBar
+import androidx.compose.runtime.CompositionLocalProvider
 import com.spela.player.presentation.ui.gamepad.InputMode
+import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.gamepad.autoFocus
+import com.spela.player.presentation.ui.gamepad.focusRestoreItem
+import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -126,6 +129,8 @@ fun NetplayLobbyScreen(
     val isGamepad = LocalInputMode.current == InputMode.GAMEPAD
 
     SpScreen {
+        val focusMemory = rememberFocusMemoryState()
+        CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
         Column(
             modifier = Modifier
                 .fillMaxSize(),
@@ -295,7 +300,12 @@ fun NetplayLobbyScreen(
                                 SpButton(
                                     text = "Invite Player",
                                     onClick = { viewModel.onIntent(NetplayLobbyIntent.ShowInviteSheet) },
-                                    modifier = Modifier.autoFocus().padding(horizontal = SpSpacing.ScreenHorizontal),
+                                    modifier = Modifier
+                                        .focusRestoreItem(
+                                            key = "netplay_lobby_invite_player",
+                                            isDefault = true,
+                                        )
+                                        .padding(horizontal = SpSpacing.ScreenHorizontal),
                                 )
                             }
                         }
@@ -345,6 +355,7 @@ fun NetplayLobbyScreen(
             onDismiss = { viewModel.onIntent(NetplayLobbyIntent.DismissInviteSuccess) },
             modifier = Modifier.align(Alignment.BottomCenter),
         )
+        } // CompositionLocalProvider
     }
 
     // Invite player dialog

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
@@ -49,8 +49,11 @@ import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpScreenTopSpacer
 import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.components.PlatformBackHandler
+import androidx.compose.runtime.CompositionLocalProvider
 import com.spela.player.presentation.ui.gamepad.InputMode
+import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
+import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.viewmodel.SharedSessionDetailViewModel
@@ -86,6 +89,8 @@ fun SharedSessionDetailScreen(
     val isGamepad = LocalInputMode.current == InputMode.GAMEPAD
 
     SpScreen {
+        val focusMemory = rememberFocusMemoryState()
+        CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
         Column(
             modifier = Modifier
                 .fillMaxSize(),
@@ -262,6 +267,7 @@ fun SharedSessionDetailScreen(
             onDismiss = { viewModel.onIntent(SharedSessionDetailIntent.DismissSuccess) },
             modifier = Modifier.align(Alignment.BottomCenter),
         )
+        } // CompositionLocalProvider
     }
 
     // Clone-to-my-library dialog — opened from the top-bar `…` menu.

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/TopListsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/TopListsScreen.kt
@@ -58,7 +58,6 @@ import com.spela.player.presentation.ui.feature.stats.RankBadge
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.gamepad.autoFocus
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
@@ -85,6 +84,8 @@ fun TopListsScreen(
     val isGamepad = LocalInputMode.current == InputMode.GAMEPAD
 
     SpScreen(modifier = Modifier.testTag("top_lists_screen")) {
+        val focusMemory = rememberFocusMemoryState()
+        CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
         Column(
             modifier = Modifier
                 .fillMaxSize(),
@@ -119,7 +120,9 @@ fun TopListsScreen(
                             modifier = Modifier.size(14.dp),
                         )
                     },
-                    modifier = Modifier.autoFocus().testTag("tab_top_rated"),
+                    modifier = Modifier
+                        .focusRestoreItem(key = "tab_top_rated", isDefault = true)
+                        .testTag("tab_top_rated"),
                 )
                 SpChip(
                     text = "Longest",
@@ -180,8 +183,6 @@ fun TopListsScreen(
                             )
                         }
                     } else {
-                        val focusMemory = rememberFocusMemoryState()
-                        CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
                         when (state.selectedTab) {
                             TopListTab.TOP_RATED -> {
                                 LazyColumn(
@@ -228,11 +229,11 @@ fun TopListsScreen(
                                 }
                             }
                         }
-                        } // CompositionLocalProvider
                     }
                 }
             }
         }
+        } // CompositionLocalProvider
 
         // Error snackbar
         SpSnackbar(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
@@ -52,7 +52,6 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.gamepad.autoFocus
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.gamepad.rememberFocus
@@ -262,7 +261,9 @@ private fun ProfileContent(
             StatCard(
                 label = "Play Time",
                 value = formatPlayTime(profile.totalPlayTime),
-                modifier = Modifier.weight(1f).autoFocus(),
+                modifier = Modifier
+                    .weight(1f)
+                    .focusRestoreItem(key = "user_profile_play_time", isDefault = true),
             )
             StatCard(
                 label = "Games Played",


### PR DESCRIPTION
## Summary

Closes #1138. Replaces every \`Modifier.autoFocus()\` call site with \`Modifier.focusRestoreItem(key, isDefault = true)\` — a strict superset that saves focus to the screen scope as well as setting it on first entry. autoFocus had no save side, so a user who pressed back from a deeper screen would land on the auto-focused element instead of where they came from.

## What changed

- 14 screens converted (5 also gained \`LocalFocusMemory\` wrapping at the screen root).
- \`TopListsScreen\` had its focus-memory scope moved up to wrap the chip strip; the chips were previously outside it.
- \`LicensesScreen\` drops a redundant \`rememberFocus(entry.name)\` since \`focusRestoreItem\` handles both save and restore.
- \`AutoFocus.kt\`'s \`autoFocus()\` function removed. The \`LocalIsForwardNavigation\` / \`LocalIsTabSwitch\` CompositionLocals stay (still consumed by FocusMemory.kt + SpelaApp).
- \`player/GAMEPAD_NAVIGATION.md\` updated to drop the "legacy autoFocus" section and document \`focusRestoreItem\` as the single primitive for default-on-entry focus.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid\` clean.
- [x] \`./gradlew :shared:detektMainDesktop :android:detektDebugAndroid :desktop:detektMainDesktop\` clean.
- [x] \`./gradlew :shared:desktopTest\` green.
- [ ] Manual sanity on a screen that gained a new scope (e.g. NetplayLobbyScreen) — first entry focuses the Invite button; back from a deeper screen restores the previously focused element.