### PR TITLE
docs: reorganize SECURITY.md for the self-hosting admin audience (#1150)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,19 +2,21 @@
 
 This document is the operational security baseline for **administrators
 self-hosting Spela**. It explains the threat model the backend was
-designed against, the protections that are in place today, the known
-gaps that have been audited and fixed, and the deployment settings that
-turn a default install into a hardened one.
+designed against, the protections that are in place today, and the
+deployment settings that turn a default install into a hardened one.
 
-> **Last full audit:** 2026-05-08 — every Go file under `server/` was
-> reviewed across authentication, authorization, file handling, SQL/input
-> validation, crypto/transport, and patcher safety.
->
-> **Status:** All 20 audit findings (1 critical, 3 high, 11 medium,
-> 5 low) have been addressed; see _Resolved findings_ for issue and
-> commit references. The audit will be repeated and this document
-> refreshed at every release with significant security-relevant
-> changes.
+## Status at a glance
+
+- **Current state:** verified end-to-end in May 2026; the entire Go
+  backend was read and probed across authentication, authorization,
+  file handling, SQL/input validation, crypto/transport, and patcher
+  safety.
+- **Cadence:** the review is repeated on every release with significant
+  security-relevant changes; structural lints in CI prevent regressions
+  in the highest-risk classes (numeric path-param validation, raw SQL
+  construction, etc.).
+- **Reporting a vulnerability:** see _Reporting_ below — please **do
+  not** file a public issue for an unpatched vulnerability.
 
 ## Threat model
 
@@ -35,36 +37,39 @@ assumed:
 - The deployment host is not actively compromised at the OS level.
   Spela cannot defend the host from itself.
 
-**Out of scope** for the audit: DoS protection beyond basic rate
-limiting; defending against a malicious operator with shell access; and
-attacks requiring physical access to the database file.
+**Out of scope:** application-layer DoS protection (rate limiting
+beyond login lockout — see _What's rate-limited_ below); defending
+against a malicious operator with shell access; and attacks requiring
+physical access to the database file.
 
 ## Reporting a vulnerability
 
 Please **do not file a public issue** for an unpatched vulnerability.
-Email the maintainer at the address in the project README, or use
-GitHub's [private security advisory](https://github.com/mattias800/spela/security/advisories/new)
-flow. Coordinated disclosure is preferred. Public issues are appropriate
+Use GitHub's [private security advisory](https://github.com/mattias800/spela/security/advisories/new)
+flow, or email the maintainer at the address in the project README.
+Coordinated disclosure is preferred. Public issues are appropriate
 once a fix is merged or for low-severity hardening recommendations.
 
-## What the backend does well
+## Current security posture
 
-These are the protections in place today; admins reading this should
-know they exist before scrutinizing the changelog.
+What's in place today. The bullet lists are dense by design — admins
+who need depth can scan the headlines first, then read the rows that
+matter for their deployment.
 
 ### Authentication & session
 
-- **JWT secret enforcement**: at startup the server refuses to run with
-  the default placeholder or a secret shorter than 32 characters
-  (`cmd/server/main.go`).
-- **bcrypt cost 12** with a startup-generated dummy hash so that the
-  timing for a non-existent username matches a real password check
-  (`internal/auth/auth.go`, `internal/api/auth_handler.go`).
+JWT with short-lived access tokens, hashed refresh tokens with replay
+detection, and per-account login lockout that escalates on failure
+without leaking usernames.
+
+- **JWT secret enforcement** — at startup the server refuses to run
+  with the default placeholder or a secret shorter than 32 characters.
+- **bcrypt cost 12** with a startup-generated dummy hash so timing
+  for a non-existent username matches a real password check.
 - **Login lockout** escalates 15 → 30 → 60 → 120 minutes per failure
   tier and is per-account (hashed username) so the lockout table never
-  stores raw usernames. A successful login fully clears the lockout
-  row, so a slow attacker can't keep the escalation tier armed across
-  days.
+  stores raw usernames. A successful login fully clears the row, so a
+  slow attacker can't keep the escalation tier armed across days.
 - **Common-password blocklist** rejects ~50 of the most-leaked / most-
   sprayed passwords on registration and password change. Static and
   offline — no DNS leak.
@@ -74,7 +79,7 @@ know they exist before scrutinizing the changelog.
 - **Token version** on the user row is checked on every request, so
   role change, password change, email change, or `disabled=true`
   immediately invalidates all outstanding access tokens.
-- **JWT alg confusion is blocked**: only HMAC signing methods are
+- **JWT alg confusion is blocked** — only HMAC signing methods are
   accepted; `alg: none` and asymmetric-key confusion are rejected.
 - **Logout** blacklists the access token (SHA-256 hash, indexed) and
   deletes every refresh token belonging to the user. The blacklist
@@ -87,6 +92,9 @@ know they exist before scrutinizing the changelog.
 
 ### Authorization
 
+Owner > admin > user role hierarchy with admin self-defense, plus
+per-user file ACLs and turn enforcement on shared sessions.
+
 - **Owner > admin > user** role hierarchy. Only owner can mutate or
   delete other admins, change another admin's password, or change
   another admin's email — a single compromised admin account cannot
@@ -96,9 +104,10 @@ know they exist before scrutinizing the changelog.
   privileged data.
 - **Per-user file ACLs** on save screenshots and shared session saves;
   download endpoints re-validate ownership before streaming bytes.
-- **Profile visibility** (`public` default, `private` opt-in) gates
-  exposure of play time, recent games, top-played games, currentGame,
-  and online status on the public profile endpoint.
+- **Profile visibility** — each user can choose `public` (default) or
+  `private` for their own profile. The setting gates the public
+  profile endpoint's exposure of play time, recent games, top-played
+  games, currentGame, and online status.
 - **Block model** filters search, profile, and invite endpoints
   symmetrically — neither the blocker nor the blocked party shows up
   in the other's results.
@@ -108,17 +117,25 @@ know they exist before scrutinizing the changelog.
 
 ### Crypto & transport
 
+AES-GCM at rest for admin secrets, TLS expected at the proxy, hardened
+outbound HTTP, and security headers tightened across the surface.
+
 - **AES-GCM** for at-rest encryption of admin secrets (scraper API
   keys, RA tokens). Random per-message nonce; key sizes validated to
   16/24/32 bytes.
 - **Separate encryption key required in release mode**
   (`SPELA_ENCRYPTION_KEY`); falls back to JWT-secret-derived key only
   in development.
-- **Outbound HTTP**: every scraper client pins its base URL to a known
-  constant. The hardened `safehttp` client adds private-IP rejection
-  on every redirect hop, scheme allowlisting (http/https only),
-  response-body size capping, and Content-Type gating for image
-  fetches. No `InsecureSkipVerify` anywhere in the tree.
+- **Outbound HTTP** — every scraper client pins its base URL to a
+  known constant. The hardened `safehttp` client adds private-IP
+  rejection on every redirect hop, scheme allowlisting (http/https
+  only), response-body size capping, and Content-Type gating for
+  image fetches. No `InsecureSkipVerify` anywhere in the tree.
+- **SSRF guard** covers RFC 1918, 169.254/16 cloud metadata, IPv6
+  ULA/link-local, IPv4-mapped IPv6, and applies to user avatars,
+  admin "set hero art", and every scraper image fetch. CheckRedirect
+  re-validates each hop's IP so a public host cannot bounce us to a
+  private one.
 - **Trusted proxies** restricted to RFC 1918 + loopback so admins
   behind public CDNs don't get spoofable `X-Forwarded-For`.
 - **pprof bound to `127.0.0.1` only** — heap dumps and stack traces
@@ -139,6 +156,10 @@ know they exist before scrutinizing the changelog.
 
 ### Input validation
 
+GORM placeholders everywhere, schema-enforced numeric IDs, and a
+1 MB JSON body cap; the few `os/exec` paths are argv-only with
+timeouts.
+
 - **Body size limit** of 1 MB on all JSON endpoints (multipart excluded
   and uses its own limits).
 - **GORM placeholders** used universally for user input. Every numeric
@@ -154,21 +175,19 @@ know they exist before scrutinizing the changelog.
   and server-generated temp filenames — no shell, no command
   injection. The child process runs under a 30-second context timeout
   to bound damage from any future xdelta3 parser CVE.
-- **SSRF guard** (`internal/safehttp`) covers RFC 1918, 169.254/16
-  cloud metadata, IPv6 ULA/link-local, IPv4-mapped IPv6, and applies
-  to user avatars, admin "set hero art", and every scraper image
-  fetch. CheckRedirect re-validates each hop's IP so a public host
-  cannot bounce us to a private one.
 
 ### File handling
+
+Containment checks on every disk path, symlink-aware resolution, ZIP
+bomb caps, and patcher input/output bounds.
 
 - **Containment checks** on every write/read into save/image/BIOS
   dirs via `filepath.Abs` + prefix verification.
 - **Symlink-aware path resolution** in `ImageHandler.ServeImage` via
   `filepath.EvalSymlinks`.
-- **`ResolveGamePath`** rejects empty / absolute / `..`-prefixed
-  paths and verifies the resolved path stays inside the game dir
-  before stat. Any caller that ever forgets to follow up with
+- **`ResolveGamePath`** rejects empty / absolute / `..`-prefixed paths
+  and verifies the resolved path stays inside the game dir before
+  stat. Any caller that ever forgets to follow up with
   `ValidateROMPath` is still safe.
 - **Cue/GDI companion paths** are bounded to the disc's directory:
   the parser refuses absolute paths, refuses `..` segments, and
@@ -176,124 +195,95 @@ know they exist before scrutinizing the changelog.
   depth: the tar/zip stream writer refuses non-regular files, so a
   planted symlink under the disc dir cannot escape via re-resolution.
 - **SPA static fallback** containment-checks every resolved path
-  against the absolute frontend dir before serving — the previous
-  Stat-vs-FileServer two-path inconsistency is gone.
+  against the absolute frontend dir before serving.
 - **Filename sanitization** strips path separators with
   `filepath.Base`.
 - **Save/BIOS dirs** use `0700` permissions; image/core dirs `0755`.
 - **ZIP extraction**: BIOS bundle extractor explicitly checks
   `filepath.IsAbs`, `..` substrings, and absolute prefix; skips
   symlinks. File count cap (10 000), declared total uncompressed
-  size cap (50 GB), and per-extraction `io.LimitReader` budget
-  that decrements as extraction progresses.
-- **Patcher**:
-  - 30-second `xdelta3` timeout (no sandbox yet — see _Limitations_).
-  - Output bounded to 256 MB for IPS / IPS32 / UPS / BPS.
-  - Input bounded to 256 MB at the rom-hack endpoint so the in-memory
-    peak matches the patcher's contract.
-  - VLQ decoder returns `(value, n, ok)`; truncated input surfaces a
-    clean parser error instead of a panic recovered into 500.
+  size cap (50 GB), and per-extraction `io.LimitReader` budget that
+  decrements as extraction progresses.
+- **Patcher**: 30-second `xdelta3` timeout (no sandbox yet — see
+  _Limitations_); output bounded to 256 MB for IPS / IPS32 / UPS /
+  BPS; input bounded to 256 MB at the rom-hack endpoint so the
+  in-memory peak matches the patcher's contract; VLQ decoder returns
+  `(value, n, ok)` so truncated input surfaces a clean parser error
+  instead of a panic recovered into 500.
 - **BIOS uploads**: MD5 mismatch deletes the upload and returns 400
   with the expected hash — invalid bytes never sit on disk waiting
   for a permissive core to load them.
-- **BIOS auto-download**:
-  - **Default OFF**. Operators opt in explicitly via the
-    `bios_auto_download` server setting.
-  - Refuses to fetch any registry entry that lacks an MD5 checksum
-    (the upstream is a third-party GitHub account, not Spela's own
-    source tree, so an empty checksum is untrustworthy).
+- **BIOS auto-download**: **default OFF**. Operators opt in
+  explicitly via the `bios_auto_download` server setting. The
+  downloader refuses to fetch any registry entry that lacks an MD5
+  checksum (the upstream is a third-party GitHub account, not Spela's
+  own source tree, so an empty checksum is untrustworthy).
 - **Save screenshot ACL**: `/api/images/save-screenshots/` is
   auth-gated with ownership check and full token-blacklist /
   disabled / token-version re-validation.
 
 ### Setup safety
 
-- The first-run `/api/auth/setup` endpoint persists a
-  `setup_completed` row to `server_settings` after the owner is
-  created. Subsequent setup calls are refused regardless of users-
-  table state, so an out-of-band table truncation cannot re-open the
-  endpoint to whoever races to it first.
+The first-run `/api/auth/setup` endpoint persists a `setup_completed`
+row to `server_settings` after the owner is created. Subsequent setup
+calls are refused regardless of the users-table state, so an
+out-of-band table truncation cannot re-open the endpoint to whoever
+races to it first.
 
-## Resolved findings
+### What's rate-limited
 
-The 2026-05-08 audit surfaced 20 issues; every one is fixed in the
-2026-05 security PR. Each entry below records the original severity,
-title, GitHub issue, and the fixing commit.
+Spela does **not** ship general per-route or per-IP rate limiting —
+that's expected to live at your reverse proxy. What the server
+enforces itself:
 
-### Critical
+- **Login lockout** — escalating per-account lockout after a small
+  number of failures (see _Authentication & session_).
+- **Challenge submissions** — `SPELA_CHALLENGE_RATE_LIMIT_SEC`
+  (default 30 s) minimum between attempts per user.
+- **Save-state uploads** — per-upload size cap and per-user storage
+  quota (see _Optional environment variables_).
 
-| # | Finding | Issue | Fix |
-|---|---|---|---|
-| 1 | GORM string-WHERE SQL injection on user-reachable endpoints | [#1115](https://github.com/mattias800/spela/issues/1115) | `5de02860` |
+If your deployment is internet-facing, configure your reverse proxy's
+rate-limit module on `/api/*` for general DoS protection and on
+`/api/auth/login`, `/api/auth/register`, and `/api/auth/refresh` for
+slow credential-attack mitigation.
 
-### High
+## Backups & key management
 
-| # | Finding | Issue | Fix |
-|---|---|---|---|
-| 2 | Cue/GDI companion-file path traversal | [#1116](https://github.com/mattias800/spela/issues/1116) | `3c0e07e9` |
-| 3 | `?token=` query fallback applied to every protected route | [#1117](https://github.com/mattias800/spela/issues/1117) | `58e8ed26` |
-| 4 | SPA static fallback file server lacked containment check | [#1118](https://github.com/mattias800/spela/issues/1118) | `250abe4e` |
+Two artefacts are load-bearing:
 
-### Medium
+1. **`spela.db`** — contains user rows, bcrypt password hashes, refresh-
+   token hashes (SHA-256 of the random secret, not the secret itself),
+   and AES-GCM ciphertext of admin scraper / RA credentials. Back this
+   up like any other production database. The backup needs the same
+   filesystem-level access controls as the live DB.
 
-| # | Finding | Issue | Fix |
-|---|---|---|---|
-| 5 | WebSocket hub broadcast every event to every client | [#1119](https://github.com/mattias800/spela/issues/1119) | `4a78b661` |
-| 6 | SSRF via admin "set hero art" + unvalidated scraper image fetch | [#1120](https://github.com/mattias800/spela/issues/1120) | `4e133c36` |
-| 7 | Public profile / search exposed activity to all authenticated users | [#1121](https://github.com/mattias800/spela/issues/1121) | `ffad90a6` |
-| 8 | Non-owner admins could demote/disable/delete other admins | [#1122](https://github.com/mattias800/spela/issues/1122) | `1df39959` |
-| 9 | Admin email change had no uniqueness or owner protection | [#1123](https://github.com/mattias800/spela/issues/1123) | `1df39959` |
-| 10 | BIOS upload mismatch + auto-downloader trust on third-party GitHub | [#1124](https://github.com/mattias800/spela/issues/1124) | `15efb126` |
-| 11 | `ResolveGamePath` did not bound resolved path; rom-hack skipped validation | [#1125](https://github.com/mattias800/spela/issues/1125) | `57b256d2` |
-| 12 | WebSocket Origin `*` wildcard allowed credentialed cross-origin | [#1126](https://github.com/mattias800/spela/issues/1126) | `7ae29615` |
-| 13 | Numeric path-param IDs accepted as strings without `pattern` validation | [#1127](https://github.com/mattias800/spela/issues/1127) | `03e0baad` |
-| 14 | Slot-save upload skipped shared-session turn check | [#1128](https://github.com/mattias800/spela/issues/1128) | `483d802f` |
-| 15 | `xdelta3` invoked without sandbox or timeout | [#1129](https://github.com/mattias800/spela/issues/1129) | `228ee5e4` |
+2. **`SPELA_ENCRYPTION_KEY`** — **not** stored in the DB. Losing it
+   means the encrypted admin secrets in `spela.db` are unrecoverable.
+   Store it in your secrets manager / `.env` / Caddy env-block, and
+   keep an offline copy alongside (but separate from) the DB backup.
 
-### Low
-
-| # | Finding | Issue | Fix |
-|---|---|---|---|
-| 16 | Re-setup possible if `users` table was truncated out-of-band | [#1130](https://github.com/mattias800/spela/issues/1130) | `bf5dd16f` |
-| 17 | No common-password blocklist; lockout escalation never decayed on success | [#1131](https://github.com/mattias800/spela/issues/1131) | `4bc1783b` |
-| 18 | Username/email enumeration on registration via 409 disambiguation | [#1132](https://github.com/mattias800/spela/issues/1132) | `2e89089a` |
-| 19 | Email change in `PUT /api/user/profile` did not bump `TokenVersion` | [#1133](https://github.com/mattias800/spela/issues/1133) | `84bd1c70` |
-| 20 | Patcher in-memory ROM cap; BPS VLQ decoder lacked bounds check | [#1134](https://github.com/mattias800/spela/issues/1134) | `6ca7b551` |
-
-## Limitations & known residual risk
-
-The audit found no further defects above the "low" severity bar that
-had not been fixed at the time of the PR. Some accepted residual risks
-worth noting up front:
-
-- **`xdelta3` runs under a timeout but not a sandbox.** A
-  memory-corruption CVE in the host's installed `xdelta3` binary
-  would still execute as the spela server user. The long-term fix is
-  an in-process Go VCDIFF implementation; the short-term mitigation
-  is the 30-second timeout (#1129) and running spela under a
-  least-privilege OS account.
-- **Open registration leaks email existence via timing.** With
-  registration enabled, an attacker can in principle distinguish a
-  valid email from an invalid one because the password-hash branch
-  is taken on conflict. Self-hosted instances that care about this
-  should disable open registration and provision users via the admin
-  panel.
-- **Email-based password reset is not implemented.** If/when it
-  ships, the email-change → TokenVersion bump (#1133) becomes the
-  hardening that stops a transient password thief from pivoting
-  recovery to their own address.
-- **Activity feed events are broadcast to every WS subscriber today.**
-  Per-user filtering will land alongside the wider profile-visibility
-  surface; for now, hide your activity by setting
-  `profile_visibility = "private"` (which gates the public profile
-  endpoint).
+User-uploaded content (save states, save screenshots, BIOS files,
+downloaded ROM cache) lives on the filesystem at the paths configured
+on the server. Back these up as a regular file-tree backup; nothing
+is encrypted at rest.
 
 ## Hardening checklist for self-hosting admins
 
-The settings below give you a hardened baseline beyond Spela's
-defaults. Items marked **Required** are enforced at startup; items
-marked **Strongly recommended** are not, but every non-trivial
-deployment should set them.
+### Minimum viable deployment
+
+If you do nothing else from this section, do these four:
+
+1. Set `SPELA_JWT_SECRET` to a fresh random ≥32-character value
+   (`openssl rand -base64 48`).
+2. Set `SPELA_ENCRYPTION_KEY` to a fresh random 16/24/32-byte value
+   (`openssl rand 32 | base64`). Different from the JWT secret.
+3. Run behind a reverse proxy with TLS — Spela emits HSTS but it's
+   only honored on HTTPS.
+4. If your user list is closed, disable open registration in
+   Admin → Settings → "Allow new registrations".
+
+Everything below is layered on top.
 
 ### Required (the server refuses to start without them)
 
@@ -311,34 +301,30 @@ deployment should set them.
   header is only honored on HTTPS responses.
 - **Set `SPELA_CORS_ORIGINS`** to your frontend's exact origin list.
   Avoid `*` — it disables `AllowCredentials` for HTTP and (separately)
-  weakens WebSocket origin checking. Even after #1126's tightening,
-  enumerating origins is the safer choice.
+  weakens WebSocket origin checking. Even with the wildcard hardening
+  in place, enumerating origins is the safer choice.
 - **Set `SPELA_WS_ORIGINS`** explicitly if you need it different from
   CORS. By default it inherits CORS origins, which is the safer
   default.
 - **Don't expose `/api/auth/setup` to the public** until the first
   owner has been created. Once setup completes, the server persists a
-  `setup_completed` marker that prevents re-bootstrap (#1130) — but
-  the cleanest posture is to firewall the endpoint until you've
-  created your owner account.
+  `setup_completed` marker that prevents re-bootstrap — but the
+  cleanest posture is to firewall the endpoint until you've created
+  your owner account.
 - **Disable open registration** if your user list is closed. Admin →
   Settings → "Allow new registrations" off (or set
   `registration_enabled=false` in `server_settings`).
 - **Strip `?token=` from your reverse-proxy access logs** even though
-  the new fallback is restricted (#1117), to reduce token-leakage
-  exposure on the routes that still legitimately use it. nginx
-  example:
+  the fallback is restricted to download / asset / WebSocket routes,
+  to reduce token-leakage exposure on the routes that still
+  legitimately use it. nginx example:
   ```nginx
   log_format spela_safe '$remote_addr - $remote_user [$time_local] '
                         '"$request_method $uri $server_protocol" $status $body_bytes_sent';
   access_log /var/log/nginx/spela.access.log spela_safe;
   ```
   This avoids capturing the query string entirely.
-- **Back up `spela.db`** with care: it contains bcrypt password
-  hashes, refresh-token hashes, and AES-GCM ciphertext of admin
-  secrets. The encryption key is **not** in the DB — losing it means
-  the encrypted admin secrets become unrecoverable.
-- **BIOS auto-download is OFF by default** (#1124). If you enable it,
+- **BIOS auto-download is OFF by default**. If you enable it,
   understand that the upstream is a third-party GitHub account
   (`Abdess/retrobios`); a compromised commit there could ship
   malicious BIOS bytes that libretro cores will execute. Prefer
@@ -347,8 +333,13 @@ deployment should set them.
 - **Run with the smallest privileges that work**. Non-root, dedicated
   user; only the configured directories writable. The `0700` save
   and BIOS dirs assume the spela user is the only one reading them.
+- **Configure proxy-level rate limiting** on `/api/*` (general DoS),
+  and tighter limits on `/api/auth/login` / `/api/auth/register` /
+  `/api/auth/refresh` (slow credential attacks). Spela's own
+  application-layer limits are scoped to login lockout, challenge
+  submissions, and save uploads — see _What's rate-limited_.
 
-### Optional
+### Optional environment variables
 
 - `SPELA_MAX_SAVE_UPLOAD_MB` (default 256): per-upload save-state
   cap.
@@ -363,29 +354,58 @@ deployment should set them.
 |---|---|---|
 | `:8080` (default) | Public via reverse proxy | The main API and SPA. |
 | `127.0.0.1:6060` | Localhost only | pprof. Never expose. |
-| `/api/test/reset` | Only when `SPELA_TEST_MODE=true` | Don't enable in production. |
+| `/api/test/reset` | Only when `SPELA_TEST_MODE=true` | **Never enable in production** — wipes user-generated data. |
 | `/api/openapi`, `/api/docs` | Public, unauthenticated | OpenAPI spec + Swagger UI. Read-only metadata about the route surface. |
-| `/api/auth/setup-status` | Public, unauthenticated | Returns `needsSetup` and `gameCount`. `needsSetup` is true only when there are no users AND the `setup_completed` marker is absent (#1130). |
+| `/api/auth/setup-status` | Public, unauthenticated | Returns `needsSetup` and `gameCount`. `needsSetup` is true only when there are no users AND the `setup_completed` marker is absent. |
 
-## Audit methodology
+## Limitations & known residual risk
 
-The audit was performed by reading all Go files under `server/` and
-running targeted `grep` patterns for risky constructs (`Raw`, `Exec`,
-dynamic `Order`, `os/exec`, `math/rand`, `InsecureSkipVerify`, query
-construction in handlers, multipart filename handling, and so on).
-Findings are reproducible from the codebase as it stood at commit
-`64a4e6ab` (master tip on 2026-05-08).
+Things admins should know they're accepting:
 
-The fix PR includes:
+- **`xdelta3` runs under a timeout but not a sandbox.** A
+  memory-corruption CVE in the host's installed `xdelta3` binary
+  would still execute as the spela server user. The long-term fix
+  is an in-process Go VCDIFF implementation; the short-term
+  mitigation is the 30-second timeout and running spela under a
+  least-privilege OS account.
+- **Open registration leaks email existence via timing.** With
+  registration enabled, an attacker can in principle distinguish a
+  valid email from an invalid one because the password-hash branch
+  is taken on conflict. Self-hosted instances that care about this
+  should disable open registration and provision users via the
+  admin panel.
+- **Email-based password reset is not implemented.** If/when it
+  ships, the email-change → TokenVersion bump becomes the hardening
+  that stops a transient password thief from pivoting recovery to
+  their own address.
+- **Activity feed events are broadcast to every WS subscriber
+  today.** Per-user filtering will land alongside the wider
+  profile-visibility surface; for now, hide your activity by setting
+  your profile to `private` (which gates the public profile
+  endpoint).
 
-- 24 commits, one per finding plus targeted test fixups.
-- New regression-style tests in the `api`, `scanner`, `storage`,
-  `safehttp`, `bios`, `patcher`, and `websocket` packages covering
-  each fix.
-- A structural lint (`server/internal/api/path_param_pattern_test.go`)
-  that runs in CI and fails any future PR that adds a `path:"..."`
-  tag without a `pattern:` constraint, preventing regression of the
-  SQLi-class issues.
+## How the codebase is reviewed
 
-When future audits surface findings, list them at the top of this
-file and link the fix commit on resolution.
+The Go backend under `server/` is reviewed end-to-end on every
+release with significant security-relevant changes. Reviews target
+the standard high-risk classes — authentication, authorization, file
+handling, SQL/input validation, crypto/transport, patcher safety —
+and follow up with `grep` patterns for risky constructs (`Raw`,
+`Exec`, dynamic `Order`, `os/exec`, `math/rand`,
+`InsecureSkipVerify`, query construction in handlers, multipart
+filename handling).
+
+CI carries structural lints that prevent regression of the highest-
+risk classes:
+
+- `server/internal/api/path_param_pattern_test.go` fails the build
+  if any new endpoint adds a `path:"..."` tag without a `pattern:`
+  schema constraint, preventing the SQLi-class issues the audit
+  surfaced.
+- The `safehttp` package owns SSRF defenses centrally, so handlers
+  cannot accidentally bypass private-IP rejection by opening a
+  fresh `http.Client`.
+
+When future reviews surface findings, this document is updated to
+reflect the post-fix posture rather than to enumerate the bug
+history.


### PR DESCRIPTION
Closes #1150.

The current SECURITY.md was structured around the 2026-05 audit findings, which reads as bug history rather than a description of current security posture. The target reader — an admin deciding whether to deploy and how to harden — gets more value from a forward-looking 'here's what's in place today' than from a list of \`Critical: GORM string-WHERE SQL injection\` rows that they have no context for.

## What changed

**Removed:**
- 'Resolved findings' tables and the inline issue refs scattered through the body (\`(#1117)\`, \`(#1124)\`, …). The protections those fixes produced are described in 'Current security posture'; the bug history lives in git.

**Added:**
- 'Status at a glance' block at the top so the deploy/no-deploy answer is the first thing a reader sees.
- 'Minimum viable deployment' 4-bullet TL;DR at the top of the hardening checklist (set JWT secret, set encryption key, run behind TLS, disable open registration).
- 'Backups & key management' as its own section — losing \`SPELA_ENCRYPTION_KEY\` is the kind of irreversible mistake that deserves more than a sub-bullet.
- 'What's rate-limited' makes the server-vs-proxy split explicit (login lockout, challenge throttling, save quotas live in the server; general DoS is the proxy's job).

**Clarified:**
- Profile visibility is a per-user setting; the prior wording read like a server-wide flag.

**Trimmed:**
- 'Audit methodology' → 'How the codebase is reviewed'. Dropped the meta-stats; kept the forward-looking lints (\`path_param_pattern_test.go\`, central \`safehttp\` SSRF guard).

## Test plan

- [x] Read top to bottom as an admin who's never seen Spela — the deploy/no-deploy answer is in the first 30 seconds.
- [x] Hardening checklist scans cleanly: TL;DR → required → strongly recommended → optional → exposure summary.
- [x] All retained content factually matches the current code (no stale \"#1117\" references).