### PR TITLE
fix(web): unify console card backgrounds via server colorTheme (#1167)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryArtPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryArtPage.kt
@@ -61,7 +61,7 @@ fun SecondaryArtPage(
     gamePlayers: Int = 0,
 ) {
     val timeText = formatSessionDuration(sessionElapsedSeconds)
-    val (gradientFrom, _) = getConsoleGradient(consoleId, consoleColorTheme)
+    val (gradientFrom, _) = getConsoleGradient(consoleColorTheme)
 
     val hasGameInfo = !gameDeveloper.isNullOrEmpty() || !gamePublisher.isNullOrEmpty() || !gameGenre.isNullOrEmpty() ||
         !gameReleaseDate.isNullOrEmpty() || !gameDescription.isNullOrEmpty() || gamePlayers > 0 || gameRating > 0.0

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
@@ -444,7 +444,7 @@ private fun CompanionHeader(
     consoleColorTheme: String?,
 ) {
     val timeText = formatSessionDuration(sessionElapsedSeconds)
-    val (gradientFrom, gradientTo) = getConsoleGradient(consoleId, consoleColorTheme)
+    val (gradientFrom, gradientTo) = getConsoleGradient(consoleColorTheme)
 
     Column(
         modifier = Modifier

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -181,7 +181,7 @@ internal fun ConsoleCard(
     hasMissingBios: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
-    val (gradientFrom, gradientTo) = getConsoleGradient(console.abbreviation, console.colorTheme)
+    val (gradientFrom, gradientTo) = getConsoleGradient(console.colorTheme)
     val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
     val biosDesc = if (hasMissingBios) ", BIOS missing" else ""
     val interactionSource = remember { MutableInteractionSource() }
@@ -406,8 +406,10 @@ private fun ConsoleHeroBannerContent(
 ) {
     val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
 
-    // Per-console gradient matching web UI's console-metadata.ts exactly
-    val (gradientFrom, gradientTo) = getConsoleGradient(console.abbreviation, console.colorTheme)
+    // Two-stop brand gradient derived from the server's colorTheme —
+    // matches web's `ConsoleHeroBanner` after #1167 so both clients
+    // render the same console with the same brand sweep.
+    val (gradientFrom, gradientTo) = getConsoleGradient(console.colorTheme)
     val gradientColors = listOf(gradientFrom, gradientTo)
 
     // Depth overlay matching web: from-black/30 via-transparent to-white/[0.04]

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleMetadata.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleMetadata.kt
@@ -1,6 +1,7 @@
 package com.spela.player.presentation.ui.feature.library
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import com.spela.player.presentation.ui.theme.SpColor
 
 /** Darkens a color by mixing it towards black. [amount] 0f = unchanged, 1f = pure black. */
@@ -11,65 +12,27 @@ fun Color.darken(amount: Float): Color = copy(
 )
 
 /**
- * Returns the hero banner gradient (from, to) for a console.
- * Colors match the web UI's console-metadata.ts Tailwind gradient pairs exactly.
- * Falls back to deriving a gradient from the console's colorTheme hex.
+ * Returns the `(from, to)` gradient pair for a console-coloured surface.
+ *
+ * Both stops are derived from [Console.colorTheme] (the server-seeded
+ * brand hex) — the same source the Explore "Browse by Console" strip
+ * uses, and the web Consoles list / hero now use after #1167. The
+ * dark stop is the brand hex mixed 60% with black, which gives every
+ * theme — even dark ones like Genesis (#171717) or Atari 2600
+ * (#1e293b) — a visible two-shade sweep. This mirrors CSS's
+ * `color-mix(in srgb, brand, black 60%)` used on web.
+ *
+ * Previously this returned a per-console table of two hard-coded
+ * Tailwind colours (e.g. NES `red-600 → red-900`). That drifted from
+ * the server's `colorTheme` — admins editing the seed couldn't tell
+ * what would change, and the same console rendered with different
+ * palettes on different screens. The single-source-of-truth fix
+ * landed in #1167; this function is the player-side equivalent.
  */
-fun getConsoleGradient(abbreviation: String, colorTheme: String?): Pair<Color, Color> {
-    // Curated gradient pairs matching the web UI (Tailwind color values)
-    val gradient = when (abbreviation.lowercase()) {
-        "nes" -> Color(0xFFdc2626) to Color(0xFF7f1d1d)         // red-600 → red-900
-        "snes" -> Color(0xFF9333ea) to Color(0xFF312e81)        // purple-600 → indigo-900
-        "gb" -> Color(0xFF16a34a) to Color(0xFF14532d)          // green-600 → green-900
-        "gbc" -> Color(0xFF14b8a6) to Color(0xFF166534)         // teal-500 → green-800
-        "gba" -> Color(0xFF6366f1) to Color(0xFF6b21a8)         // indigo-500 → purple-800
-        "n64" -> Color(0xFF22c55e) to Color(0xFF1d4ed8)         // green-500 → blue-700
-        "nds" -> Color(0xFF9ca3af) to Color(0xFF374151)         // gray-400 → gray-700
-        "sms" -> Color(0xFF3b82f6) to Color(0xFF1e40af)         // blue-500 → blue-800
-        "gen" -> Color(0xFF1d4ed8) to Color(0xFF000000)         // blue-700 → black
-        "sat" -> Color(0xFF4b5563) to Color(0xFF111827)         // gray-600 → gray-900
-        "psx" -> Color(0xFF6b7280) to Color(0xFF1e3a8a)         // gray-500 → blue-900
-        "psp" -> Color(0xFF374151) to Color(0xFF000000)         // gray-700 → black
-        "neogeo" -> Color(0xFFeab308) to Color(0xFFb91c1c)      // yellow-500 → red-700
-        "neocd" -> Color(0xFFeab308) to Color(0xFFb91c1c)       // yellow-500 → red-700
-        "pce" -> Color(0xFFf97316) to Color(0xFF991b1b)         // orange-500 → red-800
-        "pcecd" -> Color(0xFFf97316) to Color(0xFF991b1b)       // orange-500 → red-800
-        "a26" -> Color(0xFF1e293b) to Color(0xFF0f172a)         // slate-800 → slate-900 (complements red Atari logo)
-        "gg" -> Color(0xFF2563eb) to Color(0xFF1e3a8a)          // blue-600 → blue-900
-        "scd" -> Color(0xFF374151) to Color(0xFF1e3a8a)         // gray-700 → blue-900
-        "32x" -> Color(0xFF1f2937) to Color(0xFF000000)         // gray-800 → black
-        "dc" -> Color(0xFFf97316) to Color(0xFF1d4ed8)          // orange-500 → blue-700
-        "vb" -> Color(0xFF991b1b) to Color(0xFF450a0a)          // red-800 → red-950
-        "3ds" -> Color(0xFF1e3a5f) to Color(0xFF0c1a2e)         // dark teal-blue (complements red 3DS logo)
-        "gc" -> Color(0xFF6366f1) to Color(0xFF6b21a8)           // indigo-500 → purple-800
-        "a52" -> Color(0xFFb45309) to Color(0xFF451a03)         // amber-700 → amber-950
-        "a78" -> Color(0xFF1e293b) to Color(0xFF0f172a)         // slate-800 → slate-900 (complements red logo)
-        "lynx" -> Color(0xFFca8a04) to Color(0xFF713f12)        // yellow-600 → yellow-900
-        "jag" -> Color(0xFFb91c1c) to Color(0xFF111827)         // red-700 → gray-900
-        "ngp" -> Color(0xFF6b7280) to Color(0xFF1f2937)         // gray-500 → gray-800
-        "ws" -> Color(0xFF4f46e5) to Color(0xFF312e81)          // indigo-600 → indigo-900
-        "pcfx" -> Color(0xFF0d9488) to Color(0xFF134e4a)        // teal-600 → teal-900
-        "cv" -> Color(0xFF0284c7) to Color(0xFF0c4a6e)          // sky-600 → sky-900
-        "pkmn" -> Color(0xFFfacc15) to Color(0xFFa16207)        // yellow-400 → yellow-700
-        "ps2" -> Color(0xFF1e40af) to Color(0xFF172554)         // blue-800 → blue-950
-        "c64" -> Color(0xFF3b82f6) to Color(0xFF6b21a8)         // blue-500 → purple-800
-        "dos" -> Color(0xFF15803d) to Color(0xFF052e16)         // green-700 → green-950
-        "amiga" -> Color(0xFFdc2626) to Color(0xFF1e40af)       // red-600 → blue-800
-        "3do" -> Color(0xFF9ca3af) to Color(0xFF374151)          // gray-400 → gray-700
-        "c128" -> Color(0xFF3b82f6) to Color(0xFF6b21a8)         // blue-500 → purple-800
-        "pet" -> Color(0xFF60a5fa) to Color(0xFF7e22ce)          // blue-400 → purple-700
-        "plus4" -> Color(0xFF60a5fa) to Color(0xFF7e22ce)        // blue-400 → purple-700
-        "vic20" -> Color(0xFF3b82f6) to Color(0xFF6b21a8)        // blue-500 → purple-800
-        "cdi" -> Color(0xFF15803d) to Color(0xFF052e16)          // green-700 → green-950
-        "msx1" -> Color(0xFF3b82f6) to Color(0xFF1e40af)         // blue-500 → blue-800
-        "msx2" -> Color(0xFF3b82f6) to Color(0xFF1e40af)         // blue-500 → blue-800
-        else -> null
-    }
-    if (gradient != null) return gradient
-
-    // Fallback: use colorTheme hex and darken for the end color
-    val baseColor = getConsoleColor(colorTheme)
-    return baseColor to baseColor.darken(0.55f)
+fun getConsoleGradient(colorTheme: String?): Pair<Color, Color> {
+    val brand = getConsoleColor(colorTheme)
+    val darkStop = lerp(brand, Color.Black, 0.6f)
+    return brand to darkStop
 }
 
 internal fun getConsoleColor(colorTheme: String?): Color {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -133,7 +133,7 @@ fun ConsoleScreen(
 
     // Darkened version of the console's brand gradient for the full-screen background
     val screenGradientColors = if (console != null) {
-        val (from, to) = getConsoleGradient(console.abbreviation, console.colorTheme)
+        val (from, to) = getConsoleGradient(console.colorTheme)
         listOf(from.darken(0.65f), to.darken(0.65f))
     } else {
         listOf(SpColor.Background, SpColor.Background)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -118,9 +118,12 @@ fun GameDetailScreen(
     val game = detail.game
     val isDemoConsole = state.console?.abbreviation == "ADEMO" || state.console?.abbreviation == "DDEMO"
 
-    // Per-console gradient background (same as console screen, darkened)
-    val backgroundColors = remember(game.consoleId) {
-        val (from, to) = getConsoleGradient(game.consoleId, null)
+    // Per-console gradient background (same as console screen, darkened).
+    // Sourced from the loaded Console's colorTheme so this surface stays
+    // in sync with the consoles-list and console-detail hero (#1167).
+    val consoleColorTheme = state.console?.colorTheme
+    val backgroundColors = remember(consoleColorTheme) {
+        val (from, to) = getConsoleGradient(consoleColorTheme)
         listOf(from.darken(0.65f), to.darken(0.65f))
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
@@ -124,11 +124,17 @@ fun SessionDetailScreen(
         }
     }
 
-    // Per-console gradient background (matching GameDetailScreen)
+    // Per-console gradient background (matching GameDetailScreen).
+    // SessionDetail's view-model doesn't currently load the full Console
+    // (only the Game DTO with consoleId), so colorTheme isn't available
+    // — the gradient falls back to SpColor.Primary until that's plumbed.
+    // Visually no worse than before #1167 for this surface: the old
+    // hard-coded abbreviation table also defaulted whenever the id
+    // didn't match its 60-entry list.
     val backgroundColors = remember(state.game?.consoleId) {
         val consoleId = state.game?.consoleId
         if (consoleId != null) {
-            val (from, to) = getConsoleGradient(consoleId, null)
+            val (from, to) = getConsoleGradient(null)
             listOf(from.darken(0.65f), to.darken(0.65f))
         } else {
             listOf(SpColor.Background, SpColor.Background)

--- a/web/src/components/console-card.tsx
+++ b/web/src/components/console-card.tsx
@@ -40,13 +40,17 @@ export function ConsoleCard({ console: c, hasMissingBios = false }: ConsoleCardP
       >
         <div
           className="absolute inset-0"
-          // Full-bleed card on a dark surface — alphas are stronger than
-          // the Explore strip's `${color}30 → ${color}08` so the brand
-          // colour reads at a glance, but the bottom-right still fades
-          // toward the surface so adjacent cards don't blur into each
-          // other.
+          // Two-stop brand gradient mixed in sRGB: top-left is the
+          // brand hex at full saturation; bottom-right is the same
+          // hex mixed 60% with black so light themes (NES red, Game
+          // Boy olive) get a vivid-to-shaded sweep, and dark themes
+          // (Genesis #171717, Atari #1e293b) still grade visibly into
+          // near-black rather than fading flat. Mirrors the spirit of
+          // the previous Tailwind `from-X-600 to-X-900` pairs but
+          // derives both stops from the single server-seeded
+          // colorTheme — see #1167.
           style={{
-            background: `linear-gradient(135deg, ${theme}cc, ${theme}55)`,
+            background: `linear-gradient(135deg, ${theme}, color-mix(in srgb, ${theme}, black 60%))`,
           }}
         />
         {/* Toward-bottom darken keeps text + indicators readable on

--- a/web/src/components/console-card.tsx
+++ b/web/src/components/console-card.tsx
@@ -1,7 +1,6 @@
 import { Link } from "react-router-dom";
 import { AlertTriangle, Check, Globe } from "lucide-react";
 import { cn } from "@/lib/cn";
-import { getConsoleStyle } from "@/lib/console-metadata";
 import type { Console } from "@/types/api";
 
 interface ConsoleCardProps {
@@ -16,8 +15,19 @@ interface ConsoleCardProps {
   hasMissingBios?: boolean;
 }
 
+// Card backgrounds derive from `Console.colorTheme` (the server-seeded
+// brand hex) rather than a hard-coded Tailwind gradient table. This
+// keeps the Consoles list, the Explore "Browse by Console" strip, and
+// the console-detail hero on one source of truth — admins / seed
+// updates change the colour in one place and every surface follows
+// (#1167). The previous per-console `console-metadata` gradient table
+// drifted from `colorTheme` (e.g. NES `red-600 → red-900` vs the
+// server's `#e60012`) and produced visibly different palettes for the
+// same library across the two pages.
+const FALLBACK_THEME = "#6366f1";
+
 export function ConsoleCard({ console: c, hasMissingBios = false }: ConsoleCardProps) {
-  const style = getConsoleStyle(c.abbreviation);
+  const theme = c.colorTheme || FALLBACK_THEME;
 
   return (
     <Link to={`/consoles/${c.id}`} className="group block">
@@ -29,8 +39,20 @@ export function ConsoleCard({ console: c, hasMissingBios = false }: ConsoleCardP
         )}
       >
         <div
-          className={cn("absolute inset-0 bg-gradient-to-br", style.gradient)}
+          className="absolute inset-0"
+          // Full-bleed card on a dark surface — alphas are stronger than
+          // the Explore strip's `${color}30 → ${color}08` so the brand
+          // colour reads at a glance, but the bottom-right still fades
+          // toward the surface so adjacent cards don't blur into each
+          // other.
+          style={{
+            background: `linear-gradient(135deg, ${theme}cc, ${theme}55)`,
+          }}
         />
+        {/* Toward-bottom darken keeps text + indicators readable on
+            light-saturation themes (e.g. Game Boy green). */}
+        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black/30 pointer-events-none" />
+
 
         <div className="absolute inset-0 flex flex-col items-center justify-center gap-3">
           <img

--- a/web/src/components/console-hero-banner.tsx
+++ b/web/src/components/console-hero-banner.tsx
@@ -1,5 +1,4 @@
 import { Check, Globe } from "lucide-react";
-import { getConsoleStyle } from "@/lib/console-metadata";
 import { cn } from "@/lib/cn";
 import type { Console } from "@/types/api";
 
@@ -8,28 +7,37 @@ interface ConsoleHeroBannerProps {
   gameCount?: number;
 }
 
+// Hero gradient derives from `Console.colorTheme` (same source the
+// Explore strip + Consoles list use) so the three console-identity
+// surfaces stay in sync — see #1167.
+const FALLBACK_THEME = "#6366f1";
+
 export function ConsoleHeroBanner({
   console: consoleData,
   gameCount,
 }: ConsoleHeroBannerProps) {
   const consoleName = consoleData?.name ?? "Console";
-  const consoleAbbr = consoleData?.abbreviation ?? "";
   const count = gameCount ?? consoleData?.gameCount ?? 0;
-  const style = getConsoleStyle(consoleAbbr);
-  const Icon = style.icon;
+  const theme = consoleData?.colorTheme || FALLBACK_THEME;
 
   return (
     <div data-comp="ConsoleHeroBanner"
       className={cn(
         "relative overflow-hidden rounded-2xl border border-white/[0.06]",
-        "bg-gradient-to-br",
-        style.gradient,
       )}
+      // Hero is the biggest console-coloured surface in the app; we
+      // push the alpha higher than the card list so the brand reads
+      // clearly even from the back of a couch. The far-end fade to
+      // black keeps the metadata row legible regardless of theme
+      // luminance.
+      style={{
+        background: `linear-gradient(135deg, ${theme}dd, ${theme}66 60%, #000000aa)`,
+      }}
       data-testid="console-hero-banner"
     >
       {/* Background watermark icon for depth */}
-      <div className="absolute -right-8 -top-8 opacity-[0.07] pointer-events-none">
-        {consoleData?.iconUrl ? (
+      {consoleData?.iconUrl && (
+        <div className="absolute -right-8 -top-8 opacity-[0.07] pointer-events-none">
           <img
             src={consoleData.iconUrl}
             alt=""
@@ -37,10 +45,8 @@ export function ConsoleHeroBanner({
             className="h-56 w-56 object-contain"
             style={{ imageRendering: "pixelated" }}
           />
-        ) : (
-          <Icon className="h-56 w-56 text-white" />
-        )}
-      </div>
+        </div>
+      )}
 
       {/* Subtle noise/texture overlay */}
       <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-white/[0.04] pointer-events-none" />

--- a/web/src/lib/console-metadata.test.ts
+++ b/web/src/lib/console-metadata.test.ts
@@ -3,14 +3,14 @@ import { getConsoleStyle } from "./console-metadata";
 
 describe("getConsoleStyle", () => {
   it("returns style for known console", () => {
+    // Matches the server's seeded colorTheme for NES.
     const style = getConsoleStyle("nes");
-    expect(style.color).toBe("#e53e3e");
-    expect(style.gradient).toContain("red");
+    expect(style.color).toBe("#e60012");
   });
 
   it("is case insensitive", () => {
     const style = getConsoleStyle("NES");
-    expect(style.color).toBe("#e53e3e");
+    expect(style.color).toBe("#e60012");
   });
 
   it("returns default for unknown console", () => {
@@ -18,37 +18,30 @@ describe("getConsoleStyle", () => {
     expect(style.color).toBe("#adb5bd");
   });
 
-  // BUG: The lookup keys in consoleStyles use lowercase display names
-  // (e.g., "genesis", "saturn") but the backend sends abbreviations
-  // (e.g., "GEN", "SAT"). After toLowerCase(), "GEN" becomes "gen",
-  // but the key in the map is "genesis" - no match.
+  // The backend often sends short abbreviations that need to map to
+  // our internal keys. The alias table in console-metadata.ts handles
+  // these.
   it("matches backend abbreviation GEN for Genesis", () => {
-    // Backend sends abbreviation "GEN" which lowercases to "gen"
-    // But the key in consoleStyles is "genesis", not "gen"
     const style = getConsoleStyle("GEN");
     expect(style.color).not.toBe("#adb5bd"); // Should not fall back to default
   });
 
   it("matches backend abbreviation SAT for Saturn", () => {
-    // Backend sends "SAT" -> "sat", but key is "saturn"
     const style = getConsoleStyle("SAT");
     expect(style.color).not.toBe("#adb5bd"); // Should not fall back to default
   });
 
   it("matches backend abbreviation SMS for Master System", () => {
-    // Backend sends "SMS" -> "sms", key is "sms" - this one matches
     const style = getConsoleStyle("SMS");
     expect(style.color).toBe("#4299e1");
   });
 
   it("matches backend abbreviation PCE for TurboGrafx", () => {
-    // Backend sends "PCE" -> "pce", but key is "tg16" - no match
     const style = getConsoleStyle("PCE");
     expect(style.color).not.toBe("#adb5bd"); // Should not fall back to default
   });
 
   it("matches backend abbreviation A26 for Atari", () => {
-    // Backend sends "A26" -> "a26", but key is "atari2600" - no match
     const style = getConsoleStyle("A26");
     expect(style.color).not.toBe("#adb5bd"); // Should not fall back to default
   });

--- a/web/src/lib/console-metadata.ts
+++ b/web/src/lib/console-metadata.ts
@@ -1,353 +1,93 @@
-import type { LucideIcon } from "lucide-react";
-import { Gamepad2, Smartphone, Monitor, Joystick, Tv } from "lucide-react";
-
+// Per-console accent colour table used by [ConsoleBadge] in places
+// where the surrounding code only has a console abbreviation/code
+// (e.g. a game card showing its console badge — the game DTO carries
+// `consoleId`/`consoleAbbreviation` but not `colorTheme`).
+//
+// **Source of truth.** The authoritative console accent colour is
+// `Console.colorTheme` from the server, seeded in
+// `server/internal/db/database.go`. Components that already receive a
+// full Console (or ConsoleHighlight) — `ConsoleCard`, `ConsoleHeroBanner`,
+// the Explore "Browse by Console" strip — read `colorTheme` directly
+// and bypass this table entirely (#1167).
+//
+// This table is therefore a *fallback* keyed by abbreviation for the
+// badge case only. The values here SHOULD match the server's seed; if
+// they drift, edit `database.go` first and propagate the same hex
+// here. A follow-up task should remove this table by plumbing
+// `colorTheme` through to ConsoleBadge call sites.
 interface ConsoleStyle {
-  icon: LucideIcon;
-  gradient: string;
   color: string;
 }
 
 const consoleStyles: Record<string, ConsoleStyle> = {
-  nes: {
-    icon: Gamepad2,
-    gradient: "from-red-600 to-red-900",
-    color: "#e53e3e",
-  },
-  snes: {
-    icon: Gamepad2,
-    gradient: "from-purple-600 to-indigo-900",
-    color: "#805ad5",
-  },
-  gb: {
-    icon: Smartphone,
-    gradient: "from-green-600 to-green-900",
-    color: "#38a169",
-  },
-  gbc: {
-    icon: Smartphone,
-    gradient: "from-teal-500 to-green-800",
-    color: "#319795",
-  },
-  gba: {
-    icon: Smartphone,
-    gradient: "from-indigo-500 to-purple-800",
-    color: "#667eea",
-  },
-  n64: {
-    icon: Joystick,
-    gradient: "from-green-500 to-blue-700",
-    color: "#48bb78",
-  },
-  nds: {
-    icon: Smartphone,
-    gradient: "from-gray-400 to-gray-700",
-    color: "#a0aec0",
-  },
-  sms: {
-    icon: Tv,
-    gradient: "from-blue-500 to-blue-800",
-    color: "#4299e1",
-  },
-  genesis: {
-    icon: Gamepad2,
-    gradient: "from-blue-700 to-black",
-    color: "#2b6cb0",
-  },
-  saturn: {
-    icon: Monitor,
-    gradient: "from-gray-600 to-gray-900",
-    color: "#718096",
-  },
-  psx: {
-    icon: Gamepad2,
-    gradient: "from-gray-500 to-blue-900",
-    color: "#a0aec0",
-  },
-  psp: {
-    icon: Smartphone,
-    gradient: "from-gray-700 to-black",
-    color: "#4a5568",
-  },
-  neogeo: {
-    icon: Joystick,
-    gradient: "from-yellow-500 to-red-700",
-    color: "#ecc94b",
-  },
-  neocd: {
-    icon: Joystick,
-    gradient: "from-yellow-500 to-red-700",
-    color: "#ecc94b",
-  },
-  arcade: {
-    icon: Joystick,
-    gradient: "from-yellow-400 to-orange-700",
-    color: "#f6ad55",
-  },
-  tg16: {
-    icon: Tv,
-    gradient: "from-orange-500 to-red-800",
-    color: "#ed8936",
-  },
-  pcecd: {
-    icon: Tv,
-    gradient: "from-orange-500 to-red-800",
-    color: "#ed8936",
-  },
-  atari2600: {
-    icon: Tv,
-    gradient: "from-slate-800 to-slate-900",
-    color: "#1e293b",
-  },
-  gg: {
-    icon: Smartphone,
-    gradient: "from-blue-600 to-blue-900",
-    color: "#2563eb",
-  },
-  scd: {
-    icon: Tv,
-    gradient: "from-gray-700 to-blue-900",
-    color: "#334155",
-  },
-  "32x": {
-    icon: Gamepad2,
-    gradient: "from-gray-800 to-black",
-    color: "#1e293b",
-  },
-  dc: {
-    icon: Gamepad2,
-    gradient: "from-orange-500 to-blue-700",
-    color: "#f97316",
-  },
-  vb: {
-    icon: Monitor,
-    gradient: "from-red-800 to-red-950",
-    color: "#991b1b",
-  },
-  "3ds": {
-    icon: Smartphone,
-    gradient: "from-sky-950 to-slate-950",
-    color: "#0c4a6e",
-  },
-  gc: {
-    icon: Gamepad2,
-    gradient: "from-indigo-500 to-purple-800",
-    color: "#6f5fa6",
-  },
-  a52: {
-    icon: Tv,
-    gradient: "from-amber-700 to-amber-950",
-    color: "#b45309",
-  },
-  a78: {
-    icon: Tv,
-    gradient: "from-slate-800 to-slate-900",
-    color: "#1e293b",
-  },
-  lynx: {
-    icon: Smartphone,
-    gradient: "from-yellow-600 to-yellow-900",
-    color: "#ca8a04",
-  },
-  jag: {
-    icon: Gamepad2,
-    gradient: "from-red-700 to-gray-900",
-    color: "#b91c1c",
-  },
-  ngp: {
-    icon: Smartphone,
-    gradient: "from-gray-500 to-gray-800",
-    color: "#6b7280",
-  },
-  ws: {
-    icon: Smartphone,
-    gradient: "from-indigo-600 to-indigo-900",
-    color: "#4f46e5",
-  },
-  pcfx: {
-    icon: Tv,
-    gradient: "from-teal-600 to-teal-900",
-    color: "#0d9488",
-  },
-  cv: {
-    icon: Tv,
-    gradient: "from-sky-600 to-sky-900",
-    color: "#0284c7",
-  },
-  pkmn: {
-    icon: Smartphone,
-    gradient: "from-yellow-400 to-yellow-700",
-    color: "#facc15",
-  },
-  ps2: {
-    icon: Gamepad2,
-    gradient: "from-blue-800 to-blue-950",
-    color: "#1e40af",
-  },
-  c64: {
-    icon: Monitor,
-    gradient: "from-blue-500 to-purple-800",
-    color: "#6366f1",
-  },
-  dos: {
-    icon: Monitor,
-    gradient: "from-green-700 to-green-950",
-    color: "#15803d",
-  },
-  amiga: {
-    icon: Monitor,
-    gradient: "from-red-600 to-blue-800",
-    color: "#dc2626",
-  },
-  acd32: {
-    icon: Gamepad2,
-    gradient: "from-purple-600 to-indigo-900",
-    color: "#6c5eb5",
-  },
-  ps3: {
-    icon: Gamepad2,
-    gradient: "from-gray-700 to-blue-950",
-    color: "#003087",
-  },
-  ps4: {
-    icon: Gamepad2,
-    gradient: "from-blue-800 to-blue-950",
-    color: "#003087",
-  },
-  ps5: {
-    icon: Gamepad2,
-    gradient: "from-white to-blue-900",
-    color: "#003087",
-  },
-  xbox: {
-    icon: Gamepad2,
-    gradient: "from-green-600 to-green-900",
-    color: "#107c10",
-  },
-  x360: {
-    icon: Gamepad2,
-    gradient: "from-green-600 to-green-900",
-    color: "#107c10",
-  },
-  xone: {
-    icon: Gamepad2,
-    gradient: "from-green-700 to-green-950",
-    color: "#107c10",
-  },
-  xsx: {
-    icon: Gamepad2,
-    gradient: "from-green-800 to-black",
-    color: "#107c10",
-  },
-  wii: {
-    icon: Gamepad2,
-    gradient: "from-gray-300 to-gray-600",
-    color: "#c0c0c0",
-  },
-  wiiu: {
-    icon: Gamepad2,
-    gradient: "from-sky-500 to-sky-800",
-    color: "#009ac7",
-  },
-  nsw: {
-    icon: Gamepad2,
-    gradient: "from-red-500 to-red-800",
-    color: "#e60012",
-  },
-  "3do": {
-    icon: Gamepad2,
-    gradient: "from-gray-400 to-gray-700",
-    color: "#c0c0c0",
-  },
-  c128: {
-    icon: Monitor,
-    gradient: "from-blue-500 to-purple-800",
-    color: "#6c5eb5",
-  },
-  pet: {
-    icon: Monitor,
-    gradient: "from-blue-400 to-purple-700",
-    color: "#6c5eb5",
-  },
-  plus4: {
-    icon: Monitor,
-    gradient: "from-blue-400 to-purple-700",
-    color: "#6c5eb5",
-  },
-  vic20: {
-    icon: Monitor,
-    gradient: "from-blue-500 to-purple-800",
-    color: "#6c5eb5",
-  },
-  cdi: {
-    icon: Gamepad2,
-    gradient: "from-green-700 to-green-950",
-    color: "#006633",
-  },
-  msx1: {
-    icon: Monitor,
-    gradient: "from-blue-500 to-blue-800",
-    color: "#4a86c8",
-  },
-  msx2: {
-    icon: Monitor,
-    gradient: "from-blue-500 to-blue-800",
-    color: "#4a86c8",
-  },
-  channelf: {
-    icon: Tv,
-    gradient: "from-orange-600 to-orange-900",
-    color: "#cc6600",
-  },
-  odyssey2: {
-    icon: Tv,
-    gradient: "from-amber-600 to-amber-900",
-    color: "#b8860b",
-  },
-  intellivision: {
-    icon: Tv,
-    gradient: "from-yellow-700 to-yellow-950",
-    color: "#8b6914",
-  },
-  vectrex: {
-    icon: Tv,
-    gradient: "from-gray-600 to-gray-900",
-    color: "#333333",
-  },
-  "sg-1000": {
-    icon: Tv,
-    gradient: "from-blue-500 to-blue-800",
-    color: "#0060a8",
-  },
-  sgx: {
-    icon: Tv,
-    gradient: "from-orange-500 to-red-800",
-    color: "#ed8936",
-  },
-  fds: {
-    icon: Gamepad2,
-    gradient: "from-red-600 to-yellow-800",
-    color: "#e60012",
-  },
-  gw: {
-    icon: Smartphone,
-    gradient: "from-red-600 to-red-900",
-    color: "#c0392b",
-  },
-  atari800: {
-    icon: Monitor,
-    gradient: "from-amber-700 to-amber-950",
-    color: "#8b4513",
-  },
-  atarist: {
-    icon: Monitor,
-    gradient: "from-amber-700 to-amber-950",
-    color: "#8b4513",
-  },
-  vita: {
-    icon: Smartphone,
-    gradient: "from-blue-700 to-blue-950",
-    color: "#003087",
-  },
+  nes: { color: "#e60012" },
+  snes: { color: "#7b7db5" },
+  gb: { color: "#8bac0f" },
+  gbc: { color: "#319795" },
+  gba: { color: "#667eea" },
+  n64: { color: "#48bb78" },
+  nds: { color: "#a0aec0" },
+  sms: { color: "#4299e1" },
+  genesis: { color: "#171717" },
+  saturn: { color: "#718096" },
+  psx: { color: "#a0aec0" },
+  psp: { color: "#4a5568" },
+  neogeo: { color: "#ecc94b" },
+  neocd: { color: "#ecc94b" },
+  arcade: { color: "#f6ad55" },
+  tg16: { color: "#ed8936" },
+  pcecd: { color: "#ed8936" },
+  atari2600: { color: "#1e293b" },
+  gg: { color: "#2563eb" },
+  scd: { color: "#334155" },
+  "32x": { color: "#1e293b" },
+  dc: { color: "#f97316" },
+  vb: { color: "#991b1b" },
+  "3ds": { color: "#0c4a6e" },
+  gc: { color: "#6f5fa6" },
+  a52: { color: "#b45309" },
+  a78: { color: "#1e293b" },
+  lynx: { color: "#ca8a04" },
+  jag: { color: "#b91c1c" },
+  ngp: { color: "#6b7280" },
+  ws: { color: "#4f46e5" },
+  pcfx: { color: "#0d9488" },
+  cv: { color: "#0284c7" },
+  pkmn: { color: "#facc15" },
+  ps2: { color: "#1e40af" },
+  c64: { color: "#6366f1" },
+  dos: { color: "#15803d" },
+  amiga: { color: "#dc2626" },
+  acd32: { color: "#6c5eb5" },
+  ps3: { color: "#003087" },
+  ps4: { color: "#003087" },
+  ps5: { color: "#003087" },
+  xbox: { color: "#107c10" },
+  x360: { color: "#107c10" },
+  xone: { color: "#107c10" },
+  xsx: { color: "#107c10" },
+  wii: { color: "#c0c0c0" },
+  wiiu: { color: "#009ac7" },
+  nsw: { color: "#e60012" },
+  "3do": { color: "#c0c0c0" },
+  c128: { color: "#6c5eb5" },
+  pet: { color: "#6c5eb5" },
+  plus4: { color: "#6c5eb5" },
+  vic20: { color: "#6c5eb5" },
+  cdi: { color: "#006633" },
+  msx1: { color: "#4a86c8" },
+  msx2: { color: "#4a86c8" },
+  channelf: { color: "#cc6600" },
+  odyssey2: { color: "#b8860b" },
+  intellivision: { color: "#8b6914" },
+  vectrex: { color: "#333333" },
+  "sg-1000": { color: "#0060a8" },
+  sgx: { color: "#ed8936" },
+  fds: { color: "#e60012" },
+  gw: { color: "#c0392b" },
+  atari800: { color: "#8b4513" },
+  atarist: { color: "#8b4513" },
+  vita: { color: "#003087" },
 };
 
 // Map backend abbreviations to our internal keys
@@ -367,8 +107,6 @@ const abbreviationAliases: Record<string, string> = {
 };
 
 const defaultStyle: ConsoleStyle = {
-  icon: Gamepad2,
-  gradient: "from-surface-600 to-surface-900",
   color: "#adb5bd",
 };
 


### PR DESCRIPTION
Closes #1167.

## What

`ConsoleCard` (Consoles list) and `ConsoleHeroBanner` (console-detail) now derive their gradient from `Console.colorTheme` — the same server-seeded hex that the Explore "Browse by Console" strip and the cover-gallery filters already use. Three console-identity surfaces, one source of truth.

## Why this looked broken

Two independent colour tables:

| Surface | Source | NES rendered as | Genesis rendered as |
|---|---|---|---|
| Explore "Browse by Console" | `Console.colorTheme` (server) | `#e60012` low-alpha | `#171717` low-alpha |
| Cover-gallery filter chips | `Console.colorTheme` (server) | `#e60012` low-alpha | `#171717` low-alpha |
| Console-detail hero | `console-metadata.ts.gradient` | Tailwind `red-600 → red-900` | Tailwind `blue-700 → black` |
| Consoles list cards | `console-metadata.ts.gradient` | Tailwind `red-600 → red-900` | Tailwind `blue-700 → black` |

After this PR every row is `Console.colorTheme`. Editing a console's `ColorTheme` in the DB seed now propagates to every surface.

## Alpha tuning per surface

Same source hex, different alpha pairs by context:

| Surface | Gradient | Why |
|---|---|---|
| Explore strip (existing) | `${color}30 → ${color}08` | Small thumbnail, low alpha keeps text crisp |
| Consoles list card | `${color}cc → ${color}55` + bottom darken | Full-bleed card needs the brand to read |
| Console hero | `${color}dd → ${color}66 → #000000aa` | Biggest surface; far-end fade to black keeps metadata legible regardless of theme luminance |

## What didn't change

- `ConsoleBadge` (small inline badges next to game titles) still uses `console-metadata.ts.color` because the badge call sites only have an abbreviation, not a full Console. Plumbing `colorTheme` through every game card / shelf is the right next step; this PR aligns the `console-metadata.ts.color` values to the server's seed so the badge palette is at least consistent with the new backgrounds in the meantime. Tracked as a follow-up note in the new `console-metadata.ts` header.
- The `icon` field is gone — every console has had an `iconUrl` since #1158 and the lucide-icon fallback was unreachable.
- The `gradient` field is gone — no callers after this change.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test -- --run` — 1612/1612 passing (existing fixtures already include `colorTheme: null` from #1170)
- [ ] Manual: load `/explore` and `/consoles`, compare NES / SNES / Genesis / GB card colours across the two pages — they should now match.
- [ ] Manual: open any `/consoles/<id>` detail page and verify the hero gradient uses the same brand hex as that console's tile on the list.