### PR TITLE
feat(player): SpCarousel uses LazyRow with focus-restore-aware scroll (#1168)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/LazyCarouselFocusRestoreTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/LazyCarouselFocusRestoreTest.kt
@@ -1,0 +1,128 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+
+/**
+ * Regression test for the lazy-carousel focus-restore guarantee
+ * introduced in #1168 PR B (SpCarousel -> LazyRow).
+ *
+ * SpCarousel now composes items lazily — only items in (or near) the
+ * visible window are in the composition tree. A naive implementation
+ * would break focus restoration for any item the user had previously
+ * scrolled to: after back-nav the LazyRow starts at index 0 and the
+ * previously-focused FocusRequester isn't bound to any layout node, so
+ * focusRestoreItem's `requestFocus` is a silent no-op.
+ *
+ * The fix: SpCarousel reads LocalFocusMemory at composition and, if the
+ * saved key matches one of its items, `scrollToItem(targetIndex)` runs
+ * before focusRestoreItem's ~120 ms layout-settle delay fires. By the
+ * time `requestFocus` runs the item has been composed and its
+ * FocusRequester is attached.
+ *
+ * This test walks the realistic user path: enough DirectionRight presses
+ * to land on an item that's almost certainly outside the initial
+ * viewport, forward-nav, back-nav, verify focus restored.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class LazyCarouselFocusRestoreTest {
+
+    private fun game(id: String, title: String): Game = Game(
+        id = id,
+        title = title,
+        consoleId = "snes",
+        consoleName = "SNES",
+        description = "Test",
+        developer = "Test",
+        publisher = "Test",
+        releaseDate = "1990",
+        genre = "Action",
+        fileSize = 1024,
+        fileName = "$id.smc",
+        scrapeAttempts = 1,
+    )
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.authRepo.preSetTokens()
+        harness.deviceManager.setDeviceName("Test Device")
+        // HomeScreen caps Continue Playing at .take(6), so 6 items is
+        // the carousel's actual size in this test. With the desktop
+        // test viewport only ~3 items are visible at a time — items at
+        // index 3+ are guaranteed off-screen on cold remount, which is
+        // the scenario the test needs to exercise.
+        val recents = (1..6).map { i ->
+            game(id = "g$i", title = "Recents Game $i")
+        }
+        harness.gameRepo.recentGamesOverride = recents
+        harness.gameRepo.games = recents
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    @Test
+    fun smoke_dPadAdvancesTwoPositions() = runComposeUiTest {
+        val harness = createHarness()
+        setContent { harness.App(animationsEnabled = true) }
+        advance(harness)
+
+        // Same shape as continuePlaying_focusRestoredAfterKeyboardEnterEscape
+        // but with the larger recents list. Two right presses should land
+        // on Recents Game 3.
+        onRoot().performKeyInput {
+            pressKey(androidx.compose.ui.input.key.Key.DirectionRight)
+            pressKey(androidx.compose.ui.input.key.Key.DirectionRight)
+        }
+        advanceFully(harness)
+        onNodeWithContentDescription("Recents Game 3, SNES").assert(isFocused())
+    }
+
+    @Test
+    fun offScreenItem_focusRestoredAfterForwardAndBackNav() = runComposeUiTest {
+        val harness = createHarness()
+        setContent { harness.App(animationsEnabled = true) }
+        advance(harness)
+
+        // Walk right with the d-pad until focused on the last item
+        // ("Recents Game 6", index 5). On a 6-item carousel with the
+        // desktop test viewport showing ~3 items, the leftmost items
+        // are disposed when the focused item is at index 5 — and on
+        // back-nav the LazyRow remounts at index 0, so item 5 is
+        // disposed unless SpCarousel's restoration logic actively
+        // scrolls back to it.
+        //
+        // All presses go through a single performKeyInput block — the
+        // intervening "rapid" window (<100 ms wall clock) tells
+        // SpCarousel to snap-scroll instead of animating.
+        val pressCount = 5
+        onRoot().performKeyInput {
+            repeat(pressCount) {
+                pressKey(androidx.compose.ui.input.key.Key.DirectionRight)
+            }
+        }
+        advanceFully(harness)
+
+        val targetTitle = "Recents Game ${pressCount + 1}, SNES"
+        onNodeWithContentDescription(targetTitle).assert(isFocused())
+
+        // Forward to game detail.
+        onRoot().performKeyInput {
+            pressKey(androidx.compose.ui.input.key.Key.Enter)
+        }
+        advanceFully(harness)
+
+        // Back to Home. The lazy carousel must scroll the saved item
+        // into view and restore focus to it.
+        onRoot().performKeyInput {
+            pressKey(androidx.compose.ui.input.key.Key.Escape)
+        }
+        advanceFully(harness)
+
+        onNodeWithContentDescription(targetTitle).assert(isFocused())
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 
@@ -164,12 +163,13 @@ private fun LandscapeLayout(
                             .align(Alignment.TopStart),
                     ) {
                         if (heroUrl != null) {
-                            SubcomposeAsyncImage(
+                            SpImage(
                                 model = heroUrl,
                                 contentDescription = null,
                                 modifier = Modifier.fillMaxSize(),
                                 contentScale = ContentScale.Crop,
-                                loading = {
+                                staggerMs = 0L,
+                                placeholder = {
                                     Box(modifier = Modifier.fillMaxSize().drawBehind {
                                         val cx = size.width / 2f
                                         val cy = size.height / 2f
@@ -320,16 +320,17 @@ private fun PortraitLayout(
                 ) {
                     // Background: hero image — sized by the content Column below via matchParentSize
                     if (heroUrl != null) {
-                        SubcomposeAsyncImage(
+                        SpImage(
                             model = heroUrl,
                             contentDescription = "Hero banner",
                             modifier = Modifier.matchParentSize(),
                             contentScale = ContentScale.Crop,
-                            loading = {
-                                Box(modifier = Modifier.matchParentSize().background(SpColor.Background))
+                            staggerMs = 0L,
+                            placeholder = {
+                                Box(modifier = Modifier.fillMaxSize().background(SpColor.Background))
                             },
                             error = {
-                                Box(modifier = Modifier.matchParentSize().background(
+                                Box(modifier = Modifier.fillMaxSize().background(
                                     Brush.verticalGradient(listOf(
                                         backgroundColors.first().copy(alpha = 0.5f),
                                         backgroundColors.last(),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenshotLightbox.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenshotLightbox.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
-import coil3.compose.AsyncImage
 import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -135,10 +134,11 @@ fun ScreenshotLightbox(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center,
                     ) {
-                        AsyncImage(
+                        SpImage(
                             model = screenshotUrls[page],
                             contentDescription = "Screenshot ${page + 1}",
                             contentScale = ContentScale.Fit,
+                            staggerMs = 0L,
                             modifier = Modifier
                                 .fillMaxSize()
                                 .padding(horizontal = SpSpacing.XLarge)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ShaderPreview.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ShaderPreview.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import coil3.compose.AsyncImage
 import com.spela.player.domain.model.ShaderPreset
 import com.spela.player.presentation.ui.feature.shader.drawShaderOverlay
 import com.spela.player.presentation.ui.theme.SpColor
@@ -40,13 +39,14 @@ fun ShaderPreview(
             .testTag("shader-preview")
             .background(SpColor.SurfaceVariant),
     ) {
-        // Load the preview image using AsyncImage (same as cover art)
+        // Load the preview image using SpImage (same as cover art)
         if (imageUrl != null) {
-            AsyncImage(
+            SpImage(
                 model = imageUrl,
                 contentDescription = null,
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Fit,
+                staggerMs = 0L,
             )
         }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpAchievementBadge.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpAchievementBadge.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -61,12 +60,12 @@ fun SpAchievementBadge(
         contentAlignment = Alignment.Center,
     ) {
         if (badgeUrl != null) {
-            SubcomposeAsyncImage(
+            SpImage(
                 model = badgeUrl,
                 contentDescription = null,
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop,
-                loading = {
+                placeholder = {
                     BadgeFallback(rarityColor = borderColor)
                 },
                 error = {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpAreaSizedImage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpAreaSizedImage.kt
@@ -10,10 +10,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
 import kotlin.math.sqrt
 
 /**
@@ -37,8 +35,7 @@ import kotlin.math.sqrt
  *   the caller (e.g. shipped by the server alongside the image URL). When
  *   supplied the container starts at its final size rather than the square-
  *   guess fallback, eliminating the size-A → size-B re-layout that happens
- *   once SubcomposeAsyncImage decodes the bytes (#1166). Null = legacy
- *   behaviour.
+ *   once SpImage decodes the bytes (#1166). Null = legacy behaviour.
  * @param loading Composable shown while the image loads.
  * @param error Composable shown if loading fails.
  */
@@ -57,15 +54,11 @@ fun SpAreaSizedImage(
 ) {
     // Track the resolved aspect ratio. Seeded by [initialAspectRatio] so
     // the layout snaps to the correct dimensions on first frame; the
-    // SubcomposeAsyncImage callback overwrites it with the painter's
+    // SpImage success callback overwrites it with the painter's
     // intrinsic ratio once the image decodes (handles SVG/PNG drift).
     var aspectRatio by remember(initialAspectRatio) {
         mutableFloatStateOf(initialAspectRatio ?: 0f)
     }
-
-    // Compute dimensions from target area and aspect ratio
-    // area = w * h, aspectRatio = w / h → w = sqrt(area * ar), h = sqrt(area / ar)
-    val density = LocalDensity.current
 
     BoxWithConstraints(modifier = modifier) {
         val computedHeight = if (aspectRatio > 0f) {
@@ -83,13 +76,15 @@ fun SpAreaSizedImage(
             maxWidth
         }
 
-        SubcomposeAsyncImage(
+        SpImage(
             model = imageUrl,
             contentDescription = contentDescription,
             modifier = Modifier
                 .heightIn(max = computedHeight)
                 .widthIn(max = computedWidth),
             contentScale = ContentScale.Fit,
+            placeholder = loading,
+            error = error,
             onSuccess = { result ->
                 val painter = result.painter
                 val intrinsicSize = painter.intrinsicSize
@@ -97,8 +92,6 @@ fun SpAreaSizedImage(
                     aspectRatio = intrinsicSize.width / intrinsicSize.height
                 }
             },
-            loading = { loading() },
-            error = { error() },
         )
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpAvatar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpAvatar.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpTypography
 
@@ -38,14 +37,14 @@ fun SpAvatar(
 ) {
     Box(modifier = modifier.size(size)) {
         if (avatarUrl != null) {
-            SubcomposeAsyncImage(
+            SpImage(
                 model = avatarUrl,
                 contentDescription = null,
                 modifier = Modifier
                     .fillMaxSize()
                     .clip(CircleShape),
                 contentScale = ContentScale.Crop,
-                loading = {
+                placeholder = {
                     AvatarPlaceholder(username = username, textStyle = placeholderTextStyle)
                 },
                 error = {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
@@ -1,12 +1,12 @@
 package com.spela.player.presentation.ui.components
 
 import androidx.compose.foundation.focusGroup
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -22,8 +22,7 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInParent
+import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.theme.SpSpacing
 
@@ -31,16 +30,30 @@ import com.spela.player.presentation.ui.theme.SpSpacing
  * Horizontal carousel with explicit per-item focus management and
  * horizontal centering.
  *
- * - Left/right uses FocusRequester per item — no spatial guessing.
+ * Built on `LazyRow` — at first paint only the visible window + a small
+ * prefetch buffer are composed, even if [itemCount] is large. This is
+ * the load-shaping pivot from #1168: the screen-level outer column is
+ * still eager (which the user prefers — no vertical scroll freeze), but
+ * each shelf's horizontal axis is lazy, so a cold-paint of a 19-section
+ * Explore page composes ~5 cards per shelf instead of ~10–20 cards per
+ * shelf as before.
+ *
+ * - Left / Right keys move the focused index by one; we
+ *   [LazyListState.animateScrollToItem] the target so it composes, then
+ *   request focus once it's in the viewport.
  * - Stops at first and last item.
- * - Focused item is scrolled to the horizontal center of the carousel.
- * - Focus index syncs automatically when entering from any direction.
+ * - Focus restoration: if [LocalFocusMemory]'s saved key matches one of
+ *   this carousel's items at entry time, the list is scrolled to that
+ *   index BEFORE [focusRestoreItem]'s ~120 ms layout-settle delay fires,
+ *   so the saved item has been composed and its FocusRequester is bound
+ *   when `requestFocus` is finally called.
+ * - Each item delegates focus management to [focusRestoreItem]; no
+ *   special-casing on top.
  *
  * @param memoryKey Optional unique group key. When set together with
  *   [itemKey], each item participates in screen-scoped focus restoration
  *   via `focusRestoreItem("$memoryKey/$itemKey")`. The enclosing screen
- *   must provide [com.spela.player.presentation.ui.gamepad.LocalFocusMemory]
- *   for restoration to take effect.
+ *   must provide [LocalFocusMemory] for restoration to take effect.
  * @param itemKey Optional stable per-item key (e.g. game id). Combined
  *   with [memoryKey] into the per-item focus-restore key so the saved
  *   item can be matched even if the underlying list reorders.
@@ -58,93 +71,132 @@ fun SpCarousel(
     isDefaultFocusGroup: Boolean = false,
     content: @Composable (index: Int, focusRequester: FocusRequester) -> Unit,
 ) {
-    val scrollState = rememberScrollState()
+    val listState = rememberLazyListState()
+    // FocusRequesters live in a list keyed by index. Only the requester
+    // for a *currently composed* item is bound to a layout node — the
+    // rest are unbound and a no-op until the LazyRow composes their
+    // item. We re-allocate when itemCount changes.
     val requesters = remember(itemCount) { List(itemCount) { FocusRequester() } }
-    var focusedIndex by remember { mutableIntStateOf(0) }
+    // Non-reactive cursor for the focus position. The key handler reads
+    // and writes this synchronously per press — using a Compose state
+    // would route the write through snapshot machinery, and a burst of
+    // presses inside a single performKeyInput block (or a real-device
+    // held d-pad firing events at >100 Hz) would all read the same
+    // stale value because the snapshot hasn't committed between events.
+    // [onFocusChanged] writes the same cursor when actual focus lands,
+    // keeping it in sync if focus moved without a key event (mouse
+    // click, focus restoration, etc.).
+    val focusCursor = remember { intArrayOf(0) }
 
-    // Track each item's position and width within the Row
-    val itemPositions = remember(itemCount) { FloatArray(itemCount) }
-    val itemWidths = remember(itemCount) { FloatArray(itemCount) }
+    // The latest "please move focus here" request from the key handler.
+    // Driven via state (not a coroutine.launch per key) so a burst of
+    // key presses naturally coalesces: each new value cancels the
+    // previous LaunchedEffect, and only the final target's scroll +
+    // requestFocus actually runs to completion. -1 = no pending target.
+    var pendingTarget by remember { mutableIntStateOf(-1) }
 
-    // Track rapid key presses for instant vs animated scroll
+    // Throttle window for "rapid key repeat" — when the user holds the
+    // d-pad and we get many keypresses in fast succession, skip the
+    // smooth scroll and snap. Otherwise the scroll animation queues up
+    // and feels laggy.
     var lastFocusChangeTime by remember { mutableLongStateOf(0L) }
 
-    // Center the focused item horizontally when focusedIndex changes
-    LaunchedEffect(focusedIndex) {
-        val itemX = itemPositions[focusedIndex]
-        val itemWidth = itemWidths[focusedIndex]
-        if (itemWidth <= 0f) return@LaunchedEffect
-
-        val viewportWidth = scrollState.viewportSize.toFloat()
-        val itemCenter = itemX + itemWidth / 2f
-        val targetScroll = (itemCenter - viewportWidth / 2f)
-            .toInt()
-            .coerceIn(0, scrollState.maxValue)
-
+    // Apply the latest pending target. Keyed on pendingTarget so a
+    // mid-flight scroll is cancelled the moment the user advances
+    // further along the carousel.
+    LaunchedEffect(pendingTarget) {
+        val target = pendingTarget
+        if (target < 0) return@LaunchedEffect
         val now = System.currentTimeMillis()
         val isRapid = now - lastFocusChangeTime < 100
         lastFocusChangeTime = now
-
         if (isRapid) {
-            scrollState.scrollTo(targetScroll)
+            listState.scrollToItem(target)
         } else {
-            scrollState.animateScrollTo(targetScroll)
+            listState.animateScrollToItem(target)
         }
+        kotlinx.coroutines.yield()
+        try { requesters[target].requestFocus() } catch (_: Exception) {}
     }
 
-    Row(
+    // Focus restoration: if the saved focus key belongs to one of this
+    // carousel's items, scroll the LazyRow so the item composes. The
+    // 120 ms layout-settle delay in focusRestoreItem then fires after
+    // composition has caught up, and requestFocus binds the requester.
+    //
+    // [itemKey] is intentionally NOT in the key list — it's a lambda
+    // and lambdas compare by referential equality, so a fresh instance
+    // per recomposition would cancel + restart the effect on every
+    // frame, abort the in-flight `scrollToItem`, and leave the saved
+    // item uncomposed when focusRestoreItem's 120 ms timer fires.
+    val focusMemory = LocalFocusMemory.current
+    LaunchedEffect(focusMemory?.value, itemCount, memoryKey) {
+        val savedKey = focusMemory?.value
+        val keyFn = itemKey
+        if (
+            savedKey.isNullOrEmpty() ||
+            memoryKey == null ||
+            keyFn == null ||
+            itemCount <= 0
+        ) {
+            return@LaunchedEffect
+        }
+        val prefix = "$memoryKey/"
+        if (!savedKey.startsWith(prefix)) return@LaunchedEffect
+        val target = savedKey.removePrefix(prefix)
+        val targetIndex = (0 until itemCount).firstOrNull { keyFn(it) == target }
+            ?: return@LaunchedEffect
+        // scrollToItem (not animate) — we want this complete by the
+        // time focusRestoreItem's 120 ms timer expires.
+        listState.scrollToItem(targetIndex)
+        focusCursor[0] = targetIndex
+    }
+
+    LazyRow(
+        state = listState,
         modifier = modifier
             .focusGroup()
-            .horizontalScroll(scrollState)
-            .padding(horizontal = SpSpacing.ScreenHorizontal)
             .onPreviewKeyEvent { event ->
                 if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
-                when (event.key) {
-                    Key.DirectionLeft -> {
-                        if (focusedIndex > 0) {
-                            try {
-                                requesters[focusedIndex - 1].requestFocus()
-                            } catch (_: Exception) {}
-                        }
-                        true
-                    }
-                    Key.DirectionRight -> {
-                        if (focusedIndex < itemCount - 1) {
-                            try {
-                                requesters[focusedIndex + 1].requestFocus()
-                            } catch (_: Exception) {}
-                        }
-                        true
-                    }
-                    else -> false
+                val delta = when (event.key) {
+                    Key.DirectionLeft -> -1
+                    Key.DirectionRight -> +1
+                    else -> return@onPreviewKeyEvent false
                 }
+                val target = focusCursor[0] + delta
+                if (target < 0 || target >= itemCount) return@onPreviewKeyEvent true
+                focusCursor[0] = target
+                pendingTarget = target
+                true
             },
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
         horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
     ) {
-        for (i in 0 until itemCount) {
+        items(
+            count = itemCount,
+            key = if (itemKey != null) { i -> itemKey(i) } else null,
+        ) { i ->
             val restoreKey = if (memoryKey != null && itemKey != null) {
                 "$memoryKey/${itemKey(i)}"
             } else null
 
             Box(
                 modifier = Modifier
-                    .onGloballyPositioned { coordinates ->
-                        itemPositions[i] = coordinates.positionInParent().x
-                        itemWidths[i] = coordinates.size.width.toFloat()
-                    }
                     .onFocusChanged { state ->
                         if (state.hasFocus) {
-                            focusedIndex = i
+                            focusCursor[0] = i
                         }
                     }
                     .let { base ->
                         if (restoreKey != null) {
-                            // Don't share `requesters[i]` here — it's already
-                            // attached by the content lambda below to the inner
-                            // focusable target. focusRestoreItem owns its own
-                            // requester on the outer Box; calling requestFocus
-                            // there propagates down to the first focusable
-                            // descendant (the card).
+                            // The per-item FocusRequester is attached by the
+                            // content lambda below to the inner focusable
+                            // target. focusRestoreItem owns its own requester
+                            // on this outer Box; calling requestFocus there
+                            // propagates down to the first focusable
+                            // descendant (the card). Don't share requesters[i]
+                            // here, which would attach the same requester to
+                            // two layout nodes and break the propagation.
                             base.focusRestoreItem(
                                 key = restoreKey,
                                 isDefault = isDefaultFocusGroup && i == 0,
@@ -152,10 +204,11 @@ fun SpCarousel(
                         } else {
                             base
                         }
-                    }
+                    },
             ) {
                 content(i, requesters[i])
             }
         }
     }
 }
+

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCoverArt.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCoverArt.kt
@@ -1,27 +1,19 @@
 package com.spela.player.presentation.ui.components
 
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
-import coil3.compose.SubcomposeAsyncImage
-import androidx.compose.ui.graphics.Color
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -37,8 +29,9 @@ fun SpCoverArt(
     cornerRadius: Dp = SpSpacing.RadiusLarge,
     aspectRatio: Float? = COVER_ASPECT_RATIO,
     onAspectRatioResolved: ((Float) -> Unit)? = null,
-    // True while a scrape is in progress — shows an animated shimmer instead of
-    // the static placeholder so the user knows something is happening.
+    // True while a scrape is in progress — surfaces the placeholder
+    // unconditionally (no Coil call yet) so the user knows the cover
+    // hasn't been fetched.
     isLoading: Boolean = false,
 ) {
     val shape = RoundedCornerShape(cornerRadius)
@@ -54,13 +47,13 @@ fun SpCoverArt(
         contentAlignment = Alignment.Center,
     ) {
         when {
-            isLoading -> CoverShimmer()
-            imageUrl != null -> SubcomposeAsyncImage(
+            isLoading -> SpImageDefaults.Placeholder()
+            else -> SpImage(
                 model = imageUrl,
                 contentDescription = contentDescription,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxSize(),
                 contentScale = scale,
-                loading = { CoverShimmer() },
+                placeholder = { CoverPlaceholder(contentDescription) },
                 error = { CoverPlaceholder(contentDescription) },
                 onSuccess = { state ->
                     if (onAspectRatioResolved != null) {
@@ -71,7 +64,6 @@ fun SpCoverArt(
                     }
                 },
             )
-            else -> CoverPlaceholder(contentDescription)
         }
     }
 }
@@ -83,22 +75,14 @@ fun SpHeroCover(
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier) {
-        if (imageUrl != null) {
-            SubcomposeAsyncImage(
-                model = imageUrl,
-                contentDescription = contentDescription,
-                modifier = Modifier.fillMaxWidth(),
-                contentScale = ContentScale.FillWidth,
-                loading = {
-                    CoverShimmer()
-                },
-                error = {
-                    CoverPlaceholder(contentDescription)
-                },
-            )
-        } else {
-            CoverPlaceholder(contentDescription)
-        }
+        SpImage(
+            model = imageUrl,
+            contentDescription = contentDescription,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.FillWidth,
+            placeholder = { CoverPlaceholder(contentDescription) },
+            error = { CoverPlaceholder(contentDescription) },
+        )
 
         // Gradient overlay at the bottom for text readability
         Box(
@@ -117,30 +101,6 @@ fun SpHeroCover(
                 ),
         )
     }
-}
-
-@Composable
-private fun CoverShimmer() {
-    val alpha = if (LocalAnimationsEnabled.current) {
-        val transition = rememberInfiniteTransition(label = "coverShimmer")
-        val animatedAlpha by transition.animateFloat(
-            initialValue = 0.15f,
-            targetValue = 0.35f,
-            animationSpec = infiniteRepeatable(
-                animation = tween(800),
-                repeatMode = RepeatMode.Reverse,
-            ),
-            label = "coverShimmerAlpha",
-        )
-        animatedAlpha
-    } else {
-        0.25f
-    }
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(SpColor.SurfaceBright.copy(alpha = alpha)),
-    )
 }
 
 @Composable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpHeroBanner.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpHeroBanner.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 
@@ -50,19 +49,21 @@ fun SpHeroBanner(
     ) {
         // Background: hero image or gradient fallback
         if (heroUrl != null) {
-            SubcomposeAsyncImage(
+            SpImage(
                 model = heroUrl,
                 contentDescription = null,
                 modifier = if (height != null) Modifier.fillMaxSize() else Modifier.matchParentSize(),
                 contentScale = ContentScale.Crop,
-                loading = {
+                staggerMs = 0L,
+                placeholder = {
                     Box(
-                        modifier = (if (height != null) Modifier.fillMaxSize() else Modifier.matchParentSize())
+                        modifier = Modifier
+                            .fillMaxSize()
                             .background(SpColor.Background),
                     )
                 },
                 error = {
-                    GradientFallback(if (height != null) Modifier.fillMaxSize() else Modifier.matchParentSize())
+                    GradientFallback(Modifier.fillMaxSize())
                 },
             )
         } else {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpImage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpImage.kt
@@ -1,0 +1,162 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImagePainter
+import coil3.compose.SubcomposeAsyncImage
+import com.spela.player.presentation.ui.theme.SpColor
+import kotlin.random.Random
+import kotlinx.coroutines.delay
+
+/**
+ * Default upper bound for the random per-request stagger, in milliseconds.
+ *
+ * On screens like Explore the eager outer column composes ~19 sections at
+ * first paint, and (until SpCarousel goes lazy) every card in every shelf
+ * — easily 100+ images simultaneously. Without this, every image kicks
+ * off its Coil request on frame 0 and the main-thread dispatcher gets
+ * swamped. With a uniform 0..N spread, requests ramp instead of pile.
+ *
+ * 1000 ms is the sweet spot from #1168 — most disk-cached images snap in
+ * imperceptibly after the stagger, cold-cache loads behave the same as
+ * before but the cluster is smoothed.
+ */
+private const val DEFAULT_STAGGER_MS: Long = 1000L
+
+/**
+ * DESIGN component — Spela's shared async image primitive.
+ *
+ * Every image-bearing surface in the app routes through this composable
+ * so we can apply load-shaping policies (request stagger, placeholder /
+ * error UX, crossfade) in exactly one place. Higher-level components
+ * (SpCoverArt, SpAreaSizedImage, SpAvatar, SpHeroBanner, …) contribute
+ * their own size / shape / clipping and delegate the image work here.
+ *
+ * Behaviour:
+ *
+ * - **Random request stagger.** Picks a uniform delay in [0, [staggerMs])
+ *   the first time a non-null [model] is observed (per call site). While
+ *   the timer is still running the [placeholder] slot is shown; the
+ *   Coil request only fires once the timer elapses. This smooths the
+ *   request burst that would otherwise hit the dispatcher pool on frame
+ *   zero of screens that compose many images at once (#1168). Cached
+ *   images still feel near-instant — the stagger just delays the Coil
+ *   call, not the decode, and Coil's memory-cache short-circuit makes
+ *   already-decoded bitmaps render in the same frame the stagger ends.
+ *   Pass `staggerMs = 0L` to opt out for screens (e.g. lightboxes,
+ *   single-shot details) where stalling is worse than bursting.
+ * - **Null model = placeholder.** No Coil request, no timer, just the
+ *   placeholder slot.
+ * - **Default placeholder / error.** A static SurfaceBright-tinted Box.
+ *   No animated shimmer — see the design note on [SpImageDefaults].
+ *
+ * Use this primitive whenever you'd otherwise reach for
+ * `SubcomposeAsyncImage` or `AsyncImage` directly.
+ *
+ * @param model The image source. Typically a URL String. `null` skips the
+ *   Coil call and renders [placeholder].
+ * @param contentDescription Accessibility description forwarded to Coil.
+ * @param modifier Outer modifier (size / shape / clipping).
+ * @param contentScale How the image fits its bounds.
+ * @param staggerMs Upper bound (inclusive) for the random pre-request
+ *   delay. Set to 0 to fire the request immediately.
+ * @param placeholder Composable shown while the stagger timer runs OR
+ *   while Coil is loading. Defaults to [SpImageDefaults.Placeholder].
+ * @param error Composable shown when Coil reports an error. Defaults to
+ *   [SpImageDefaults.Placeholder] — visually indistinguishable so a
+ *   loaded-vs-failed image doesn't flicker through different surfaces.
+ * @param onSuccess Optional callback invoked when Coil reports success
+ *   (e.g. for callers that want to read the painter's intrinsic size).
+ */
+@Composable
+fun SpImage(
+    model: Any?,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Fit,
+    staggerMs: Long = DEFAULT_STAGGER_MS,
+    placeholder: @Composable () -> Unit = { SpImageDefaults.Placeholder() },
+    error: @Composable () -> Unit = { SpImageDefaults.Placeholder() },
+    onSuccess: ((AsyncImagePainter.State.Success) -> Unit)? = null,
+) {
+    if (model == null) {
+        Box(modifier = modifier) { placeholder() }
+        return
+    }
+
+    // Gate the Coil request behind a random delay. The gate is keyed on
+    // `model`: if the URL changes (e.g. a card is recycled into a
+    // different game), the timer restarts so we don't show a stale
+    // placeholder while waiting for a leftover timer on a different URL.
+    var ready by remember(model, staggerMs) {
+        mutableStateOf(staggerMs <= 0L)
+    }
+    LaunchedEffect(model, staggerMs) {
+        if (staggerMs > 0L && !ready) {
+            // Random.nextLong is half-open [0, bound). Add 1 so the
+            // declared bound is inclusive — purely for tidiness, the
+            // single-ms difference is irrelevant in practice.
+            delay(Random.nextLong(0L, staggerMs + 1L))
+            ready = true
+        }
+    }
+
+    Box(modifier = modifier) {
+        if (!ready) {
+            placeholder()
+        } else {
+            SubcomposeAsyncImage(
+                model = model,
+                contentDescription = contentDescription,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = contentScale,
+                loading = { placeholder() },
+                error = { error() },
+                onSuccess = { state -> onSuccess?.invoke(state) },
+            )
+        }
+    }
+}
+
+/**
+ * Default slot composables for [SpImage].
+ *
+ * `Placeholder` is a static tinted Box. We deliberately do NOT animate
+ * it — the previous shimmer pattern ran a `rememberInfiniteTransition`
+ * per card, which on cold-paint of a many-card screen amounted to 100+
+ * concurrent per-frame tickers fighting the composition thread. Image
+ * arrival is its own "loading finished" signal; the shimmer didn't earn
+ * its cost.
+ *
+ * If a future design calls for a load-in animation, add it here so a
+ * single composable owns it for the whole app — never per-leaf.
+ */
+object SpImageDefaults {
+    @Composable
+    fun Placeholder() {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.SurfaceBright.copy(alpha = 0.25f)),
+        )
+    }
+
+    @Composable
+    fun ErrorTinted() {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.3f)),
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/challenge/SpChallengeCard.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/challenge/SpChallengeCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -30,9 +31,9 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.domain.model.Challenge
 import com.spela.player.presentation.ui.components.SpAvatar
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.SpShimmer
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -63,13 +64,13 @@ fun SpChallengeCard(
                 .background(SpColor.SurfaceVariant),
         ) {
             if (challenge.screenshotUrl != null) {
-                SubcomposeAsyncImage(
+                SpImage(
                     model = challenge.screenshotUrl,
                     contentDescription = null,
                     modifier = Modifier.matchParentSize(),
                     contentScale = ContentScale.Crop,
-                    loading = {
-                        SpShimmer(modifier = Modifier.matchParentSize())
+                    placeholder = {
+                        SpShimmer(modifier = Modifier.fillMaxSize())
                     },
                 )
             } else {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ArtworkShowcaseSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ArtworkShowcaseSection.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -26,11 +27,11 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.domain.model.ArtworkItem
 import androidx.compose.ui.focus.focusRequester
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpCarousel
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.SpShimmer
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -88,26 +89,24 @@ private fun ArtworkCard(
                 .clip(shape),
         ) {
             // Artwork image
-            SubcomposeAsyncImage(
+            SpImage(
                 model = artwork.url,
                 contentDescription = "${artwork.gameTitle} artwork",
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(ARTWORK_ASPECT_RATIO),
                 contentScale = ContentScale.Crop,
-                loading = {
+                placeholder = {
                     Box(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(ARTWORK_ASPECT_RATIO)
+                            .fillMaxSize()
                             .background(SpColor.SurfaceBright.copy(alpha = 0.25f)),
                     )
                 },
                 error = {
                     Box(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(ARTWORK_ASPECT_RATIO)
+                            .fillMaxSize()
                             .background(
                                 Brush.linearGradient(
                                     listOf(SpColor.SurfaceVariant, SpColor.SurfaceElevated),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.domain.model.CompanyInfo
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.MakerDetail
@@ -55,6 +54,7 @@ import androidx.compose.ui.focus.focusRequester
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpCarousel
 import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.SpLinkText
 import com.spela.player.presentation.ui.components.SpCarouselGameCard
 import com.spela.player.presentation.ui.components.SpShimmer
@@ -86,12 +86,13 @@ internal fun DeveloperHeroBanner(
     ) {
         // Background: hero image or gradient fallback
         if (detail.heroUrl != null) {
-            SubcomposeAsyncImage(
+            SpImage(
                 model = detail.heroUrl,
                 contentDescription = "${detail.name} hero image",
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop,
-                loading = {
+                staggerMs = 0L,
+                placeholder = {
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -190,7 +191,7 @@ internal fun DeveloperHeroBanner(
                     // Company logo or name text
                     val logoUrl = companyInfo?.logoUrl
                     if (logoUrl != null) {
-                        SubcomposeAsyncImage(
+                        SpImage(
                             model = logoUrl,
                             contentDescription = "${detail.name} logo",
                             modifier = Modifier
@@ -198,7 +199,8 @@ internal fun DeveloperHeroBanner(
                                 .heightIn(max = 80.dp)
                                 .testTag("developer_company_logo"),
                             contentScale = ContentScale.Fit,
-                            loading = {
+                            staggerMs = 0L,
+                            placeholder = {
                                 Text(
                                     text = detail.name,
                                     style = SpTypography.HeadlineLarge,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
@@ -41,12 +41,12 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpGameGrid
 import com.spela.player.presentation.ui.components.SpProgressBar
 import com.spela.player.presentation.ui.components.SpGridGameCard
 import com.spela.player.presentation.ui.components.SpHeroBanner
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpEmptyState
@@ -144,12 +144,13 @@ fun ExploreGroupDetailContent(
                                     // Franchise/series logo image or name text fallback
                                     val logoUrl = detail.logoUrl
                                     if (logoUrl != null) {
-                                        SubcomposeAsyncImage(
+                                        SpImage(
                                             model = logoUrl,
                                             contentDescription = detail.name,
                                             modifier = Modifier
                                                 .heightIn(max = 120.dp),
                                             contentScale = ContentScale.Fit,
+                                            staggerMs = 0L,
                                             error = {
                                                 Text(
                                                     text = detail.name,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/HeroCarousel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/HeroCarousel.kt
@@ -45,12 +45,12 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.domain.model.FeaturedGame
 import com.spela.player.presentation.ui.components.LocalAnimationsEnabled
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpAreaSizedImage
 import com.spela.player.presentation.ui.components.SpConsoleChip
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.SpShimmer
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -194,12 +194,13 @@ private fun HeroSlide(
     ) {
         // Hero art background
         if (game.heroUrl != null) {
-            SubcomposeAsyncImage(
+            SpImage(
                 model = game.heroUrl,
                 contentDescription = "Hero art for ${game.title}",
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop,
-                loading = {
+                staggerMs = 0L,
+                placeholder = {
                     Box(
                         modifier = Modifier
                             .fillMaxSize()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameDetailSections.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameDetailSections.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.outlined.Flag
@@ -29,6 +28,7 @@ import com.spela.player.presentation.ui.components.SpCarousel
 import com.spela.player.presentation.ui.components.ScreenshotLightbox
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.SpInnerCard
 import com.spela.player.presentation.ui.components.SpTitledSection
 import com.spela.player.presentation.ui.components.social.SharedSaveItem
@@ -58,7 +58,7 @@ fun ScreenshotsSection(screenshots: List<String>) {
                 .height(180.dp),
             onClick = { lightboxIndex = index },
         ) {
-            AsyncImage(
+            SpImage(
                 model = screenshots[index],
                 contentDescription = "Screenshot ${index + 1}",
                 modifier = Modifier.height(180.dp),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/home/RecentAchievementsRow.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/home/RecentAchievementsRow.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -24,10 +25,10 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.domain.model.RecentAchievement
 import androidx.compose.ui.focus.focusRequester
 import com.spela.player.presentation.ui.components.SpCarousel
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.SpShimmer
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -72,15 +73,15 @@ private fun AchievementCard(
         ) {
             // Badge image
             if (achievement.badgeUrl != null) {
-                SubcomposeAsyncImage(
+                SpImage(
                     model = achievement.badgeUrl,
                     contentDescription = null,
                     modifier = Modifier
                         .size(48.dp)
                         .clip(RoundedCornerShape(SpSpacing.RadiusMedium)),
                     contentScale = ContentScale.Crop,
-                    loading = {
-                        SpShimmer(modifier = Modifier.size(48.dp))
+                    placeholder = {
+                        SpShimmer(modifier = Modifier.fillMaxSize())
                     },
                 )
             } else {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryArtPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryArtPage.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.feature.library.getConsoleGradient
 import com.spela.player.presentation.ui.screen.formatSessionDuration
 import com.spela.player.presentation.ui.theme.SpColor
@@ -77,18 +77,18 @@ fun SecondaryArtPage(
     ) {
         if (heroUrl != null) {
             // Hero image at fixed aspect ratio
-            SubcomposeAsyncImage(
+            SpImage(
                 model = heroUrl,
                 contentDescription = "Hero artwork for $gameTitle",
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(16f / 9f),
                 contentScale = ContentScale.Crop,
-                loading = {
+                staggerMs = 0L,
+                placeholder = {
                     Box(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(16f / 9f)
+                            .fillMaxSize()
                             .background(SpColor.SurfaceVariant),
                     )
                 },
@@ -96,8 +96,7 @@ fun SecondaryArtPage(
                     // On error, show console gradient header instead
                     Box(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(16f / 9f)
+                            .fillMaxSize()
                             .background(
                                 Brush.verticalGradient(
                                     colors = listOf(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondarySaveSlotsPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondarySaveSlotsPage.kt
@@ -34,10 +34,10 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.presentation.state.SaveSlotInfo
 import androidx.compose.ui.focus.focusRequester
 import com.spela.player.presentation.ui.components.SpCarousel
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -210,7 +210,7 @@ private fun SaveSlotCard(
         ) {
             if (isFilled && slotInfo.screenshotUrl != null) {
                 // Thumbnail image
-                SubcomposeAsyncImage(
+                SpImage(
                     model = slotInfo.screenshotUrl,
                     contentDescription = "Save slot $slot screenshot",
                     modifier = Modifier
@@ -218,7 +218,7 @@ private fun SaveSlotCard(
                         .weight(1f)
                         .clip(RoundedCornerShape(SpSpacing.CardCornerRadius / 2)),
                     contentScale = ContentScale.Crop,
-                    loading = {
+                    placeholder = {
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -68,6 +68,7 @@ import coil3.compose.AsyncImage
 import com.spela.player.domain.model.Console
 import com.spela.player.presentation.ui.components.SpAreaSizedImage
 import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.components.SpShimmer
 import com.spela.player.presentation.ui.theme.SpColor
@@ -238,7 +239,7 @@ internal fun ConsoleCard(
                 .alpha(0.07f),
         ) {
             if (console.iconUrl.isNotEmpty()) {
-                AsyncImage(
+                SpImage(
                     model = console.iconUrl,
                     contentDescription = null,
                     modifier = Modifier.fillMaxSize(),
@@ -452,7 +453,7 @@ private fun ConsoleHeroBannerContent(
                 .alpha(0.07f),
         ) {
             if (console.iconUrl.isNotEmpty()) {
-                AsyncImage(
+                SpImage(
                     model = console.iconUrl,
                     contentDescription = null,
                     modifier = Modifier.size(224.dp),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/QuickResultsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/QuickResultsSection.kt
@@ -24,12 +24,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
 import com.spela.player.domain.model.SearchSuggestion
 import com.spela.player.domain.model.SuggestionNavigationType
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -161,7 +161,7 @@ private fun QuickResultThumbnail(
 
             when {
                 isConsole && !suggestion.imageUrl.isNullOrBlank() -> {
-                    AsyncImage(
+                    SpImage(
                         model = suggestion.imageUrl,
                         contentDescription = null,
                         modifier = Modifier.size(24.dp),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultSections.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultSections.kt
@@ -22,13 +22,13 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
 import com.spela.player.domain.model.SearchCollectionResult
 import com.spela.player.domain.model.SearchConsoleResult
 import com.spela.player.domain.model.SearchFranchiseResult
 import com.spela.player.domain.model.SearchGameResult
 import com.spela.player.domain.model.SearchSeriesResult
 import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.SpLinkText
 import com.spela.player.presentation.ui.components.SpWideGameCard
 import com.spela.player.presentation.ui.components.SpWideIconCard
@@ -138,7 +138,7 @@ fun ConsoleSearchResultItem(
             testTag = "search_result_console_${console.id}",
             icon = {
                 if (console.iconUrl.isNotBlank()) {
-                    AsyncImage(
+                    SpImage(
                         model = console.iconUrl,
                         contentDescription = null,
                         modifier = Modifier.size(28.dp),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ChallengeDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ChallengeDetailScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.shape.RoundedCornerShape
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.presentation.intent.ChallengeIntent
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.components.SpAvatar
@@ -47,6 +46,7 @@ import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.components.SpEmptyStates
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.SpShimmer
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpScreenTopSpacer
@@ -131,11 +131,12 @@ fun ChallengeDetailScreen(
                         .background(SpColor.SurfaceVariant),
                 ) {
                     if (challenge.screenshotUrl != null) {
-                        SubcomposeAsyncImage(
+                        SpImage(
                             model = challenge.screenshotUrl,
                             contentDescription = "Challenge screenshot",
                             modifier = Modifier.matchParentSize(),
                             contentScale = ContentScale.Crop,
+                            staggerMs = 0L,
                         )
                     } else {
                         Icon(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
 import com.spela.player.presentation.ui.TestTags
 import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.ui.components.PlatformBackHandler
@@ -47,6 +46,7 @@ import com.spela.player.presentation.ui.components.SpScreenTopSpacer
 import com.spela.player.presentation.ui.components.SpScrollableContent
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpIconButton
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpSnackbar
@@ -336,7 +336,7 @@ fun ConsoleScreen(
                 onBack = onBack,
                 titleLeadingContent = if (console?.iconUrl?.isNotEmpty() == true) {
                     {
-                        AsyncImage(
+                        SpImage(
                             model = console.iconUrl,
                             contentDescription = null,
                             modifier = Modifier.size(28.dp),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreGalleryScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreGalleryScreen.kt
@@ -35,12 +35,12 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.domain.model.ScreenshotItem
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -213,26 +213,24 @@ private fun ScreenshotGridCard(
                 .fillMaxWidth()
                 .clip(shape),
         ) {
-            SubcomposeAsyncImage(
+            SpImage(
                 model = screenshot.url,
                 contentDescription = "${screenshot.gameTitle} screenshot",
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(SCREENSHOT_ASPECT_RATIO),
                 contentScale = ContentScale.Crop,
-                loading = {
+                placeholder = {
                     Box(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(SCREENSHOT_ASPECT_RATIO)
+                            .fillMaxSize()
                             .background(SpColor.SurfaceBright.copy(alpha = 0.25f)),
                     )
                 },
                 error = {
                     Box(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(SCREENSHOT_ASPECT_RATIO)
+                            .fillMaxSize()
                             .background(
                                 Brush.linearGradient(
                                     listOf(SpColor.SurfaceVariant, SpColor.SurfaceElevated),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
@@ -24,8 +24,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
+import androidx.compose.ui.draw.alpha
 import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpImage
 import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.components.SpCard
@@ -296,11 +297,10 @@ private fun androidx.compose.foundation.lazy.LazyListScope.consolesContent(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     if (console.iconUrl.isNotEmpty()) {
-                        AsyncImage(
+                        SpImage(
                             model = console.iconUrl,
                             contentDescription = null,
-                            modifier = Modifier.size(32.dp),
-                            alpha = 0.7f,
+                            modifier = Modifier.size(32.dp).alpha(0.7f),
                         )
                     } else {
                         Icon(


### PR DESCRIPTION
Closes #1168.

## What

`SpCarousel` was an eager `Row + horizontalScroll` that composed every card in every shelf at first paint. On Explore that meant ~190 cards (~19 sections × ~10) all coming up simultaneously — each spinning up its own image request and shimmer animation. With #1171's `SpImage` request stagger already in place, the deeper structural fix is making each shelf lazy on its horizontal axis.

This PR:

1. Replaces `Row + horizontalScroll` with `LazyRow`. Default prefetch + viewport composition means each shelf composes ~3-5 cards initially instead of N. Vertical axis stays an eager Column (LazyColumn was tried in #1165 and caused freeze-on-scroll because each new section had to compose a whole carousel; that's not changed here).
2. **Preserves focus restoration**: on entry, `SpCarousel` reads `LocalFocusMemory` and if the saved key matches one of its items, `listState.scrollToItem(targetIndex)` runs before `focusRestoreItem`'s 120 ms layout-settle delay fires. The saved item composes in time for `requestFocus` to bind it. Same back-nav UX as before.
3. **Coalesces d-pad bursts** via a single `pendingTarget` state + one `LaunchedEffect`. Rapid presses (held d-pad, or a test sending N `pressKey` in one block) cancel earlier scrolls in flight; only the latest target's scroll + `requestFocus` runs to completion.
4. **Non-reactive `intArrayOf` cursor** for the focus position. The key handler reads/writes it synchronously per press — using a Compose state would route the write through snapshot machinery, and a burst of presses inside one frame would all read the same stale 0 because the snapshot hasn't committed between events. `onFocusChanged` writes the same cursor when actual focus lands, keeping it in sync if focus moved without a key event (mouse click, restoration, etc.).

## Why "horizontal lazy only"

The user explicitly rejected a vertical LazyColumn refactor (#1165) because it caused visible freeze-on-scroll — each newly-entering section had to compose a whole shelf of cards before painting. Horizontal LazyRow does NOT have this problem: the shelves themselves are already composed in the outer column, only the leftmost cards within each shelf are composed initially. Horizontally scrolling within a shelf is the user's explicit interaction, so the small composition cost lands at the moment they're already paying attention.

## Test plan

- [x] `LazyCarouselFocusRestoreTest.offScreenItem_focusRestoredAfterForwardAndBackNav` — walks the d-pad through a 6-card Continue Playing carousel until focused on the last item (3+ items disposed at that point), forward-navs, back-navs, asserts the same card regains focus. Animations enabled to catch timing bugs the static composition mode silently masks.
- [x] `LazyCarouselFocusRestoreTest.smoke_dPadAdvancesTwoPositions` — verifies the d-pad → scroll → focus chain works at the smallest interesting depth.
- [x] Existing `HomeContinuePlayingFocusRestoreTest` (3 tests) — visible-item restore, keyboard-driven restore with animations, multi-carousel "last-focused-wins". All pass.
- [x] Full `./gradlew :shared:desktopTest :desktop:desktopTest` — one pre-existing flake (`GamepadConfigTest.activityIndicatorShowsActiveAfterInput`, passes on isolated rerun, unrelated).
- [ ] Manual on AYN Thor: Explore cold-paint feels smoother — fewer cards composing at once, image-request burst smoothed by #1171's stagger; d-pad-right through a long carousel scrolls + focuses correctly; navigating away + back restores the deep card.

## Follow-up

Issue #1168 also mentions per-section "compose when scrolled near" gating + section batching as further levers. Not done here — the LazyRow change is the highest-impact-per-LOC, and the stagger from #1171 already smooths the inevitable below-the-fold prefetch. Re-measure on Thor after this lands before deciding if more is warranted.