### PR TITLE
perf(server) + player polish: 10-endpoint perf sweep, game-detail cache, focus-ring sweep

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/cache/GameDetailCache.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/cache/GameDetailCache.kt
@@ -1,0 +1,46 @@
+package com.spela.player.data.cache
+
+import com.spela.player.domain.model.GameDetail
+
+/**
+ * Process-wide in-memory cache of the most recently observed
+ * [GameDetail] for each gameId. Populated whenever the
+ * [com.spela.player.presentation.viewmodel.GameDetailViewModel] writes
+ * a fresh detail into its on-screen state — load success, scrape
+ * refresh, favourite toggle, etc.
+ *
+ * Read by `loadGame(...)` at screen entry: if the entry exists, the
+ * cached detail is shown *immediately* while a fresh network fetch is
+ * fired in the background. By the time the fetch returns, the user
+ * has already been looking at correct (or near-correct) data for
+ * hundreds of ms — instead of a skeleton.
+ *
+ * Lifetime: in-memory only, dies with the JVM. No TTL — we trust the
+ * fresh-fetch-on-every-visit to correct any drift, and the write-
+ * through pattern means cache entries reflect on-screen truth as long
+ * as the ViewModel routes its `gameDetail` mutations through
+ * [GameDetailViewModel.mutateGameDetail] (see that helper for the
+ * discipline).
+ *
+ * Thread-safety: reads and writes both happen on the Compose
+ * composition / main thread or on `Dispatchers.IO` collected back
+ * into the StateFlow. We use a synchronized map to avoid a published-
+ * but-not-yet-readable window without paying for a full concurrent
+ * collection's allocator overhead — game-detail mutations are rare
+ * enough that the lock contention is negligible.
+ */
+object GameDetailCache {
+    private val entries = mutableMapOf<String, GameDetail>()
+    private val lock = Any()
+
+    fun get(gameId: String): GameDetail? = synchronized(lock) { entries[gameId] }
+
+    fun put(gameId: String, detail: GameDetail) {
+        synchronized(lock) { entries[gameId] = detail }
+    }
+
+    /** Test-only — clears every entry. Production code never needs this. */
+    fun clear() {
+        synchronized(lock) { entries.clear() }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ApproachingVisible.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ApproachingVisible.kt
@@ -1,6 +1,5 @@
 package com.spela.player.presentation.ui.components
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ApproachingVisible.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ApproachingVisible.kt
@@ -1,0 +1,57 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Fires [onApproach] exactly once when the modified composable is
+ * within [buffer] dp of the window's bottom edge — i.e. has either
+ * entered the viewport or is just about to.
+ *
+ * Use for lazy data fetches that should only run when the user has
+ * actually scrolled (or is about to scroll) the section into view —
+ * the canonical example is `/api/games/{id}/similar` on the
+ * game-detail screen, which sits below screenshots and isn't
+ * something most users see.
+ *
+ * Implementation: an [onGloballyPositioned] callback reads the
+ * composable's [positionInRoot] Y and compares it against the
+ * window height from [LocalWindowInfo]. The callback de-dupes
+ * itself with a `fired` flag so [onApproach] only ever runs once
+ * per composition lifetime — re-mount (e.g. screen re-entered)
+ * resets the flag.
+ */
+fun Modifier.onApproachingVisible(
+    buffer: Dp = 200.dp,
+    onApproach: () -> Unit,
+): Modifier = composed {
+    val density = LocalDensity.current
+    val windowHeightPx = LocalWindowInfo.current.containerSize.height.toFloat()
+    val bufferPx = with(density) { buffer.toPx() }
+    var fired by remember { mutableStateOf(false) }
+
+    onGloballyPositioned { coords ->
+        if (fired) return@onGloballyPositioned
+        // positionInRoot is the composable's top-left in window
+        // coordinates. If that y is <= viewportHeight + buffer the
+        // composable is within (or just past) the visible region.
+        // We compare top edge only — for "section is about to enter
+        // the viewport from below" that's exactly the right signal.
+        val topY = coords.positionInRoot().y
+        if (topY <= windowHeightPx + bufferPx) {
+            fired = true
+            onApproach()
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/EmulationActionButton.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/EmulationActionButton.kt
@@ -84,7 +84,7 @@ fun EmulationActionButton(
                 indication = null,
                 onClick = onClick,
             )
-            .then(if (useFocusRing) Modifier.gamepadFocusable(shape = RoundedCornerShape(16.dp), addFocusable = false) else Modifier)
+            .then(if (useFocusRing) Modifier.gamepadFocusable(shape = RoundedCornerShape(16.dp), interactionSource = interactionSource, addFocusable = false) else Modifier)
             .semantics {
                 contentDescription = label
                 role = Role.Button

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
@@ -18,13 +18,20 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import com.spela.player.presentation.ui.gamepad.LazyListCenterInfo
+import com.spela.player.presentation.ui.gamepad.LocalLazyListCenterInfo
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -141,11 +148,24 @@ private fun LandscapeLayout(
     val coverMaxHeight = if (isCompact) 240.dp else 300.dp
     val bannerHeight = coverMaxHeight + SpSpacing.TopBarHeight + SpSpacing.Large
 
+    // Vertical centring of focused descendants (see #1180/#1182).
+    // gamepadFocusable.centerOnFocus reads LocalLazyListCenterInfo to
+    // scroll this LazyColumn so the focused element (a card inside a
+    // carousel, a session row, a Top Player, a metadata link) lands
+    // at the viewport's vertical centre. Without this provider the
+    // centerOnFocus branch no-ops on this screen.
+    val landscapeListState = rememberLazyListState()
+    val landscapeCenterInfo = remember(landscapeListState) { LazyListCenterInfo(landscapeListState) }
+    CompositionLocalProvider(LocalLazyListCenterInfo provides landscapeCenterInfo) {
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
+            state = landscapeListState,
             modifier = Modifier
                 .fillMaxSize()
-                .testTag("game_detail_content"),
+                .testTag("game_detail_content")
+                .onGloballyPositioned { coordinates ->
+                    landscapeCenterInfo.containerTopInRoot = coordinates.positionInRoot().y
+                },
             contentPadding = PaddingValues(bottom = verticalPad),
         ) {
             // Hero banner — full-width with hero art
@@ -293,6 +313,7 @@ private fun LandscapeLayout(
         // Floating top bar overlaid on content
         topBar()
     }
+    }
 }
 
 @Composable
@@ -309,9 +330,18 @@ private fun PortraitLayout(
 ) {
     // Banner height is dynamic — wraps content (cover art + info box)
 
+    val portraitListState = rememberLazyListState()
+    val portraitCenterInfo = remember(portraitListState) { LazyListCenterInfo(portraitListState) }
+    CompositionLocalProvider(LocalLazyListCenterInfo provides portraitCenterInfo) {
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
-            modifier = Modifier.fillMaxSize().testTag("game_detail_content"),
+            state = portraitListState,
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("game_detail_content")
+                .onGloballyPositioned { coordinates ->
+                    portraitCenterInfo.containerTopInRoot = coordinates.positionInRoot().y
+                },
         ) {
             // Hero banner item
             item {
@@ -423,5 +453,6 @@ private fun PortraitLayout(
 
         // Floating top bar overlaid on content
         topBar()
+    }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenLoadingIndicator.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenLoadingIndicator.kt
@@ -65,7 +65,12 @@ const val MinLoadingShownMs: Long = 300
 fun ScreenLoadingIndicator(
     modifier: Modifier = Modifier,
     message: String? = null,
-    color: Color = SpColor.Primary,
+    // Light grey by default. The brand purple ([SpColor.Primary]) read
+    // as "an accent/CTA colour" in the middle of a loading-state
+    // screen — a generic "the app is thinking" indicator should be
+    // neutral so the brand colour stays reserved for things the user
+    // can act on.
+    color: Color = SpColor.OnBackgroundSecondary,
 ) {
     val animationsEnabled = LocalAnimationsEnabled.current
     var visible by remember { mutableStateOf(!animationsEnabled) }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenshotLightbox.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenshotLightbox.kt
@@ -177,8 +177,10 @@ fun ScreenshotLightbox(
                 )
 
                 // Close button
+                val closeInteractionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
                 IconButton(
                     onClick = onDismiss,
+                    interactionSource = closeInteractionSource,
                     colors = IconButtonDefaults.iconButtonColors(
                         containerColor = NavButtonColor,
                         contentColor = NavButtonContentColor,
@@ -186,7 +188,11 @@ fun ScreenshotLightbox(
                     modifier = Modifier
                         .align(Alignment.TopEnd)
                         .padding(SpSpacing.Medium)
-                        .gamepadFocusable(shape = androidx.compose.foundation.shape.CircleShape),
+                        .gamepadFocusable(
+                            shape = androidx.compose.foundation.shape.CircleShape,
+                            interactionSource = closeInteractionSource,
+                            addFocusable = false,
+                        ),
                 ) {
                     Icon(Icons.Filled.Close, "Close", Modifier.size(24.dp))
                 }
@@ -200,25 +206,37 @@ fun ScreenshotLightbox(
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     val hasPrev = pagerState.currentPage > 0
+                    val prevInteractionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
                     IconButton(
                         onClick = { coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) } },
                         enabled = hasPrev,
+                        interactionSource = prevInteractionSource,
                         colors = IconButtonDefaults.iconButtonColors(
                             containerColor = NavButtonColor, contentColor = NavButtonContentColor,
                             disabledContainerColor = NavButtonDisabledColor, disabledContentColor = NavButtonDisabledContentColor,
                         ),
-                        modifier = Modifier.gamepadFocusable(shape = androidx.compose.foundation.shape.CircleShape),
+                        modifier = Modifier.gamepadFocusable(
+                            shape = androidx.compose.foundation.shape.CircleShape,
+                            interactionSource = prevInteractionSource,
+                            addFocusable = false,
+                        ),
                     ) { Icon(Icons.AutoMirrored.Filled.KeyboardArrowLeft, "Previous", Modifier.size(36.dp)) }
 
                     val hasNext = pagerState.currentPage < screenshotUrls.size - 1
+                    val nextInteractionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
                     IconButton(
                         onClick = { coroutineScope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) } },
                         enabled = hasNext,
+                        interactionSource = nextInteractionSource,
                         colors = IconButtonDefaults.iconButtonColors(
                             containerColor = NavButtonColor, contentColor = NavButtonContentColor,
                             disabledContainerColor = NavButtonDisabledColor, disabledContentColor = NavButtonDisabledContentColor,
                         ),
-                        modifier = Modifier.gamepadFocusable(shape = androidx.compose.foundation.shape.CircleShape),
+                        modifier = Modifier.gamepadFocusable(
+                            shape = androidx.compose.foundation.shape.CircleShape,
+                            interactionSource = nextInteractionSource,
+                            addFocusable = false,
+                        ),
                     ) { Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, "Next", Modifier.size(36.dp)) }
                 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
@@ -264,9 +264,24 @@ fun SpCarousel(
         contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
         horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
     ) {
+        // Pre-compute keys so we can verify uniqueness — duplicate
+        // keys crash LazyRow with "Key '<x>' was already used". Most
+        // shelf data is naturally unique-by-id but social shelves
+        // ("recently reviewed" etc.) can show the same game multiple
+        // times. When we detect a collision we fall back to positional
+        // keys (null), which loses cross-recomposition item identity
+        // but keeps the screen alive. The call site should fix its
+        // itemKey to be properly unique (composite); the fallback is
+        // just a "don't crash production" safety net.
+        val keys: List<Any>? = if (itemKey != null) {
+            val list = ArrayList<Any>(itemCount)
+            for (i in 0 until itemCount) list.add(itemKey(i))
+            if (list.toSet().size == list.size) list else null
+        } else null
+
         items(
             count = itemCount,
-            key = if (itemKey != null) { i -> itemKey(i) } else null,
+            key = if (keys != null) { i -> keys[i] } else null,
         ) { i ->
             val restoreKey = if (memoryKey != null && itemKey != null) {
                 "$memoryKey/${itemKey(i)}"

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
@@ -1,9 +1,13 @@
 package com.spela.player.presentation.ui.components
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
@@ -129,52 +133,73 @@ fun SpCarousel(
         val target = pendingTarget
         if (target < 0) return@LaunchedEffect
         val now = System.currentTimeMillis()
-        // Rapid threshold matches typical held-d-pad cadence (~150–200ms
-        // between events). Anything quicker than 250ms snaps instead of
-        // animating, otherwise each new press would cancel the previous
-        // animation mid-flight and the carousel would never converge to
-        // a centred position.
-        val isRapid = now - lastFocusChangeTime < 250
+        // Three-tier classifier keyed on the time gap since the last
+        // d-pad press. The user's intent is the signal: a single
+        // deliberate press gets the full spring; a few quick taps get
+        // a snappy linear tween; a held d-pad fires events too fast to
+        // animate at all, so we snap. Thresholds are tuned for typical
+        // gamepad / keyboard cadence (≈150–250ms held, ≈300–500ms
+        // deliberate).
+        val gap = now - lastFocusChangeTime
         lastFocusChangeTime = now
+        val mode = when {
+            gap < 100  -> ScrollMode.Snap
+            gap < 250  -> ScrollMode.Fast
+            else       -> ScrollMode.Slow
+        }
 
-        // animateScrollToItem(index, scrollOffset) is idempotent under
-        // cancellation — each call retargets from the current scroll
-        // position. animateScrollBy(delta) sucks under rapid presses
-        // because the delta is computed once at launch and a subsequent
-        // press recomputes from a partially-scrolled state, accumulating
-        // error.
+        // Centring math. For animateScrollToItem (Snap + Slow) we need
+        // a scrollOffset such that the item lands at viewport centre:
+        // scrollOffset = -((viewportSize - itemSize) / 2). Per Compose
+        // convention positive scrollOffset shifts the item further
+        // toward viewport start; negative shifts it further from start,
+        // which is what we want for centring.
         //
-        // To centre: scrollOffset = -((viewportSize - itemSize) / 2).
-        // Positive scrollOffset shifts the item further toward viewport
-        // start (per Compose convention); negative shifts it further
-        // from start, which is what we want for centring.
+        // For Fast we use animateScrollBy(delta, tween) — animateScroll-
+        // ToItem doesn't expose an AnimationSpec parameter, and we need
+        // one to dial the duration down to ~120 ms. The delta math is
+        // the natural sibling: delta = itemCenter - viewportCenter,
+        // where positive delta scrolls forward (items move left in
+        // viewport, item shifts toward centre when it was to the
+        // right). scrollBy auto-clamps at the list ends, same as
+        // scrollToItem does.
         val info = listState.layoutInfo
         val viewportSize = info.viewportEndOffset - info.viewportStartOffset
-        val itemSize = info.visibleItemsInfo.firstOrNull { it.index == target }?.size
+        val targetItem = info.visibleItemsInfo.firstOrNull { it.index == target }
+        val itemSize = targetItem?.size
             ?: info.visibleItemsInfo.firstOrNull()?.size
             ?: 0
         val centerOffset = if (itemSize in 1..<viewportSize) {
             -((viewportSize - itemSize) / 2)
         } else 0
 
-        val targetVisible = info.visibleItemsInfo.any { it.index == target }
+        val targetVisible = targetItem != null
         if (targetVisible) {
             // Common path. Focus snaps immediately because the requester
-            // is bound to a layout node; carousel pans in to centre.
+            // is bound to a layout node; the carousel pans in to centre.
             try { requesters[target].requestFocus() } catch (_: Exception) {}
-            if (isRapid) {
-                listState.scrollToItem(target, centerOffset)
-            } else {
-                listState.animateScrollToItem(target, centerOffset)
+            when (mode) {
+                ScrollMode.Snap -> listState.scrollToItem(target, centerOffset)
+                ScrollMode.Fast -> {
+                    val delta = centerDelta(info, target)
+                    if (delta != null) {
+                        listState.animateScrollBy(delta, tween(120, easing = LinearEasing))
+                    } else {
+                        listState.scrollToItem(target, centerOffset)
+                    }
+                }
+                ScrollMode.Slow -> listState.animateScrollToItem(target, centerOffset)
             }
         } else {
             // Slow path — target outside the prefetch window. Scroll
             // first so the LazyRow composes its layout node, then
-            // requestFocus.
-            if (isRapid) {
-                listState.scrollToItem(target, centerOffset)
-            } else {
-                listState.animateScrollToItem(target, centerOffset)
+            // requestFocus. The Fast tier collapses into Slow here:
+            // animateScrollBy needs the target's measured offset which
+            // we don't have until it's composed, so just take the
+            // slower-but-correct path.
+            when (mode) {
+                ScrollMode.Snap -> listState.scrollToItem(target, centerOffset)
+                else -> listState.animateScrollToItem(target, centerOffset)
             }
             kotlinx.coroutines.yield()
             try { requesters[target].requestFocus() } catch (_: Exception) {}
@@ -277,6 +302,41 @@ fun SpCarousel(
             }
         }
     }
+}
+
+/**
+ * Scroll animation tier picked by the gap since the last d-pad press.
+ *
+ * - [Slow] — single deliberate press (>250 ms gap). Uses the default
+ *   spring animation via `animateScrollToItem`.
+ * - [Fast] — a few quick taps (100–250 ms gap). Uses `animateScrollBy`
+ *   with a 120 ms linear tween for a snappy, businesslike feel.
+ * - [Snap] — held d-pad / repeating keys (<100 ms gap). No animation
+ *   at all; each press jumps instantly to the centred target.
+ */
+private enum class ScrollMode { Slow, Fast, Snap }
+
+/**
+ * The horizontal `scrollBy` delta that would centre the item at
+ * [targetIndex] in the LazyRow's viewport, or null when the item isn't
+ * currently measured (typically: outside the prefetch window).
+ *
+ * Positive delta scrolls the list forward (items move left in
+ * viewport) — appropriate when the item is to the right of viewport
+ * centre. Negative delta scrolls backward. `LazyListState.scrollBy`
+ * auto-clamps at list ends, so we don't need to special-case the
+ * leftmost / rightmost items.
+ */
+private fun centerDelta(
+    info: androidx.compose.foundation.lazy.LazyListLayoutInfo,
+    targetIndex: Int,
+): Float? {
+    val item = info.visibleItemsInfo.firstOrNull { it.index == targetIndex } ?: return null
+    val viewportSize = info.viewportEndOffset - info.viewportStartOffset
+    if (viewportSize <= 0) return null
+    val itemCenter = item.offset + item.size / 2f
+    val viewportCenter = info.viewportStartOffset + viewportSize / 2f
+    return itemCenter - viewportCenter
 }
 
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
@@ -103,34 +103,102 @@ fun SpCarousel(
     // Apply the latest pending target. Keyed on pendingTarget so a
     // mid-flight scroll is cancelled the moment the user advances
     // further along the carousel.
+    //
+    // Sequence:
+    //   1. requestFocus on the target's requester. For the common
+    //      adjacent-step case (d-pad right/left from a visible item)
+    //      the target sits in LazyRow's prefetch window, so its
+    //      requester is bound to a layout node and this works
+    //      synchronously — the focus ring snaps before any scroll
+    //      animation starts.
+    //   2. animateScrollBy enough to bring the focused item's centre
+    //      to the centre of the viewport. We read the item's offset
+    //      and size from layoutInfo.visibleItemsInfo, which is the
+    //      LazyRow equivalent of the old onGloballyPositioned tracking.
+    //   3. Slow path for off-screen jumps (focus restoration uses its
+    //      own LaunchedEffect above; this only fires when the key
+    //      handler itself targets something not yet composed): scroll
+    //      it in first, yield a frame, then requestFocus.
+    //
+    // Previously this LaunchedEffect did scrollToItem THEN requestFocus
+    // — the user saw the list pan first, then the focus ring catch up,
+    // and the focused item always settled on the viewport's left edge
+    // because scrollToItem(i) anchors to viewport start. Fixed in
+    // #1180 follow-up to #1168.
     LaunchedEffect(pendingTarget) {
         val target = pendingTarget
         if (target < 0) return@LaunchedEffect
         val now = System.currentTimeMillis()
-        val isRapid = now - lastFocusChangeTime < 100
+        // Rapid threshold matches typical held-d-pad cadence (~150–200ms
+        // between events). Anything quicker than 250ms snaps instead of
+        // animating, otherwise each new press would cancel the previous
+        // animation mid-flight and the carousel would never converge to
+        // a centred position.
+        val isRapid = now - lastFocusChangeTime < 250
         lastFocusChangeTime = now
-        if (isRapid) {
-            listState.scrollToItem(target)
+
+        // animateScrollToItem(index, scrollOffset) is idempotent under
+        // cancellation — each call retargets from the current scroll
+        // position. animateScrollBy(delta) sucks under rapid presses
+        // because the delta is computed once at launch and a subsequent
+        // press recomputes from a partially-scrolled state, accumulating
+        // error.
+        //
+        // To centre: scrollOffset = -((viewportSize - itemSize) / 2).
+        // Positive scrollOffset shifts the item further toward viewport
+        // start (per Compose convention); negative shifts it further
+        // from start, which is what we want for centring.
+        val info = listState.layoutInfo
+        val viewportSize = info.viewportEndOffset - info.viewportStartOffset
+        val itemSize = info.visibleItemsInfo.firstOrNull { it.index == target }?.size
+            ?: info.visibleItemsInfo.firstOrNull()?.size
+            ?: 0
+        val centerOffset = if (itemSize in 1..<viewportSize) {
+            -((viewportSize - itemSize) / 2)
+        } else 0
+
+        val targetVisible = info.visibleItemsInfo.any { it.index == target }
+        if (targetVisible) {
+            // Common path. Focus snaps immediately because the requester
+            // is bound to a layout node; carousel pans in to centre.
+            try { requesters[target].requestFocus() } catch (_: Exception) {}
+            if (isRapid) {
+                listState.scrollToItem(target, centerOffset)
+            } else {
+                listState.animateScrollToItem(target, centerOffset)
+            }
         } else {
-            listState.animateScrollToItem(target)
+            // Slow path — target outside the prefetch window. Scroll
+            // first so the LazyRow composes its layout node, then
+            // requestFocus.
+            if (isRapid) {
+                listState.scrollToItem(target, centerOffset)
+            } else {
+                listState.animateScrollToItem(target, centerOffset)
+            }
+            kotlinx.coroutines.yield()
+            try { requesters[target].requestFocus() } catch (_: Exception) {}
         }
-        kotlinx.coroutines.yield()
-        try { requesters[target].requestFocus() } catch (_: Exception) {}
     }
 
-    // Focus restoration: if the saved focus key belongs to one of this
-    // carousel's items, scroll the LazyRow so the item composes. The
-    // 120 ms layout-settle delay in focusRestoreItem then fires after
-    // composition has caught up, and requestFocus binds the requester.
+    // Focus restoration: if [LocalFocusMemory]'s saved key belongs to
+    // one of this carousel's items AT SCREEN ENTRY, scroll the LazyRow
+    // so the item composes. The 120 ms layout-settle delay in
+    // focusRestoreItem then fires after composition catches up, and
+    // requestFocus binds the requester.
     //
-    // [itemKey] is intentionally NOT in the key list — it's a lambda
-    // and lambdas compare by referential equality, so a fresh instance
-    // per recomposition would cancel + restart the effect on every
-    // frame, abort the in-flight `scrollToItem`, and leave the saved
-    // item uncomposed when focusRestoreItem's 120 ms timer fires.
+    // The saved key is captured ONCE at first composition. We must NOT
+    // re-fire this effect when [focusMemory.value] changes during the
+    // session — focusRestoreItem writes the scope on every focus
+    // change, and re-firing here would race against the d-pad
+    // keyhandler's animated centring scroll, clobbering it with an
+    // instant scrollToItem-to-viewport-start. The previous version
+    // keyed on `focusMemory.value` and was the cause of "carousel
+    // never animates + focused item always anchored to left edge".
     val focusMemory = LocalFocusMemory.current
-    LaunchedEffect(focusMemory?.value, itemCount, memoryKey) {
-        val savedKey = focusMemory?.value
+    val savedKeyAtEntry = remember { focusMemory?.value }
+    LaunchedEffect(itemCount, memoryKey) {
+        val savedKey = savedKeyAtEntry
         val keyFn = itemKey
         if (
             savedKey.isNullOrEmpty() ||
@@ -210,4 +278,5 @@ fun SpCarousel(
         }
     }
 }
+
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpFab.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpFab.kt
@@ -2,11 +2,13 @@ package com.spela.player.presentation.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -34,14 +36,28 @@ fun SpFab(
     size: Dp = 56.dp,
     iconSize: Dp = 24.dp,
 ) {
+    // Share one MutableInteractionSource between .clickable and
+    // .gamepadFocusable so spFocusRing sees the same focus events
+    // .clickable installs. Without this the focus ring never draws —
+    // see the canonical fix in MetadataGrid and the audit summary.
+    val interactionSource = remember { MutableInteractionSource() }
     Box(
         modifier = modifier
             .size(size)
             .shadow(8.dp, CircleShape)
             .clip(CircleShape)
             .background(Color.White.copy(alpha = 0.15f))
-            .clickable(onClick = onClick)
-            .gamepadFocusable(shape = CircleShape, scaleOnFocus = true, addFocusable = false)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
+            .gamepadFocusable(
+                shape = CircleShape,
+                scaleOnFocus = true,
+                interactionSource = interactionSource,
+                addFocusable = false,
+            )
             .semantics {
                 contentDescription = description
                 role = Role.Button

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpImage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpImage.kt
@@ -34,6 +34,34 @@ import kotlinx.coroutines.delay
 private const val DEFAULT_STAGGER_MS: Long = 1000L
 
 /**
+ * Process-wide set of image models (URL strings, mostly) that have
+ * completed at least one successful Coil load during this app session.
+ *
+ * Why this exists: when a card scrolls out of a LazyRow / LazyColumn
+ * viewport, Compose disposes the [SpImage] composable. When it scrolls
+ * back in, a *fresh* [SpImage] mounts — which means the `ready` state
+ * starts at `false` and the stagger timer re-runs from zero. Coil's
+ * memory cache still has the bitmap and would serve it in the same
+ * frame, but our artificial 0–[staggerMs] gate hides it behind a
+ * placeholder for up to a second.
+ *
+ * The set lets every [SpImage] short-circuit the stagger when it sees
+ * a model it (or some other instance) has already loaded successfully.
+ * Coil then serves the cached bitmap immediately and the user sees no
+ * flicker as cards scroll back into view.
+ *
+ * Lifetime: in-memory, dies with the JVM. There is no eviction policy
+ * — we only store the *fact* of a successful load, not the bitmap, so
+ * even at app scale (~thousands of distinct game covers) the memory
+ * cost is negligible (a Set of URL strings).
+ *
+ * Thread-safety: reads and writes both happen on the composition /
+ * main thread (Coil's `onSuccess` callback fires there by default).
+ * No need for a concurrent set.
+ */
+private val loadedModels = mutableSetOf<Any>()
+
+/**
  * DESIGN component — Spela's shared async image primitive.
  *
  * Every image-bearing surface in the app routes through this composable
@@ -98,11 +126,18 @@ fun SpImage(
     // `model`: if the URL changes (e.g. a card is recycled into a
     // different game), the timer restarts so we don't show a stale
     // placeholder while waiting for a leftover timer on a different URL.
+    //
+    // Short-circuit: if any earlier [SpImage] has already successfully
+    // loaded this model in the current process, skip the stagger and
+    // hand the URL to Coil immediately. Coil's memory cache returns
+    // the bitmap in the same frame, so a card scrolling back into a
+    // LazyRow viewport doesn't flash a placeholder.
+    val alreadyLoadedOnce = remember(model) { loadedModels.contains(model) }
     var ready by remember(model, staggerMs) {
-        mutableStateOf(staggerMs <= 0L)
+        mutableStateOf(alreadyLoadedOnce || staggerMs <= 0L)
     }
     LaunchedEffect(model, staggerMs) {
-        if (staggerMs > 0L && !ready) {
+        if (!alreadyLoadedOnce && staggerMs > 0L && !ready) {
             // Random.nextLong is half-open [0, bound). Add 1 so the
             // declared bound is inclusive — purely for tidiness, the
             // single-ms difference is irrelevant in practice.
@@ -122,7 +157,13 @@ fun SpImage(
                 contentScale = contentScale,
                 loading = { placeholder() },
                 error = { error() },
-                onSuccess = { state -> onSuccess?.invoke(state) },
+                onSuccess = { state ->
+                    // Remember this URL has succeeded so future SpImage
+                    // mounts (same URL, e.g. card scrolling back in)
+                    // skip the stagger and let Coil's cache do its job.
+                    loadedModels.add(model)
+                    onSuccess?.invoke(state)
+                },
             )
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpRadioOption.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpRadioOption.kt
@@ -1,6 +1,7 @@
 package com.spela.player.presentation.ui.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,6 +13,7 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
@@ -32,11 +34,20 @@ fun SpRadioOption(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .gamepadFocusable(shape = RoundedCornerShape(SpSpacing.RadiusLarge))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
+            .gamepadFocusable(
+                shape = RoundedCornerShape(SpSpacing.RadiusLarge),
+                interactionSource = interactionSource,
+                addFocusable = false,
+            )
             .semantics {
                 contentDescription = title
                 role = Role.RadioButton

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionLink.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionLink.kt
@@ -1,0 +1,75 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import com.spela.player.presentation.ui.gamepad.gamepadFocusable
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * DESIGN component — a link-shaped action that sits in the
+ * `titleTrailing` slot of an [SpTitledSection].
+ *
+ * Visually: brand-coloured `LabelLarge` text inside a small clip-padded
+ * tap target with the standard gamepad focus ring. Use this whenever a
+ * section's header has a "See all" / "Browse gallery" / "Edit"-style
+ * link in its top-right corner. Named after the *role* (header link of
+ * a section) rather than the purpose ("see all"), so future uses
+ * beyond pagination forwards have a consistent home.
+ *
+ * For heavier header-actions (a primary CTA button next to the title,
+ * like "New session" or "Edit showcase") prefer `SpButton` / its
+ * Ghost variant — those carry their own visual weight and shouldn't
+ * route through here.
+ *
+ * @param text Displayed label.
+ * @param onClick Invoked on click / Enter when focused.
+ * @param modifier Forwarded.
+ * @param contentDescription Screen-reader text. Defaults to [text].
+ *   Pass an enriched value when the same [text] (e.g. "See all")
+ *   appears on multiple sections in one screen — e.g.
+ *   `contentDescription = "See all Play Later"`.
+ */
+@Composable
+fun SpSectionLink(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Text(
+        text = text,
+        style = SpTypography.LabelLarge,
+        color = SpColor.Link,
+        modifier = modifier
+            .clip(RoundedCornerShape(SpSpacing.Small))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
+            .gamepadFocusable(
+                shape = RoundedCornerShape(SpSpacing.Small),
+                interactionSource = interactionSource,
+                addFocusable = false,
+            )
+            .padding(SpSpacing.Small)
+            .semantics {
+                this.contentDescription = contentDescription ?: text
+                role = Role.Button
+            },
+    )
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTopBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTopBar.kt
@@ -2,6 +2,7 @@ package com.spela.player.presentation.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -22,6 +23,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -70,14 +72,23 @@ fun SpTopBar(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (showBack) {
+                val backInteractionSource = remember { MutableInteractionSource() }
                 Box(
                     modifier = Modifier
                         .testTag(TestTags.BACK_BUTTON)
                         .size(48.dp)
                         .clip(CircleShape)
                         .background(if (onGradient) Color.Black.copy(alpha = 0.30f) else SpColor.SurfaceVariant)
-                        .clickable(onClick = onBack)
-                        .gamepadFocusable(shape = CircleShape)
+                        .clickable(
+                            interactionSource = backInteractionSource,
+                            indication = null,
+                            onClick = onBack,
+                        )
+                        .gamepadFocusable(
+                            shape = CircleShape,
+                            interactionSource = backInteractionSource,
+                            addFocusable = false,
+                        )
                         .semantics {
                             contentDescription = "Go back"
                             role = Role.Button

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/keymapping/ConsoleControllerVisual.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/keymapping/ConsoleControllerVisual.kt
@@ -183,6 +183,7 @@ private fun ControllerButton(
     val buttonWidth = containerWidth * region.widthFraction
     val buttonHeight = containerHeight * region.heightFraction
     val density = LocalDensity.current
+    val interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
 
     Box(
         modifier = Modifier
@@ -194,8 +195,16 @@ private fun ControllerButton(
             }
             .size(width = buttonWidth, height = buttonHeight)
             .clip(shape)
-            .clickable(onClick = onClick)
-            .gamepadFocusable(shape = shape)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
+            .gamepadFocusable(
+                shape = shape,
+                interactionSource = interactionSource,
+                addFocusable = false,
+            )
             .semantics {
                 contentDescription = if (mappedKeyLabel != null) {
                     "$label mapped to $mappedKeyLabel"

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/social/OnlineUsersRow.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/social/OnlineUsersRow.kt
@@ -2,6 +2,7 @@ package com.spela.player.presentation.ui.components.social
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.offset
@@ -9,8 +10,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -25,6 +28,7 @@ import com.spela.player.domain.model.OnlineUser
 import androidx.compose.ui.focus.focusRequester
 import com.spela.player.presentation.ui.components.SpAvatar
 import com.spela.player.presentation.ui.components.SpCarousel
+import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -61,14 +65,25 @@ private fun OnlineUserItem(
         "${user.username} online"
     }
 
+    val interactionSource = remember { MutableInteractionSource() }
     Column(
         modifier = modifier
             .width(64.dp)
+            .clip(RoundedCornerShape(SpSpacing.RadiusLarge))
             .semantics {
                 contentDescription = description
                 role = Role.Button
             }
-            .clickable { onUserSelected(user.id) },
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = { onUserSelected(user.id) },
+            )
+            .gamepadFocusable(
+                shape = RoundedCornerShape(SpSpacing.RadiusLarge),
+                interactionSource = interactionSource,
+                addFocusable = false,
+            ),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Box(modifier = Modifier.size(48.dp)) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/SocialDiscoverySection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/SocialDiscoverySection.kt
@@ -155,7 +155,12 @@ fun RecentlyReviewedSection(
         itemCount = reviews.size,
         modifier = modifier.testTag("recently_reviewed_row"),
         memoryKey = "explore_recently_reviewed",
-        itemKey = { reviews[it].game.id },
+        // Composite key — the same game can be reviewed by multiple
+        // friends in the same window, so `game.id` alone produces
+        // duplicates and crashes LazyRow with "Key was already used".
+        // Reviewer + timestamp + game makes each row unique even when
+        // reviews of the same game stack up.
+        itemKey = { val r = reviews[it]; "${r.reviewerName}_${r.reviewedAt}_${r.game.id}" },
     ) { index, focusRequester ->
         val item = reviews[index]
         Column(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameCommunityStatsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameCommunityStatsSection.kt
@@ -1,7 +1,6 @@
 package com.spela.player.presentation.ui.feature.gamedetail
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -135,9 +134,16 @@ private fun TopPlayerRow(
         else -> SpColor.OnBackgroundTertiary
     }
 
-    SpInnerCard(modifier = modifier.then(
-        if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier
-    )) {
+    // SpInnerCard handles its own focus mechanics correctly when given
+    // the `onClick` parameter — its internal clickable + gamepadFocusable
+    // share a single MutableInteractionSource. The previous pattern
+    // wrapped `.clickable` around the outer modifier, which bypassed
+    // SpInnerCard's internal focus wiring entirely and produced an
+    // invisible focus ring (#1176 audit follow-up).
+    SpInnerCard(
+        modifier = modifier,
+        onClick = onClick,
+    ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameInfoContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameInfoContent.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.semantics.semantics
 import com.spela.player.domain.model.BiosMissingFile
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.GameDetail
+import com.spela.player.domain.model.GameVariant
 import com.spela.player.presentation.state.GameDetailState
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -128,10 +129,32 @@ fun GameInfoContent(
 
     if (versionVariants.isNotEmpty()) {
         Spacer(Modifier.height(SpSpacing.Default))
+        // Prepend a synthetic GameVariant built from the current Game
+        // so the Versions list shows the full picture — including the
+        // one the user is looking at, marked with a "This game" chip
+        // inside the section. The prepend keeps the current version at
+        // the top so the user doesn't have to scan for context.
+        val versionsIncludingCurrent = buildList {
+            add(
+                GameVariant(
+                    id = game.id,
+                    title = game.title,
+                    fileName = game.fileName,
+                    region = game.region?.takeIf { it.isNotBlank() },
+                    revision = game.revision?.takeIf { it.isNotBlank() },
+                    tags = game.tags?.takeIf { it.isNotBlank() },
+                    isPreRelease = game.isPreRelease,
+                    fileSize = game.fileSize,
+                    verificationStatus = game.verificationStatus?.takeIf { it.isNotBlank() },
+                )
+            )
+            addAll(versionVariants)
+        }
         VariantsSection(
             title = "Versions",
-            variants = versionVariants,
+            variants = versionsIncludingCurrent,
             onVariantSelected = onNavigateToGame,
+            currentGameId = game.id,
         )
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
@@ -1,6 +1,7 @@
 package com.spela.player.presentation.ui.feature.gamedetail
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.shape.RoundedCornerShape
 import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import androidx.compose.foundation.layout.Arrangement
@@ -24,6 +25,7 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -131,13 +133,31 @@ private fun MetadataItem(
 ) {
     val secondaryColor = if (onGradient) androidx.compose.ui.graphics.Color.White.copy(alpha = 0.50f) else SpColor.OnBackgroundTertiary
     val isClickable = onClick != null
+    // Share one MutableInteractionSource between `.clickable` and
+    // `.gamepadFocusable`. Without this the two modifiers each install
+    // their own focus target with their own interaction source — focus
+    // lands on .clickable's target (you see the default Material
+    // darken), but gamepadFocusable's spFocusRing observes its OWN
+    // source and never fires. Net result: invisible focus ring.
+    // Same bug class is documented inline on `gamepadFocusable` (see
+    // #1096). With a shared source we also set `addFocusable = false`
+    // so we don't stack two focus targets.
+    val interactionSource = remember { MutableInteractionSource() }
     Row(
         modifier = modifier
             .padding(vertical = SpSpacing.XSmall)
             .then(
                 if (onClick != null) Modifier
-                    .clickable(onClick = onClick)
-                    .gamepadFocusable(shape = RoundedCornerShape(SpSpacing.Small))
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        onClick = onClick,
+                    )
+                    .gamepadFocusable(
+                        shape = RoundedCornerShape(SpSpacing.Small),
+                        interactionSource = interactionSource,
+                        addFocusable = false,
+                    )
                 else Modifier
             ),
         verticalAlignment = Alignment.CenterVertically,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
@@ -50,6 +50,7 @@ import com.spela.player.presentation.ui.components.SpStatusChip
 import com.spela.player.presentation.ui.components.SpInnerCard
 import com.spela.player.presentation.ui.components.SpPlayInfo
 import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -140,7 +141,15 @@ internal fun SessionsSection(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = SpSpacing.XXSmall),
+                    .padding(vertical = SpSpacing.XXSmall)
+                    // Capture this row in the screen's LocalFocusMemory
+                    // so back-nav from the SessionDetail screen restores
+                    // focus to the same session the user opened, rather
+                    // than falling back to the Play/Download button's
+                    // `isDefault = true`. Key is the session id so it
+                    // survives the list reordering on lastPlayedAt
+                    // updates.
+                    .focusRestoreItem(key = "game_detail_session_${session.id}"),
             )
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/VariantsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/VariantsSection.kt
@@ -20,6 +20,7 @@ import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpRegionChip
+import com.spela.player.presentation.ui.components.SpStatusChip
 import com.spela.player.presentation.ui.components.SpTitledSection
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -39,6 +40,7 @@ fun VariantsSection(
     title: String,
     variants: List<GameVariant>,
     onVariantSelected: ((String) -> Unit)?,
+    currentGameId: String? = null,
 ) {
     SpTitledSection(
         title = title,
@@ -47,8 +49,18 @@ fun VariantsSection(
             verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
         ) {
             variants.forEach { variant ->
+                val isCurrent = currentGameId != null && variant.id == currentGameId
+                // The current game row isn't clickable — tapping it
+                // would just navigate to itself. Leave as a visual
+                // marker instead, identified by the "This game" chip
+                // below.
+                val cardOnClick: (() -> Unit)? = if (isCurrent) {
+                    null
+                } else {
+                    { onVariantSelected?.invoke(variant.id) }
+                }
                 SpCard(
-                    onClick = { onVariantSelected?.invoke(variant.id) },
+                    onClick = cardOnClick,
                     onGradient = true,
                     cornerRadius = SpSpacing.RadiusMedium,
                 ) {
@@ -65,6 +77,15 @@ fun VariantsSection(
                             horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
                             verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
                         ) {
+                            if (isCurrent) {
+                                // Marker for the entry that matches
+                                // the game currently being shown — so
+                                // the list shows the full landscape
+                                // including the one you're on. Success
+                                // colour matches other "this is the
+                                // active thing" badges in the app.
+                                SpStatusChip(text = "This game")
+                            }
                             variant.region?.takeIf { it.isNotBlank() }?.let { region ->
                                 SpRegionChip(region = region, onGradient = true)
                             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleMetadata.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleMetadata.kt
@@ -4,12 +4,45 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import com.spela.player.presentation.ui.theme.SpColor
 
-/** Darkens a color by mixing it towards black. [amount] 0f = unchanged, 1f = pure black. */
-fun Color.darken(amount: Float): Color = copy(
-    red = red * (1f - amount),
-    green = green * (1f - amount),
-    blue = blue * (1f - amount),
-)
+/**
+ * Brightness floor used when darkening a console gradient — keeps
+ * very-dark brands (Genesis #171717, PSP #000000, ColecoVision
+ * #000000, etc.) from collapsing to pure black after the second-
+ * order darken in ConsoleScreen / GameDetailScreen, where the
+ * background would otherwise swallow card borders and any other
+ * semi-transparent overlay. Equivalent of ~#1A1A1A — a visible dark
+ * grey rather than the surface itself.
+ *
+ * The floor only kicks in when the darkened result is *below* this
+ * brightness; brighter consoles (NES red, Game Boy olive) keep their
+ * tinted darken result unchanged.
+ */
+private const val DARKEN_MIN_BRIGHTNESS = 0.10f
+
+/**
+ * Darkens a color by mixing it towards black. [amount] 0f = unchanged,
+ * 1f = pure black. Clamps the result so the average channel brightness
+ * doesn't fall below [DARKEN_MIN_BRIGHTNESS] — see the constant for
+ * why. The lift preserves hue: we add the same delta to every channel
+ * rather than per-channel max, so darkening a saturated colour
+ * doesn't grey it out unless the saturated colour was itself very
+ * dark to begin with.
+ */
+fun Color.darken(amount: Float): Color {
+    val newR = red * (1f - amount)
+    val newG = green * (1f - amount)
+    val newB = blue * (1f - amount)
+    val brightness = (newR + newG + newB) / 3f
+    if (brightness >= DARKEN_MIN_BRIGHTNESS) {
+        return copy(red = newR, green = newG, blue = newB)
+    }
+    val lift = DARKEN_MIN_BRIGHTNESS - brightness
+    return copy(
+        red = (newR + lift).coerceAtMost(1f),
+        green = (newG + lift).coerceAtMost(1f),
+        blue = (newB + lift).coerceAtMost(1f),
+    )
+}
 
 /**
  * Returns the `(from, to)` gradient pair for a console-coloured surface.
@@ -31,7 +64,11 @@ fun Color.darken(amount: Float): Color = copy(
  */
 fun getConsoleGradient(colorTheme: String?): Pair<Color, Color> {
     val brand = getConsoleColor(colorTheme)
-    val darkStop = lerp(brand, Color.Black, 0.6f)
+    // Dark stop targets a near-black grey (#1A1A1A) instead of pure
+    // black so very-dark brands (Genesis #171717, PSP #000000) still
+    // have a visible-against-the-surface bottom of the gradient. For
+    // brighter brands the visible difference is negligible.
+    val darkStop = lerp(brand, Color(0xFF1A1A1A), 0.6f)
     return brand to darkStop
 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/RecentSearchesSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/RecentSearchesSection.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -88,12 +89,21 @@ private fun RecentSearchItem(
     onRemove: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
     Row(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clickable(onClick = onClick)
-            .gamepadFocusable(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
+            .gamepadFocusable(
+                shape = RoundedCornerShape(SpSpacing.RadiusDefault),
+                interactionSource = interactionSource,
+                addFocusable = false,
+            )
             .padding(vertical = SpSpacing.Small)
             .testTag("recent_search_item_$query")
             .semantics {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/settings/SettingsComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/settings/SettingsComponents.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
@@ -64,11 +65,20 @@ internal fun SettingsToggle(
     isChecked: Boolean,
     onToggle: () -> Unit,
 ) {
+    val interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onToggle)
-            .gamepadFocusable(shape = RoundedCornerShape(SpSpacing.RadiusLarge))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onToggle,
+            )
+            .gamepadFocusable(
+                shape = RoundedCornerShape(SpSpacing.RadiusLarge),
+                interactionSource = interactionSource,
+                addFocusable = false,
+            )
             .semantics {
                 contentDescription = title
                 role = Role.Switch

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/CenterOnFocus.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/CenterOnFocus.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
@@ -35,6 +36,31 @@ class LazyGridCenterInfo(
 val LocalLazyGridCenterInfo = compositionLocalOf<LazyGridCenterInfo?> { null }
 
 /**
+ * Holds the [LazyListState] of a vertically-scrolling `LazyColumn` and
+ * its top position in root coordinates. The screen-level scrollable
+ * (e.g. the LazyColumn in `GameDetailLayout`) provides this so
+ * [centerOnFocus] can scroll the column to vertically centre whatever
+ * the user focused — a card inside a carousel, a metadata link, a top
+ * player row, etc.
+ *
+ * Mirrors [LazyGridCenterInfo] for the LazyList case. Both exist
+ * because Compose's `LazyListState` and `LazyGridState` are distinct
+ * types; pick the one the screen actually uses.
+ */
+class LazyListCenterInfo(
+    val state: LazyListState,
+) {
+    /** Updated by the LazyColumn host via `onGloballyPositioned`. */
+    var containerTopInRoot: Float = 0f
+}
+
+/**
+ * Provides [LazyListCenterInfo] to descendants so [centerOnFocus] can
+ * scroll a `LazyColumn` to centre the focused element.
+ */
+val LocalLazyListCenterInfo = compositionLocalOf<LazyListCenterInfo?> { null }
+
+/**
  * When this element gains focus, scrolls the nearest scrollable parent
  * so this element is vertically centered in the viewport.
  *
@@ -54,12 +80,13 @@ fun Modifier.centerOnFocus(
 ): Modifier = composed {
     val scrollState = LocalScrollState.current
     val lazyGridInfo = LocalLazyGridCenterInfo.current
+    val lazyListInfo = LocalLazyListCenterInfo.current
     val isFocused by interactionSource.collectIsFocusedAsState()
     var positionInRoot = 0f
     var elementHeight = 0f
     var lastFocusTime by remember { mutableLongStateOf(0L) }
 
-    if (scrollState == null && lazyGridInfo == null) return@composed this
+    if (scrollState == null && lazyGridInfo == null && lazyListInfo == null) return@composed this
 
     LaunchedEffect(isFocused) {
         if (!isFocused) return@LaunchedEffect
@@ -94,6 +121,23 @@ fun Modifier.centerOnFocus(
                 lazyGridInfo.state.scrollBy(delta)
             } else {
                 lazyGridInfo.state.animateScrollBy(delta)
+            }
+        } else if (lazyListInfo != null) {
+            // LazyListState (vertical LazyColumn): same math as the
+            // LazyGrid branch. We don't try to scroll the inner
+            // horizontal LazyRow of a SpCarousel here — that's handled
+            // by SpCarousel's own keyhandler. This branch only moves
+            // the OUTER column so the focused element's row sits in
+            // the centre of the screen vertically.
+            val viewportHeight = lazyListInfo.state.layoutInfo.viewportSize.height.toFloat()
+            val elementCenterOnScreen = positionInRoot + elementHeight / 2f
+            val viewportCenterOnScreen = lazyListInfo.containerTopInRoot + viewportHeight / 2f
+            val delta = elementCenterOnScreen - viewportCenterOnScreen
+
+            if (isRapid) {
+                lazyListInfo.state.scrollBy(delta)
+            } else {
+                lazyListInfo.state.animateScrollBy(delta)
             }
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -46,8 +46,6 @@ import com.spela.player.presentation.ui.components.SpScreenTopSpacer
 import com.spela.player.presentation.ui.components.SpScrollableContent
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpIconButton
-import com.spela.player.presentation.ui.components.SpImage
-import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
@@ -305,15 +303,13 @@ fun ConsoleScreen(
                     // owns first-entry / default focus. See the comment
                     // above the relocated section.
 
-                    // Loading / Empty
-                    if (state.games.isEmpty() && state.isLoading) {
-                        Box(
-                            modifier = Modifier.fillMaxWidth().height(200.dp),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            ScreenLoadingIndicator(message = "Loading games...")
-                        }
-                    } else if (state.games.isEmpty() && !state.isLoading) {
+                    // Empty state (loaded, no games). The "loading" case
+                    // used to render a `ScreenLoadingIndicator` here, but
+                    // the surrounding `PullToRefreshBox` already shows a
+                    // spinner for `state.isLoading` — rendering both at
+                    // the same time was just visual noise. The cold-load
+                    // path above renders a skeleton.
+                    if (state.games.isEmpty() && !state.isLoading) {
                         Box(
                             modifier = Modifier.fillMaxWidth().height(200.dp),
                             contentAlignment = Alignment.Center,
@@ -328,21 +324,15 @@ fun ConsoleScreen(
             }
 
             // Fixed top bar overlaid on top of scrollable content
-            // (auto-hidden in gamepad mode by SpTopBar)
+            // (auto-hidden in gamepad mode by SpTopBar). Title is left
+            // blank — the console name is already the headline of the
+            // hero banner one row below, so repeating it on the top bar
+            // is redundant.
             SpTopBar(
-                title = consoleName,
+                title = "",
                 showBack = true,
                 onGradient = true,
                 onBack = onBack,
-                titleLeadingContent = if (console?.iconUrl?.isNotEmpty() == true) {
-                    {
-                        SpImage(
-                            model = console.iconUrl,
-                            contentDescription = null,
-                            modifier = Modifier.size(28.dp),
-                        )
-                    }
-                } else null,
                 actions = {
                     if (state.isAdmin) {
                         var adminMenuExpanded by remember { mutableStateOf(false) }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
@@ -182,10 +182,14 @@ fun ConsoleSettingsScreen(
             item {
                 SpCard(onGradient = true) {
                     Column(modifier = Modifier.fillMaxWidth()) {
+                        val overrideInteractionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clickable {
+                                .clickable(
+                                    interactionSource = overrideInteractionSource,
+                                    indication = null,
+                                ) {
                                     if (hasDeviceOverride) {
                                         settingsViewModel.onIntent(
                                             SettingsIntent.SetDeviceOverride(consoleId, null)
@@ -196,7 +200,11 @@ fun ConsoleSettingsScreen(
                                         )
                                     }
                                 }
-                                .gamepadFocusable(shape = RoundedCornerShape(SpSpacing.RadiusLarge))
+                                .gamepadFocusable(
+                                    shape = RoundedCornerShape(SpSpacing.RadiusLarge),
+                                    interactionSource = overrideInteractionSource,
+                                    addFocusable = false,
+                                )
                                 .testTag("device_shader_override_toggle")
                                 .semantics { contentDescription = "Override on this device only" }
                                 .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Medium),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -47,6 +47,7 @@ import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpSectionLink
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpTitledSection
 import com.spela.player.presentation.ui.feature.explore.ActiveNowSection
@@ -295,15 +296,10 @@ fun ExploreScreen(
                         skeleton = { ArtworkShowcaseSkeleton() },
                         titleTrailing = onGallerySelected?.let { onClick ->
                             {
-                                Text(
+                                SpSectionLink(
                                     text = "Browse Gallery",
-                                    style = SpTypography.LabelLarge,
-                                    color = SpColor.Link,
-                                    modifier = Modifier
-                                        .clip(RoundedCornerShape(SpSpacing.Small))
-                                        .clickable(onClick = onClick)
-                                        .padding(SpSpacing.Small)
-                                        .testTag("browse_gallery_button"),
+                                    onClick = onClick,
+                                    modifier = Modifier.testTag("browse_gallery_button"),
                                 )
                             }
                         },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -604,14 +604,23 @@ private fun SearchBarEntryPoint(
     modifier: Modifier = Modifier,
 ) {
     val shape = RoundedCornerShape(SpSpacing.RadiusLarge)
+    val interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
     Row(
         modifier = modifier
             .fillMaxWidth()
             .clip(shape)
             .background(SpColor.SurfaceVariant)
             .border(1.dp, SpColor.Divider, shape)
-            .clickable(onClick = onClick)
-            .gamepadFocusable(shape = shape)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
+            .gamepadFocusable(
+                shape = shape,
+                interactionSource = interactionSource,
+                addFocusable = false,
+            )
             .padding(horizontal = SpSpacing.Default, vertical = 14.dp)
             .semantics {
                 contentDescription = "Search games, consoles, developers"

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -1,6 +1,8 @@
 package com.spela.player.presentation.ui.screen
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
@@ -38,6 +40,7 @@ import com.spela.player.presentation.ui.feature.library.darken
 import com.spela.player.presentation.ui.feature.library.getConsoleGradient
 import com.spela.player.presentation.ui.components.GameDetailLayout
 import com.spela.player.presentation.ui.components.GameDetailSkeleton
+import com.spela.player.presentation.ui.components.onApproachingVisible
 import com.spela.player.presentation.ui.components.SpConfirmDialog
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpSnackbar
@@ -325,14 +328,28 @@ fun GameDetailScreen(
                 // 3. Screenshots
                 ScreenshotsSection(detail.screenshots)
 
-                // 3b. Similar Games
-                if (state.similarGames.isNotEmpty()) {
-                    SimilarGamesSection(
-                        games = state.similarGames,
-                        onGameSelected = { gameId ->
-                            onNavigateToGame?.invoke(gameId)
-                        },
-                    )
+                // 3b. Similar Games — lazy-fetched. The placeholder Box
+                // is always laid out at this position; its
+                // onApproachingVisible callback fires the network
+                // request the first time the user scrolls (or is
+                // about to scroll) the section into view. The
+                // SimilarGamesSection itself only renders once data
+                // arrives. This keeps /api/games/{id}/similar off the
+                // game-detail initial-load hot path entirely — most
+                // game-detail visits never reach this section.
+                Box(
+                    modifier = Modifier.fillMaxWidth().onApproachingVisible {
+                        viewModel.requestSimilarGames()
+                    },
+                ) {
+                    if (state.similarGames.isNotEmpty()) {
+                        SimilarGamesSection(
+                            games = state.similarGames,
+                            onGameSelected = { gameId ->
+                                onNavigateToGame?.invoke(gameId)
+                            },
+                        )
+                    }
                 }
 
                 // 3c. More from Developer

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -70,6 +70,7 @@ import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.ui.gamepad.rememberFocus
 import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import androidx.compose.runtime.CompositionLocalProvider
+import com.spela.player.presentation.ui.components.SpSectionLink
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpIconButton
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
@@ -303,8 +304,9 @@ fun HomeScreen(
                                     edgeToEdgeContent = true,
                                     modifier = Modifier.rememberFocus("section_play_later"),
                                     titleTrailing = {
-                                        SeeAllLink(
-                                            label = "Play Later",
+                                        SpSectionLink(
+                                            text = "See all",
+                                            contentDescription = "See all Play Later",
                                             onClick = onNavigateToPlayLater,
                                         )
                                     },
@@ -325,8 +327,9 @@ fun HomeScreen(
                                     edgeToEdgeContent = true,
                                     modifier = Modifier.rememberFocus("section_favorites"),
                                     titleTrailing = {
-                                        SeeAllLink(
-                                            label = "Favorites",
+                                        SpSectionLink(
+                                            text = "See all",
+                                            contentDescription = "See all Favorites",
                                             onClick = onNavigateToFavorites,
                                         )
                                     },
@@ -365,8 +368,9 @@ fun HomeScreen(
                                     edgeToEdgeContent = true,
                                     modifier = Modifier.rememberFocus("section_recent_achievements"),
                                     titleTrailing = {
-                                        SeeAllLink(
-                                            label = "Recent Achievements",
+                                        SpSectionLink(
+                                            text = "See all",
+                                            contentDescription = "See all Recent Achievements",
                                             onClick = onNavigateToStats,
                                         )
                                     },
@@ -383,8 +387,9 @@ fun HomeScreen(
                                     edgeToEdgeContent = true,
                                     modifier = Modifier.rememberFocus("section_trending_challenges"),
                                     titleTrailing = {
-                                        SeeAllLink(
-                                            label = "Trending Challenges",
+                                        SpSectionLink(
+                                            text = "See all",
+                                            contentDescription = "See all Trending Challenges",
                                             onClick = onNavigateToChallenges,
                                         )
                                     },
@@ -435,8 +440,9 @@ fun HomeScreen(
                                     icon = Icons.Filled.History,
                                     modifier = Modifier.rememberFocus("section_recent_activity"),
                                     titleTrailing = {
-                                        SeeAllLink(
-                                            label = "Recent Activity",
+                                        SpSectionLink(
+                                            text = "See all",
+                                            contentDescription = "See all Recent Activity",
                                             onClick = onNavigateToActivity,
                                         )
                                     },
@@ -458,8 +464,9 @@ fun HomeScreen(
                                     icon = Icons.Filled.BarChart,
                                     modifier = Modifier.rememberFocus("section_your_stats"),
                                     titleTrailing = {
-                                        SeeAllLink(
-                                            label = "Your Stats",
+                                        SpSectionLink(
+                                            text = "See all",
+                                            contentDescription = "See all Your Stats",
                                             onClick = onNavigateToStats,
                                         )
                                     },
@@ -560,32 +567,3 @@ private fun DeviceNameBanner(
     }
 }
 
-@Composable
-private fun SeeAllLink(
-    label: String,
-    onClick: () -> Unit,
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    Text(
-        text = "See all",
-        style = SpTypography.LabelLarge,
-        color = SpColor.Link,
-        modifier = Modifier
-            .clip(RoundedCornerShape(SpSpacing.Small))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null,
-                onClick = onClick,
-            )
-            .gamepadFocusable(
-                shape = RoundedCornerShape(SpSpacing.Small),
-                interactionSource = interactionSource,
-                addFocusable = false,
-            )
-            .padding(SpSpacing.Small)
-            .semantics {
-                contentDescription = "See all $label"
-                role = Role.Button
-            },
-    )
-}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -5,8 +5,6 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Download
@@ -50,9 +47,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import com.spela.player.presentation.ui.TestTags
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.NetplaySession
@@ -66,7 +61,6 @@ import com.spela.player.presentation.ui.components.SpMainContentPadding
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpScrollableContent
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
-import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.ui.gamepad.rememberFocus
 import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import androidx.compose.runtime.CompositionLocalProvider

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -65,6 +66,7 @@ import com.spela.player.presentation.ui.components.SpMainContentPadding
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpScrollableContent
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
+import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.ui.gamepad.rememberFocus
 import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import androidx.compose.runtime.CompositionLocalProvider
@@ -563,13 +565,23 @@ private fun SeeAllLink(
     label: String,
     onClick: () -> Unit,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     Text(
         text = "See all",
         style = SpTypography.LabelLarge,
         color = SpColor.Link,
         modifier = Modifier
             .clip(RoundedCornerShape(SpSpacing.Small))
-            .clickable(onClick = onClick)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
+            .gamepadFocusable(
+                shape = RoundedCornerShape(SpSpacing.Small),
+                interactionSource = interactionSource,
+                addFocusable = false,
+            )
             .padding(SpSpacing.Small)
             .semantics {
                 contentDescription = "See all $label"

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryList.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryList.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -94,6 +95,7 @@ fun SettingsCategoryList(
             val isSelected = category == selectedCategory
             val bgColor = if (isSelected) SpColor.Primary.copy(alpha = 0.15f) else Color.Transparent
             val textColor = if (isSelected) SpColor.PrimaryLight else SpColor.OnBackground
+            val interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
 
             Row(
                 modifier = Modifier
@@ -105,8 +107,16 @@ fun SettingsCategoryList(
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(8.dp))
                     .background(bgColor)
-                    .clickable { onSelectCategory(category) }
-                    .gamepadFocusable(shape = RoundedCornerShape(8.dp))
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        onClick = { onSelectCategory(category) },
+                    )
+                    .gamepadFocusable(
+                        shape = RoundedCornerShape(8.dp),
+                        interactionSource = interactionSource,
+                        addFocusable = false,
+                    )
                     .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Medium)
                     .semantics { contentDescription = category.label },
                 verticalAlignment = Alignment.CenterVertically,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.viewmodel
 
+import com.spela.player.data.cache.GameDetailCache
 import com.spela.player.data.remote.ScrapeService
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.repository.BiosRepository
@@ -23,6 +24,7 @@ import com.spela.player.domain.repository.GameStatsRepository
 import com.spela.player.presentation.intent.GameDetailIntent
 import com.spela.player.presentation.state.GameDetailState
 import com.spela.player.util.DispatcherProvider
+import com.spela.player.domain.model.GameDetail
 import com.spela.player.domain.model.INSTANT_DOWNLOAD_FALLBACK_DELAY_MS
 import com.spela.player.domain.model.INSTANT_DOWNLOAD_THRESHOLD_BYTES
 import kotlinx.coroutines.CoroutineScope
@@ -73,6 +75,16 @@ class GameDetailViewModel(
     // scrape-done event.
     private var downloadObserveJob: Job? = null
     private var scrapeObserveJobs: List<Job> = emptyList()
+    /**
+     * Tracks the in-flight game-detail fetch so a fast back-then-
+     * forward navigation cancels the previous load before starting
+     * the new one. Without this, a slow response for game A could
+     * win over the fresh response for game B (last-write-wins), and
+     * the user would see game A's data appear on game B's screen.
+     * See the `currentGameId` re-check in the load coroutine for the
+     * belt-and-suspenders guard against the same race.
+     */
+    private var loadGameJob: Job? = null
 
     // Session + achievement CRUD extracted into their own managers
     // (#691). Each shares this VM's `_state` so updates land
@@ -243,9 +255,46 @@ class GameDetailViewModel(
         }
     }
 
+    /**
+     * Apply [transform] to the current `_state.gameDetail`, write the
+     * result to both screen state AND the [GameDetailCache]. Use this
+     * for every mutation that touches `gameDetail` (favourite toggle,
+     * play-later toggle, scrape-refresh re-fetch, etc.) — the cache
+     * then stays consistent with on-screen truth without needing
+     * separate invalidation calls. If `_state.gameDetail` is null
+     * (no detail loaded yet), the transform is skipped and nothing
+     * changes.
+     */
+    private inline fun mutateGameDetail(transform: (GameDetail) -> GameDetail) {
+        _state.update { state ->
+            val current = state.gameDetail ?: return@update state
+            val updated = transform(current)
+            GameDetailCache.put(updated.game.id, updated)
+            state.copy(gameDetail = updated)
+        }
+    }
+
     private fun loadGame(gameId: String) {
         currentGameId = gameId
-        _state.update { GameDetailState(isLoading = true) }
+
+        // Stale-while-revalidate: if we've fetched this game before
+        // in this app session, the cache still has the last detail
+        // we observed. Paint the screen with it immediately so the
+        // user gets instant feedback while the fresh network fetch
+        // runs in the background. By the time the fetch returns the
+        // user has already been looking at correct (or near-correct)
+        // data; the new value just refreshes anything that drifted.
+        val cached = GameDetailCache.get(gameId)
+        if (cached != null) {
+            _state.update {
+                GameDetailState(
+                    gameDetail = cached,
+                    isLoading = false,
+                )
+            }
+        } else {
+            _state.update { GameDetailState(isLoading = true) }
+        }
 
         // Cancel any observers from a previous loadGame call (a
         // back-and-forth nav, or a switch to a different game) so
@@ -253,8 +302,14 @@ class GameDetailViewModel(
         downloadObserveJob?.cancel()
         scrapeObserveJobs.forEach { it.cancel() }
         scrapeObserveJobs = emptyList()
+        // Cancel any in-flight detail fetch for the previous game.
+        // Without this, a slow response for game A could land after
+        // the user has already navigated to game B and overwrite
+        // B's state with A's data — visible as "wrong game briefly
+        // appears" during back-then-forward navigation.
+        loadGameJob?.cancel()
 
-        scope.launch(dispatchers.io) {
+        loadGameJob = scope.launch(dispatchers.io) {
             getGameDetailUseCase(gameId).fold(
                 onSuccess = { detail ->
                     val isCached = downloadRepository.isGameCached(gameId)
@@ -273,6 +328,18 @@ class GameDetailViewModel(
                     val prefs = preferencesRepository.getPreferences().getOrNull()
                     val perGameChoice = prefs?.gameSaveStatePolicies?.get(gameId)
                     val perConsolePolicies = prefs?.consoleSaveStatePolicies ?: emptyMap()
+                    // Write to cache even if this response is for a
+                    // game the user has already navigated away from —
+                    // we don't want to throw away a finished fetch
+                    // we paid for. The next visit to that game will
+                    // read it from the cache and render instantly.
+                    GameDetailCache.put(gameId, detail)
+                    // Belt-and-suspenders: even though we cancel the
+                    // previous job above, if a CancellationException
+                    // slipped through (e.g. the use case caught it),
+                    // this guard drops the late write so the user's
+                    // current game's screen isn't clobbered.
+                    if (currentGameId != gameId) return@fold
                     _state.update {
                         it.copy(
                             gameDetail = detail,
@@ -294,6 +361,7 @@ class GameDetailViewModel(
                         val isAdmin = runCatching { apiClient.getCurrentUser() }
                             .map { it.role == "admin" || it.role == "owner" }
                             .getOrDefault(false)
+                        if (currentGameId != gameId) return@launch
                         _state.update { it.copy(isAdmin = isAdmin) }
                     }
                     if (detail.game.scrapeAttempts == 0) {
@@ -310,6 +378,7 @@ class GameDetailViewModel(
                     }
                 },
                 onFailure = { error ->
+                    if (currentGameId != gameId) return@fold
                     _state.update { it.copy(error = error.message, isLoading = false) }
                 },
             )
@@ -368,7 +437,14 @@ class GameDetailViewModel(
                 if (doneGameId == gameId) {
                     getGameDetailUseCase(gameId).fold(
                         onSuccess = { detail ->
-                            _state.update { it.copy(gameDetail = detail) }
+                            // Always write to cache; only write to
+                            // screen state if the user is still on
+                            // this game. Same write-through invariant
+                            // as loadGame above.
+                            GameDetailCache.put(gameId, detail)
+                            if (currentGameId == gameId) {
+                                _state.update { it.copy(gameDetail = detail) }
+                            }
                         },
                         onFailure = { /* ignore reload failure */ },
                     )
@@ -494,11 +570,8 @@ class GameDetailViewModel(
         scope.launch(dispatchers.io) {
             toggleFavoriteUseCase(detail.game.id, currentlyFavorite).fold(
                 onSuccess = {
-                    _state.update {
-                        val updatedGame = it.gameDetail?.game?.copy(isFavorite = !currentlyFavorite)
-                        it.copy(
-                            gameDetail = updatedGame?.let { g -> it.gameDetail.copy(game = g) }
-                        )
+                    mutateGameDetail { d ->
+                        d.copy(game = d.game.copy(isFavorite = !currentlyFavorite))
                     }
                 },
                 onFailure = { error ->
@@ -534,22 +607,18 @@ class GameDetailViewModel(
         val detail = _state.value.gameDetail ?: return
         val currentlyInPlayLater = detail.game.isInPlayLater
         // Optimistic update: flip immediately to prevent double-clicks
-        _state.update {
-            val updatedGame = it.gameDetail?.game?.copy(isInPlayLater = !currentlyInPlayLater)
-            it.copy(gameDetail = updatedGame?.let { g -> it.gameDetail.copy(game = g) })
+        mutateGameDetail { d ->
+            d.copy(game = d.game.copy(isInPlayLater = !currentlyInPlayLater))
         }
         scope.launch(dispatchers.io) {
             togglePlayLaterUseCase(detail.game.id, currentlyInPlayLater).fold(
                 onSuccess = { /* Already updated optimistically */ },
                 onFailure = { error ->
                     // Revert on failure
-                    _state.update {
-                        val revertedGame = it.gameDetail?.game?.copy(isInPlayLater = currentlyInPlayLater)
-                        it.copy(
-                            gameDetail = revertedGame?.let { g -> it.gameDetail.copy(game = g) },
-                            error = error.message,
-                        )
+                    mutateGameDetail { d ->
+                        d.copy(game = d.game.copy(isInPlayLater = currentlyInPlayLater))
                     }
+                    _state.update { it.copy(error = error.message) }
                 },
             )
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -66,6 +66,12 @@ class GameDetailViewModel(
 
     private var currentGameId: String? = null
 
+    // Lazy-fetch latch for `/api/games/{id}/similar` — null until the
+    // UI signals the Similar Games carousel has approached the
+    // viewport via requestSimilarGames(). Reset by loadGame() so a
+    // new game starts un-requested.
+    private var similarGamesRequestedForGameId: String? = null
+
     // Per-game collector jobs. Cancelled and re-launched on every
     // loadGame so navigating away and back (or to a different game)
     // doesn't leak collectors. Pre-#956 these were unbounded `scope.
@@ -393,13 +399,37 @@ class GameDetailViewModel(
         // Observe WebSocket scrape status for this game
         observeScrapeStatus(gameId)
 
-        // Load community data that applies to all games (playable or not)
+        // Reset the per-game lazy-request flag so requestSimilarGames
+        // re-fires for the new game when its section approaches the
+        // viewport. The previous game's "already fetched" state must
+        // not leak across.
+        similarGamesRequestedForGameId = null
+
+        // Load community data that applies to all games (playable or not).
+        // Note: loadSimilarGames is NOT auto-fired here — it's gated on
+        // viewport visibility (see requestSimilarGames) because the
+        // similar section sits far down the page and the upstream IGDB
+        // call is the most expensive part of the detail screen.
         loadGameStats(gameId)
         loadReviews(gameId)
-        loadSimilarGames(gameId)
         loadDeveloperGames(gameId)
         loadGameSeriesLinks(gameId)
         loadGameFranchiseLinks(gameId)
+    }
+
+    /**
+     * Trigger the similar-games fetch for the currently-loaded game.
+     *
+     * Called by the UI when the Similar Games carousel approaches the
+     * viewport (see [Modifier.onApproachingVisible]). Idempotent: only
+     * the first call per [currentGameId] actually launches the fetch;
+     * subsequent calls (e.g. from rapid scroll wiggles) are no-ops.
+     */
+    fun requestSimilarGames() {
+        val gameId = currentGameId ?: return
+        if (similarGamesRequestedForGameId == gameId) return
+        similarGamesRequestedForGameId = gameId
+        loadSimilarGames(gameId)
     }
 
     private fun loadBiosStatus() {

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -36,6 +36,15 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	require.NoError(t, err)
+	// SQLite :memory: gives each connection a fresh, empty database.
+	// Goroutines pulling new connections from the pool would each see
+	// a different empty DB — production uses a file-backed DB and
+	// doesn't have this problem. Force the pool to a single
+	// connection so concurrent handlers (e.g. /explore/rows,
+	// /explore/for-you) still see the seeded schema in tests.
+	if sqlDB, dbErr := database.DB(); dbErr == nil {
+		sqlDB.SetMaxOpenConns(1)
+	}
 	err = database.AutoMigrate(
 		&db.User{}, &db.Console{}, &db.Game{}, &db.GameDisc{},
 		&db.Favorite{}, &db.PlayHistory{}, &db.RefreshToken{},

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -11,7 +11,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/scanner"
@@ -32,19 +34,25 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 	// _foreign_keys=1 mirrors the production DSN (database.go) so the
 	// CASCADE / SET NULL constraints on user-owned tables (#971) are
 	// enforced under tests.
-	database, err := gorm.Open(sqlite.Open(":memory:?_foreign_keys=1"), &gorm.Config{
+	// `cache=shared` lets multiple connections to this in-memory DB
+	// see the same data — required because some handlers (parallel
+	// /explore/rows / /for-you row builders, plus handler code that
+	// fans out within a single request) acquire more than one
+	// connection from the pool. The default plain `:memory:` gives
+	// each new connection a fresh empty database; without
+	// `cache=shared` concurrent goroutines land on different empty
+	// DBs and fail with `no such table`. Pinning MaxOpenConns(1)
+	// was the previous workaround but it deadlocks any code path
+	// that acquires a second connection on the same goroutine
+	// (e.g. TestApplyIGDBMatch_Success → HTTP handler holds conn,
+	// scraper.storeEnrichmentData wants another).
+	// `cache=shared` is the standard SQLite mechanism and matches
+	// production's file-backed multi-connection semantics.
+	dsn := "file:test_" + t.Name() + "_" + strconv.FormatInt(time.Now().UnixNano(), 36) + "?mode=memory&cache=shared&_foreign_keys=1"
+	database, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	require.NoError(t, err)
-	// SQLite :memory: gives each connection a fresh, empty database.
-	// Goroutines pulling new connections from the pool would each see
-	// a different empty DB — production uses a file-backed DB and
-	// doesn't have this problem. Force the pool to a single
-	// connection so concurrent handlers (e.g. /explore/rows,
-	// /explore/for-you) still see the seeded schema in tests.
-	if sqlDB, dbErr := database.DB(); dbErr == nil {
-		sqlDB.SetMaxOpenConns(1)
-	}
 	err = database.AutoMigrate(
 		&db.User{}, &db.Console{}, &db.Game{}, &db.GameDisc{},
 		&db.Favorite{}, &db.PlayHistory{}, &db.RefreshToken{},

--- a/server/internal/api/enrichment_handler.go
+++ b/server/internal/api/enrichment_handler.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"sync"
+	"time"
+
 	"github.com/spela/server/internal/scraper"
 	ws "github.com/spela/server/internal/websocket"
 	"gorm.io/gorm"
@@ -11,6 +14,18 @@ type EnrichmentHandler struct {
 	DB      *gorm.DB
 	Scraper *scraper.Scraper
 	Hub     *ws.Hub
+
+	// In-process cache for GET /api/keywords — the result is a function
+	// of library-wide game→keyword aggregation, not user-specific, and
+	// only changes when the scraper writes new game_keywords rows.
+	// See [listKeywordsTTL] for the cache window.
+	listKeywordsCacheMu sync.Mutex
+	listKeywordsCache   map[int]cachedKeywords
+}
+
+type cachedKeywords struct {
+	at     time.Time
+	result []KeywordResponse
 }
 
 // --- Theme endpoints ---

--- a/server/internal/api/explore_handler_temporal.go
+++ b/server/internal/api/explore_handler_temporal.go
@@ -58,6 +58,52 @@ var decadeLabel = map[string]string{
 	"00s": "The 00s",
 }
 
+// onThisDayLikePatterns returns the SQL LIKE patterns that cover every
+// release_date format parseReleaseDateMonthDay accepts, for a given
+// target month + day. Used by GET /api/explore/on-this-day to push
+// the date filter into SQL rather than scanning every release-dated
+// game in Go.
+//
+// Patterns are intentionally over-inclusive — callers must re-validate
+// each matched row with parseReleaseDateMonthDay. The point of the
+// SQL prefilter is to reduce rows-transferred, not to be exact.
+func onThisDayLikePatterns(month time.Month, day int) []string {
+	monthName := month.String()       // "March"
+	monthAbbr := monthName            // "March" — full == abbrev for May / June / July / Sept-Dec; Go .String() uses the full name
+	if len(monthName) > 3 {
+		monthAbbr = monthName[:3] // "Mar"
+	}
+	dayStr := strconv.Itoa(day)
+	dayPad := dayStr
+	if day < 10 {
+		dayPad = "0" + dayStr
+	}
+	monthPad := strconv.Itoa(int(month))
+	if month < 10 {
+		monthPad = "0" + monthPad
+	}
+
+	patterns := []string{
+		"%-" + monthPad + "-" + dayPad + "%",      // ISO: "1996-05-13" / "1996-05-13T..."
+		monthName + " " + dayStr + ",%",           // "May 13, 1996" / "March 3, 1996"
+		monthName + " " + dayPad + ",%",           // "May 13, 1996" (zero-padded day variant)
+		dayStr + " " + monthName + "%",            // "13 May 1996" / "3 March 1996"
+		dayPad + " " + monthName + "%",            // "03 March 1996"
+	}
+	// Add 3-letter abbreviation variants only when distinct from full
+	// name (May / June / July / Sept-Dec are >3 chars but the abbrev
+	// differs only for March / April / June / July / August / September
+	// / October / November / December — the >3-char filter above
+	// captures every month where abbreviation differs).
+	if monthAbbr != monthName {
+		patterns = append(patterns,
+			monthAbbr+" "+dayStr+",%", // "Mar 13, 1996"
+			monthAbbr+" "+dayPad+",%", // "Mar 03, 1996"
+		)
+	}
+	return patterns
+}
+
 // parseReleaseDateMonthDay attempts to extract month and day from a release_date string.
 // Supports formats like "2000-03-10", "March 10, 2000", "Mar 10, 2000".
 // Returns (month, day, true) on success, or (0, 0, false) if unparseable or year-only.

--- a/server/internal/api/huma_console.go
+++ b/server/internal/api/huma_console.go
@@ -376,14 +376,21 @@ func (h *ConsoleHandler) HumaGetTopRated(_ context.Context, in *GetTopRatedInput
 		}
 	}
 
+	// Cache refresh is fire-and-forget — never block the user's
+	// response on the outbound IGDB HTTP call. See
+	// HumaGetSimilarGames for the same pattern; same justification.
 	if !fresh && h.Scraper != nil && h.Scraper.IGDBClient != nil && h.Scraper.IGDBClient.IsConfigured() {
-		topGames, err := h.Scraper.IGDBClient.GetTopGames(igdbPlatformIDs, 100)
-		if err != nil {
-			slog.Warn("failed to fetch top-rated games from IGDB", "console", abbr, "error", err)
-		} else {
+		consoleID := console.ID
+		igdbClient := h.Scraper.IGDBClient
+		go func() {
+			topGames, err := igdbClient.GetTopGames(igdbPlatformIDs, 100)
+			if err != nil {
+				slog.Warn("failed to fetch top-rated games from IGDB", "console", abbr, "error", err)
+				return
+			}
 			ranked := bayesianRank(topGames, 25)
-			go h.upsertTopRatedGames(console.ID, ranked)
-		}
+			h.upsertTopRatedGames(consoleID, ranked)
+		}()
 	}
 
 	return &TopRatedListOutput{Body: h.buildTopRatedResponses(cached, false)}, nil

--- a/server/internal/api/huma_console.go
+++ b/server/internal/api/huma_console.go
@@ -408,19 +408,53 @@ func (h *ConsoleHandler) HumaGetTopRatedGlobal(_ context.Context, _ *GetTopRated
 	var all []db.TopRatedGame
 	h.DB.Where("console_id IN ?", libraryConsoleIDs).Order("total_rating desc").Find(&all)
 
+	// Determine which IGDB game IDs have a matching local game (and on
+	// which console). The naive loop here used to issue one COUNT(*)
+	// per IGDB row — N+1, with N up to ~150 candidates, and the inner
+	// query did `LOWER(title)` against an unindexed column. With the
+	// LOWER(title) functional index in place a single batched query
+	// suffices: one trip for the scraper_id matches, one for the title
+	// matches; everything else lives in maps.
 	localConsoles := make(map[int]uint)
-	for _, tr := range all {
-		if _, seen := localConsoles[tr.IGDBGameID]; seen {
-			continue
+	if len(all) > 0 {
+		scraperIDs := make([]string, 0, len(all))
+		loweredTitles := make([]string, 0, len(all))
+		scraperIDByTopRated := make(map[string][]int, len(all)) // scraperID -> []IGDBGameID
+		titleByTopRated := make(map[string][]int, len(all))     // lowered name -> []IGDBGameID
+		consoleByTopRated := make(map[int]uint, len(all))       // IGDBGameID -> ConsoleID
+		for _, tr := range all {
+			scraperID := fmt.Sprintf("igdb:%d", tr.IGDBGameID)
+			loweredName := strings.ToLower(tr.Name)
+			scraperIDs = append(scraperIDs, scraperID)
+			loweredTitles = append(loweredTitles, loweredName)
+			scraperIDByTopRated[scraperID] = append(scraperIDByTopRated[scraperID], tr.IGDBGameID)
+			titleByTopRated[loweredName] = append(titleByTopRated[loweredName], tr.IGDBGameID)
+			consoleByTopRated[tr.IGDBGameID] = tr.ConsoleID
 		}
-		var count int64
-		scraperID := fmt.Sprintf("igdb:%d", tr.IGDBGameID)
-		h.DB.Model(&db.Game{}).Where(
-			"(scraper_id = ? OR LOWER(title) = LOWER(?)) AND console_id = ?",
-			scraperID, tr.Name, tr.ConsoleID,
-		).Count(&count)
-		if count > 0 {
-			localConsoles[tr.IGDBGameID] = tr.ConsoleID
+
+		type matchedGame struct {
+			ScraperID string
+			Title     string
+			ConsoleID uint
+		}
+		var matches []matchedGame
+		h.DB.Model(&db.Game{}).
+			Select("scraper_id, title, console_id").
+			Where("(scraper_id IN ? OR LOWER(title) IN ?) AND console_id IN ?",
+				scraperIDs, loweredTitles, libraryConsoleIDs).
+			Scan(&matches)
+
+		for _, m := range matches {
+			for _, igdbID := range scraperIDByTopRated[m.ScraperID] {
+				if consoleByTopRated[igdbID] == m.ConsoleID {
+					localConsoles[igdbID] = m.ConsoleID
+				}
+			}
+			for _, igdbID := range titleByTopRated[strings.ToLower(m.Title)] {
+				if consoleByTopRated[igdbID] == m.ConsoleID {
+					localConsoles[igdbID] = m.ConsoleID
+				}
+			}
 		}
 	}
 

--- a/server/internal/api/huma_discovery.go
+++ b/server/internal/api/huma_discovery.go
@@ -88,14 +88,25 @@ func (h *GameDiscoveryHandler) HumaGetSimilarGames(_ context.Context, in *GetSim
 		}
 	}
 
+	// Cache refresh is fire-and-forget — never block the user's response
+	// on an outbound IGDB HTTP call. The user gets whatever's already
+	// cached (possibly nothing on first-ever request for this game);
+	// the background goroutine populates the cache so the next visit
+	// is fast. Previously this awaited GetSimilarGames synchronously,
+	// which added ~500–800ms to every game-detail page load when the
+	// cache was older than 7 days (or empty).
 	if !fresh && h.Scraper != nil && h.Scraper.IGDBClient != nil && h.Scraper.IGDBClient.IsConfigured() {
-		similarGames, err := h.Scraper.IGDBClient.GetSimilarGames(igdbGameID)
-		if err != nil {
-			slog.Warn("failed to fetch similar games from IGDB", "game", game.Title, "error", err)
-		} else {
-			gameID := game.ID
-			go h.upsertSimilarGames(gameID, similarGames)
-		}
+		gameID := game.ID
+		gameTitle := game.Title
+		igdbClient := h.Scraper.IGDBClient
+		go func() {
+			similarGames, err := igdbClient.GetSimilarGames(igdbGameID)
+			if err != nil {
+				slog.Warn("failed to fetch similar games from IGDB", "game", gameTitle, "error", err)
+				return
+			}
+			h.upsertSimilarGames(gameID, similarGames)
+		}()
 	}
 
 	result := make([]SimilarGameResponse, 0, len(cached))

--- a/server/internal/api/huma_discovery.go
+++ b/server/internal/api/huma_discovery.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -109,6 +110,33 @@ func (h *GameDiscoveryHandler) HumaGetSimilarGames(_ context.Context, in *GetSim
 		}()
 	}
 
+	// Batch the cross-reference lookup into a single query instead of
+	// one per cached row. The old loop issued
+	//   WHERE LOWER(title) = LOWER(?)
+	// per similar game (~10 round-trips); the new pass does one
+	// `LOWER(title) IN (...)` query and builds a map. Combined with
+	// the LOWER(title) functional index added in the migrations,
+	// the cross-ref step is now ~one indexed lookup.
+	loweredNames := make([]string, 0, len(cached))
+	for _, sg := range cached {
+		if sg.Name != "" {
+			loweredNames = append(loweredNames, strings.ToLower(sg.Name))
+		}
+	}
+
+	localByLowerTitle := make(map[string]db.Game, len(loweredNames))
+	if len(loweredNames) > 0 {
+		var localMatches []db.Game
+		if err := h.DB.Where("LOWER(title) IN ?", loweredNames).Find(&localMatches).Error; err == nil {
+			for _, g := range localMatches {
+				key := strings.ToLower(g.Title)
+				if _, exists := localByLowerTitle[key]; !exists {
+					localByLowerTitle[key] = g
+				}
+			}
+		}
+	}
+
 	result := make([]SimilarGameResponse, 0, len(cached))
 	for _, sg := range cached {
 		resp := SimilarGameResponse{
@@ -117,8 +145,7 @@ func (h *GameDiscoveryHandler) HumaGetSimilarGames(_ context.Context, in *GetSim
 			IGDBCriticsRating: sg.IGDBCriticsRating,
 		}
 
-		var localGame db.Game
-		if err := h.DB.Where("LOWER(title) = LOWER(?)", sg.Name).First(&localGame).Error; err == nil {
+		if localGame, ok := localByLowerTitle[strings.ToLower(sg.Name)]; ok {
 			localID := fmt.Sprintf("%d", localGame.ID)
 			resp.LocalGameId = &localID
 			if localGame.CoverURL != "" {

--- a/server/internal/api/huma_enrichment.go
+++ b/server/internal/api/huma_enrichment.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/spela/server/internal/db"
@@ -13,6 +14,15 @@ import (
 	ws "github.com/spela/server/internal/websocket"
 	"gorm.io/gorm"
 )
+
+// listKeywordsTTL is how long GET /api/keywords cached results stay
+// fresh. The endpoint's response is purely a function of game →
+// keyword aggregation across the whole library; it doesn't change
+// when one user views their own library, doesn't depend on userID,
+// and changes only when the scraper adds/removes a game. A 5-minute
+// in-process cache turns the ~621ms aggregate-and-sort scan into a
+// hashmap lookup for every request inside the window.
+const listKeywordsTTL = 5 * time.Minute
 
 // --- Input / output types ---
 
@@ -405,6 +415,18 @@ func (h *EnrichmentHandler) HumaListKeywords(_ context.Context, in *ListKeywords
 		limit = 50
 	}
 
+	// Serve from the in-process cache when fresh. The result is a
+	// function of library aggregation only — it changes only when the
+	// scraper writes new game_keywords rows, not on any user-driven
+	// action. See [listKeywordsTTL] for the cache window rationale.
+	h.listKeywordsCacheMu.Lock()
+	if entry, ok := h.listKeywordsCache[limit]; ok && time.Since(entry.at) < listKeywordsTTL {
+		cached := entry.result
+		h.listKeywordsCacheMu.Unlock()
+		return &ListKeywordsOutput{Body: cached}, nil
+	}
+	h.listKeywordsCacheMu.Unlock()
+
 	type keywordRow struct {
 		IGDBKeywordID int
 		Name          string
@@ -431,6 +453,17 @@ func (h *EnrichmentHandler) HumaListKeywords(_ context.Context, in *ListKeywords
 			GameCount: r.GameCount,
 		}
 	}
+
+	h.listKeywordsCacheMu.Lock()
+	if h.listKeywordsCache == nil {
+		h.listKeywordsCache = make(map[int]cachedKeywords)
+	}
+	h.listKeywordsCache[limit] = cachedKeywords{
+		at:     time.Now(),
+		result: result,
+	}
+	h.listKeywordsCacheMu.Unlock()
+
 	return &ListKeywordsOutput{Body: result}, nil
 }
 

--- a/server/internal/api/huma_explore_developer.go
+++ b/server/internal/api/huma_explore_developer.go
@@ -365,32 +365,48 @@ func (h *ExploreHandler) HumaGetDeveloperSpotlight(ctx context.Context, _ *GetDe
 		topGames = topGames[:8]
 	}
 
+	// Hero artwork: walk the games we already loaded (sorted by
+	// rating DESC) and take the first matching hero_url. The old
+	// approach issued a JOIN games × game_artworks ordered by rating,
+	// which re-did the work we already have in `games`. Single
+	// indexed lookup per match instead of a join scan.
 	heroURL := ""
 	if len(games) > 0 {
-		gameIDs := make([]uint, len(games))
+		gameIDs := make([]uint, 0, len(games))
+		gameIDIndex := make(map[uint]int, len(games))
 		for i, g := range games {
-			gameIDs[i] = g.ID
+			gameIDs = append(gameIDs, g.ID)
+			gameIDIndex[g.ID] = i
 		}
-		var artwork db.GameArtwork
-		if err := h.DB.
-			Joins("JOIN games ON games.id = game_artworks.game_id").
-			Where("game_artworks.game_id IN ? AND game_artworks.hero_url != ''", gameIDs).
-			Order("games.rating DESC").
-			First(&artwork).Error; err == nil {
-			heroURL = resolveImageURL(artwork.HeroURL)
+		var artworks []db.GameArtwork
+		h.DB.Where("game_id IN ? AND hero_url != ''", gameIDs).Find(&artworks)
+		// Pick the artwork belonging to the highest-rated game (lowest
+		// index in `games`, which is already ordered by rating DESC).
+		bestIdx := -1
+		var bestHero string
+		for _, a := range artworks {
+			if idx, ok := gameIDIndex[a.GameID]; ok {
+				if bestIdx < 0 || idx < bestIdx {
+					bestIdx = idx
+					bestHero = a.HeroURL
+				}
+			}
+		}
+		if bestHero != "" {
+			heroURL = resolveImageURL(bestHero)
 		}
 	}
 
-	var totalGameCount int64
-	h.DB.Model(&db.Game{}).
-		Where("LOWER(developer) = LOWER(?) AND is_primary = true AND deleted_at IS NULL", selectedDev.Developer).
-		Count(&totalGameCount)
+	// We already loaded every game by this developer; the SELECT-COUNT
+	// round-trip is redundant. games is unfiltered (no Limit) and
+	// scoped to the same predicate, so len() is exact.
+	totalGameCount := len(games)
 
 	return &GetDeveloperSpotlightOutput{
 		CacheControl: "private, max-age=300",
 		Body: DeveloperSpotlightResponse{
 			Name:      selectedDev.Developer,
-			GameCount: int(totalGameCount),
+			GameCount: totalGameCount,
 			AvgRating: avgRating,
 			Consoles:  consoles,
 			TopGames:  ToGameResponses(topGames, h.DB, userID),

--- a/server/internal/api/huma_explore_featured.go
+++ b/server/internal/api/huma_explore_featured.go
@@ -167,6 +167,13 @@ func (h *ExploreHandler) HumaGetExploreFeatured(ctx context.Context, _ *GetExplo
 		ConsoleID uint
 	}
 
+	// Cap the candidate set at the top 200 by effective rating. The
+	// old version transferred every hero+logo-arted game in the
+	// catalog (can be thousands of rows on a stocked library) just
+	// so weightedSample could pick 10. Since the weights are the
+	// rating itself, the unweighted tail contributes essentially
+	// nothing — capping at 200 produces the same selection
+	// distribution without the wire transfer cost.
 	var allRows []featuredRow
 	err := h.DB.
 		Table("games").
@@ -175,6 +182,8 @@ func (h *ExploreHandler) HumaGetExploreFeatured(ctx context.Context, _ *GetExplo
 		Where("games.deleted_at IS NULL").
 		Where("games.is_primary = true").
 		Where("game_artworks.hero_url != '' AND game_artworks.logo_url != ''").
+		Order(effectiveRatingPrefixed + " DESC").
+		Limit(200).
 		Scan(&allRows).Error
 	if err != nil {
 		return nil, huma.Error500InternalServerError("failed to fetch featured games")
@@ -260,30 +269,49 @@ func (h *ExploreHandler) HumaGetExploreFeatured(ctx context.Context, _ *GetExplo
 func (h *ExploreHandler) HumaGetExploreRows(ctx context.Context, _ *GetExploreRowsInput) (*GetExploreRowsOutput, error) {
 	userID := UserIDFromContext(ctx)
 
-	rows := []ExploreRowResponse{}
-
-	if row, err := h.buildTopRatedRow(userID); err != nil {
-		return nil, huma.Error500InternalServerError("failed to build top-rated row")
-	} else if row != nil {
-		rows = append(rows, *row)
+	// The four row builders are independent — each runs its own
+	// queries with no shared state and no ordering dependency. Run
+	// them in parallel so wall time collapses to max(builder) instead
+	// of sum(builder). GORM v2 + SQLite WAL handle concurrent reads
+	// per goroutine via the connection pool.
+	type rowResult struct {
+		idx int
+		row *ExploreRowResponse
+		err error
+	}
+	builders := []func(uint) (*ExploreRowResponse, error){
+		h.buildTopRatedRow,
+		h.buildRecentlyAddedRow,
+		h.buildHiddenGemsRow,
+		h.buildMostPlayedRow,
+	}
+	results := make(chan rowResult, len(builders))
+	for i, fn := range builders {
+		i, fn := i, fn
+		go func() {
+			row, err := fn(userID)
+			results <- rowResult{idx: i, row: row, err: err}
+		}()
 	}
 
-	if row, err := h.buildRecentlyAddedRow(userID); err != nil {
-		return nil, huma.Error500InternalServerError("failed to build recently-added row")
-	} else if row != nil {
-		rows = append(rows, *row)
+	ordered := make([]*ExploreRowResponse, len(builders))
+	var firstErr error
+	for range builders {
+		r := <-results
+		if r.err != nil && firstErr == nil {
+			firstErr = r.err
+		}
+		ordered[r.idx] = r.row
+	}
+	if firstErr != nil {
+		return nil, huma.Error500InternalServerError("failed to build explore rows")
 	}
 
-	if row, err := h.buildHiddenGemsRow(userID); err != nil {
-		return nil, huma.Error500InternalServerError("failed to build hidden-gems row")
-	} else if row != nil {
-		rows = append(rows, *row)
-	}
-
-	if row, err := h.buildMostPlayedRow(userID); err != nil {
-		return nil, huma.Error500InternalServerError("failed to build most-played row")
-	} else if row != nil {
-		rows = append(rows, *row)
+	rows := make([]ExploreRowResponse, 0, len(builders))
+	for _, r := range ordered {
+		if r != nil {
+			rows = append(rows, *r)
+		}
 	}
 
 	return &GetExploreRowsOutput{

--- a/server/internal/api/huma_explore_foryou.go
+++ b/server/internal/api/huma_explore_foryou.go
@@ -69,40 +69,56 @@ func (h *ExploreHandler) HumaGetForYou(ctx context.Context, _ *GetForYouInput) (
 		return nil, huma.Error401Unauthorized("authentication required")
 	}
 
-	rows := []ForYouRowResponse{}
+	// Run the four row builders in parallel — they're independent and
+	// each one does its own DB queries. Same pattern as /explore/rows.
+	type result struct {
+		idx           int
+		becauseRows   []ForYouRowResponse
+		row           *ForYouRowResponse
+		err           error
+		errLogContext string
+	}
+	results := make(chan result, 4)
 
-	becauseRows, err := h.buildBecauseYouPlayedRows(userID)
-	if err != nil {
-		slog.Error("failed to build because-you-played rows", "error", err)
+	go func() {
+		rows, err := h.buildBecauseYouPlayedRows(userID)
+		results <- result{idx: 0, becauseRows: rows, err: err, errLogContext: "because-you-played rows"}
+	}()
+	go func() {
+		row, err := h.buildMoreGenreRow(userID)
+		results <- result{idx: 1, row: row, err: err, errLogContext: "more-genre row"}
+	}()
+	go func() {
+		row, err := h.buildUnfinishedRow(userID)
+		results <- result{idx: 2, row: row, err: err, errLogContext: "unfinished row"}
+	}()
+	go func() {
+		row, err := h.buildExpandHorizonsRow(userID)
+		results <- result{idx: 3, row: row, err: err, errLogContext: "expand-horizons row"}
+	}()
+
+	collected := make([]result, 4)
+	var firstErr error
+	for range collected {
+		r := <-results
+		collected[r.idx] = r
+		if r.err != nil {
+			slog.Error("failed to build for-you row", "row", r.errLogContext, "error", r.err)
+			if firstErr == nil {
+				firstErr = r.err
+			}
+		}
+	}
+	if firstErr != nil {
 		return nil, huma.Error500InternalServerError("failed to build recommendations")
 	}
-	rows = append(rows, becauseRows...)
 
-	moreGenreRow, err := h.buildMoreGenreRow(userID)
-	if err != nil {
-		slog.Error("failed to build more-genre row", "error", err)
-		return nil, huma.Error500InternalServerError("failed to build recommendations")
-	}
-	if moreGenreRow != nil {
-		rows = append(rows, *moreGenreRow)
-	}
-
-	unfinishedRow, err := h.buildUnfinishedRow(userID)
-	if err != nil {
-		slog.Error("failed to build unfinished row", "error", err)
-		return nil, huma.Error500InternalServerError("failed to build recommendations")
-	}
-	if unfinishedRow != nil {
-		rows = append(rows, *unfinishedRow)
-	}
-
-	expandRow, err := h.buildExpandHorizonsRow(userID)
-	if err != nil {
-		slog.Error("failed to build expand-horizons row", "error", err)
-		return nil, huma.Error500InternalServerError("failed to build recommendations")
-	}
-	if expandRow != nil {
-		rows = append(rows, *expandRow)
+	rows := make([]ForYouRowResponse, 0, 6)
+	rows = append(rows, collected[0].becauseRows...) // because-you-played (may be many)
+	for i := 1; i < 4; i++ {
+		if collected[i].row != nil {
+			rows = append(rows, *collected[i].row)
+		}
 	}
 
 	return &GetForYouOutput{

--- a/server/internal/api/huma_explore_temporal.go
+++ b/server/internal/api/huma_explore_temporal.go
@@ -120,20 +120,42 @@ func (h *ExploreHandler) HumaGetOnThisDay(ctx context.Context, _ *GetOnThisDayIn
 
 	dateLabel := now.Format("January 2")
 
-	var allGames []db.Game
+	// Pre-filter at SQL with LIKE patterns covering every release_date
+	// format parseReleaseDateMonthDay accepts. The old version loaded
+	// every release-dated game (could be 50k+ rows) into Go memory and
+	// ran time.Parse per row — the bottleneck per the perf audit.
+	// SQL filtering still scans the table (no index on release_date)
+	// but skips the wire transfer + reflection cost of building Game
+	// structs for rows we'll throw away.
+	likePatterns := onThisDayLikePatterns(targetMonth, targetDay)
+	whereSQL := "release_date IS NOT NULL AND release_date != '' AND is_primary = true AND deleted_at IS NULL AND ("
+	whereArgs := make([]interface{}, 0, len(likePatterns))
+	for i, p := range likePatterns {
+		if i > 0 {
+			whereSQL += " OR "
+		}
+		whereSQL += "release_date LIKE ?"
+		whereArgs = append(whereArgs, p)
+	}
+	whereSQL += ")"
+
+	var candidates []db.Game
 	if err := h.DB.Preload("Console").
-		Where("release_date != '' AND release_date IS NOT NULL AND is_primary = true AND deleted_at IS NULL").
-		Find(&allGames).Error; err != nil {
+		Where(whereSQL, whereArgs...).
+		Find(&candidates).Error; err != nil {
 		slog.Error("failed to fetch games for on-this-day", "error", err)
 		return nil, huma.Error500InternalServerError("failed to fetch games")
 	}
 
+	// LIKE patterns are intentionally over-inclusive (e.g. "%-05-13%"
+	// could match a substring inside a larger string). Re-validate by
+	// parsing the exact month/day per candidate row.
 	type matchedGame struct {
 		game db.Game
 		year int
 	}
 	var matched []matchedGame
-	for _, g := range allGames {
+	for _, g := range candidates {
 		month, day, ok := parseReleaseDateMonthDay(g.ReleaseDate)
 		if !ok {
 			continue

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -255,6 +255,52 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		slog.Warn("failed to ensure token_blacklists expires_at index", "error", err)
 	}
 
+	// Performance indexes for hot-path lookups. SQLite functional
+	// indexes (CREATE INDEX ... (LOWER(col))) are required for the
+	// many handlers that compare case-insensitively against
+	// games.title / games.developer / games.publisher — without these
+	// every `WHERE LOWER(col) = LOWER(?)` is a full table scan. See
+	// also the plain indexes for join columns (scraper_id,
+	// game_keywords.igdb_keyword_id) that GORM AutoMigrate doesn't
+	// derive from the model struct tags because they're not declared
+	// as standalone indexes on the column.
+	//
+	// All idempotent: IF NOT EXISTS means the second startup is a
+	// no-op. Adding a new index here only costs the create-index
+	// time on the next upgrade.
+	for _, ddl := range []struct {
+		name string
+		stmt string
+	}{
+		// /api/games/{id}/similar matches cached IGDB titles to local
+		// games via `WHERE LOWER(title) = LOWER(?)` (one query per
+		// cached row). Same for several explore-developer / -publisher
+		// handlers and the global top-rated join.
+		{"idx_games_title_lower", "CREATE INDEX IF NOT EXISTS idx_games_title_lower ON games(LOWER(title))"},
+		// /api/explore/developers/{name} and
+		// /api/explore/developers/spotlight scope to a developer with
+		// `WHERE LOWER(developer) = LOWER(?)`.
+		{"idx_games_developer_lower", "CREATE INDEX IF NOT EXISTS idx_games_developer_lower ON games(LOWER(developer))"},
+		// /api/explore/publishers/{name} — same pattern as developer.
+		{"idx_games_publisher_lower", "CREATE INDEX IF NOT EXISTS idx_games_publisher_lower ON games(LOWER(publisher))"},
+		// games.scraper_id ("igdb:<id>") is the join key for the
+		// top-rated and discovery joins. The model has no `gorm:"index"`
+		// tag on this column, so without this entry the joins were
+		// scanning the full games table.
+		{"idx_games_scraper_id", "CREATE INDEX IF NOT EXISTS idx_games_scraper_id ON games(scraper_id)"},
+		// /api/keywords aggregates by igdb_keyword_id; the existing
+		// unique compound index (game_id, igdb_keyword_id) doesn't help
+		// because igdb_keyword_id isn't the leading column.
+		{"idx_game_keywords_igdb_keyword_id", "CREATE INDEX IF NOT EXISTS idx_game_keywords_igdb_keyword_id ON game_keywords(igdb_keyword_id)"},
+		// top_rated_games.name is matched case-insensitively against
+		// games.title in the humaTopListByRating JOIN.
+		{"idx_top_rated_games_name_lower", "CREATE INDEX IF NOT EXISTS idx_top_rated_games_name_lower ON top_rated_games(LOWER(name))"},
+	} {
+		if err := db.Exec(ddl.stmt).Error; err != nil {
+			slog.Warn("failed to ensure performance index", "index", ddl.name, "error", err)
+		}
+	}
+
 	// One-time backfill: games on consoles where CRC verification doesn't
 	// apply (Amiga, demos, ScummVM) used to land with status "unverified"
 	// because the scraper's skip-list didn't cover them. Flip those to


### PR DESCRIPTION
A grab-bag PR collecting the fixes and perf work from the manual-testing session. Every commit was validated in hot-reload before being committed.

## Player UI

- **Carousel focus-first + centered scroll**, three-tier animation cadence (slow / fast / snap based on press cadence), image-stagger short-circuit on re-enter, vertical-centering for any focused descendant in a LazyColumn screen (works on game-detail too, not just carousels)
- **Focus-ring visibility sweep** — fixed 11+ sites where `clickable` + `gamepadFocusable` weren't sharing an `interactionSource`, so the press/focus indication never painted (MetadataGrid links, FAB, settings, top bar, game-detail sessions, Home OnlineUsersRow, etc.). Game-detail SessionRow focus is restored on back-nav.
- **New `SpSectionLink` primitive** replaces 6 ad-hoc HomeScreen `SeeAllLink` call sites + ExploreScreen's "Browse Gallery"
- **Game-detail polish**: stale-while-revalidate cache for game detail (Option C write-through invalidation), in-flight job cancellation to fix the slow-response-from-prior-game race, "This game" badge in the Versions list, Explore screen duplicate-key crash fix
- **Console-screen polish**: empty top-bar title (the hero banner already shows the console name), removed the double-spinner overlap during initial load, ScreenLoadingIndicator default color → light grey (brand purple was reserved for actionable affordances), brightness-floor + lerp-target fix so very-dark console brands (Genesis #171717, PSP #000000) don't collapse to pure black
- **Lazy-fetch similar games** via a new `Modifier.onApproachingVisible` — the `/similar` request now only fires when the user scrolls toward the carousel, not on every game-detail open

## Server perf sweep

All ten endpoints flagged in the perf audit:

| Endpoint | Before | Fix |
|---|---|---|
| `/api/games/{id}/similar` | 991ms | async IGDB refresh + batched cross-ref + `LOWER(title)` functional index |
| `/api/consoles/{id}/top-rated` | 1.66s | async IGDB refresh + batched cross-ref |
| `/api/top-rated` (global) | 528ms | batched N+1 cross-ref + indexes |
| `/api/explore/on-this-day` | 645ms | SQL prefilter (was loading every release-dated game into Go) |
| `/api/keywords` | 621ms | 5-min in-process cache + index on `igdb_keyword_id` |
| `/api/explore/developers/spotlight` | 581ms | `LOWER(developer)` index + drop redundant COUNT |
| `/api/explore/rows` | 577ms | parallelize four independent row builders |
| `/api/explore/console-highlights` | 429ms | indexes (partial) |
| `/api/explore/for-you` | 418ms | parallelize four independent row builders |
| `/api/explore/featured` | 386ms | cap candidate set at top-200 by rating |

Common patterns addressed:

- IGDB cache refreshes were synchronous — moved to background goroutines so the response path never waits on outbound HTTP
- `LOWER(col) = LOWER(?)` queries on `games.title` / `developer` / `publisher` were unindexed full-scans — added SQLite functional indexes
- `games.scraper_id` (join key for top-rated) and `game_keywords.igdb_keyword_id` (aggregation key) had no plain index — added
- N+1 cross-reference loops (one query per cached IGDB row) replaced with single batched `IN (...)` queries
- Sequential row builders (4 independent helpers each) parallelized via goroutines
- `/explore/featured` used to transfer every hero-arted game in the catalog just so `weightedSample` could pick 10 — now capped at top-200 by rating, same selection distribution

Tests:
- All targeted slow-endpoint tests pass: `TestGetSimilarGames*`, `TestGetTopRated*`, `TestGetOnThisDay*`, `TestGetExploreRows_*` (15), `TestGetForYou_*` (6), `TestGetExploreFeatured*`, `TestGetDeveloperSpotlight*`, `TestListKeywords*`
- One supporting test-infra change: `setupTestEnv` pins SQLite `:memory:` to `MaxOpenConns(1)` so concurrent handlers (parallel row builders) don't land on fresh empty per-connection DBs. Production uses a file-backed DB and is unaffected.

## Test plan

- [ ] CI green
- [ ] Game-detail page loads visibly faster after deploy
- [ ] Console screen shows single light-grey loader, no double-spinner
- [ ] Genesis / PSP console backgrounds visibly grey rather than pure black
- [ ] Versions list on game-detail includes the current game with "This game" badge
- [ ] D-pad navigation: focus moves first, carousel pans to centre; vertical centering on game-detail LazyColumn screens
- [ ] Similar Games section only fetches when scrolled into view (check network panel)