### PR TITLE
feat: SegmentedControl primitive + console grouping migration (#1176 Issue B)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -405,6 +405,7 @@ class SpelaTestHarness(
                 presenceService = presenceService,
                 connectivityMonitor = connectivityMonitor,
                 downloadRepository = downloadRepo,
+                preferencesRepository = preferencesRepo,
                 sessionDetailViewModel = sessionDetailViewModel,
                 topListsViewModel = topListsViewModel,
                 exploreViewModel = exploreViewModel,

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -793,6 +793,9 @@ class FakePreferencesRepository : PreferencesRepository {
     override fun getControlTab(consoleId: String): String =
         controlTabs[consoleId] ?: if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
     override fun setControlTab(consoleId: String, tab: String) { controlTabs[consoleId] = tab }
+    private var consoleListGrouping: String = "generation"
+    override fun getConsoleListGrouping(): String = consoleListGrouping
+    override fun setConsoleListGrouping(grouping: String) { consoleListGrouping = grouping }
 }
 
 class FakeAchievementsRepository : AchievementsRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
@@ -217,6 +217,15 @@ class PreferencesRepositoryImpl(
         database.spelaDatabaseQueries.insertDeviceSetting("control_tab:$consoleId", tab)
     }
 
+    override fun getConsoleListGrouping(): String {
+        return database.spelaDatabaseQueries.getDeviceSetting("console_list_grouping")
+            .executeAsOneOrNull() ?: "generation"
+    }
+
+    override fun setConsoleListGrouping(grouping: String) {
+        database.spelaDatabaseQueries.insertDeviceSetting("console_list_grouping", grouping)
+    }
+
     override suspend fun pushKeyMappingsToServer() {
         runCatching {
             val allMappings = database.spelaDatabaseQueries.getAllKeyMappings().executeAsList()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/PreferencesRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/PreferencesRepository.kt
@@ -42,4 +42,14 @@ interface PreferencesRepository {
     fun setOrientationLock(mode: String)
     fun getControlTab(consoleId: String): String
     fun setControlTab(consoleId: String, tab: String)
+
+    /**
+     * Device-local console list grouping preference ("generation" |
+     * "manufacturer"). Defaults to "generation" when unset — matches
+     * the web behaviour in `consoles-page.tsx` and so a user landing
+     * on either client for the first time sees the same default
+     * grouping. See #1176.
+     */
+    fun getConsoleListGrouping(): String
+    fun setConsoleListGrouping(grouping: String)
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/App.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/App.kt
@@ -72,6 +72,7 @@ fun App() {
     val gamepadConfigViewModel: GamepadConfigViewModel = koinInject()
     val scrapeService: ScrapeService = koinInject()
     val downloadRepository: com.spela.player.domain.repository.DownloadRepository = koinInject()
+    val preferencesRepository: com.spela.player.domain.repository.PreferencesRepository = koinInject()
 
     SpelaApp(
         SpelaAppDependencies(
@@ -106,6 +107,7 @@ fun App() {
             gamepadConfigViewModel = gamepadConfigViewModel,
             scrapeService = scrapeService,
             downloadRepository = downloadRepository,
+            preferencesRepository = preferencesRepository,
         ),
     )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/ScreenRouter.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/ScreenRouter.kt
@@ -863,6 +863,7 @@ fun ScreenRouter(
                             is SpScreen.Consoles -> {
                                 ConsolesScreen(
                                     viewModel = gameListViewModel,
+                                    preferencesRepository = preferencesRepository,
                                     onConsoleSelected = { consoleId ->
                                         navigationViewModel.onIntent(
                                             NavigationIntent.NavigateTo(SpScreen.Console(consoleId))

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaAppDependencies.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaAppDependencies.kt
@@ -4,6 +4,7 @@ import com.spela.player.data.remote.ConnectivityMonitor
 import com.spela.player.data.remote.PresenceService
 import com.spela.player.data.remote.ScrapeService
 import com.spela.player.domain.repository.DownloadRepository
+import com.spela.player.domain.repository.PreferencesRepository
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.presentation.navigation.NavigationEventBus
 import com.spela.player.presentation.navigation.NavigationViewModel
@@ -78,6 +79,7 @@ data class SpelaAppDependencies(
     val presenceService: PresenceService,
     val connectivityMonitor: ConnectivityMonitor,
     val downloadRepository: DownloadRepository,
+    val preferencesRepository: PreferencesRepository,
 
     // ── Optional slots ──────────────────────────────────────────
     // These matched `= null` defaults on the original `SpelaApp`

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSegmentedControl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSegmentedControl.kt
@@ -1,0 +1,200 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.CollectionInfo
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.collectionInfo
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * DESIGN component — a view-switcher over a closed set of
+ * mutually-exclusive options.
+ *
+ * Use when the screen has exactly N "shapes" and the user picks one
+ * (group by generation vs manufacturer, list vs grid view, …). Do NOT
+ * use this for picking an item from a long list — that's a dropdown.
+ * Do NOT use this for multi-select filters — that's `SpChip`.
+ *
+ * Replaces the "two adjacent SpChips" pattern. Chips read as passive
+ * metadata; on the AYN Thor under bright light they were visually
+ * indistinguishable from region / status badges on the cards below
+ * (#1176).
+ *
+ * Layout: a single connected pill track containing N equal-padding
+ * segments. Selected segment uses a *filled* brand background so the
+ * choice is unambiguous on bright handheld screens. Tap / A-press to
+ * change. Per-segment gamepad focus is provided by [focusable]; the
+ * outer Row is a [focusGroup] descendant via composition (left/right
+ * DPAD inside the row naturally cycles focus across segments).
+ *
+ * No animation between segments — adding a thumb-slide transition is
+ * a follow-up; first land the right primitive and palette.
+ *
+ * @param options Ordered list of `(value, label)` pairs. Equal-spaced.
+ *   Provide at least 2.
+ * @param selectedValue The currently-selected value. Must equal one of
+ *   the option values, otherwise no segment is highlighted.
+ * @param onValueChange Invoked with the new value when the user picks
+ *   a different segment.
+ * @param label Optional visible label rendered above the control
+ *   (e.g. "Group by"). Helps first-time users.
+ * @param onGradient True when this control sits on a console-coloured
+ *   gradient background and needs higher-contrast surface colours.
+ */
+@Composable
+fun <T> SpSegmentedControl(
+    options: List<SegmentedOption<T>>,
+    selectedValue: T,
+    onValueChange: (T) -> Unit,
+    modifier: Modifier = Modifier,
+    label: String? = null,
+    onGradient: Boolean = false,
+) {
+    val outerShape = RoundedCornerShape(SpSpacing.RadiusPill)
+    val trackBackground = if (onGradient) {
+        Color.Black.copy(alpha = 0.30f)
+    } else {
+        SpColor.SurfaceBright.copy(alpha = 0.20f)
+    }
+    val trackBorder = if (onGradient) {
+        Color.White.copy(alpha = 0.15f)
+    } else {
+        SpColor.Divider
+    }
+
+    androidx.compose.foundation.layout.Column(modifier = modifier) {
+        if (label != null) {
+            Text(
+                text = label,
+                style = SpTypography.LabelSmall,
+                color = if (onGradient) SpColor.OnGradientSecondary else SpColor.OnBackgroundSecondary,
+                modifier = Modifier.padding(bottom = SpSpacing.XSmall),
+            )
+        }
+        Row(
+            modifier = Modifier
+                .height(48.dp) // Material touch-target minimum
+                .clip(outerShape)
+                .background(trackBackground)
+                .border(1.dp, trackBorder, outerShape)
+                .semantics {
+                    collectionInfo = CollectionInfo(rowCount = 1, columnCount = options.size)
+                },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            options.forEach { option ->
+                val isSelected = option.value == selectedValue
+                SpSegmentedControlSegment(
+                    option = option,
+                    isSelected = isSelected,
+                    onClick = { onValueChange(option.value) },
+                    onGradient = onGradient,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Stable description of one segment in [SpSegmentedControl]. Carries
+ * the underlying value (an enum, string, or whatever the caller uses
+ * to identify the choice) and the visible label.
+ *
+ * Kept as a separate type rather than `Pair<T, String>` so call sites
+ * are self-documenting and the API can grow (icon, badge count, etc.)
+ * without breaking existing callers.
+ */
+data class SegmentedOption<T>(
+    val value: T,
+    val label: String,
+    /** Optional testTag forwarded to the segment for UI-test targeting. */
+    val testTag: String? = null,
+)
+
+@Composable
+private fun <T> RowScopeSegment(content: @Composable () -> Unit) = content()
+
+@Composable
+private fun SpSegmentedControlSegment(
+    option: SegmentedOption<*>,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    onGradient: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val innerShape = RoundedCornerShape(SpSpacing.RadiusPill)
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
+    // Filled brand for selected (not the 15%-alpha tint SpChip uses —
+    // a primary view-switcher needs the choice to read at-a-glance,
+    // especially on a sunny handheld screen).
+    val background = when {
+        isSelected -> SpColor.Primary
+        else -> Color.Transparent
+    }
+    val textColor = when {
+        isSelected -> SpColor.OnPrimary
+        onGradient -> SpColor.OnGradientPrimary
+        else -> SpColor.OnBackgroundSecondary
+    }
+    // Focus indicator is the same white-ring vocabulary used everywhere
+    // else in the player so gamepad users get a consistent cue.
+    val focusBorder = if (isFocused) Color.White.copy(alpha = 0.85f) else Color.Transparent
+
+    Box(
+        modifier = modifier
+            .padding(2.dp)
+            .clip(innerShape)
+            .background(background)
+            .border(2.dp, focusBorder, innerShape)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
+            .focusable(interactionSource = interactionSource)
+            .semantics {
+                role = Role.RadioButton
+                selected = isSelected
+            }
+            .let { mod ->
+                val tag = option.testTag
+                if (tag != null) mod.testTag(tag) else mod
+            }
+            .padding(horizontal = SpSpacing.Small, vertical = SpSpacing.XSmall),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = option.label,
+            style = SpTypography.LabelMedium,
+            color = textColor,
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/LibraryConsolesTab.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/LibraryConsolesTab.kt
@@ -1,9 +1,7 @@
 package com.spela.player.presentation.ui.feature.library
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,13 +19,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.spela.player.domain.repository.PreferencesRepository
 import com.spela.player.presentation.intent.GameListIntent
-import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SegmentedOption
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpMainContentPadding
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpScreenTopSpacer
 import com.spela.player.presentation.ui.components.SpScrollableContent
+import com.spela.player.presentation.ui.components.SpSegmentedControl
 import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -37,16 +37,32 @@ import com.spela.player.presentation.viewmodel.GameListViewModel
 @Composable
 internal fun LibraryConsolesTab(
     viewModel: GameListViewModel,
+    preferencesRepository: PreferencesRepository,
     onConsoleSelected: (String) -> Unit,
 ) {
     val state by viewModel.state.collectAsState()
 
-    // #1106 — toggle state lives at the tab level so the segmented
-    // control and the grid render from the same source of truth.
-    // `remember` keeps the choice for the lifetime of the tab; cross-
-    // restart persistence (and rotation persistence on Android) is
-    // filed as a follow-up.
-    var grouping by remember { mutableStateOf(ConsoleGrouping.Generation) }
+    // Persist the grouping choice device-locally — mirrors the web's
+    // `localStorage["consoleListGrouping"]` so a user landing on either
+    // client sees the same default and their pick survives screen
+    // disposal (#1176). The repository's getter falls back to
+    // "generation" when unset, which matches the web default.
+    var grouping by remember {
+        val initial = when (preferencesRepository.getConsoleListGrouping()) {
+            "manufacturer" -> ConsoleGrouping.Manufacturer
+            else -> ConsoleGrouping.Generation
+        }
+        mutableStateOf(initial)
+    }
+    val onGroupingChange: (ConsoleGrouping) -> Unit = { next ->
+        grouping = next
+        preferencesRepository.setConsoleListGrouping(
+            when (next) {
+                ConsoleGrouping.Generation -> "generation"
+                ConsoleGrouping.Manufacturer -> "manufacturer"
+            }
+        )
+    }
 
     LaunchedEffect(Unit) {
         viewModel.onIntent(GameListIntent.LoadConsoles)
@@ -90,7 +106,7 @@ internal fun LibraryConsolesTab(
                         SpMainContentPadding {
                             ConsoleGroupingToggle(
                                 grouping = grouping,
-                                onGroupingChange = { grouping = it },
+                                onGroupingChange = onGroupingChange,
                             )
                             Spacer(Modifier.height(SpSpacing.Medium))
                             BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
@@ -118,25 +134,27 @@ private fun ConsoleGroupingToggle(
     grouping: ConsoleGrouping,
     onGroupingChange: (ConsoleGrouping) -> Unit,
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .testTag("console-grouping-toggle"),
-        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-    ) {
-        SpChip(
-            text = "By generation",
-            isSelected = grouping == ConsoleGrouping.Generation,
-            onClick = { onGroupingChange(ConsoleGrouping.Generation) },
-            onGradient = true,
-            modifier = Modifier.testTag("console-grouping-generation"),
-        )
-        SpChip(
-            text = "By manufacturer",
-            isSelected = grouping == ConsoleGrouping.Manufacturer,
-            onClick = { onGroupingChange(ConsoleGrouping.Manufacturer) },
-            onGradient = true,
-            modifier = Modifier.testTag("console-grouping-manufacturer"),
-        )
-    }
+    // Migrated from two SpChips to SpSegmentedControl in #1176 so the
+    // primary "switch how the entire screen is organised" affordance
+    // doesn't look like passive metadata. testTag values are preserved
+    // for the existing UI tests.
+    SpSegmentedControl(
+        options = listOf(
+            SegmentedOption(
+                value = ConsoleGrouping.Generation,
+                label = "Generation",
+                testTag = "console-grouping-generation",
+            ),
+            SegmentedOption(
+                value = ConsoleGrouping.Manufacturer,
+                label = "Manufacturer",
+                testTag = "console-grouping-manufacturer",
+            ),
+        ),
+        selectedValue = grouping,
+        onValueChange = onGroupingChange,
+        label = "Group by",
+        onGradient = true,
+        modifier = Modifier.testTag("console-grouping-toggle"),
+    )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsolesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsolesScreen.kt
@@ -1,16 +1,19 @@
 package com.spela.player.presentation.ui.screen
 
 import androidx.compose.runtime.Composable
+import com.spela.player.domain.repository.PreferencesRepository
 import com.spela.player.presentation.ui.feature.library.LibraryConsolesTab
 import com.spela.player.presentation.viewmodel.GameListViewModel
 
 @Composable
 fun ConsolesScreen(
     viewModel: GameListViewModel,
+    preferencesRepository: PreferencesRepository,
     onConsoleSelected: (String) -> Unit,
 ) {
     LibraryConsolesTab(
         viewModel = viewModel,
+        preferencesRepository = preferencesRepository,
         onConsoleSelected = onConsoleSelected,
     )
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
@@ -181,6 +181,8 @@ class SyncEngineTest {
         override fun getControlTab(consoleId: String): String =
             if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
         override fun setControlTab(consoleId: String, tab: String) {}
+        override fun getConsoleListGrouping(): String = "generation"
+        override fun setConsoleListGrouping(grouping: String) {}
     }
 
     private class NoOpGameRepository : GameRepository {
@@ -224,6 +226,8 @@ class SyncEngineTest {
         override fun getControlTab(consoleId: String): String =
             if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
         override fun setControlTab(consoleId: String, tab: String) {}
+        override fun getConsoleListGrouping(): String = "generation"
+        override fun setConsoleListGrouping(grouping: String) {}
     }
 
     private class FailingGameRepository : GameRepository {
@@ -271,6 +275,8 @@ class SyncEngineTest {
         override fun getControlTab(consoleId: String): String =
             if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
         override fun setControlTab(consoleId: String, tab: String) {}
+        override fun getConsoleListGrouping(): String = "generation"
+        override fun setConsoleListGrouping(grouping: String) {}
     }
 
     private class TrackingGameRepository : GameRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -458,6 +458,8 @@ class NavigationViewModelTest {
         override fun getControlTab(consoleId: String): String =
             if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
         override fun setControlTab(consoleId: String, tab: String) {}
+        override fun getConsoleListGrouping(): String = "generation"
+        override fun setConsoleListGrouping(grouping: String) {}
     }
 
     private class NoOpGameRepository : GameRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt
@@ -409,6 +409,8 @@ class KeyMappingViewModelTest {
         override fun getControlTab(consoleId: String): String =
             if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
         override fun setControlTab(consoleId: String, tab: String) {}
+        override fun getConsoleListGrouping(): String = "generation"
+        override fun setConsoleListGrouping(grouping: String) {}
     }
 
     private class FakeKeyMappingRepository : KeyMappingRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -328,6 +328,8 @@ class StubPreferencesRepository : PreferencesRepository {
     override fun getControlTab(consoleId: String): String =
         if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
     override fun setControlTab(consoleId: String, tab: String) {}
+    override fun getConsoleListGrouping(): String = "generation"
+    override fun setConsoleListGrouping(grouping: String) {}
 }
 
 class StubAchievementsRepository : AchievementsRepository {

--- a/web/src/components/ui/__tests__/segmented-control.test.tsx
+++ b/web/src/components/ui/__tests__/segmented-control.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { SegmentedControl } from "../segmented-control";
+
+const options = [
+  { value: "a", label: "Alpha", testId: "seg-a" },
+  { value: "b", label: "Bravo", testId: "seg-b" },
+  { value: "c", label: "Charlie", testId: "seg-c" },
+] as const;
+
+function setup(initial: "a" | "b" | "c" = "a") {
+  const onChange = vi.fn();
+  render(
+    <SegmentedControl
+      options={options as unknown as { value: "a" | "b" | "c"; label: string; testId: string }[]}
+      value={initial}
+      onChange={onChange}
+      label="Pick one"
+      testId="seg"
+    />,
+  );
+  return { onChange };
+}
+
+describe("SegmentedControl", () => {
+  it("renders a radiogroup with one radio per option", () => {
+    setup();
+    const group = screen.getByRole("radiogroup");
+    expect(group).toBeInTheDocument();
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(3);
+  });
+
+  it("marks the selected option with aria-checked=true and the rest false", () => {
+    setup("b");
+    expect(screen.getByTestId("seg-a")).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByTestId("seg-b")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("seg-c")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("only the selected segment is a tab stop", () => {
+    setup("b");
+    expect(screen.getByTestId("seg-a")).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByTestId("seg-b")).toHaveAttribute("tabindex", "0");
+    expect(screen.getByTestId("seg-c")).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("clicking a segment calls onChange with its value", async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup("a");
+    await user.click(screen.getByTestId("seg-c"));
+    expect(onChange).toHaveBeenCalledWith("c");
+  });
+
+  it("ArrowRight moves selection forward", async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup("a");
+    screen.getByTestId("seg-a").focus();
+    await user.keyboard("{ArrowRight}");
+    expect(onChange).toHaveBeenLastCalledWith("b");
+  });
+
+  it("ArrowLeft moves selection backward", async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup("b");
+    screen.getByTestId("seg-b").focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(onChange).toHaveBeenLastCalledWith("a");
+  });
+
+  it("ArrowRight wraps from last to first", async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup("c");
+    screen.getByTestId("seg-c").focus();
+    await user.keyboard("{ArrowRight}");
+    expect(onChange).toHaveBeenLastCalledWith("a");
+  });
+
+  it("ArrowLeft wraps from first to last", async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup("a");
+    screen.getByTestId("seg-a").focus();
+    await user.keyboard("{ArrowLeft}");
+    expect(onChange).toHaveBeenLastCalledWith("c");
+  });
+
+  it("Home jumps to the first option", async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup("c");
+    screen.getByTestId("seg-c").focus();
+    await user.keyboard("{Home}");
+    expect(onChange).toHaveBeenLastCalledWith("a");
+  });
+
+  it("End jumps to the last option", async () => {
+    const user = userEvent.setup();
+    const { onChange } = setup("a");
+    screen.getByTestId("seg-a").focus();
+    await user.keyboard("{End}");
+    expect(onChange).toHaveBeenLastCalledWith("c");
+  });
+
+  it("uses ariaLabel when no visible label is provided", () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl
+        options={options as unknown as { value: "a" | "b" | "c"; label: string }[]}
+        value="a"
+        onChange={onChange}
+        ariaLabel="Pick a letter"
+      />,
+    );
+    const group = screen.getByRole("radiogroup");
+    expect(group).toHaveAttribute("aria-label", "Pick a letter");
+  });
+
+  it("renders the visible label and links it via aria-labelledby", () => {
+    setup();
+    const group = screen.getByRole("radiogroup");
+    const labelEl = screen.getByText("Pick one");
+    expect(labelEl).toBeInTheDocument();
+    expect(group).toHaveAttribute("aria-labelledby", labelEl.id);
+  });
+});

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -30,5 +30,7 @@ export { LeaderboardRow } from "./leaderboard-row";
 export { FilterChip } from "./filter-chip";
 export { Chip, ChipPicker } from "./chip";
 export type { ChipPickerOption } from "./chip";
+export { SegmentedControl } from "./segmented-control";
+export type { SegmentedControlProps } from "./segmented-control";
 export { Divider } from "./divider";
 export { ProgressBar } from "./progress-bar";

--- a/web/src/components/ui/segmented-control.tsx
+++ b/web/src/components/ui/segmented-control.tsx
@@ -1,0 +1,165 @@
+import { useRef, useId } from "react";
+import { cn } from "@/lib/cn";
+
+// DESIGN component — a view-switcher over a closed set of
+// mutually-exclusive options.
+//
+// Use this whenever the user picks one of N "shapes" the same screen
+// can take (group by generation vs manufacturer, list vs grid view,
+// week vs month range, …). Do NOT use it for selecting an item from a
+// long list — that's a `<Select>`. Do NOT use it for multi-select
+// filters — that's `<ChipPicker>`.
+//
+// The previous pattern of "two adjacent `<Chip>` toggles" looked
+// passive (chips read as metadata) and didn't carry the right ARIA —
+// see #1176 for the writeup.
+//
+// Accessibility:
+// - The whole control is a single radiogroup with one tab stop.
+// - Arrow keys / Home / End move *roving focus* between segments and
+//   simultaneously change the selected value (instant-apply — there's
+//   nowhere "applied later" for this control to live).
+// - `aria-checked` on each segment reflects the selected value.
+// - When [label] is provided we render a visible <span> and link via
+//   `aria-labelledby`. Otherwise [ariaLabel] is set via `aria-label`.
+
+interface SegmentedControlOption<T extends string> {
+  value: T;
+  label: React.ReactNode;
+  /** Test id forwarded to the segment button. */
+  testId?: string;
+}
+
+export interface SegmentedControlProps<T extends string> {
+  options: SegmentedControlOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  /** Visible label, e.g. "Group by:". Rendered alongside the control. */
+  label?: React.ReactNode;
+  /**
+   * Programmatic label for screen readers when no visible label is shown.
+   * One of [label] or [ariaLabel] must be supplied.
+   */
+  ariaLabel?: string;
+  testId?: string;
+  className?: string;
+}
+
+export function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+  label,
+  ariaLabel,
+  testId,
+  className,
+}: SegmentedControlProps<T>) {
+  const labelId = useId();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selectedIndex = Math.max(
+    0,
+    options.findIndex((o) => o.value === value),
+  );
+
+  const moveBy = (delta: number) => {
+    if (options.length === 0) return;
+    const next = (selectedIndex + delta + options.length) % options.length;
+    onChange(options[next].value);
+    // Move actual DOM focus to keep the visible focus ring in sync.
+    const buttons = containerRef.current?.querySelectorAll<HTMLButtonElement>(
+      "[role=radio]",
+    );
+    buttons?.[next]?.focus();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    switch (event.key) {
+      case "ArrowLeft":
+      case "ArrowUp":
+        event.preventDefault();
+        moveBy(-1);
+        break;
+      case "ArrowRight":
+      case "ArrowDown":
+        event.preventDefault();
+        moveBy(1);
+        break;
+      case "Home":
+        event.preventDefault();
+        if (options[0]) onChange(options[0].value);
+        break;
+      case "End":
+        event.preventDefault();
+        if (options.length > 0) onChange(options[options.length - 1].value);
+        break;
+    }
+  };
+
+  return (
+    <div
+      data-comp="SegmentedControl"
+      data-testid={testId}
+      className={cn("inline-flex items-center gap-2", className)}
+    >
+      {label && (
+        <span
+          id={labelId}
+          className="text-sm font-medium text-surface-300"
+        >
+          {label}
+        </span>
+      )}
+      <div
+        ref={containerRef}
+        role="radiogroup"
+        aria-labelledby={label ? labelId : undefined}
+        aria-label={!label ? ariaLabel : undefined}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          // Connected track — single rounded container with internal
+          // separators handled by the segment buttons themselves
+          // (rounded corners only on the ends, border between
+          // segments).
+          "inline-flex items-stretch rounded-full bg-surface-900 p-0.5 border border-surface-800",
+        )}
+      >
+        {options.map((opt, i) => {
+          const isSelected = opt.value === value;
+          // Only the selected segment is a tab stop — arrow keys move
+          // roving focus across the others. This is the WAI-ARIA
+          // "radiogroup" pattern.
+          const tabIndex = isSelected ? 0 : -1;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              tabIndex={tabIndex}
+              data-testid={opt.testId}
+              onClick={() => onChange(opt.value)}
+              className={cn(
+                "relative px-4 py-2 rounded-full text-sm font-medium transition-colors cursor-pointer",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950",
+                // ≥44px tall comes from py-2 (8px) + text-sm line-height
+                // (20px) + the parent track's p-0.5 = 0.5+8+20+8+0.5 ≈
+                // 37px button, 41-42px outer including padding. Bump if
+                // tooling reports below WCAG AA touch-target on the
+                // narrowest viewport.
+                isSelected
+                  ? "bg-brand-600 text-white shadow-sm"
+                  : "text-surface-300 hover:text-surface-100 hover:bg-surface-800",
+                // Subtle visual separation between adjacent segments
+                // when neither is selected — a 1px divider that fades
+                // when the segment becomes the selected one.
+                !isSelected && i > 0 && "before:absolute before:left-0 before:top-1/4 before:h-1/2 before:w-px before:bg-surface-700",
+              )}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/consoles-page.tsx
+++ b/web/src/pages/consoles-page.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Gamepad2 } from "lucide-react";
 import { ConsoleCard } from "@/components/console-card";
-import { Chip, ConsoleCardSkeleton, EmptyState } from "@/components/ui";
+import { ConsoleCardSkeleton, EmptyState, SegmentedControl } from "@/components/ui";
 import { useBiosStatus } from "@/hooks/use-bios";
 import { useConsoles } from "@/hooks/use-consoles";
 import { PageLayout, SectionList } from "@/components/layout";
@@ -65,27 +65,24 @@ export function ConsolesPage() {
         />
       ) : (
         <div className="space-y-8">
-          <div
-            data-testid="console-grouping-toggle"
-            className="flex items-center gap-2"
-            role="group"
-            aria-label="Console grouping"
-          >
-            <Chip
-              data-testid="console-grouping-generation"
-              selected={grouping === "generation"}
-              onClick={() => setGrouping("generation")}
-            >
-              By generation
-            </Chip>
-            <Chip
-              data-testid="console-grouping-manufacturer"
-              selected={grouping === "manufacturer"}
-              onClick={() => setGrouping("manufacturer")}
-            >
-              By manufacturer
-            </Chip>
-          </div>
+          <SegmentedControl<ConsoleGrouping>
+            testId="console-grouping-toggle"
+            label="Group by:"
+            value={grouping}
+            onChange={setGrouping}
+            options={[
+              {
+                value: "generation",
+                label: "Generation",
+                testId: "console-grouping-generation",
+              },
+              {
+                value: "manufacturer",
+                label: "Manufacturer",
+                testId: "console-grouping-manufacturer",
+              },
+            ]}
+          />
           {groups.map((group) => (
             <section key={group.key}>
               <div className="flex items-baseline gap-3 mb-4">


### PR DESCRIPTION
Closes #1176 (with Issue A already merged in #1178).

## What

New Design-layer primitives — web `SegmentedControl` + player `SpSegmentedControl` — for view-switchers over a closed set of mutually-exclusive options. Migrate the consoles-list grouping toggle on both clients to use them, and persist the player choice device-locally so the user's pick survives screen disposal.

## Why the chip primitive was wrong for the job

The Consoles screen's grouping toggle was *two adjacent chips*. Chips are passive metadata in this design system (region, status, rarity). Using them as a primary "switch how the entire screen is organised" affordance meant on the AYN Thor handheld they were visually indistinguishable from the region/status chips on the cards below them — the control didn't read as a control. The segmented-control shape (connected pill, brand-filled active segment) is the textbook fit.

## What ships

**Web `SegmentedControl`** — `web/src/components/ui/segmented-control.tsx`
- `role="radiogroup"`, segments `role="radio"` + `aria-checked`
- Single tab stop; arrow keys + Home/End cycle selected value (instant apply)
- 12 vitest cases covering ARIA, keyboard nav, wrap-around, label

**Player `SpSegmentedControl`** — `player/shared/.../components/SpSegmentedControl.kt`
- Generic over T (works with the existing `ConsoleGrouping` enum)
- 48dp tall, connected `RoundedCornerShape` pill, brand-filled active segment (deliberately stronger than `SpChip`'s 15%-alpha selected tint — a primary switcher needs the choice to read at a glance on bright handheld screens)
- White focus ring matching the rest of the gamepad-nav vocabulary
- `Role.RadioButton` + `selected=true` semantics on the active segment

**Grouping persistence on player**
- `PreferencesRepository` gains `getConsoleListGrouping` / `setConsoleListGrouping` (device-local, SQLite-backed via the existing `DeviceSetting` table — same pattern as `orientation_lock` and `control_tab:*`).
- `LibraryConsolesTab` seeds its grouping state from the repo on first composition instead of always resetting to `Generation`, and writes every change back. Mirrors web's `localStorage["consoleListGrouping"]`.
- `preferencesRepository` plumbed through `SpelaAppDependencies` → `ScreenRouter` → `ConsolesScreen` → `LibraryConsolesTab`; 6 fake `PreferencesRepository` test implementations updated with the new stub methods.

**Migration of the actual toggle**
- Web `consoles-page.tsx`: two `<Chip>`s become one `<SegmentedControl>`. `data-testid` values preserved.
- Player `LibraryConsolesTab.kt`: two `SpChip`s become one `SpSegmentedControl`. `testTag` values preserved so the existing `GamepadNavigationTest` assertions still resolve.

## Out of scope

Auditing every other `Chip` / `SpChip` call site and migrating the ones that are actually view-switchers (sort-order toggles, view-mode switchers) rather than metadata. Issue #1176 mentions this as the next pass; defer.

## Test plan

- [x] 12 new vitest cases for `SegmentedControl`
- [x] All 1614+ web tests pass; `npm run build` clean
- [x] `./gradlew :shared:desktopTest :desktop:desktopTest` clean (10m32s)
- [ ] Manual on AYN Thor: open Consoles, see "Group by" label + filled-pill control, DPad left/right cycles selection, pick Manufacturer, navigate away, return — selection survives.
- [ ] Manual on web: hover the segments (pointer cursor + brand-on-hover), Tab into → see focus ring, ←/→ to switch, refresh → selection survives.