### PR TITLE
feat(web): add See-all-consoles link to Explore quick-jump (#1175)

### DIFF
--- a/web/src/features/explore/components/__tests__/console-quick-jump.test.tsx
+++ b/web/src/features/explore/components/__tests__/console-quick-jump.test.tsx
@@ -144,4 +144,25 @@ describe("ConsoleQuickJump", () => {
     const items = screen.getAllByRole("listitem");
     expect(items).toHaveLength(3);
   });
+
+  // #1175 — the "See all consoles" affordance is the section's only
+  // exit ramp to the full Consoles directory; without it users assume
+  // the carousel is the complete inventory.
+  it("renders See-all-consoles link pointing at /consoles", () => {
+    renderComponent();
+    const link = screen.getByTestId("console-quick-jump-see-all");
+    expect(link).toBeInTheDocument();
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("href", "/consoles");
+  });
+
+  // The link must also render in the loading skeleton so it doesn't
+  // pop in when data arrives — the section header layout is the same
+  // in both states.
+  it("renders See-all-consoles link in the loading skeleton too", () => {
+    renderComponent(undefined, true);
+    const link = screen.getByTestId("console-quick-jump-see-all");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/consoles");
+  });
 });

--- a/web/src/features/explore/components/console-quick-jump.tsx
+++ b/web/src/features/explore/components/console-quick-jump.tsx
@@ -9,12 +9,31 @@ interface ConsoleQuickJumpProps {
   isLoading: boolean;
 }
 
+// Section header layout — extracted so the loading skeleton and the
+// hydrated section both render the same flex row and the "See all"
+// link doesn't shift in/out as data arrives (#1175).
+function SectionHeader() {
+  return (
+    <div className="flex items-baseline justify-between mb-5">
+      <h2 className="text-xl font-bold text-surface-100">
+        Browse by Console
+      </h2>
+      <Link
+        to="/consoles"
+        data-testid="console-quick-jump-see-all"
+        className="inline-flex items-center gap-1 text-sm font-medium text-surface-400 hover:text-brand-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950 rounded-md transition-colors"
+      >
+        See all consoles
+        <ChevronRight className="h-4 w-4" aria-hidden="true" />
+      </Link>
+    </div>
+  );
+}
+
 function ConsoleQuickJumpSkeleton() {
   return (
     <section data-comp="ConsoleQuickJumpSkeleton" data-testid="console-quick-jump-skeleton">
-      <h2 className="text-xl font-bold text-surface-100 mb-5">
-        Browse by Console
-      </h2>
+      <SectionHeader />
       <div className="flex gap-4 overflow-hidden">
         {Array.from({ length: 8 }, (_, i) => (
           <Skeleton key={i} className="w-36 h-24 rounded-xl flex-shrink-0" />
@@ -75,9 +94,7 @@ export function ConsoleQuickJump({
       data-testid="console-quick-jump"
       className="group/console-jump relative"
     >
-      <h2 className="text-xl font-bold text-surface-100 mb-5">
-        Browse by Console
-      </h2>
+      <SectionHeader />
 
       <div className="relative">
         {/* Scroll arrows */}


### PR DESCRIPTION
Closes #1175.

## What

A small chevron-suffixed "See all consoles" link in the top-right of the `ConsoleQuickJump` section header. Navigates to `/consoles` — the full directory.

## Why

The Browse-by-Console carousel had no in-context exit ramp. Users had to know `/consoles` existed and reach it via the side nav, which leaves the implicit message "this carousel is the whole inventory."

## How

- Extracted `SectionHeader` into a private subcomponent so the loading skeleton and the hydrated section render the same flex row — no layout shift when data arrives.
- Subtle by default (`text-surface-400`), brand-colour on hover, focus-visible ring matching the rest of the design system.
- Added `data-testid="console-quick-jump-see-all"` for tests.

## Test plan

- [x] 2 new vitest cases:
  - link is present in the hydrated section, points at `/consoles`
  - link is present in the loading skeleton with the same href
- [x] All 13 `console-quick-jump.test.tsx` cases pass
- [x] `npm run build` clean
- [ ] Manual: load `/explore`, hover the link (cursor + colour change), click → land on `/consoles`. Tab from elsewhere to confirm focus-visible ring.