### PR TITLE
feat(player): faster Android E2E iteration loop (#1148)

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -98,6 +98,39 @@ cd player
 - **Cascading test failures** → A failed `restartApp()` can leave the app in a broken state, causing subsequent tests to fail. Tests are designed to recover via `ensureLoggedIn()` but this doesn't always work after a stuck Activity recreation.
 - **Continuous Compose animations** → The neon UI has continuous animations (gradient glow, ambient blobs). `IdlingPolicies.setMasterPolicyTimeout(10s)` is set as mitigation. System animation scale = 0 doesn't help because Compose animations are independent of system settings.
 
+#### Iterating on a single Android E2E test
+
+The full `run-e2e.sh` invocation tears down the docker volumes, rebuilds the
+backend image, uninstalls + reinstalls the APK, and runs every test class.
+End-to-end that's ~25 min — fine for CI, brutal for iterating on one bug.
+
+Use `player/scripts/e2e-android-quick.sh` to keep the backend + AVD warm
+between iterations. After a one-time setup, each test cycle is ~2 min:
+
+```bash
+# One-time per machine (once per dev session):
+emulator -avd spela-test -no-snapshot-load &
+docker compose -f docker-compose.e2e.yml up -d --build --wait
+
+# Iterate on a single class as many times as needed:
+./player/scripts/e2e-android-quick.sh CloneSessionSmokeTest
+# (FQCN also works: com.spela.player.android.CloneSessionSmokeTest)
+```
+
+The wrapper validates both prereqs up-front, then delegates to
+`run-e2e.sh --emulator --skip-reset <class>` so the heavy lifting (adb
+reverse, animation disable, core pre-cache, failure diagnostics) stays
+in one place. Backend state is preserved across iterations because the
+`--skip-reset` flag avoids `docker compose down -v` — the trade-off is
+that you must call `POST /api/test/reset` from any test that needs a
+clean DB (`BaseE2ETest.@Before` already does).
+
+If you want to log diagnostic data from `commonMain` and have it surface
+in the workflow's failure dump, use `spelaLog(tag, message)` from
+`com.spela.player.util` rather than `println`. On Android it routes to
+`Log.i("Spela", ...)`, which the dump's `-s Spela:V` filter explicitly
+includes; `println` (tag `System.out`) is silently dropped.
+
 ### Test Tag Convention (Player App)
 
 Screen-level and element-level test tags are defined in `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/TestTags.kt`. Both the composables and the test suites reference these constants, so tests don't break when display text changes.

--- a/player/scripts/e2e-android-quick.sh
+++ b/player/scripts/e2e-android-quick.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Fast iteration loop for a single Android E2E test class.
+#
+# Assumes one-time setup is already done (see docs/e2e-testing.md
+# "Iterating on a single Android E2E test"):
+#
+#   1. AVD running          : emulator -avd spela-test -no-snapshot-load &
+#   2. docker-compose up    : docker compose -f docker-compose.e2e.yml up -d --build --wait
+#
+# Then iterate with:
+#
+#   ./player/scripts/e2e-android-quick.sh CloneSessionSmokeTest
+#   ./player/scripts/e2e-android-quick.sh com.spela.player.android.CloneSessionSmokeTest
+#
+# Both forms work — the FQCN is auto-prefixed when missing. End-to-end
+# wall time is ~2 min after the first run instead of ~25 min via PR CI.
+#
+# This wrapper:
+#   * validates the AVD is online
+#   * validates the backend is healthy (no recreate / reset — keeps
+#     state warm across iterations)
+#   * delegates to run-e2e.sh with --emulator --skip-reset so the heavy
+#     lifting (adb reverse, animation disable, core pre-cache,
+#     diagnostics) stays in one place
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLAYER_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$PLAYER_DIR/.." && pwd)"
+
+if [ "$#" -lt 1 ]; then
+  cat <<EOF >&2
+usage: $0 <TestClass | FullyQualifiedClassName>
+
+Examples:
+  $0 CloneSessionSmokeTest
+  $0 com.spela.player.android.CoreDecisionFlagsSmokeTest
+
+Prereqs (one-time per machine):
+  emulator -avd spela-test -no-snapshot-load &
+  docker compose -f docker-compose.e2e.yml up -d --build --wait
+
+See docs/e2e-testing.md "Iterating on a single Android E2E test" for
+the full setup walkthrough.
+EOF
+  exit 64
+fi
+
+TEST_CLASS="$1"
+case "$TEST_CLASS" in
+  *.*) FQCN="$TEST_CLASS" ;;
+  *) FQCN="com.spela.player.android.$TEST_CLASS" ;;
+esac
+
+# Preflight: emulator running?
+if ! adb devices | awk '/^emulator-[0-9]+/ && $2 == "device" {found=1} END{exit !found}'; then
+  cat <<'EOF' >&2
+error: no running emulator detected.
+
+Start the spela-test AVD:
+  emulator -avd spela-test -no-snapshot-load &
+
+Then re-run this script.
+EOF
+  exit 1
+fi
+
+# Preflight: backend healthy?
+if ! curl -fs --max-time 2 http://localhost:8080/api/health >/dev/null; then
+  cat <<EOF >&2
+error: backend not responding on localhost:8080.
+
+Bring up the E2E stack (one-time per session):
+  docker compose -f $REPO_ROOT/docker-compose.e2e.yml up -d --build --wait
+
+Then re-run this script.
+EOF
+  exit 1
+fi
+
+echo "── Quick iterate: $FQCN ──"
+exec "$PLAYER_DIR/run-e2e.sh" --emulator --skip-reset "$FQCN"

--- a/player/shared/src/androidMain/kotlin/com/spela/player/util/SpelaLog.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/util/SpelaLog.android.kt
@@ -1,0 +1,7 @@
+package com.spela.player.util
+
+import android.util.Log
+
+actual fun spelaLog(tag: String, message: String) {
+    Log.i("Spela", "[$tag] $message")
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/SpelaLog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/SpelaLog.kt
@@ -1,0 +1,26 @@
+package com.spela.player.util
+
+/**
+ * Logs a diagnostic line that survives the Android E2E workflow's
+ * logcat dump filter.
+ *
+ * The CI logcat dump on test failure runs:
+ *   adb logcat -d -s E2E_SETUP:V E2E_NAV:V Spela:V SpelaTest:V ...
+ *
+ * which means messages from `kotlin.io.println` (tag "System.out") are
+ * dropped — even when a wider grep pass runs, "System.out" doesn't
+ * match the `com.spela|ktor|...` filter either. To get a shared-code
+ * log line into the failure dump, route it through this primitive: on
+ * Android it lands under tag "Spela" (which the dump explicitly
+ * includes); on desktop it goes to stdout.
+ *
+ * Reach for this when temporarily diagnosing an integration bug whose
+ * data flow crosses commonMain (auth, networking, repos). Remove the
+ * call once the bug is fixed — these are intentionally unstructured
+ * `println`-style lines, not a substitute for proper structured
+ * logging.
+ *
+ * Don't go through `android.util.Log` directly from common code (it's
+ * Android-only) or `println` (filtered out by the dump).
+ */
+expect fun spelaLog(tag: String, message: String)

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/util/SpelaLog.desktop.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/util/SpelaLog.desktop.kt
@@ -1,0 +1,5 @@
+package com.spela.player.util
+
+actual fun spelaLog(tag: String, message: String) {
+    println("[Spela:$tag] $message")
+}


### PR DESCRIPTION
Closes #1148.

Two pieces of developer infra that came out of debugging #1146 (CloneSessionSmokeTest 401), where each diagnostic CI cycle was ~25 min and a \`println\` from shared code didn't survive the workflow's logcat tag-filter.

## What's in here

**1. \`spelaLog(tag, message)\` — shared-code logging primitive**

\`commonMain\` expect, \`androidMain\` + \`desktopMain\` actuals.

- Android actual: \`Log.i(\"Spela\", \"[\$tag] \$msg\")\` — the \"Spela\" tag is what the workflow's logcat dump (\`-s Spela:V\`) explicitly includes, so diagnostic lines from shared code now actually show up in the failure dump.
- Desktop actual: \`println(\"[Spela:\$tag] \$msg\")\`.

Reach for this when temporarily diagnosing an integration bug whose data flow crosses commonMain (auth, networking, repos). \`kotlin.io.println\` from common code goes to tag \`System.out\`, which the tag-filter drops *and* the wider \`com.spela|ktor|...\` grep doesn't match — so \`println\` is invisible in CI today.

**2. \`scripts/e2e-android-quick.sh\` — fast-iterate wrapper for one test**

\`./player/scripts/e2e-android-quick.sh CloneSessionSmokeTest\`

Validates the AVD + backend are already up (errors out with the exact commands to fix if not), then delegates to \`run-e2e.sh --emulator --skip-reset <FQCN>\`. Wall-clock drops from ~25 min to ~2 min after the first cycle because docker-compose stays up and the APK gets reused.

\`docs/e2e-testing.md\` gains an \"Iterating on a single Android E2E test\" section that walks the one-time setup + iterate loop and points at \`spelaLog\`.

**3. ~~Master-cron Android E2E~~** — turned out to already exist (daily at 04:07 UTC, has been firing). No change needed.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid\` — passes
- [x] \`bash -n player/scripts/e2e-android-quick.sh\` + smoke run with no args (prints usage + prereqs)
- [ ] Manual: invoke \`spelaLog(\"AuthDiag\", \"hello\")\` from a desktop test — line shows on stdout
- [ ] Manual: invoke from an Android E2E run — line appears in the failure dump under tag \`Spela\`