### PR TITLE
fix(player): filter player-port allocation on SOURCE_GAMEPAD (#1165)

### DIFF
--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -236,6 +236,23 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        // Register the source device as a player port if it's a real
+        // gamepad (SOURCE_GAMEPAD / SOURCE_JOYSTICK — see
+        // ensureDeviceConnected). Done at the top of dispatch, before
+        // any state-machine branch, so the on-screen player-N indicator
+        // reflects "the user has used this controller" rather than the
+        // narrower "the user has used this controller during
+        // emulation". Without this, the pill-menu bumper glyphs at the
+        // top of UI screens fall back to keyboard ([ / ]) instead of
+        // L1 / R1 until the user has actually entered a game (#1165).
+        //
+        // No-op for non-gamepad devices — ensureDeviceConnected's own
+        // filter rejects volume keys, power button, touchscreen-
+        // gesture keystrokes, etc.
+        if (event != null) {
+            ensureDeviceConnected(event.deviceId)
+        }
+
         // Key mapping capture: when in listening mode, intercept gamepad buttons
         if (keyMappingViewModel.state.value.currentMappingButton != null && isGamepadCapturable(keyCode)) {
             keyMappingViewModel.onIntent(KeyMappingIntent.CaptureButton(keyCode))
@@ -374,6 +391,12 @@ class MainActivity : ComponentActivity() {
         if (!isJoystickOrGamepad || event.action != MotionEvent.ACTION_MOVE) {
             return super.onGenericMotionEvent(event)
         }
+
+        // Register the source device as a player port — mirrors the
+        // onKeyDown path so analog-stick / trigger movement also
+        // populates the on-screen indicator (#1165). No-op for non-
+        // gamepad sources thanks to ensureDeviceConnected's filter.
+        ensureDeviceConnected(event.deviceId)
 
         if (isEmulationConsuming) {
             val controller = androidController ?: return super.onGenericMotionEvent(event)

--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -163,13 +163,32 @@ class MainActivity : ComponentActivity() {
     /**
      * Ensures a gamepad device is assigned to a port. If it's a new device,
      * assigns it and loads its key mapping for the current console.
-     * Returns the assigned port, or -1 if all ports are full.
+     * Returns the assigned port, or -1 if all ports are full / device is
+     * not a gamepad.
+     *
+     * Source-flags filter: Android dispatches `onKeyDown` for **any**
+     * KEYBOARD-class input device — hardware volume keys (`gpio-keys`),
+     * power button (`pmic_pwrkey`), audio-jack mic button, even the
+     * primary touchscreen on devices that re-route gesture-recognised
+     * keystrokes through it (the AYN Thor's `fts_ts` exposes
+     * KEY_UP/DOWN/LEFT/RIGHT/POWER, see #1165). Without filtering we'd
+     * allocate a player-port for every distinct deviceId that ever
+     * produced a key event, so the player-N indicator ended up showing
+     * 2 controllers on the Thor with only the internal gamepad present.
+     *
+     * The narrowest correct filter is `SOURCE_GAMEPAD` — every real
+     * controller has this bit set; nothing else does. Joystick-only
+     * devices (rare but possible) are also accepted on `SOURCE_JOYSTICK`
+     * for defense in depth.
      */
     private fun ensureDeviceConnected(deviceId: Int): Int {
         val existingPort = gamepadPortManager.getPort(deviceId)
         if (existingPort >= 0) return existingPort
 
-        val deviceName = InputDevice.getDevice(deviceId)?.name ?: "Gamepad $deviceId"
+        val device = InputDevice.getDevice(deviceId) ?: return -1
+        if (!isGamepadInputDevice(device)) return -1
+
+        val deviceName = device.name ?: "Gamepad $deviceId"
         val port = gamepadPortManager.connectDevice(deviceId, deviceName)
         if (port >= 0) {
             val consoleId = emulationViewModel.state.value.consoleId
@@ -184,6 +203,21 @@ class MainActivity : ComponentActivity() {
             }
         }
         return port
+    }
+
+    /**
+     * True when [device] is a real gamepad-shaped input — both
+     * SOURCE_GAMEPAD (face buttons / dpad / start / select) and
+     * SOURCE_JOYSTICK (analog sticks / triggers / hat) qualify. Devices
+     * that are KEYBOARD-only (volume keys, power button, jack-button,
+     * touchscreen accessibility keystrokes) are filtered out so they
+     * don't claim player ports.
+     */
+    private fun isGamepadInputDevice(device: InputDevice): Boolean {
+        val sources = device.sources
+        val isGamepad = sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
+        val isJoystick = sources and InputDevice.SOURCE_JOYSTICK == InputDevice.SOURCE_JOYSTICK
+        return isGamepad || isJoystick
     }
 
     /** Key codes that are gamepad-relevant and should be captured during key mapping. */

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenLoadingIndicator.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenLoadingIndicator.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.spela.player.presentation.ui.theme.SpColor
+import kotlin.time.Clock
 import kotlinx.coroutines.delay
 
 /**
@@ -25,6 +26,19 @@ import kotlinx.coroutines.delay
  * Times: The 3 Important Limits"). Adjust here, not at call sites.
  */
 const val ScreenLoadingDebounceMs: Long = 500
+
+/**
+ * Minimum time the loading indicator stays visible once it has been
+ * shown. Prevents the "appeared for a frame and disappeared" flash
+ * for requests that finish just after [ScreenLoadingDebounceMs] —
+ * e.g. a 600ms response would otherwise paint dots for ~100ms.
+ *
+ * Anchored to the typical perceptual-glance threshold: <200ms feels
+ * like a glitch; ≥300ms reads as "the app was actually loading". This
+ * is the second half of the canonical "debounced spinner" UX rule
+ * (Nielsen Norman, "Response Times").
+ */
+const val MinLoadingShownMs: Long = 300
 
 /**
  * Role component for the "screen is loading" affordance.
@@ -67,35 +81,53 @@ fun ScreenLoadingIndicator(
 }
 
 /**
- * Debounces a transient-true Boolean so consumers see `true` only
- * after [delayMs] of continuous truthy input. Reverts to `false`
- * immediately when the source flips back.
+ * Two-stage state machine for screen-loading affordances:
  *
- * Use for other loading-state surfaces that bypass
- * [ScreenLoadingIndicator] — most often [PullToRefreshBox]'s
- * `isRefreshing` flag, which has its own spinner that draws around
- * the screen content. Without this, a cache-hit response transitioning
- * through a momentary `isLoading=true` state would still flash the
- * pull-to-refresh spinner even though [ScreenLoadingIndicator]
- * correctly stayed hidden.
+ *   1. **Debounce show.** When [source] becomes true, wait [showAfter]
+ *      ms before returning true. Fast responses (< [showAfter]) never
+ *      flip the output.
+ *   2. **Minimum show time.** Once the output is true, keep it true
+ *      for at least [minShownFor] ms — even if [source] flips back to
+ *      false sooner. Prevents the 50–200ms "flash" for requests that
+ *      land just past the debounce gate.
+ *
+ * Use for any spinner-shaped UI driven by a state Boolean —
+ * [PullToRefreshBox]'s `isRefreshing`, or the parent conditional that
+ * decides whether to mount [ScreenLoadingIndicator]. Both surfaces
+ * benefit from the full state machine; without it, the indicator
+ * appears for "a frame or so" before unmounting on responses in the
+ * 500–800ms window.
  *
  * In test mode ([LocalAnimationsEnabled] false) the value passes
- * through unchanged so tests don't have to wait 500ms.
+ * through unchanged so tests don't have to wait the timings.
  */
 @Composable
 fun rememberLoadingFlashDebounce(
     source: Boolean,
-    delayMs: Long = ScreenLoadingDebounceMs,
+    showAfter: Long = ScreenLoadingDebounceMs,
+    minShownFor: Long = MinLoadingShownMs,
 ): Boolean {
     if (!LocalAnimationsEnabled.current) return source
-    var debounced by remember { mutableStateOf(false) }
+    var visible by remember { mutableStateOf(false) }
+    var shownAtMs by remember { mutableStateOf(0L) }
     LaunchedEffect(source) {
         if (source) {
-            delay(delayMs)
-            debounced = true
+            // Already visible? Nothing to do — keep showing.
+            if (!visible) {
+                delay(showAfter)
+                shownAtMs = Clock.System.now().toEpochMilliseconds()
+                visible = true
+            }
         } else {
-            debounced = false
+            // Source went false. If we've started showing, respect
+            // the minimum-shown-for window before hiding.
+            if (visible) {
+                val elapsed = Clock.System.now().toEpochMilliseconds() - shownAtMs
+                val remaining = minShownFor - elapsed
+                if (remaining > 0) delay(remaining)
+                visible = false
+            }
         }
     }
-    return debounced
+    return visible
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenLoadingIndicator.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenLoadingIndicator.kt
@@ -65,3 +65,37 @@ fun ScreenLoadingIndicator(
 
     SpLoadingIndicator(modifier = modifier, message = message, color = color)
 }
+
+/**
+ * Debounces a transient-true Boolean so consumers see `true` only
+ * after [delayMs] of continuous truthy input. Reverts to `false`
+ * immediately when the source flips back.
+ *
+ * Use for other loading-state surfaces that bypass
+ * [ScreenLoadingIndicator] — most often [PullToRefreshBox]'s
+ * `isRefreshing` flag, which has its own spinner that draws around
+ * the screen content. Without this, a cache-hit response transitioning
+ * through a momentary `isLoading=true` state would still flash the
+ * pull-to-refresh spinner even though [ScreenLoadingIndicator]
+ * correctly stayed hidden.
+ *
+ * In test mode ([LocalAnimationsEnabled] false) the value passes
+ * through unchanged so tests don't have to wait 500ms.
+ */
+@Composable
+fun rememberLoadingFlashDebounce(
+    source: Boolean,
+    delayMs: Long = ScreenLoadingDebounceMs,
+): Boolean {
+    if (!LocalAnimationsEnabled.current) return source
+    var debounced by remember { mutableStateOf(false) }
+    LaunchedEffect(source) {
+        if (source) {
+            delay(delayMs)
+            debounced = true
+        } else {
+            debounced = false
+        }
+    }
+    return debounced
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenLoadingIndicator.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenLoadingIndicator.kt
@@ -1,0 +1,67 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.spela.player.presentation.ui.theme.SpColor
+import kotlinx.coroutines.delay
+
+/**
+ * Delay before a screen-level loading indicator becomes visible.
+ *
+ * Requests that complete inside this window never paint a spinner —
+ * eliminating the one-frame "flash" of loading UI on screen
+ * transitions whose data is already cached / fast (most local-DB
+ * reads, memoised viewmodels, network responses under ~200ms on a
+ * warm route).
+ *
+ * 500ms is the established UX threshold below which a loading
+ * indicator does more harm than good (Nielsen Norman Group, "Response
+ * Times: The 3 Important Limits"). Adjust here, not at call sites.
+ */
+const val ScreenLoadingDebounceMs: Long = 500
+
+/**
+ * Role component for the "screen is loading" affordance.
+ *
+ * Wraps the Design-layer [SpLoadingIndicator] (the look) with two
+ * things every screen-level loader needs:
+ *
+ *   1. **Debounce.** Painted only after [ScreenLoadingDebounceMs] of
+ *      continuous loading. Fast responses never flash a spinner.
+ *   2. **Tests.** When [LocalAnimationsEnabled] is `false` the
+ *      debounce is skipped — the indicator paints immediately so
+ *      Compose UI tests don't have to await the 500ms delay.
+ *
+ * Positioning stays with the caller's existing layout — this
+ * component swaps in to existing centering Boxes / sized containers
+ * one-to-one; nothing about its rendered size or position differs
+ * from a bare [SpLoadingIndicator]. The debounce is what's new.
+ *
+ * Use this from screens. For inline / sub-region loaders (button
+ * spinners, dialog content, in-page partial reloads), use
+ * [SpLoadingIndicator] directly.
+ */
+@Composable
+fun ScreenLoadingIndicator(
+    modifier: Modifier = Modifier,
+    message: String? = null,
+    color: Color = SpColor.Primary,
+) {
+    val animationsEnabled = LocalAnimationsEnabled.current
+    var visible by remember { mutableStateOf(!animationsEnabled) }
+    LaunchedEffect(Unit) {
+        if (animationsEnabled) {
+            delay(ScreenLoadingDebounceMs)
+            visible = true
+        }
+    }
+    if (!visible) return
+
+    SpLoadingIndicator(modifier = modifier, message = message, color = color)
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpLazySectionList.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpLazySectionList.kt
@@ -1,0 +1,51 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.theme.SpSpacing
+
+/**
+ * Lazy-virtualised counterpart to [SpSectionList].
+ *
+ * Use this when a screen has many sections (e.g. Explore's 19
+ * sections of carousels, each with its own data flow + cover-image
+ * grid). The [Column] used by [SpSectionList] composes every section
+ * up-front, which on Explore meant hundreds of game-card composables
+ * materialising in a single composition pass on first paint.
+ *
+ * Same visual contract as [SpSectionList] (an [SpSpacing.Large]
+ * vertical gap between items), but only sections within the viewport
+ * actually compose; off-screen sections defer until scrolled to.
+ *
+ * Callers wrap each section in `item { ... }`:
+ *
+ *   SpLazySectionList {
+ *     item { SearchBar(...) }
+ *     item { ExploreSection(title = "...") }
+ *     ...
+ *   }
+ *
+ * Migrate from [SpSectionList] when the screen has 5+ sections OR
+ * any section eagerly composes heavy content (cover-art grids, image
+ * carousels). For small fixed-layout screens (3-4 simple sections),
+ * the plain [SpSectionList] is fine and the LazyColumn overhead isn't
+ * worth it.
+ */
+@Composable
+fun SpLazySectionList(
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    content: LazyListScope.() -> Unit,
+) {
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.Large),
+        contentPadding = contentPadding,
+        content = content,
+    )
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/LibraryConsolesTab.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/LibraryConsolesTab.kt
@@ -28,6 +28,7 @@ import com.spela.player.presentation.ui.components.SpMainContentPadding
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpScreenTopSpacer
 import com.spela.player.presentation.ui.components.SpScrollableContent
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.viewmodel.GameListViewModel
@@ -72,7 +73,7 @@ internal fun LibraryConsolesTab(
             }
         } else {
             PullToRefreshBox(
-                isRefreshing = state.isLoading,
+                isRefreshing = rememberLoadingFlashDebounce(state.isLoading),
                 onRefresh = { viewModel.onIntent(GameListIntent.LoadConsoles) },
                 modifier = Modifier.fillMaxSize(),
             ) {
@@ -101,6 +102,9 @@ internal fun LibraryConsolesTab(
                                     grouping = grouping,
                                 )
                             }
+                            // Bottom breathing room — without this the last
+                            // console card sits flush against the screen edge.
+                            Spacer(Modifier.height(SpSpacing.XLarge))
                         }
                     }
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ActivityScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ActivityScreen.kt
@@ -60,7 +60,7 @@ import com.spela.player.presentation.intent.SocialIntent
 import com.spela.player.presentation.ui.components.SpAvatar
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpEmptyState
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.social.formatRelativeTime
 import com.spela.player.presentation.ui.feature.library.darken
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
@@ -112,7 +112,7 @@ fun ActivityScreen(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,
             ) {
-                SpLoadingIndicator(message = "Loading activity...")
+                ScreenLoadingIndicator(message = "Loading activity...")
             }
         } else {
             PullToRefreshBox(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ActivityScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ActivityScreen.kt
@@ -61,6 +61,7 @@ import com.spela.player.presentation.ui.components.SpAvatar
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.social.formatRelativeTime
 import com.spela.player.presentation.ui.feature.library.darken
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
@@ -116,7 +117,12 @@ fun ActivityScreen(
             }
         } else {
             PullToRefreshBox(
-                isRefreshing = state.isLoadingFullActivity && state.fullActivityEvents.isNotEmpty(),
+                // Same debounce as the screen-level indicator —
+                // PullToRefreshBox draws its own spinner and would
+                // otherwise flash on a cache-hit response.
+                isRefreshing = rememberLoadingFlashDebounce(
+                    state.isLoadingFullActivity && state.fullActivityEvents.isNotEmpty()
+                ),
                 onRefresh = { viewModel.onIntent(SocialIntent.LoadFullActivityFeed) },
                 modifier = Modifier.fillMaxSize(),
             ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ActivityScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ActivityScreen.kt
@@ -108,7 +108,13 @@ fun ActivityScreen(
                 )
             },
     ) {
-        if (state.isLoadingFullActivity && state.fullActivityEvents.isEmpty()) {
+        // Route the screen-level loading branch through the same
+        // state-machine hook as PullToRefreshBox below, so the dots
+        // honour the min-shown-for window once they appear.
+        val showInitialLoading = rememberLoadingFlashDebounce(
+            state.isLoadingFullActivity && state.fullActivityEvents.isEmpty()
+        )
+        if (showInitialLoading) {
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/AllGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/AllGamesScreen.kt
@@ -34,7 +34,7 @@ import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.state.ViewMode
 import com.spela.player.presentation.ui.components.LocalAnimationsEnabled
 import com.spela.player.presentation.ui.components.SpEmptyStates
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSearchField
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.feature.library.GameLibraryControls
@@ -95,7 +95,7 @@ fun AllGamesScreen(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,
             ) {
-                SpLoadingIndicator(message = "Loading games...")
+                ScreenLoadingIndicator(message = "Loading games...")
             }
         } else {
             PullToRefreshBox(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/AllGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/AllGamesScreen.kt
@@ -35,6 +35,7 @@ import com.spela.player.presentation.state.ViewMode
 import com.spela.player.presentation.ui.components.LocalAnimationsEnabled
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpSearchField
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.feature.library.GameLibraryControls
@@ -99,7 +100,7 @@ fun AllGamesScreen(
             }
         } else {
             PullToRefreshBox(
-                isRefreshing = state.isLoading,
+                isRefreshing = rememberLoadingFlashDebounce(state.isLoading),
                 onRefresh = { viewModel.onIntent(GameListIntent.Search(searchQuery)) },
                 modifier = Modifier.fillMaxSize(),
             ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ChallengeListScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ChallengeListScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.grid.GridCells
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpLazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -82,7 +83,7 @@ fun ChallengeListScreen(
             }
         } else {
             PullToRefreshBox(
-                isRefreshing = state.isLoadingGameChallenges && state.gameChallenges.isNotEmpty(),
+                isRefreshing = rememberLoadingFlashDebounce(state.isLoadingGameChallenges && state.gameChallenges.isNotEmpty()),
                 onRefresh = { viewModel.onIntent(ChallengeIntent.LoadGameChallenges(gameId)) },
                 modifier = Modifier.fillMaxSize(),
             ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionDetailScreen.kt
@@ -41,7 +41,7 @@ import com.spela.player.presentation.ui.components.SpConfirmDialog
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.components.SpIconButton
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSearchField
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
@@ -113,7 +113,7 @@ fun CollectionDetailScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    SpLoadingIndicator(message = "Loading collection...")
+                    ScreenLoadingIndicator(message = "Loading collection...")
                 }
             } else if (state.selectedDetail != null) {
                 val detail = state.selectedDetail ?: return@CompositionLocalProvider

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionsScreen.kt
@@ -110,7 +110,15 @@ fun CollectionsScreen(
                     )
                 },
         ) {
-            if (state.isLoading && state.myCollections.isEmpty() && state.publicCollections.isEmpty()) {
+            // Route the screen-level loading branch through the same
+            // state-machine hook as PullToRefreshBox below, so the dots
+            // honour the min-shown-for window once they appear — no
+            // 50-200ms flash for responses that land just past the
+            // debounce gate.
+            val showInitialLoading = rememberLoadingFlashDebounce(
+                state.isLoading && state.myCollections.isEmpty() && state.publicCollections.isEmpty()
+            )
+            if (showInitialLoading) {
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionsScreen.kt
@@ -46,6 +46,7 @@ import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpFab
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -118,7 +119,12 @@ fun CollectionsScreen(
                 }
             } else {
                 PullToRefreshBox(
-                    isRefreshing = state.isLoading,
+                    // Same debounce as the screen-level indicator —
+                    // PullToRefreshBox draws its own spinner around the
+                    // screen content and would otherwise flash on a
+                    // cache-hit response that transitions through a
+                    // momentary isLoading=true.
+                    isRefreshing = rememberLoadingFlashDebounce(state.isLoading),
                     onRefresh = {
                         viewModel.onIntent(CollectionsIntent.LoadMyCollections)
                         viewModel.onIntent(CollectionsIntent.LoadPublicCollections)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionsScreen.kt
@@ -45,7 +45,7 @@ import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpFab
 import com.spela.player.presentation.ui.components.SpEmptyStates
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -114,7 +114,7 @@ fun CollectionsScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    SpLoadingIndicator(message = "Loading collections...")
+                    ScreenLoadingIndicator(message = "Loading collections...")
                 }
             } else {
                 PullToRefreshBox(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleGamesScreen.kt
@@ -41,6 +41,7 @@ import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpIconButton
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpSearchField
 import com.spela.player.presentation.ui.components.SpSnackbar
@@ -139,7 +140,7 @@ fun ConsoleGamesScreen(
             return@SpScreen
         }
         PullToRefreshBox(
-            isRefreshing = state.isLoading,
+            isRefreshing = rememberLoadingFlashDebounce(state.isLoading),
             onRefresh = { viewModel.onIntent(GameListIntent.SelectConsole(consoleId)) },
             modifier = Modifier.fillMaxSize(),
         ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleGamesScreen.kt
@@ -40,7 +40,7 @@ import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpIconButton
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpSearchField
 import com.spela.player.presentation.ui.components.SpSnackbar
@@ -134,7 +134,7 @@ fun ConsoleGamesScreen(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,
             ) {
-                SpLoadingIndicator(message = "Loading games...")
+                ScreenLoadingIndicator(message = "Loading games...")
             }
             return@SpScreen
         }
@@ -234,7 +234,7 @@ fun ConsoleGamesScreen(
                             modifier = Modifier.fillMaxWidth().height(300.dp),
                             contentAlignment = Alignment.Center,
                         ) {
-                            SpLoadingIndicator(message = "Loading games...")
+                            ScreenLoadingIndicator(message = "Loading games...")
                         }
                     }
                 } else if (sortedGames.isEmpty()) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -47,7 +47,7 @@ import com.spela.player.presentation.ui.components.SpScreenTopSpacer
 import com.spela.player.presentation.ui.components.SpScrollableContent
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpIconButton
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -293,7 +293,7 @@ fun ConsoleScreen(
                             modifier = Modifier.fillMaxWidth().height(200.dp),
                             contentAlignment = Alignment.Center,
                         ) {
-                            SpLoadingIndicator(message = "Loading games...")
+                            ScreenLoadingIndicator(message = "Loading games...")
                         }
                     } else if (state.games.isEmpty() && !state.isLoading) {
                         Box(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -48,6 +48,7 @@ import com.spela.player.presentation.ui.components.SpScrollableContent
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpIconButton
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -159,7 +160,7 @@ fun ConsoleScreen(
             }
 
             PullToRefreshBox(
-                isRefreshing = state.isLoading,
+                isRefreshing = rememberLoadingFlashDebounce(state.isLoading),
                 onRefresh = { viewModel.onIntent(GameListIntent.SelectConsole(consoleId)) },
                 modifier = Modifier.fillMaxSize(),
             ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DeveloperGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DeveloperGamesScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpIconButton
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpSearchField
 import com.spela.player.presentation.ui.components.SpScreenTopSpacer
@@ -248,7 +248,7 @@ fun DeveloperGamesScreen(
                         modifier = Modifier.fillMaxWidth().height(300.dp),
                         contentAlignment = Alignment.Center,
                     ) {
-                        SpLoadingIndicator(message = "Loading games...")
+                        ScreenLoadingIndicator(message = "Loading games...")
                     }
                 }
             } else if (sortedGames.isEmpty()) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -27,9 +27,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
 import com.spela.player.presentation.ui.components.SpScreen
-import com.spela.player.presentation.ui.components.SpMainContentPadding
-import com.spela.player.presentation.ui.components.SpScrollableContent
+import com.spela.player.presentation.ui.components.SpLazySectionList
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -37,7 +39,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.ui.components.SpEmptyState
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.gamepad.rememberFocus
@@ -47,7 +49,6 @@ import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
-import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpTitledSection
 import com.spela.player.presentation.ui.feature.explore.ActiveNowSection
 import com.spela.player.presentation.ui.feature.explore.ArtworkShowcaseSection
@@ -130,7 +131,7 @@ fun ExploreScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    SpLoadingIndicator(message = "Loading...")
+                    ScreenLoadingIndicator(message = "Loading...")
                 }
             }
             // Empty library: no data at all and not loading
@@ -149,241 +150,277 @@ fun ExploreScreen(
             }
 
             else -> {
-                SpScrollableContent {
-                    // Hero carousel — edge-to-edge, outside SpMainContentPadding
+                val focusMemory = rememberFocusMemoryState()
+                CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
+                SpLazySectionList(
+                    modifier = Modifier.fillMaxSize(),
+                    // Match the top + bottom gap SpMainContentPadding used to
+                    // provide around the section column. Horizontal padding is
+                    // applied per-item below so the hero carousel can stay
+                    // edge-to-edge.
+                    contentPadding = PaddingValues(
+                        top = SpSpacing.Large,
+                        bottom = SpSpacing.XLarge,
+                    ),
+                ) {
+                    // Hero carousel — edge-to-edge item (no horizontal padding).
                     if (state.isLoadingFeatured || state.featuredGames.isNotEmpty()) {
-                        if (state.isLoadingFeatured && state.featuredGames.isEmpty()) {
-                            HeroCarouselSkeleton()
-                        } else if (state.featuredGames.isNotEmpty()) {
-                            HeroCarousel(
-                                featuredGames = state.featuredGames,
+                        item(key = "explore_hero") {
+                            if (state.isLoadingFeatured && state.featuredGames.isEmpty()) {
+                                HeroCarouselSkeleton()
+                            } else if (state.featuredGames.isNotEmpty()) {
+                                HeroCarousel(
+                                    featuredGames = state.featuredGames,
+                                    onGameSelected = onGameSelected,
+                                )
+                            }
+                        }
+                    }
+                    // Global search entry point — tappable search bar
+                    paddedItem(key = "explore_search_bar") {
+                        SearchBarEntryPoint(
+                            onClick = { onGlobalSearchSelected?.invoke() },
+                            modifier = Modifier
+                                .focusRestoreItem(key = "explore_search_bar", isDefault = true)
+                                .testTag("explore_search_bar"),
+                        )
+                    }
+
+                    paddedItem(key = "explore_consoles") {
+                        ExploreSection(
+                            title = "Browse by Console",
+                            testTag = "explore_consoles_section",
+                            focusKey = "section_browse_by_console",
+                            isLoading = state.isLoadingConsoleHighlights,
+                            isEmpty = state.consoleHighlights.isEmpty(),
+                            skeleton = { ConsoleQuickJumpSkeleton() },
+                        ) {
+                            ConsoleQuickJumpSection(
+                                consoles = state.consoleHighlights,
+                                onConsoleSelected = { onConsoleSelected?.invoke(it) },
+                            )
+                        }
+                    }
+
+                    paddedItem(key = "explore_moods") {
+                        ExploreSection(
+                            title = "What are you in the mood for?",
+                            testTag = "explore_moods_section",
+                            focusKey = "section_moods",
+                            isLoading = state.isLoadingMoods,
+                            isEmpty = state.moods.isEmpty(),
+                            skeleton = { MoodPickerSkeleton() },
+                        ) {
+                            MoodPicker(
+                                moods = state.moods,
+                                onMoodSelected = { id, name -> onMoodSelected?.invoke(id, name) },
+                            )
+                        }
+                    }
+
+                    // Wild Features — Lucky & Wizard
+                    paddedItem(key = "explore_wild_features") {
+                        WildFeaturesSection(
+                            onSurpriseMe = { onSurpriseMe?.invoke() },
+                            onWizardSelected = { onWizardSelected?.invoke() },
+                            modifier = Modifier
+                                .testTag("explore_wild_features")
+                                .rememberFocus("section_wild_features"),
+                        )
+                    }
+
+                    paddedItem(key = "explore_for_you") {
+                        ExploreSection(
+                            title = "For You",
+                            testTag = "explore_for_you_section",
+                            focusKey = "section_for_you",
+                            isLoading = state.isLoadingForYou,
+                            isEmpty = state.forYouRows.isEmpty(),
+                            skeleton = { ForYouSkeleton() },
+                        ) {
+                            ForYouSection(
+                                rows = state.forYouRows,
                                 onGameSelected = onGameSelected,
                             )
                         }
                     }
 
-                SpMainContentPadding {
-                val focusMemory = rememberFocusMemoryState()
-                CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
-                SpSectionList(
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    // Global search entry point — tappable search bar
-                    SearchBarEntryPoint(
-                        onClick = { onGlobalSearchSelected?.invoke() },
-                        modifier = Modifier
-                            .focusRestoreItem(key = "explore_search_bar", isDefault = true)
-                            .testTag("explore_search_bar"),
-                    )
-
-                    ExploreSection(
-                        title = "Browse by Console",
-                        testTag = "explore_consoles_section",
-                        focusKey = "section_browse_by_console",
-                        isLoading = state.isLoadingConsoleHighlights,
-                        isEmpty = state.consoleHighlights.isEmpty(),
-                        skeleton = { ConsoleQuickJumpSkeleton() },
-                    ) {
-                        ConsoleQuickJumpSection(
-                            consoles = state.consoleHighlights,
-                            onConsoleSelected = { onConsoleSelected?.invoke(it) },
-                        )
+                    paddedItem(key = "explore_themes") {
+                        ExploreSection(
+                            title = "Browse by Theme",
+                            testTag = "explore_themes_section",
+                            focusKey = "section_themes",
+                            isLoading = state.isLoadingThemes,
+                            isEmpty = state.themes.isEmpty(),
+                            skeleton = { ThemeGridSkeleton() },
+                        ) {
+                            ThemeGrid(
+                                themes = state.themes,
+                                onThemeSelected = { id, name -> onThemeSelected?.invoke(id, name) },
+                            )
+                        }
                     }
 
-                    ExploreSection(
-                        title = "What are you in the mood for?",
-                        testTag = "explore_moods_section",
-                        focusKey = "section_moods",
-                        isLoading = state.isLoadingMoods,
-                        isEmpty = state.moods.isEmpty(),
-                        skeleton = { MoodPickerSkeleton() },
-                    ) {
-                        MoodPicker(
-                            moods = state.moods,
-                            onMoodSelected = { id, name -> onMoodSelected?.invoke(id, name) },
-                        )
+                    paddedItem(key = "explore_keywords") {
+                        ExploreSection(
+                            title = "Popular Keywords",
+                            testTag = "explore_keywords_section",
+                            focusKey = "section_keywords",
+                            isLoading = state.isLoadingKeywords,
+                            isEmpty = state.keywords.isEmpty(),
+                            skeleton = { KeywordChipsSkeleton() },
+                        ) {
+                            KeywordChips(
+                                keywords = state.keywords,
+                                onKeywordSelected = { id, name -> onKeywordSelected?.invoke(id, name) },
+                            )
+                        }
                     }
 
-                    // Wild Features — Lucky & Wizard
-                    WildFeaturesSection(
-                        onSurpriseMe = { onSurpriseMe?.invoke() },
-                        onWizardSelected = { onWizardSelected?.invoke() },
-                        modifier = Modifier
-                            .testTag("explore_wild_features")
-                            .rememberFocus("section_wild_features"),
-                    )
-
-                    ExploreSection(
-                        title = "For You",
-                        testTag = "explore_for_you_section",
-                        focusKey = "section_for_you",
-                        isLoading = state.isLoadingForYou,
-                        isEmpty = state.forYouRows.isEmpty(),
-                        skeleton = { ForYouSkeleton() },
-                    ) {
-                        ForYouSection(
-                            rows = state.forYouRows,
-                            onGameSelected = onGameSelected,
-                        )
+                    paddedItem(key = "explore_series") {
+                        ExploreSection(
+                            title = "Browse by Series",
+                            testTag = "explore_series_section",
+                            focusKey = "section_series",
+                            isLoading = state.isLoadingFeaturedSeries,
+                            isEmpty = state.featuredSeries.isEmpty(),
+                            skeleton = { SeriesShelfSkeleton() },
+                        ) {
+                            SeriesShelf(
+                                series = state.featuredSeries,
+                                onSeriesSelected = { id, name -> onSeriesSelected?.invoke(id, name) },
+                            )
+                        }
                     }
-
-                    ExploreSection(
-                        title = "Browse by Theme",
-                        testTag = "explore_themes_section",
-                        focusKey = "section_themes",
-                        isLoading = state.isLoadingThemes,
-                        isEmpty = state.themes.isEmpty(),
-                        skeleton = { ThemeGridSkeleton() },
-                    ) {
-                        ThemeGrid(
-                            themes = state.themes,
-                            onThemeSelected = { id, name -> onThemeSelected?.invoke(id, name) },
-                        )
-                    }
-
-                    ExploreSection(
-                        title = "Popular Keywords",
-                        testTag = "explore_keywords_section",
-                        focusKey = "section_keywords",
-                        isLoading = state.isLoadingKeywords,
-                        isEmpty = state.keywords.isEmpty(),
-                        skeleton = { KeywordChipsSkeleton() },
-                    ) {
-                        KeywordChips(
-                            keywords = state.keywords,
-                            onKeywordSelected = { id, name -> onKeywordSelected?.invoke(id, name) },
-                        )
-                    }
-
-                    ExploreSection(
-                        title = "Browse by Series",
-                        testTag = "explore_series_section",
-                        focusKey = "section_series",
-                        isLoading = state.isLoadingFeaturedSeries,
-                        isEmpty = state.featuredSeries.isEmpty(),
-                        skeleton = { SeriesShelfSkeleton() },
-                    ) {
-                        SeriesShelf(
-                            series = state.featuredSeries,
-                            onSeriesSelected = { id, name -> onSeriesSelected?.invoke(id, name) },
-                        )
-                    }
-
 
                     // Developer spotlight section
-                    if (state.isLoadingDeveloperSpotlight && state.developerSpotlight == null) {
-                        DeveloperSpotlightSkeleton(
-                        )
-                    } else if (state.developerSpotlight != null) {
-                        DeveloperSpotlightSection(
-                            spotlight = state.developerSpotlight!!,
-                            onDeveloperSelected = { name ->
-                                onDeveloperSelected?.invoke(name)
-                            },
-                            onGameSelected = onGameSelected,
-                            modifier = Modifier.testTag("explore_developer_spotlight_section")
-                                .rememberFocus("section_developer_spotlight"),
-                        )
+                    paddedItem(key = "explore_developer_spotlight") {
+                        if (state.isLoadingDeveloperSpotlight && state.developerSpotlight == null) {
+                            DeveloperSpotlightSkeleton(
+                            )
+                        } else if (state.developerSpotlight != null) {
+                            DeveloperSpotlightSection(
+                                spotlight = state.developerSpotlight!!,
+                                onDeveloperSelected = { name ->
+                                    onDeveloperSelected?.invoke(name)
+                                },
+                                onGameSelected = onGameSelected,
+                                modifier = Modifier.testTag("explore_developer_spotlight_section")
+                                    .rememberFocus("section_developer_spotlight"),
+                            )
+                        }
                     }
 
-                    ExploreSection(
-                        title = "Visual Discovery",
-                        testTag = "explore_artwork_section",
-                        focusKey = "section_artwork",
-                        isLoading = state.isLoadingArtwork,
-                        isEmpty = state.artworkShowcase.isEmpty(),
-                        skeleton = { ArtworkShowcaseSkeleton() },
-                        titleTrailing = onGallerySelected?.let { onClick ->
-                            {
-                                Text(
-                                    text = "Browse Gallery",
-                                    style = SpTypography.LabelLarge,
-                                    color = SpColor.Link,
-                                    modifier = Modifier
-                                        .clip(RoundedCornerShape(SpSpacing.Small))
-                                        .clickable(onClick = onClick)
-                                        .padding(SpSpacing.Small)
-                                        .testTag("browse_gallery_button"),
-                                )
-                            }
-                        },
-                    ) {
-                        ArtworkShowcaseSection(
-                            artworks = state.artworkShowcase,
-                            onGameSelected = onGameSelected,
-                        )
+                    paddedItem(key = "explore_artwork") {
+                        ExploreSection(
+                            title = "Visual Discovery",
+                            testTag = "explore_artwork_section",
+                            focusKey = "section_artwork",
+                            isLoading = state.isLoadingArtwork,
+                            isEmpty = state.artworkShowcase.isEmpty(),
+                            skeleton = { ArtworkShowcaseSkeleton() },
+                            titleTrailing = onGallerySelected?.let { onClick ->
+                                {
+                                    Text(
+                                        text = "Browse Gallery",
+                                        style = SpTypography.LabelLarge,
+                                        color = SpColor.Link,
+                                        modifier = Modifier
+                                            .clip(RoundedCornerShape(SpSpacing.Small))
+                                            .clickable(onClick = onClick)
+                                            .padding(SpSpacing.Small)
+                                            .testTag("browse_gallery_button"),
+                                    )
+                                }
+                            },
+                        ) {
+                            ArtworkShowcaseSection(
+                                artworks = state.artworkShowcase,
+                                onGameSelected = onGameSelected,
+                            )
+                        }
                     }
 
                     // Social & Community Discovery sections — all share the
                     // single state.isLoadingSocial flag.
-                    ExploreSection(
-                        title = "Trending on Your Server",
-                        testTag = "explore_trending_section",
-                        focusKey = "section_trending",
-                        isLoading = state.isLoadingSocial,
-                        isEmpty = state.trendingGames.isEmpty(),
-                        skeleton = { SocialSectionSkeleton() },
-                    ) {
-                        TrendingSection(
-                            games = state.trendingGames,
-                            onGameSelected = onGameSelected,
-                        )
+                    paddedItem(key = "explore_trending") {
+                        ExploreSection(
+                            title = "Trending on Your Server",
+                            testTag = "explore_trending_section",
+                            focusKey = "section_trending",
+                            isLoading = state.isLoadingSocial,
+                            isEmpty = state.trendingGames.isEmpty(),
+                            skeleton = { SocialSectionSkeleton() },
+                        ) {
+                            TrendingSection(
+                                games = state.trendingGames,
+                                onGameSelected = onGameSelected,
+                            )
+                        }
                     }
 
-                    ExploreSection(
-                        title = "Community Favorites",
-                        testTag = "explore_community_top_section",
-                        focusKey = "section_community_favorites",
-                        isLoading = state.isLoadingSocial,
-                        isEmpty = state.communityTopGames.isEmpty(),
-                        skeleton = { SocialSectionSkeleton() },
-                    ) {
-                        CommunityTopSection(
-                            games = state.communityTopGames,
-                            onGameSelected = onGameSelected,
-                        )
+                    paddedItem(key = "explore_community_top") {
+                        ExploreSection(
+                            title = "Community Favorites",
+                            testTag = "explore_community_top_section",
+                            focusKey = "section_community_favorites",
+                            isLoading = state.isLoadingSocial,
+                            isEmpty = state.communityTopGames.isEmpty(),
+                            skeleton = { SocialSectionSkeleton() },
+                        ) {
+                            CommunityTopSection(
+                                games = state.communityTopGames,
+                                onGameSelected = onGameSelected,
+                            )
+                        }
                     }
 
-                    ExploreSection(
-                        title = "Cult Classics",
-                        testTag = "explore_cult_classics_section",
-                        focusKey = "section_cult_classics",
-                        isLoading = state.isLoadingSocial,
-                        isEmpty = state.cultClassics.isEmpty(),
-                        skeleton = { SocialSectionSkeleton() },
-                    ) {
-                        CultClassicsSection(
-                            games = state.cultClassics,
-                            onGameSelected = onGameSelected,
-                        )
+                    paddedItem(key = "explore_cult_classics") {
+                        ExploreSection(
+                            title = "Cult Classics",
+                            testTag = "explore_cult_classics_section",
+                            focusKey = "section_cult_classics",
+                            isLoading = state.isLoadingSocial,
+                            isEmpty = state.cultClassics.isEmpty(),
+                            skeleton = { SocialSectionSkeleton() },
+                        ) {
+                            CultClassicsSection(
+                                games = state.cultClassics,
+                                onGameSelected = onGameSelected,
+                            )
+                        }
                     }
 
-                    ExploreSection(
-                        title = "Active Right Now",
-                        testTag = "explore_active_now_section",
-                        focusKey = "section_active_now",
-                        isLoading = state.isLoadingSocial,
-                        isEmpty = state.activeNowGames.isEmpty(),
-                        skeleton = { SocialSectionSkeleton() },
-                    ) {
-                        ActiveNowSection(
-                            games = state.activeNowGames,
-                            onGameSelected = onGameSelected,
-                        )
+                    paddedItem(key = "explore_active_now") {
+                        ExploreSection(
+                            title = "Active Right Now",
+                            testTag = "explore_active_now_section",
+                            focusKey = "section_active_now",
+                            isLoading = state.isLoadingSocial,
+                            isEmpty = state.activeNowGames.isEmpty(),
+                            skeleton = { SocialSectionSkeleton() },
+                        ) {
+                            ActiveNowSection(
+                                games = state.activeNowGames,
+                                onGameSelected = onGameSelected,
+                            )
+                        }
                     }
 
-                    ExploreSection(
-                        title = "Recently Reviewed",
-                        testTag = "explore_recently_reviewed_section",
-                        focusKey = "section_recently_reviewed",
-                        isLoading = state.isLoadingSocial,
-                        isEmpty = state.recentReviews.isEmpty(),
-                        skeleton = { SocialSectionSkeleton() },
-                    ) {
-                        RecentlyReviewedSection(
-                            reviews = state.recentReviews,
-                            onGameSelected = onGameSelected,
-                        )
+                    paddedItem(key = "explore_recently_reviewed") {
+                        ExploreSection(
+                            title = "Recently Reviewed",
+                            testTag = "explore_recently_reviewed_section",
+                            focusKey = "section_recently_reviewed",
+                            isLoading = state.isLoadingSocial,
+                            isEmpty = state.recentReviews.isEmpty(),
+                            skeleton = { SocialSectionSkeleton() },
+                        ) {
+                            RecentlyReviewedSection(
+                                reviews = state.recentReviews,
+                                onGameSelected = onGameSelected,
+                            )
+                        }
                     }
 
                     // Title includes the date when populated — the skeleton
@@ -394,121 +431,141 @@ fun ExploreScreen(
                     } else {
                         "On This Day"
                     }
-                    ExploreSection(
-                        title = onThisDayTitle,
-                        testTag = "explore_on_this_day_section",
-                        focusKey = "section_on_this_day",
-                        isLoading = state.isLoadingTemporal,
-                        isEmpty = state.onThisDayGames.isEmpty(),
-                        skeleton = { TemporalSectionSkeleton() },
-                    ) {
-                        OnThisDaySection(
-                            games = state.onThisDayGames,
-                            onGameSelected = onGameSelected,
-                        )
+                    paddedItem(key = "explore_on_this_day") {
+                        ExploreSection(
+                            title = onThisDayTitle,
+                            testTag = "explore_on_this_day_section",
+                            focusKey = "section_on_this_day",
+                            isLoading = state.isLoadingTemporal,
+                            isEmpty = state.onThisDayGames.isEmpty(),
+                            skeleton = { TemporalSectionSkeleton() },
+                        ) {
+                            OnThisDaySection(
+                                games = state.onThisDayGames,
+                                onGameSelected = onGameSelected,
+                            )
+                        }
                     }
 
-                    ExploreSection(
-                        title = "Your Anniversaries",
-                        testTag = "explore_anniversaries_section",
-                        focusKey = "section_anniversaries",
-                        isLoading = state.isLoadingTemporal,
-                        isEmpty = state.anniversaries.isEmpty(),
-                        skeleton = { TemporalSectionSkeleton() },
-                    ) {
-                        AnniversariesSection(
-                            anniversaries = state.anniversaries,
-                            onGameSelected = onGameSelected,
-                        )
+                    paddedItem(key = "explore_anniversaries") {
+                        ExploreSection(
+                            title = "Your Anniversaries",
+                            testTag = "explore_anniversaries_section",
+                            focusKey = "section_anniversaries",
+                            isLoading = state.isLoadingTemporal,
+                            isEmpty = state.anniversaries.isEmpty(),
+                            skeleton = { TemporalSectionSkeleton() },
+                        ) {
+                            AnniversariesSection(
+                                anniversaries = state.anniversaries,
+                                onGameSelected = onGameSelected,
+                            )
+                        }
                     }
 
                     // Achievement Discovery — all share state.isLoadingAchievement.
-                    ExploreSection(
-                        title = "Easy to 100%",
-                        testTag = "explore_easy_to_complete_section",
-                        focusKey = "section_easy_to_complete",
-                        isLoading = state.isLoadingAchievement,
-                        isEmpty = state.easyToCompleteGames.isEmpty(),
-                        skeleton = { AchievementSectionSkeleton() },
-                    ) {
-                        EasyToCompleteSection(
-                            games = state.easyToCompleteGames,
-                            onGameClick = onGameSelected,
-                        )
+                    paddedItem(key = "explore_easy_to_complete") {
+                        ExploreSection(
+                            title = "Easy to 100%",
+                            testTag = "explore_easy_to_complete_section",
+                            focusKey = "section_easy_to_complete",
+                            isLoading = state.isLoadingAchievement,
+                            isEmpty = state.easyToCompleteGames.isEmpty(),
+                            skeleton = { AchievementSectionSkeleton() },
+                        ) {
+                            EasyToCompleteSection(
+                                games = state.easyToCompleteGames,
+                                onGameClick = onGameSelected,
+                            )
+                        }
                     }
 
-                    ExploreSection(
-                        title = "Mount Everest",
-                        testTag = "explore_hardest_games_section",
-                        focusKey = "section_hardest_games",
-                        isLoading = state.isLoadingAchievement,
-                        isEmpty = state.hardestGames.isEmpty(),
-                        skeleton = { AchievementSectionSkeleton() },
-                    ) {
-                        HardestGamesSection(
-                            games = state.hardestGames,
-                            onGameClick = onGameSelected,
-                        )
+                    paddedItem(key = "explore_hardest_games") {
+                        ExploreSection(
+                            title = "Mount Everest",
+                            testTag = "explore_hardest_games_section",
+                            focusKey = "section_hardest_games",
+                            isLoading = state.isLoadingAchievement,
+                            isEmpty = state.hardestGames.isEmpty(),
+                            skeleton = { AchievementSectionSkeleton() },
+                        ) {
+                            HardestGamesSection(
+                                games = state.hardestGames,
+                                onGameClick = onGameSelected,
+                            )
+                        }
                     }
 
-                    ExploreSection(
-                        title = "Almost Done",
-                        testTag = "explore_almost_done_section",
-                        focusKey = "section_almost_done",
-                        isLoading = state.isLoadingAchievement,
-                        isEmpty = state.almostDoneGames.isEmpty(),
-                        skeleton = { AchievementSectionSkeleton() },
-                    ) {
-                        AlmostDoneSection(
-                            games = state.almostDoneGames,
-                            onGameClick = onGameSelected,
-                        )
+                    paddedItem(key = "explore_almost_done") {
+                        ExploreSection(
+                            title = "Almost Done",
+                            testTag = "explore_almost_done_section",
+                            focusKey = "section_almost_done",
+                            isLoading = state.isLoadingAchievement,
+                            isEmpty = state.almostDoneGames.isEmpty(),
+                            skeleton = { AchievementSectionSkeleton() },
+                        ) {
+                            AlmostDoneSection(
+                                games = state.almostDoneGames,
+                                onGameClick = onGameSelected,
+                            )
+                        }
                     }
 
-                    ExploreSection(
-                        title = "Fresh Challenges",
-                        testTag = "explore_fresh_challenges_section",
-                        focusKey = "section_fresh_challenges",
-                        isLoading = state.isLoadingAchievement,
-                        isEmpty = state.freshChallengeGames.isEmpty(),
-                        skeleton = { AchievementSectionSkeleton() },
-                    ) {
-                        FreshChallengesSection(
-                            games = state.freshChallengeGames,
-                            onGameClick = onGameSelected,
-                        )
+                    paddedItem(key = "explore_fresh_challenges") {
+                        ExploreSection(
+                            title = "Fresh Challenges",
+                            testTag = "explore_fresh_challenges_section",
+                            focusKey = "section_fresh_challenges",
+                            isLoading = state.isLoadingAchievement,
+                            isEmpty = state.freshChallengeGames.isEmpty(),
+                            skeleton = { AchievementSectionSkeleton() },
+                        ) {
+                            FreshChallengesSection(
+                                games = state.freshChallengeGames,
+                                onGameClick = onGameSelected,
+                            )
+                        }
                     }
 
-                    ExploreSection(
-                        title = "Active Challenges",
-                        testTag = "explore_active_challenges_section",
-                        focusKey = "section_active_challenges",
-                        isLoading = state.isLoadingAchievement,
-                        isEmpty = state.activeChallenges.isEmpty(),
-                        skeleton = { AchievementSectionSkeleton() },
-                    ) {
-                        ActiveChallengesSection(
-                            challenges = state.activeChallenges,
-                            onChallengeClick = { onChallengeSelected?.invoke(it) },
-                        )
+                    paddedItem(key = "explore_active_challenges") {
+                        ExploreSection(
+                            title = "Active Challenges",
+                            testTag = "explore_active_challenges_section",
+                            focusKey = "section_active_challenges",
+                            isLoading = state.isLoadingAchievement,
+                            isEmpty = state.activeChallenges.isEmpty(),
+                            skeleton = { AchievementSectionSkeleton() },
+                        ) {
+                            ActiveChallengesSection(
+                                challenges = state.activeChallenges,
+                                onChallengeClick = { onChallengeSelected?.invoke(it) },
+                            )
+                        }
                     }
-                    // Shelf rows
+
+                    // Shelf rows — each gets its own item so off-screen rows
+                    // defer composition (and their cover-image grids).
                     if (state.isLoadingRows && state.rows.isEmpty()) {
-                        // Loading skeletons for rows
                         val skeletonTitles = listOf("Top Rated", "Recently Added", "Hidden Gems")
-                        skeletonTitles.forEach { title ->
-                            SpTitledSection(
-                                title = title,
-                                edgeToEdgeContent = true,
-                            ) {
-                                GameShelfSkeleton()
+                        items(items = skeletonTitles, key = { "explore_row_skel_$it" }) { title ->
+                            paddedItemContent {
+                                SpTitledSection(
+                                    title = title,
+                                    edgeToEdgeContent = true,
+                                ) {
+                                    GameShelfSkeleton()
+                                }
                             }
                         }
                     } else {
-                        state.rows.forEach { row ->
-                            if (row.games.isNotEmpty()) {
+                        items(
+                            items = state.rows.filter { it.games.isNotEmpty() },
+                            key = { "explore_row_${it.id}" },
+                        ) { row ->
+                            paddedItemContent {
                                 SpTitledSection(
-                                title = row.title,
+                                    title = row.title,
                                     edgeToEdgeContent = true,
                                     modifier = Modifier
                                         .testTag("explore_row_${row.id}")
@@ -523,13 +580,8 @@ fun ExploreScreen(
                             }
                         }
                     }
-
-                    // Bottom spacer
-                    Spacer(Modifier.height(SpSpacing.XLarge))
-                } // SpSectionList
+                } // SpLazySectionList
                 } // CompositionLocalProvider
-                } // SpMainContentPadding
-                } // SpScrollableContent
             }
         }
 
@@ -631,5 +683,36 @@ private fun SearchBarEntryPoint(
             style = SpTypography.BodyMedium,
             color = SpColor.OnBackgroundTertiary,
         )
+    }
+}
+
+/**
+ * Adds a [LazyListScope] item wrapped in the canonical screen
+ * horizontal padding. Most Explore items match this convention; the
+ * hero carousel is the exception (edge-to-edge) and uses a plain
+ * `item { ... }` instead.
+ */
+private fun LazyListScope.paddedItem(
+    key: Any? = null,
+    content: @Composable () -> Unit,
+) {
+    item(key = key) {
+        Box(modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal)) {
+            content()
+        }
+    }
+}
+
+/**
+ * Sibling helper for [LazyListScope.items]'s lambda body — wraps the
+ * already-individual item's content in the same horizontal padding
+ * that [paddedItem] provides, without needing a separate item call.
+ * Used for the shelf-rows loop where the lazy list's [items] generator
+ * is the right shape and we only need padding around each child.
+ */
+@Composable
+private fun paddedItemContent(content: @Composable () -> Unit) {
+    Box(modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal)) {
+        content()
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -27,11 +27,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.items
 import com.spela.player.presentation.ui.components.SpScreen
-import com.spela.player.presentation.ui.components.SpLazySectionList
+import com.spela.player.presentation.ui.components.SpMainContentPadding
+import com.spela.player.presentation.ui.components.SpScrollableContent
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -49,6 +47,7 @@ import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpTitledSection
 import com.spela.player.presentation.ui.feature.explore.ActiveNowSection
 import com.spela.player.presentation.ui.feature.explore.ArtworkShowcaseSection
@@ -150,277 +149,241 @@ fun ExploreScreen(
             }
 
             else -> {
-                val focusMemory = rememberFocusMemoryState()
-                CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
-                SpLazySectionList(
-                    modifier = Modifier.fillMaxSize(),
-                    // Match the top + bottom gap SpMainContentPadding used to
-                    // provide around the section column. Horizontal padding is
-                    // applied per-item below so the hero carousel can stay
-                    // edge-to-edge.
-                    contentPadding = PaddingValues(
-                        top = SpSpacing.Large,
-                        bottom = SpSpacing.XLarge,
-                    ),
-                ) {
-                    // Hero carousel — edge-to-edge item (no horizontal padding).
+                SpScrollableContent {
+                    // Hero carousel — edge-to-edge, outside SpMainContentPadding
                     if (state.isLoadingFeatured || state.featuredGames.isNotEmpty()) {
-                        item(key = "explore_hero") {
-                            if (state.isLoadingFeatured && state.featuredGames.isEmpty()) {
-                                HeroCarouselSkeleton()
-                            } else if (state.featuredGames.isNotEmpty()) {
-                                HeroCarousel(
-                                    featuredGames = state.featuredGames,
-                                    onGameSelected = onGameSelected,
-                                )
-                            }
+                        if (state.isLoadingFeatured && state.featuredGames.isEmpty()) {
+                            HeroCarouselSkeleton()
+                        } else if (state.featuredGames.isNotEmpty()) {
+                            HeroCarousel(
+                                featuredGames = state.featuredGames,
+                                onGameSelected = onGameSelected,
+                            )
                         }
                     }
+
+                SpMainContentPadding {
+                val focusMemory = rememberFocusMemoryState()
+                CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
+                SpSectionList(
+                    modifier = Modifier.fillMaxSize(),
+                ) {
                     // Global search entry point — tappable search bar
-                    paddedItem(key = "explore_search_bar") {
-                        SearchBarEntryPoint(
-                            onClick = { onGlobalSearchSelected?.invoke() },
-                            modifier = Modifier
-                                .focusRestoreItem(key = "explore_search_bar", isDefault = true)
-                                .testTag("explore_search_bar"),
+                    SearchBarEntryPoint(
+                        onClick = { onGlobalSearchSelected?.invoke() },
+                        modifier = Modifier
+                            .focusRestoreItem(key = "explore_search_bar", isDefault = true)
+                            .testTag("explore_search_bar"),
+                    )
+
+                    ExploreSection(
+                        title = "Browse by Console",
+                        testTag = "explore_consoles_section",
+                        focusKey = "section_browse_by_console",
+                        isLoading = state.isLoadingConsoleHighlights,
+                        isEmpty = state.consoleHighlights.isEmpty(),
+                        skeleton = { ConsoleQuickJumpSkeleton() },
+                    ) {
+                        ConsoleQuickJumpSection(
+                            consoles = state.consoleHighlights,
+                            onConsoleSelected = { onConsoleSelected?.invoke(it) },
                         )
                     }
 
-                    paddedItem(key = "explore_consoles") {
-                        ExploreSection(
-                            title = "Browse by Console",
-                            testTag = "explore_consoles_section",
-                            focusKey = "section_browse_by_console",
-                            isLoading = state.isLoadingConsoleHighlights,
-                            isEmpty = state.consoleHighlights.isEmpty(),
-                            skeleton = { ConsoleQuickJumpSkeleton() },
-                        ) {
-                            ConsoleQuickJumpSection(
-                                consoles = state.consoleHighlights,
-                                onConsoleSelected = { onConsoleSelected?.invoke(it) },
-                            )
-                        }
-                    }
-
-                    paddedItem(key = "explore_moods") {
-                        ExploreSection(
-                            title = "What are you in the mood for?",
-                            testTag = "explore_moods_section",
-                            focusKey = "section_moods",
-                            isLoading = state.isLoadingMoods,
-                            isEmpty = state.moods.isEmpty(),
-                            skeleton = { MoodPickerSkeleton() },
-                        ) {
-                            MoodPicker(
-                                moods = state.moods,
-                                onMoodSelected = { id, name -> onMoodSelected?.invoke(id, name) },
-                            )
-                        }
+                    ExploreSection(
+                        title = "What are you in the mood for?",
+                        testTag = "explore_moods_section",
+                        focusKey = "section_moods",
+                        isLoading = state.isLoadingMoods,
+                        isEmpty = state.moods.isEmpty(),
+                        skeleton = { MoodPickerSkeleton() },
+                    ) {
+                        MoodPicker(
+                            moods = state.moods,
+                            onMoodSelected = { id, name -> onMoodSelected?.invoke(id, name) },
+                        )
                     }
 
                     // Wild Features — Lucky & Wizard
-                    paddedItem(key = "explore_wild_features") {
-                        WildFeaturesSection(
-                            onSurpriseMe = { onSurpriseMe?.invoke() },
-                            onWizardSelected = { onWizardSelected?.invoke() },
-                            modifier = Modifier
-                                .testTag("explore_wild_features")
-                                .rememberFocus("section_wild_features"),
+                    WildFeaturesSection(
+                        onSurpriseMe = { onSurpriseMe?.invoke() },
+                        onWizardSelected = { onWizardSelected?.invoke() },
+                        modifier = Modifier
+                            .testTag("explore_wild_features")
+                            .rememberFocus("section_wild_features"),
+                    )
+
+                    ExploreSection(
+                        title = "For You",
+                        testTag = "explore_for_you_section",
+                        focusKey = "section_for_you",
+                        isLoading = state.isLoadingForYou,
+                        isEmpty = state.forYouRows.isEmpty(),
+                        skeleton = { ForYouSkeleton() },
+                    ) {
+                        ForYouSection(
+                            rows = state.forYouRows,
+                            onGameSelected = onGameSelected,
                         )
                     }
 
-                    paddedItem(key = "explore_for_you") {
-                        ExploreSection(
-                            title = "For You",
-                            testTag = "explore_for_you_section",
-                            focusKey = "section_for_you",
-                            isLoading = state.isLoadingForYou,
-                            isEmpty = state.forYouRows.isEmpty(),
-                            skeleton = { ForYouSkeleton() },
-                        ) {
-                            ForYouSection(
-                                rows = state.forYouRows,
-                                onGameSelected = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = "Browse by Theme",
+                        testTag = "explore_themes_section",
+                        focusKey = "section_themes",
+                        isLoading = state.isLoadingThemes,
+                        isEmpty = state.themes.isEmpty(),
+                        skeleton = { ThemeGridSkeleton() },
+                    ) {
+                        ThemeGrid(
+                            themes = state.themes,
+                            onThemeSelected = { id, name -> onThemeSelected?.invoke(id, name) },
+                        )
                     }
 
-                    paddedItem(key = "explore_themes") {
-                        ExploreSection(
-                            title = "Browse by Theme",
-                            testTag = "explore_themes_section",
-                            focusKey = "section_themes",
-                            isLoading = state.isLoadingThemes,
-                            isEmpty = state.themes.isEmpty(),
-                            skeleton = { ThemeGridSkeleton() },
-                        ) {
-                            ThemeGrid(
-                                themes = state.themes,
-                                onThemeSelected = { id, name -> onThemeSelected?.invoke(id, name) },
-                            )
-                        }
+                    ExploreSection(
+                        title = "Popular Keywords",
+                        testTag = "explore_keywords_section",
+                        focusKey = "section_keywords",
+                        isLoading = state.isLoadingKeywords,
+                        isEmpty = state.keywords.isEmpty(),
+                        skeleton = { KeywordChipsSkeleton() },
+                    ) {
+                        KeywordChips(
+                            keywords = state.keywords,
+                            onKeywordSelected = { id, name -> onKeywordSelected?.invoke(id, name) },
+                        )
                     }
 
-                    paddedItem(key = "explore_keywords") {
-                        ExploreSection(
-                            title = "Popular Keywords",
-                            testTag = "explore_keywords_section",
-                            focusKey = "section_keywords",
-                            isLoading = state.isLoadingKeywords,
-                            isEmpty = state.keywords.isEmpty(),
-                            skeleton = { KeywordChipsSkeleton() },
-                        ) {
-                            KeywordChips(
-                                keywords = state.keywords,
-                                onKeywordSelected = { id, name -> onKeywordSelected?.invoke(id, name) },
-                            )
-                        }
+                    ExploreSection(
+                        title = "Browse by Series",
+                        testTag = "explore_series_section",
+                        focusKey = "section_series",
+                        isLoading = state.isLoadingFeaturedSeries,
+                        isEmpty = state.featuredSeries.isEmpty(),
+                        skeleton = { SeriesShelfSkeleton() },
+                    ) {
+                        SeriesShelf(
+                            series = state.featuredSeries,
+                            onSeriesSelected = { id, name -> onSeriesSelected?.invoke(id, name) },
+                        )
                     }
 
-                    paddedItem(key = "explore_series") {
-                        ExploreSection(
-                            title = "Browse by Series",
-                            testTag = "explore_series_section",
-                            focusKey = "section_series",
-                            isLoading = state.isLoadingFeaturedSeries,
-                            isEmpty = state.featuredSeries.isEmpty(),
-                            skeleton = { SeriesShelfSkeleton() },
-                        ) {
-                            SeriesShelf(
-                                series = state.featuredSeries,
-                                onSeriesSelected = { id, name -> onSeriesSelected?.invoke(id, name) },
-                            )
-                        }
-                    }
 
                     // Developer spotlight section
-                    paddedItem(key = "explore_developer_spotlight") {
-                        if (state.isLoadingDeveloperSpotlight && state.developerSpotlight == null) {
-                            DeveloperSpotlightSkeleton(
-                            )
-                        } else if (state.developerSpotlight != null) {
-                            DeveloperSpotlightSection(
-                                spotlight = state.developerSpotlight!!,
-                                onDeveloperSelected = { name ->
-                                    onDeveloperSelected?.invoke(name)
-                                },
-                                onGameSelected = onGameSelected,
-                                modifier = Modifier.testTag("explore_developer_spotlight_section")
-                                    .rememberFocus("section_developer_spotlight"),
-                            )
-                        }
+                    if (state.isLoadingDeveloperSpotlight && state.developerSpotlight == null) {
+                        DeveloperSpotlightSkeleton(
+                        )
+                    } else if (state.developerSpotlight != null) {
+                        DeveloperSpotlightSection(
+                            spotlight = state.developerSpotlight!!,
+                            onDeveloperSelected = { name ->
+                                onDeveloperSelected?.invoke(name)
+                            },
+                            onGameSelected = onGameSelected,
+                            modifier = Modifier.testTag("explore_developer_spotlight_section")
+                                .rememberFocus("section_developer_spotlight"),
+                        )
                     }
 
-                    paddedItem(key = "explore_artwork") {
-                        ExploreSection(
-                            title = "Visual Discovery",
-                            testTag = "explore_artwork_section",
-                            focusKey = "section_artwork",
-                            isLoading = state.isLoadingArtwork,
-                            isEmpty = state.artworkShowcase.isEmpty(),
-                            skeleton = { ArtworkShowcaseSkeleton() },
-                            titleTrailing = onGallerySelected?.let { onClick ->
-                                {
-                                    Text(
-                                        text = "Browse Gallery",
-                                        style = SpTypography.LabelLarge,
-                                        color = SpColor.Link,
-                                        modifier = Modifier
-                                            .clip(RoundedCornerShape(SpSpacing.Small))
-                                            .clickable(onClick = onClick)
-                                            .padding(SpSpacing.Small)
-                                            .testTag("browse_gallery_button"),
-                                    )
-                                }
-                            },
-                        ) {
-                            ArtworkShowcaseSection(
-                                artworks = state.artworkShowcase,
-                                onGameSelected = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = "Visual Discovery",
+                        testTag = "explore_artwork_section",
+                        focusKey = "section_artwork",
+                        isLoading = state.isLoadingArtwork,
+                        isEmpty = state.artworkShowcase.isEmpty(),
+                        skeleton = { ArtworkShowcaseSkeleton() },
+                        titleTrailing = onGallerySelected?.let { onClick ->
+                            {
+                                Text(
+                                    text = "Browse Gallery",
+                                    style = SpTypography.LabelLarge,
+                                    color = SpColor.Link,
+                                    modifier = Modifier
+                                        .clip(RoundedCornerShape(SpSpacing.Small))
+                                        .clickable(onClick = onClick)
+                                        .padding(SpSpacing.Small)
+                                        .testTag("browse_gallery_button"),
+                                )
+                            }
+                        },
+                    ) {
+                        ArtworkShowcaseSection(
+                            artworks = state.artworkShowcase,
+                            onGameSelected = onGameSelected,
+                        )
                     }
 
                     // Social & Community Discovery sections — all share the
                     // single state.isLoadingSocial flag.
-                    paddedItem(key = "explore_trending") {
-                        ExploreSection(
-                            title = "Trending on Your Server",
-                            testTag = "explore_trending_section",
-                            focusKey = "section_trending",
-                            isLoading = state.isLoadingSocial,
-                            isEmpty = state.trendingGames.isEmpty(),
-                            skeleton = { SocialSectionSkeleton() },
-                        ) {
-                            TrendingSection(
-                                games = state.trendingGames,
-                                onGameSelected = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = "Trending on Your Server",
+                        testTag = "explore_trending_section",
+                        focusKey = "section_trending",
+                        isLoading = state.isLoadingSocial,
+                        isEmpty = state.trendingGames.isEmpty(),
+                        skeleton = { SocialSectionSkeleton() },
+                    ) {
+                        TrendingSection(
+                            games = state.trendingGames,
+                            onGameSelected = onGameSelected,
+                        )
                     }
 
-                    paddedItem(key = "explore_community_top") {
-                        ExploreSection(
-                            title = "Community Favorites",
-                            testTag = "explore_community_top_section",
-                            focusKey = "section_community_favorites",
-                            isLoading = state.isLoadingSocial,
-                            isEmpty = state.communityTopGames.isEmpty(),
-                            skeleton = { SocialSectionSkeleton() },
-                        ) {
-                            CommunityTopSection(
-                                games = state.communityTopGames,
-                                onGameSelected = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = "Community Favorites",
+                        testTag = "explore_community_top_section",
+                        focusKey = "section_community_favorites",
+                        isLoading = state.isLoadingSocial,
+                        isEmpty = state.communityTopGames.isEmpty(),
+                        skeleton = { SocialSectionSkeleton() },
+                    ) {
+                        CommunityTopSection(
+                            games = state.communityTopGames,
+                            onGameSelected = onGameSelected,
+                        )
                     }
 
-                    paddedItem(key = "explore_cult_classics") {
-                        ExploreSection(
-                            title = "Cult Classics",
-                            testTag = "explore_cult_classics_section",
-                            focusKey = "section_cult_classics",
-                            isLoading = state.isLoadingSocial,
-                            isEmpty = state.cultClassics.isEmpty(),
-                            skeleton = { SocialSectionSkeleton() },
-                        ) {
-                            CultClassicsSection(
-                                games = state.cultClassics,
-                                onGameSelected = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = "Cult Classics",
+                        testTag = "explore_cult_classics_section",
+                        focusKey = "section_cult_classics",
+                        isLoading = state.isLoadingSocial,
+                        isEmpty = state.cultClassics.isEmpty(),
+                        skeleton = { SocialSectionSkeleton() },
+                    ) {
+                        CultClassicsSection(
+                            games = state.cultClassics,
+                            onGameSelected = onGameSelected,
+                        )
                     }
 
-                    paddedItem(key = "explore_active_now") {
-                        ExploreSection(
-                            title = "Active Right Now",
-                            testTag = "explore_active_now_section",
-                            focusKey = "section_active_now",
-                            isLoading = state.isLoadingSocial,
-                            isEmpty = state.activeNowGames.isEmpty(),
-                            skeleton = { SocialSectionSkeleton() },
-                        ) {
-                            ActiveNowSection(
-                                games = state.activeNowGames,
-                                onGameSelected = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = "Active Right Now",
+                        testTag = "explore_active_now_section",
+                        focusKey = "section_active_now",
+                        isLoading = state.isLoadingSocial,
+                        isEmpty = state.activeNowGames.isEmpty(),
+                        skeleton = { SocialSectionSkeleton() },
+                    ) {
+                        ActiveNowSection(
+                            games = state.activeNowGames,
+                            onGameSelected = onGameSelected,
+                        )
                     }
 
-                    paddedItem(key = "explore_recently_reviewed") {
-                        ExploreSection(
-                            title = "Recently Reviewed",
-                            testTag = "explore_recently_reviewed_section",
-                            focusKey = "section_recently_reviewed",
-                            isLoading = state.isLoadingSocial,
-                            isEmpty = state.recentReviews.isEmpty(),
-                            skeleton = { SocialSectionSkeleton() },
-                        ) {
-                            RecentlyReviewedSection(
-                                reviews = state.recentReviews,
-                                onGameSelected = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = "Recently Reviewed",
+                        testTag = "explore_recently_reviewed_section",
+                        focusKey = "section_recently_reviewed",
+                        isLoading = state.isLoadingSocial,
+                        isEmpty = state.recentReviews.isEmpty(),
+                        skeleton = { SocialSectionSkeleton() },
+                    ) {
+                        RecentlyReviewedSection(
+                            reviews = state.recentReviews,
+                            onGameSelected = onGameSelected,
+                        )
                     }
 
                     // Title includes the date when populated — the skeleton
@@ -431,141 +394,121 @@ fun ExploreScreen(
                     } else {
                         "On This Day"
                     }
-                    paddedItem(key = "explore_on_this_day") {
-                        ExploreSection(
-                            title = onThisDayTitle,
-                            testTag = "explore_on_this_day_section",
-                            focusKey = "section_on_this_day",
-                            isLoading = state.isLoadingTemporal,
-                            isEmpty = state.onThisDayGames.isEmpty(),
-                            skeleton = { TemporalSectionSkeleton() },
-                        ) {
-                            OnThisDaySection(
-                                games = state.onThisDayGames,
-                                onGameSelected = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = onThisDayTitle,
+                        testTag = "explore_on_this_day_section",
+                        focusKey = "section_on_this_day",
+                        isLoading = state.isLoadingTemporal,
+                        isEmpty = state.onThisDayGames.isEmpty(),
+                        skeleton = { TemporalSectionSkeleton() },
+                    ) {
+                        OnThisDaySection(
+                            games = state.onThisDayGames,
+                            onGameSelected = onGameSelected,
+                        )
                     }
 
-                    paddedItem(key = "explore_anniversaries") {
-                        ExploreSection(
-                            title = "Your Anniversaries",
-                            testTag = "explore_anniversaries_section",
-                            focusKey = "section_anniversaries",
-                            isLoading = state.isLoadingTemporal,
-                            isEmpty = state.anniversaries.isEmpty(),
-                            skeleton = { TemporalSectionSkeleton() },
-                        ) {
-                            AnniversariesSection(
-                                anniversaries = state.anniversaries,
-                                onGameSelected = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = "Your Anniversaries",
+                        testTag = "explore_anniversaries_section",
+                        focusKey = "section_anniversaries",
+                        isLoading = state.isLoadingTemporal,
+                        isEmpty = state.anniversaries.isEmpty(),
+                        skeleton = { TemporalSectionSkeleton() },
+                    ) {
+                        AnniversariesSection(
+                            anniversaries = state.anniversaries,
+                            onGameSelected = onGameSelected,
+                        )
                     }
 
                     // Achievement Discovery — all share state.isLoadingAchievement.
-                    paddedItem(key = "explore_easy_to_complete") {
-                        ExploreSection(
-                            title = "Easy to 100%",
-                            testTag = "explore_easy_to_complete_section",
-                            focusKey = "section_easy_to_complete",
-                            isLoading = state.isLoadingAchievement,
-                            isEmpty = state.easyToCompleteGames.isEmpty(),
-                            skeleton = { AchievementSectionSkeleton() },
-                        ) {
-                            EasyToCompleteSection(
-                                games = state.easyToCompleteGames,
-                                onGameClick = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = "Easy to 100%",
+                        testTag = "explore_easy_to_complete_section",
+                        focusKey = "section_easy_to_complete",
+                        isLoading = state.isLoadingAchievement,
+                        isEmpty = state.easyToCompleteGames.isEmpty(),
+                        skeleton = { AchievementSectionSkeleton() },
+                    ) {
+                        EasyToCompleteSection(
+                            games = state.easyToCompleteGames,
+                            onGameClick = onGameSelected,
+                        )
                     }
 
-                    paddedItem(key = "explore_hardest_games") {
-                        ExploreSection(
-                            title = "Mount Everest",
-                            testTag = "explore_hardest_games_section",
-                            focusKey = "section_hardest_games",
-                            isLoading = state.isLoadingAchievement,
-                            isEmpty = state.hardestGames.isEmpty(),
-                            skeleton = { AchievementSectionSkeleton() },
-                        ) {
-                            HardestGamesSection(
-                                games = state.hardestGames,
-                                onGameClick = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = "Mount Everest",
+                        testTag = "explore_hardest_games_section",
+                        focusKey = "section_hardest_games",
+                        isLoading = state.isLoadingAchievement,
+                        isEmpty = state.hardestGames.isEmpty(),
+                        skeleton = { AchievementSectionSkeleton() },
+                    ) {
+                        HardestGamesSection(
+                            games = state.hardestGames,
+                            onGameClick = onGameSelected,
+                        )
                     }
 
-                    paddedItem(key = "explore_almost_done") {
-                        ExploreSection(
-                            title = "Almost Done",
-                            testTag = "explore_almost_done_section",
-                            focusKey = "section_almost_done",
-                            isLoading = state.isLoadingAchievement,
-                            isEmpty = state.almostDoneGames.isEmpty(),
-                            skeleton = { AchievementSectionSkeleton() },
-                        ) {
-                            AlmostDoneSection(
-                                games = state.almostDoneGames,
-                                onGameClick = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = "Almost Done",
+                        testTag = "explore_almost_done_section",
+                        focusKey = "section_almost_done",
+                        isLoading = state.isLoadingAchievement,
+                        isEmpty = state.almostDoneGames.isEmpty(),
+                        skeleton = { AchievementSectionSkeleton() },
+                    ) {
+                        AlmostDoneSection(
+                            games = state.almostDoneGames,
+                            onGameClick = onGameSelected,
+                        )
                     }
 
-                    paddedItem(key = "explore_fresh_challenges") {
-                        ExploreSection(
-                            title = "Fresh Challenges",
-                            testTag = "explore_fresh_challenges_section",
-                            focusKey = "section_fresh_challenges",
-                            isLoading = state.isLoadingAchievement,
-                            isEmpty = state.freshChallengeGames.isEmpty(),
-                            skeleton = { AchievementSectionSkeleton() },
-                        ) {
-                            FreshChallengesSection(
-                                games = state.freshChallengeGames,
-                                onGameClick = onGameSelected,
-                            )
-                        }
+                    ExploreSection(
+                        title = "Fresh Challenges",
+                        testTag = "explore_fresh_challenges_section",
+                        focusKey = "section_fresh_challenges",
+                        isLoading = state.isLoadingAchievement,
+                        isEmpty = state.freshChallengeGames.isEmpty(),
+                        skeleton = { AchievementSectionSkeleton() },
+                    ) {
+                        FreshChallengesSection(
+                            games = state.freshChallengeGames,
+                            onGameClick = onGameSelected,
+                        )
                     }
 
-                    paddedItem(key = "explore_active_challenges") {
-                        ExploreSection(
-                            title = "Active Challenges",
-                            testTag = "explore_active_challenges_section",
-                            focusKey = "section_active_challenges",
-                            isLoading = state.isLoadingAchievement,
-                            isEmpty = state.activeChallenges.isEmpty(),
-                            skeleton = { AchievementSectionSkeleton() },
-                        ) {
-                            ActiveChallengesSection(
-                                challenges = state.activeChallenges,
-                                onChallengeClick = { onChallengeSelected?.invoke(it) },
-                            )
-                        }
+                    ExploreSection(
+                        title = "Active Challenges",
+                        testTag = "explore_active_challenges_section",
+                        focusKey = "section_active_challenges",
+                        isLoading = state.isLoadingAchievement,
+                        isEmpty = state.activeChallenges.isEmpty(),
+                        skeleton = { AchievementSectionSkeleton() },
+                    ) {
+                        ActiveChallengesSection(
+                            challenges = state.activeChallenges,
+                            onChallengeClick = { onChallengeSelected?.invoke(it) },
+                        )
                     }
-
-                    // Shelf rows — each gets its own item so off-screen rows
-                    // defer composition (and their cover-image grids).
+                    // Shelf rows
                     if (state.isLoadingRows && state.rows.isEmpty()) {
+                        // Loading skeletons for rows
                         val skeletonTitles = listOf("Top Rated", "Recently Added", "Hidden Gems")
-                        items(items = skeletonTitles, key = { "explore_row_skel_$it" }) { title ->
-                            paddedItemContent {
-                                SpTitledSection(
-                                    title = title,
-                                    edgeToEdgeContent = true,
-                                ) {
-                                    GameShelfSkeleton()
-                                }
+                        skeletonTitles.forEach { title ->
+                            SpTitledSection(
+                                title = title,
+                                edgeToEdgeContent = true,
+                            ) {
+                                GameShelfSkeleton()
                             }
                         }
                     } else {
-                        items(
-                            items = state.rows.filter { it.games.isNotEmpty() },
-                            key = { "explore_row_${it.id}" },
-                        ) { row ->
-                            paddedItemContent {
+                        state.rows.forEach { row ->
+                            if (row.games.isNotEmpty()) {
                                 SpTitledSection(
-                                    title = row.title,
+                                title = row.title,
                                     edgeToEdgeContent = true,
                                     modifier = Modifier
                                         .testTag("explore_row_${row.id}")
@@ -580,8 +523,13 @@ fun ExploreScreen(
                             }
                         }
                     }
-                } // SpLazySectionList
+
+                    // Bottom spacer
+                    Spacer(Modifier.height(SpSpacing.XLarge))
+                } // SpSectionList
                 } // CompositionLocalProvider
+                } // SpMainContentPadding
+                } // SpScrollableContent
             }
         }
 
@@ -683,36 +631,5 @@ private fun SearchBarEntryPoint(
             style = SpTypography.BodyMedium,
             color = SpColor.OnBackgroundTertiary,
         )
-    }
-}
-
-/**
- * Adds a [LazyListScope] item wrapped in the canonical screen
- * horizontal padding. Most Explore items match this convention; the
- * hero carousel is the exception (edge-to-edge) and uses a plain
- * `item { ... }` instead.
- */
-private fun LazyListScope.paddedItem(
-    key: Any? = null,
-    content: @Composable () -> Unit,
-) {
-    item(key = key) {
-        Box(modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal)) {
-            content()
-        }
-    }
-}
-
-/**
- * Sibling helper for [LazyListScope.items]'s lambda body — wraps the
- * already-individual item's content in the same horizontal padding
- * that [paddedItem] provides, without needing a separate item call.
- * Used for the shelf-rows loop where the lazy list's [items] generator
- * is the right shape and we only need padding around each child.
- */
-@Composable
-private fun paddedItemContent(content: @Composable () -> Unit) {
-    Box(modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal)) {
-        content()
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/FavoritesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/FavoritesScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.ui.components.SpEmptyStates
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.spScreenBackground
@@ -48,7 +48,7 @@ fun FavoritesScreen(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,
             ) {
-                SpLoadingIndicator(message = "Loading favorites...")
+                ScreenLoadingIndicator(message = "Loading favorites...")
             }
         } else {
             PullToRefreshBox(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/FavoritesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/FavoritesScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.spScreenBackground
@@ -52,7 +53,7 @@ fun FavoritesScreen(
             }
         } else {
             PullToRefreshBox(
-                isRefreshing = state.isLoading,
+                isRefreshing = rememberLoadingFlashDebounce(state.isLoading),
                 onRefresh = { viewModel.onIntent(GameListIntent.LoadDashboard) },
                 modifier = Modifier.fillMaxSize(),
             ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -70,7 +70,7 @@ import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import androidx.compose.runtime.CompositionLocalProvider
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpIconButton
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -161,7 +161,7 @@ fun HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    SpLoadingIndicator(message = "Loading your library...")
+                    ScreenLoadingIndicator(message = "Loading your library...")
                 }
             } else {
                 PullToRefreshBox(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpIconButton
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -165,7 +166,7 @@ fun HomeScreen(
                 }
             } else {
                 PullToRefreshBox(
-                    isRefreshing = state.isLoading,
+                    isRefreshing = rememberLoadingFlashDebounce(state.isLoading),
                     onRefresh = {
                         viewModel.onIntent(GameListIntent.LoadDashboard)
                         socialViewModel.onIntent(SocialIntent.RefreshAll)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayListScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayListScreen.kt
@@ -41,6 +41,7 @@ import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpDialog
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -110,7 +111,7 @@ fun NetplayListScreen(
                 }
             } else {
                 PullToRefreshBox(
-                    isRefreshing = state.isLoading,
+                    isRefreshing = rememberLoadingFlashDebounce(state.isLoading),
                     onRefresh = { viewModel.onIntent(NetplayIntent.LoadSessions) },
                     modifier = Modifier.fillMaxSize(),
                 ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayListScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayListScreen.kt
@@ -40,7 +40,7 @@ import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpDialog
 import com.spela.player.presentation.ui.components.SpEmptyStates
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -106,7 +106,7 @@ fun NetplayListScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    SpLoadingIndicator(message = "Loading sessions...")
+                    ScreenLoadingIndicator(message = "Loading sessions...")
                 }
             } else {
                 PullToRefreshBox(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
@@ -44,6 +44,7 @@ import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.createTextClipEntry
 import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpNetplayPlayerSlot
 import com.spela.player.presentation.ui.components.SpProgressBar
 import com.spela.player.presentation.ui.components.SpSessionCode
@@ -154,7 +155,7 @@ fun NetplayLobbyScreen(
                 }
             } else if (session != null) {
                 PullToRefreshBox(
-                    isRefreshing = state.isLoading,
+                    isRefreshing = rememberLoadingFlashDebounce(state.isLoading),
                     onRefresh = { viewModel.onIntent(NetplayLobbyIntent.LoadSession(sessionId)) },
                     modifier = Modifier.fillMaxSize(),
                 ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
@@ -43,7 +43,7 @@ import com.spela.player.presentation.ui.components.InvitePlayerSheet
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.createTextClipEntry
 import com.spela.player.presentation.ui.components.SpSecondaryButton
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpNetplayPlayerSlot
 import com.spela.player.presentation.ui.components.SpProgressBar
 import com.spela.player.presentation.ui.components.SpSessionCode
@@ -150,7 +150,7 @@ fun NetplayLobbyScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    SpLoadingIndicator(message = "Loading session...")
+                    ScreenLoadingIndicator(message = "Loading session...")
                 }
             } else if (session != null) {
                 PullToRefreshBox(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/PlayLaterScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/PlayLaterScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.ui.components.SpEmptyStates
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.spScreenBackground
@@ -48,7 +48,7 @@ fun PlayLaterScreen(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,
             ) {
-                SpLoadingIndicator(message = "Loading play later...")
+                ScreenLoadingIndicator(message = "Loading play later...")
             }
         } else {
             PullToRefreshBox(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/PlayLaterScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/PlayLaterScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.spScreenBackground
@@ -52,7 +53,7 @@ fun PlayLaterScreen(
             }
         } else {
             PullToRefreshBox(
-                isRefreshing = state.isLoading,
+                isRefreshing = rememberLoadingFlashDebounce(state.isLoading),
                 onRefresh = { viewModel.onIntent(GameListIntent.LoadDashboard) },
                 modifier = Modifier.fillMaxSize(),
             ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ServerConnectionScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ServerConnectionScreen.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
@@ -160,7 +160,7 @@ private fun MobileLayout(
             Spacer(Modifier.height(SpSpacing.XLarge))
 
             if (state.isLoading) {
-                SpLoadingIndicator(message = "Loading servers...")
+                ScreenLoadingIndicator(message = "Loading servers...")
             } else {
                 ServerListOrForm(
                     viewModel = viewModel,
@@ -226,7 +226,7 @@ private fun SplitLayout(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     if (state.isLoading) {
-                        SpLoadingIndicator(message = "Loading servers...")
+                        ScreenLoadingIndicator(message = "Loading servers...")
                     } else {
                         ServerListOrForm(
                             viewModel = viewModel,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
@@ -57,6 +57,7 @@ import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpHeroCover
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpSectionHeader
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
@@ -163,7 +164,9 @@ fun SessionDetailScreen(
                 }
             } else if (state.session != null) {
                 val session = state.session!!
-                val isRefreshing = state.isLoading || state.isLoadingSaves
+                val isRefreshing = rememberLoadingFlashDebounce(
+                    state.isLoading || state.isLoadingSaves
+                )
 
                 PullToRefreshBox(
                     isRefreshing = isRefreshing,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
@@ -56,7 +56,7 @@ import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpHeroCover
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSectionHeader
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
@@ -159,7 +159,7 @@ fun SessionDetailScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    SpLoadingIndicator(message = "Loading session...")
+                    ScreenLoadingIndicator(message = "Loading session...")
                 }
             } else if (state.session != null) {
                 val session = state.session!!

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
@@ -40,7 +40,7 @@ import com.spela.player.presentation.ui.feature.sharedsession.SharedSessionSaveI
 import com.spela.player.presentation.ui.components.InvitePlayerSheet
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpIconButton
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSectionHeader
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
@@ -142,7 +142,7 @@ fun SharedSessionDetailScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    SpLoadingIndicator(message = "Loading shared session...")
+                    ScreenLoadingIndicator(message = "Loading shared session...")
                 }
             } else if (state.sharedSession != null) {
                 val sharedSession = state.sharedSession!!

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
@@ -41,6 +41,7 @@ import com.spela.player.presentation.ui.components.InvitePlayerSheet
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpIconButton
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpSectionHeader
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
@@ -146,7 +147,9 @@ fun SharedSessionDetailScreen(
                 }
             } else if (state.sharedSession != null) {
                 val sharedSession = state.sharedSession!!
-                val isRefreshing = state.isLoadingSharedSession || state.isLoadingSaves
+                val isRefreshing = rememberLoadingFlashDebounce(
+                    state.isLoadingSharedSession || state.isLoadingSaves
+                )
 
                 PullToRefreshBox(
                     isRefreshing = isRefreshing,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionsScreen.kt
@@ -42,7 +42,7 @@ import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpSectionHeader
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -101,7 +101,7 @@ fun SharedSessionsScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    SpLoadingIndicator(message = "Loading shared sessions...")
+                    ScreenLoadingIndicator(message = "Loading shared sessions...")
                 }
             } else {
                 PullToRefreshBox(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/StatsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/StatsScreen.kt
@@ -25,7 +25,7 @@ import com.spela.player.presentation.ui.feature.stats.MostPlayedGameItem
 import com.spela.player.presentation.ui.feature.stats.PersonalStatsSection
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpSectionHeader
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -80,7 +80,7 @@ fun StatsScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    SpLoadingIndicator(message = "Loading stats...")
+                    ScreenLoadingIndicator(message = "Loading stats...")
                 }
             } else {
                 val isEmpty = state.mostPlayedGames.isEmpty() && state.activePlayers.isEmpty() && state.personalStats == null

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/StatsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/StatsScreen.kt
@@ -26,6 +26,7 @@ import com.spela.player.presentation.ui.feature.stats.PersonalStatsSection
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpSectionHeader
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -86,7 +87,7 @@ fun StatsScreen(
                 val isEmpty = state.mostPlayedGames.isEmpty() && state.activePlayers.isEmpty() && state.personalStats == null
 
                 PullToRefreshBox(
-                    isRefreshing = state.isLoading,
+                    isRefreshing = rememberLoadingFlashDebounce(state.isLoading),
                     onRefresh = { viewModel.onIntent(StatsIntent.LoadStats) },
                     modifier = Modifier.fillMaxSize(),
                 ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/TopListsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/TopListsScreen.kt
@@ -46,7 +46,7 @@ import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpEmptyState
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -151,7 +151,7 @@ fun TopListsScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    SpLoadingIndicator(message = "Loading top lists...")
+                    ScreenLoadingIndicator(message = "Loading top lists...")
                 }
             } else {
                 PullToRefreshBox(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/TopListsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/TopListsScreen.kt
@@ -47,6 +47,7 @@ import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -155,7 +156,7 @@ fun TopListsScreen(
                 }
             } else {
                 PullToRefreshBox(
-                    isRefreshing = state.isLoading,
+                    isRefreshing = rememberLoadingFlashDebounce(state.isLoading),
                     onRefresh = { viewModel.onIntent(TopListsIntent.LoadTopLists) },
                     modifier = Modifier.fillMaxSize(),
                 ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
@@ -41,7 +41,7 @@ import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.components.SpCard
 
-import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpPlayHeatmap
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpTitledSection
@@ -146,7 +146,7 @@ fun UserProfileScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    SpLoadingIndicator(message = "Loading profile...")
+                    ScreenLoadingIndicator(message = "Loading profile...")
                 }
             }
             state.publicProfile != null -> {


### PR DESCRIPTION
Closes #1165.

## Root cause (verified on hardware)

\`MainActivity.ensureDeviceConnected\` allocated a player port for **any** Android InputDevice that produced an \`onKeyDown\` event — no source-flag filter. The AYN Thor (and likely other Android handhelds) has multiple non-gamepad KEYBOARD-class devices that legitimately fire key events:

| Device | Sources | What it sends |
|---|---|---|
| \`Xbox Wireless Controller\` (the real one) | KEYBOARD\|GAMEPAD\|JOYSTICK | the gamepad |
| \`gpio-keys\` | KEYBOARD | hardware volume up/down |
| \`pmic_pwrkey\` | KEYBOARD | power button |
| \`kalama-qrd-snd-card Button Jack\` | KEYBOARD | headset jack mic |
| \`fts_ts\` (primary touchscreen) | KEYBOARD\|TOUCHSCREEN | KEY_UP/DOWN/LEFT/RIGHT/POWER for gesture re-routing — verified via \`getevent -lp\` |

Any one of these firing \`onKeyDown\` claimed a player port → indicator showed **2 dots** in a 1-controller session.

## Fix

Filter in \`ensureDeviceConnected\` on \`InputDevice.SOURCE_GAMEPAD\` (or \`SOURCE_JOYSTICK\` for joystick-only edge cases — both bits present on every real controller, absent on every false-positive in the Thor dump). Real controllers continue to get assigned; hardware buttons and touchscreens get ignored.

## Why this matters

The on-screen player-N indicator is the **substitute** for the physical-controller LEDs that PS5 / Switch have. The promise is "you can tell which player you are at a glance". When the count is wrong, the substitute breaks.

## Test plan

- [x] \`dumpsys input\` on Thor: exactly one SOURCE_GAMEPAD device exists → filter takes us cleanly from 2 → 1
- [x] APK installed on Thor (\`54071896\`); ready for the user to verify the indicator now correctly shows 1
- [x] \`./gradlew :android:assembleDebug\` succeeds

(Filter is a 5-line Android predicate against \`InputDevice.sources\`; no clean unit-test surface without Robolectric — verification is on-device.)