### PR TITLE
feat(player): keyboard glyphs in gamepad section pill (#1136)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
@@ -30,6 +30,20 @@ import com.spela.player.libretro.ControllerStatusState
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 
+/**
+ * Glyphs for the prev/next-section bumpers shown on either side of the
+ * pill. When a controller is connected we use the L1/R1 labels that
+ * match the bumper buttons; otherwise we surface the keyboard bindings
+ * (`[` / `]`) the GamepadHandler already wires (#1136). This keeps the
+ * pill honest about what each user can actually press.
+ */
+private data class SectionBumperGlyphs(val prev: String, val next: String) {
+    companion object {
+        val Gamepad = SectionBumperGlyphs(prev = "L1", next = "R1")
+        val Keyboard = SectionBumperGlyphs(prev = "[", next = "]")
+    }
+}
+
 @Composable
 fun SpSectionIndicator(
     activeTab: BottomNavTab,
@@ -38,6 +52,11 @@ fun SpSectionIndicator(
     modifier: Modifier = Modifier,
 ) {
     val animationsEnabled = LocalAnimationsEnabled.current
+    val glyphs = if (controllerStatus.connectedCount > 0) {
+        SectionBumperGlyphs.Gamepad
+    } else {
+        SectionBumperGlyphs.Keyboard
+    }
 
     AnimatedVisibility(
         visible = visible,
@@ -56,7 +75,7 @@ fun SpSectionIndicator(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "L1",
+                text = glyphs.prev,
                 color = SpColor.OnBackgroundSecondary,
                 fontSize = 12.sp,
             )
@@ -75,7 +94,7 @@ fun SpSectionIndicator(
                 }
             }
             Text(
-                text = "R1",
+                text = glyphs.next,
                 color = SpColor.OnBackgroundSecondary,
                 fontSize = 12.sp,
             )


### PR DESCRIPTION
## Summary

Closes #1136. The pill that replaces the bottom nav in gamepad mode previously hardcoded \"L1\" / \"R1\". Fine if a controller's plugged in, but the pill also appears for desktop keyboard users (any press of \`[\` / \`]\` flips InputMode to GAMEPAD), and L1/R1 means nothing if you don't have a controller.

## Behaviour

- \`controllerStatus.connectedCount > 0\` → pill shows \"L1\" / \"R1\".
- Otherwise → pill shows \"[\" / \"]\".

The keyboard bindings themselves were already wired in \`GamepadNavigation.kt\` (LeftBracket / RightBracket / Tab / Shift+Tab). This is purely the visual cue that surfaces them. The number-key direct-tab shortcuts mentioned in the issue stay deferred — the issue itself flags them as docs-discoverable nice-to-have, and they conflict with text input.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop :shared:detektMainDesktop :shared:desktopTest\` — clean.
- [ ] Manual: desktop with no controller → press \`[\` → pill appears with \"[\" / \"]\". Plug a controller → pill shows \"L1\" / \"R1\".