### PR TITLE
fix: demo-console scrape backfill, screen layout sweep, focus polish

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/social/StarRatingRow.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/social/StarRatingRow.kt
@@ -1,18 +1,23 @@
 package com.spela.player.presentation.ui.components.social
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
@@ -21,6 +26,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -51,15 +57,33 @@ fun StarRatingRow(
             Row(horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall)) {
                 for (star in 1..5) {
                     val isFilled = currentRating != null && star <= currentRating
-                    Icon(
-                        imageVector = if (isFilled) Icons.Filled.Star else Icons.Outlined.StarOutline,
-                        contentDescription = "$star star",
-                        tint = if (isFilled) SpColor.Warning else SpColor.OnBackgroundTertiary,
+                    // Shared interactionSource so clickable + gamepadFocusable
+                    // see the same press/focus events — the canonical fix
+                    // from the focus-ring sweep. Without it the stars have
+                    // no visible focus / press indication.
+                    val interactionSource = remember { MutableInteractionSource() }
+                    Box(
                         modifier = Modifier
-                            .size(starSize)
-                            .semantics { role = Role.Button }
-                            .clickable { onRate(star) },
-                    )
+                            .clickable(
+                                interactionSource = interactionSource,
+                                indication = null,
+                                onClick = { onRate(star) },
+                            )
+                            .gamepadFocusable(
+                                shape = CircleShape,
+                                interactionSource = interactionSource,
+                                addFocusable = false,
+                            )
+                            .padding(SpSpacing.XXSmall)
+                            .semantics { role = Role.Button },
+                    ) {
+                        Icon(
+                            imageVector = if (isFilled) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                            contentDescription = "$star star",
+                            tint = if (isFilled) SpColor.Warning else SpColor.OnBackgroundTertiary,
+                            modifier = Modifier.size(starSize),
+                        )
+                    }
                 }
             }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -188,15 +187,18 @@ internal fun DeveloperHeroBanner(
                         .padding(SpSpacing.Large),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    // Company logo or name text
+                    // Company logo or name text. Use a fixed-size
+                    // container so ContentScale.Fit actually scales small
+                    // logos UP — widthIn/heightIn (upper bounds only)
+                    // let a 100×30 logo render at 100×30 inside a much
+                    // larger slot.
                     val logoUrl = companyInfo?.logoUrl
                     if (logoUrl != null) {
                         SpImage(
                             model = logoUrl,
                             contentDescription = "${detail.name} logo",
                             modifier = Modifier
-                                .widthIn(max = 200.dp)
-                                .heightIn(max = 80.dp)
+                                .size(width = 200.dp, height = 80.dp)
                                 .testTag("developer_company_logo"),
                             contentScale = ContentScale.Fit,
                             staggerMs = 0L,
@@ -317,12 +319,21 @@ internal fun DeveloperTopRatedRow(
     topGames: List<Game>,
     onGameSelected: (String) -> Unit,
     modifier: Modifier = Modifier,
+    /**
+     * When true, the first item in this carousel claims the screen's
+     * default focus on first entry. Use on the publisher/developer
+     * detail pages to land focus on the top of the content rather
+     * than dropping into "All games" further down (which would scroll
+     * the page on first paint).
+     */
+    isDefaultFocusGroup: Boolean = false,
 ) {
     SpCarousel(
         itemCount = topGames.size,
         modifier = modifier,
         memoryKey = "explore_developer_top_rated",
         itemKey = { topGames[it].id },
+        isDefaultFocusGroup = isDefaultFocusGroup,
     ) { index, focusRequester ->
         Box(modifier = Modifier.focusRequester(focusRequester)) {
             DeveloperTopRatedCard(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameActionsMenu.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameActionsMenu.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.WatchLater
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.filled.Refresh
@@ -40,6 +41,15 @@ internal fun GameActionsMenu(
     onTogglePlayLater: () -> Unit,
     onAddToCollection: () -> Unit,
     onGradient: Boolean = false,
+    /**
+     * Optional "Save state settings" menu item — opens the per-game
+     * save-state policy override sheet. Provided only for consoles
+     * whose save-state tier is Medium or Large (where the override
+     * is actually meaningful); for Small-tier consoles this is null
+     * and no menu item renders, since the per-game opt-out is
+     * pointless when the console itself never opted out.
+     */
+    onSaveStateSettings: (() -> Unit)? = null,
     onAdminScrape: (() -> Unit)? = null,
     onAdminRefreshAchievements: (() -> Unit)? = null,
     isAdminActionLoading: Boolean = false,
@@ -130,6 +140,29 @@ internal fun GameActionsMenu(
                     )
                 },
             )
+
+            if (onSaveStateSettings != null) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = "Save state settings",
+                            style = SpTypography.BodyMedium,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onSaveStateSettings()
+                    },
+                    modifier = Modifier.testTag("game_detail_menu_save_state_settings"),
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    },
+                )
+            }
 
             // Admin actions
             if (onAdminScrape != null || onAdminRefreshAchievements != null) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -12,7 +12,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.History
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
@@ -100,9 +99,10 @@ fun GameHeroContent(
     onAdminScrape: (() -> Unit)? = null,
     onAdminRefreshAchievements: (() -> Unit)? = null,
     /**
-     * Per-game save-state policy override. The control lives behind a
-     * gear icon in this hero action row → Game settings sheet (#855),
-     * not inline in the info column where it used to be.
+     * Per-game save-state policy override. The control lives inside
+     * the "..." actions menu under "Save state settings", and only
+     * appears for Medium/Large-tier consoles where the override is
+     * meaningful.
      */
     onSetGameSaveStatePolicy: (com.spela.player.domain.model.SaveStateChoice?) -> Unit = {},
 ) {
@@ -311,6 +311,14 @@ fun GameHeroContent(
                 )
             }
 
+            // Per-game save-state policy override is only meaningful
+            // for Medium/Large console tiers — Small-tier consoles
+            // (NES / GB / SNES, KB-sized states) never opt out at the
+            // console level, so the per-game override has nothing to
+            // override. Hide the menu entry entirely on those consoles
+            // rather than show a sheet with only a no-op toggle.
+            val showSaveStateSettings = game.consoleSaveStatePolicy !=
+                com.spela.player.domain.model.SaveStatePolicyTier.Small
             GameActionsMenu(
                 isFavorite = game.isFavorite,
                 isInPlayLater = game.isInPlayLater,
@@ -318,23 +326,12 @@ fun GameHeroContent(
                 onTogglePlayLater = onTogglePlayLater,
                 onAddToCollection = onAddToCollection,
                 onGradient = true,
+                onSaveStateSettings = if (showSaveStateSettings) {
+                    { showGameSettingsSheet = true }
+                } else null,
                 onAdminScrape = onAdminScrape,
                 onAdminRefreshAchievements = onAdminRefreshAchievements,
                 isAdminActionLoading = state.isAdminActionLoading,
-            )
-
-            // Game settings — currently only the per-game save-state
-            // policy override (#855). Lives behind a gear icon, not
-            // inline, so the rare-use override doesn't compete with
-            // Play / Resume for vertical real-estate. Future per-game
-            // policies (shader, core, input remap) can land in the
-            // same sheet without re-litigating placement.
-            com.spela.player.presentation.ui.components.SpIconButton(
-                icon = Icons.Filled.Settings,
-                contentDescription = "Game settings",
-                onClick = { showGameSettingsSheet = true },
-                onGradient = true,
-                modifier = Modifier.testTag("game_detail_settings_button"),
             )
 
             // Playtime + last played grouped so they wrap together
@@ -469,7 +466,7 @@ fun GameHeroContent(
     if (showGameSettingsSheet) {
         AlertDialog(
             onDismissRequest = { showGameSettingsSheet = false },
-            title = { Text("Game settings") },
+            title = { Text("Save state settings") },
             text = {
                 GameSaveStatePolicyToggle(
                     current = state.gameSaveStatePolicy,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
@@ -3,6 +3,7 @@ package com.spela.player.presentation.ui.feature.gamedetail
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.shape.RoundedCornerShape
+import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -148,6 +149,11 @@ private fun MetadataItem(
             .padding(vertical = SpSpacing.XSmall)
             .then(
                 if (onClick != null) Modifier
+                    // Save focus per metadata link so back-nav from the
+                    // developer / publisher detail screen restores focus
+                    // to the link the user clicked, instead of dropping
+                    // back to the screen's default-focus element.
+                    .focusRestoreItem(key = "metadata_$label")
                     .clickable(
                         interactionSource = interactionSource,
                         indication = null,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/FocusMemory.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/FocusMemory.kt
@@ -4,14 +4,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalWindowInfo
 import kotlinx.coroutines.delay
 
 /**
@@ -49,10 +54,21 @@ fun rememberFocusMemoryState(): MutableState<String> {
  *  - On back/tab-switch entry, if the saved key matches [key], focus is
  *    requested on this element after a brief layout-settle delay.
  *  - When [isDefault] is true and the saved key is empty (first visit, or
- *    cleared scope), focus is requested on this element instead — the
- *    "sensible default focus on entry" behavior. Only ONE element per
- *    scope should set [isDefault] = true; if multiple do, the first to
- *    fire claims focus and the rest skip.
+ *    cleared scope), focus is requested on this element — the "sensible
+ *    default focus on entry" behavior — **but only if the element is on
+ *    screen at the time of firing**. Off-screen defaults would force the
+ *    page to scroll on forward navigation (centerOnFocus pulls the focused
+ *    element to viewport center), which is jarring when the user expects to
+ *    land on a freshly-rendered page at the top. Restore (back navigation)
+ *    is intentionally unaffected — the user remembers being there and
+ *    expects to land back on the same element, scroll cost or no.
+ *
+ *    Without a default that fires, gamepad navigation still activates: the
+ *    [GamepadHandler] wrapper Box self-focuses on screen mount, and the
+ *    first d-pad press calls `moveFocus(Next)` to enter the content tree.
+ *
+ *    Only ONE element per scope should set [isDefault] = true; if multiple
+ *    do, the first to fire claims focus and the rest skip.
  *
  * Call sites can pass an existing [requester] when they already manage one
  * (e.g. SpCarousel's per-item requesters used for left/right navigation).
@@ -61,7 +77,8 @@ fun rememberFocusMemoryState(): MutableState<String> {
  * @param key Stable identifier for this element within its scope. For list
  *   items use a composite like `"$groupKey/$itemId"` so reorder is handled.
  * @param isDefault If true, this is the screen's default-focus element —
- *   it gets focus on first entry when no saved key exists.
+ *   it gets focus on first entry when no saved key exists AND the element
+ *   is on screen.
  * @param requester Optional shared [FocusRequester]. If null, one is created.
  */
 fun Modifier.focusRestoreItem(
@@ -72,6 +89,13 @@ fun Modifier.focusRestoreItem(
     val scope = LocalFocusMemory.current ?: return@composed this
     val isForward = LocalIsForwardNavigation.current
     val fr = requester ?: remember { FocusRequester() }
+
+    // Window height for the viewport-visibility gate on Action.Default.
+    // Read from LocalWindowInfo so it adapts to window resizes and
+    // works the same on desktop / Android.
+    val windowHeightPx = LocalWindowInfo.current.containerSize.height.toFloat()
+    var elementY by remember { mutableStateOf(Float.NaN) }
+    var elementHeight by remember { mutableStateOf(0) }
 
     // Capture the firing decision exactly once at first composition. We must
     // NOT re-evaluate later — if `isForward` flips during a back transition
@@ -99,14 +123,35 @@ fun Modifier.focusRestoreItem(
                 Action.Default -> current.isEmpty()
                 Action.None -> false
             }
-            if (stillValid) {
-                try { fr.requestFocus() } catch (_: Exception) {}
+            if (!stillValid) return@LaunchedEffect
+
+            // Default-focus only fires when the target is on screen at
+            // firing time. See the kdoc above for why. Action.Restore
+            // skips this gate — back-nav should always land on the
+            // remembered element, even if it requires scrolling.
+            if (initialAction == Action.Default) {
+                val measured = !elementY.isNaN()
+                val topInside = measured && elementY in 0f..windowHeightPx
+                val bottomInside = measured &&
+                    (elementY + elementHeight) in 0f..windowHeightPx
+                if (!measured || (!topInside && !bottomInside)) {
+                    return@LaunchedEffect
+                }
             }
+
+            try { fr.requestFocus() } catch (_: Exception) {}
         }
     }
 
     this
         .focusRequester(fr)
+        .onGloballyPositioned { coords ->
+            // Captured for the Default-action viewport gate above. The
+            // value updates every layout pass; the LaunchedEffect reads
+            // whatever is current at the 120 ms firing point.
+            elementY = coords.positionInRoot().y
+            elementHeight = coords.size.height
+        }
         .onFocusChanged { state ->
             if (state.hasFocus) {
                 scope.value = key

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ActivityScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ActivityScreen.kt
@@ -45,9 +45,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -57,10 +54,11 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.ActivityEvent
 import com.spela.player.presentation.intent.SocialIntent
+import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.SpAvatar
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpEmptyState
-import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.social.formatRelativeTime
 import com.spela.player.presentation.ui.feature.library.darken
@@ -92,22 +90,7 @@ fun ActivityScreen(
     val focusMemory = rememberFocusMemoryState()
 
     CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .drawBehind {
-                val cx = size.width / 2f
-                val cy = size.height / 2f
-                val d = (size.width + size.height) * 0.25f
-                drawRect(
-                    brush = Brush.linearGradient(
-                        colors = gradientColors,
-                        start = Offset(cx - d, cy - d),
-                        end = Offset(cx + d, cy + d),
-                    ),
-                )
-            },
-    ) {
+    SpScreen(gradientColors = gradientColors) {
         // Route the screen-level loading branch through the same
         // state-machine hook as PullToRefreshBox below, so the dots
         // honour the min-shown-for window once they appear.

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/AllGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/AllGamesScreen.kt
@@ -40,9 +40,9 @@ import com.spela.player.presentation.ui.components.SpSearchField
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.feature.library.GameLibraryControls
 import com.spela.player.presentation.ui.feature.library.GameListRowItem
+import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
-import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.GameListViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -61,7 +61,8 @@ fun AllGamesScreen(
         viewModel.onIntent(GameListIntent.Search(""))
     }
 
-    Column(modifier = Modifier.fillMaxSize().spScreenBackground()) {
+    SpScreen {
+    Column(modifier = Modifier.fillMaxSize()) {
         SpSearchField(
             value = searchQuery,
             onValueChange = { query ->
@@ -205,5 +206,6 @@ fun AllGamesScreen(
                 }
             }
         }
-    }
+    } // Column
+    } // SpScreen
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionDetailScreen.kt
@@ -42,6 +42,7 @@ import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.components.SpIconButton
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpSearchField
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
@@ -82,12 +83,8 @@ fun CollectionDetailScreen(
     val focusMemory = rememberFocusMemoryState()
 
     CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
-    Box(modifier = Modifier.fillMaxSize()) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
-        ) {
+    SpScreen {
+        Column(modifier = Modifier.fillMaxSize()) {
             SpTopBar(
                 title = state.selectedDetail?.name ?: "Collection",
                 showBack = true,
@@ -116,7 +113,10 @@ fun CollectionDetailScreen(
                     ScreenLoadingIndicator(message = "Loading collection...")
                 }
             } else if (state.selectedDetail != null) {
-                val detail = state.selectedDetail ?: return@CompositionLocalProvider
+                // We just null-checked; safe to bang. (Previously a
+                // non-local return through Box, but SpScreen isn't
+                // inline so labelled returns don't traverse it.)
+                val detail = state.selectedDetail!!
                 var searchQuery by rememberSaveable { mutableStateOf("") }
                 val showSearch = detail.games.size > 5
                 val filteredGames = if (searchQuery.isBlank()) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionsScreen.kt
@@ -29,9 +29,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionsScreen.kt
@@ -45,6 +45,7 @@ import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpFab
 import com.spela.player.presentation.ui.components.SpEmptyStates
+import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
 import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.components.SpSnackbar
@@ -93,23 +94,10 @@ fun CollectionsScreen(
     )
 
     CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
-    Box(modifier = Modifier.fillMaxSize().testTag(TestTags.SCREEN_COLLECTIONS)) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .drawBehind {
-                    val cx = size.width / 2f
-                    val cy = size.height / 2f
-                    val d = (size.width + size.height) * 0.25f
-                    drawRect(
-                        brush = Brush.linearGradient(
-                            colors = gradientColors,
-                            start = Offset(cx - d, cy - d),
-                            end = Offset(cx + d, cy + d),
-                        ),
-                    )
-                },
-        ) {
+    SpScreen(
+        gradientColors = gradientColors,
+        modifier = Modifier.testTag(TestTags.SCREEN_COLLECTIONS),
+    ) {
             // Route the screen-level loading branch through the same
             // state-machine hook as PullToRefreshBox below, so the dots
             // honour the min-shown-for window once they appear — no
@@ -215,7 +203,6 @@ fun CollectionsScreen(
                     }
                 }
             }
-        }
 
         // FAB
         SpFab(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.ui.layout.layout
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.runtime.Composable
@@ -33,8 +32,10 @@ import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.components.SpMainContentPadding
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpScreenTopSpacer
+import com.spela.player.presentation.ui.components.SpScrollableContent
 import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.feature.explore.DeveloperCompanyDescription
 import com.spela.player.presentation.ui.feature.explore.DeveloperDetailSkeleton
@@ -74,12 +75,9 @@ fun ExploreDeveloperScreen(
 
     SpScreen(modifier = Modifier.testTag("developer_detail_screen")) {
         CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize(),
-        ) {
-            when {
-                state.isLoading && state.detail == null -> {
+        when {
+            state.isLoading && state.detail == null -> {
+                Column(modifier = Modifier.fillMaxSize()) {
                     if (isGamepad) {
                         SpScreenTopSpacer()
                     } else {
@@ -91,33 +89,26 @@ fun ExploreDeveloperScreen(
                     }
                     DeveloperDetailSkeleton()
                 }
+            }
 
-                state.detail != null -> {
-                    val detail = state.detail!!
-                    val horizontalPadding = SpSpacing.ScreenHorizontal
+            state.detail != null -> {
+                val detail = state.detail!!
 
-                    Box(modifier = Modifier.fillMaxSize()) {
-                    SpSectionList(
-                        modifier = Modifier.fillMaxSize().testTag("developer_detail_content"),
-                    ) {
-                        // 0. Hero Banner — full-width edge-to-edge
-                        DeveloperHeroBanner(
-                            detail = detail,
-                            modifier = Modifier
-                                .focusRestoreItem(key = "explore_developer_hero", isDefault = true)
-                                .layout { measurable, constraints ->
-                                    val extraWidth = (horizontalPadding * 2).roundToPx()
-                                    val newConstraints = constraints.copy(
-                                        maxWidth = constraints.maxWidth + extraWidth,
-                                        minWidth = if (constraints.minWidth > 0) constraints.minWidth + extraWidth else 0,
-                                    )
-                                    val placeable = measurable.measure(newConstraints)
-                                    layout(placeable.width, placeable.height) {
-                                        placeable.place(-horizontalPadding.roundToPx(), 0)
-                                    }
-                                }
-                                .testTag("developer_hero_banner"),
-                        )
+                // Hero-banner page pattern from player/LAYOUT.md:
+                // SpScrollableContent → HeroBanner (edge-to-edge, no padding)
+                // → SpMainContentPadding → SpSectionList → sections. Top bar
+                // overlays as a sibling so it floats on the banner.
+                SpScrollableContent {
+                    DeveloperHeroBanner(
+                        detail = detail,
+                        modifier = Modifier
+                            .focusRestoreItem(key = "explore_developer_hero", isDefault = true)
+                            .testTag("developer_hero_banner"),
+                    )
+                    SpMainContentPadding {
+                        SpSectionList(
+                            modifier = Modifier.testTag("developer_detail_content"),
+                        ) {
                         // 1. About (company description)
                         val companyInfo = detail.companyInfo
                         if (companyInfo?.description != null) {
@@ -243,22 +234,26 @@ fun ExploreDeveloperScreen(
                                 )
                             }
                         }
-                    }
-                    // Top bar overlaid on everything — floats over the banner
-                    if (isGamepad) {
-                        SpScreenTopSpacer()
-                    } else {
-                        SpTopBar(
-                            title = "",
-                            showBack = true,
-                            onBack = onBack,
-                            onGradient = true,
-                        )
-                    }
-                    } // Box
-                }
+                        } // SpSectionList
+                    } // SpMainContentPadding
+                } // SpScrollableContent
 
-                else -> {
+                // Top bar overlaid on everything — floats over the banner.
+                // Sibling of SpScrollableContent inside SpScreen's Box scope.
+                if (isGamepad) {
+                    SpScreenTopSpacer()
+                } else {
+                    SpTopBar(
+                        title = "",
+                        showBack = true,
+                        onBack = onBack,
+                        onGradient = true,
+                    )
+                }
+            }
+
+            else -> {
+                Column(modifier = Modifier.fillMaxSize()) {
                     if (isGamepad) {
                         SpScreenTopSpacer()
                     } else {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
@@ -99,20 +99,31 @@ fun ExploreDeveloperScreen(
                 // → SpMainContentPadding → SpSectionList → sections. Top bar
                 // overlays as a sibling so it floats on the banner.
                 SpScrollableContent {
+                    // Hero banner is decorative — no focusable descendants
+                    // — so isDefault=true silently failed here and the
+                    // page's default-focus walked to the next candidate
+                    // ("All games" first item), which scrolled the page
+                    // to the bottom on first entry. Default-focus claim
+                    // moved to the first card in Top Rated (see below).
                     DeveloperHeroBanner(
                         detail = detail,
                         modifier = Modifier
-                            .focusRestoreItem(key = "explore_developer_hero", isDefault = true)
+                            .focusRestoreItem(key = "explore_developer_hero")
                             .testTag("developer_hero_banner"),
                     )
                     SpMainContentPadding {
                         SpSectionList(
                             modifier = Modifier.testTag("developer_detail_content"),
                         ) {
-                        // 1. About (company description)
+                        // 1. About — entity description (when IGDB has one).
+                        // Heading explicitly names the entity type so a
+                        // visitor landing on this page knows whether
+                        // they're reading about a developer or publisher
+                        // (the hero banner alone doesn't always make that
+                        // unambiguous).
                         val companyInfo = detail.companyInfo
                         if (companyInfo?.description != null) {
-                            SpTitledSection(title = "About") {
+                            SpTitledSection(title = "About this developer") {
                                 DeveloperCompanyDescription(
                                     companyInfo = companyInfo,
                                     modifier = Modifier.testTag("developer_company_description_section"),
@@ -120,45 +131,7 @@ fun ExploreDeveloperScreen(
                             }
                         }
 
-                        // 3. Related chips (publishers + related developers)
-                        val hasPublishers = detail.publishers.isNotEmpty()
-                        val hasRelated = detail.relatedDevelopers.isNotEmpty()
-                        if (hasPublishers || hasRelated) {
-                            FlowRow(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .testTag("developer_related_chips"),
-                                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-                                verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-                            ) {
-                                detail.publishers.forEach { publisher ->
-                                    SpChip(
-                                        text = "${publisher.name} (${publisher.count})",
-                                        onClick = { onPublisherSelected(publisher.name) },
-                                        modifier = Modifier
-                                            .testTag("developer_publisher_chip_${publisher.name}")
-                                            .semantics {
-                                                contentDescription = "${publisher.name}, ${publisher.count} games"
-                                                role = Role.Button
-                                            },
-                                    )
-                                }
-                                detail.relatedDevelopers.forEach { related ->
-                                    SpChip(
-                                        text = related.name,
-                                        onClick = { onDeveloperSelected(related.name) },
-                                        modifier = Modifier
-                                            .testTag("developer_related_chip_${related.name}")
-                                            .semantics {
-                                                contentDescription = "${related.name}, ${related.gameCount} games"
-                                                role = Role.Button
-                                            },
-                                    )
-                                }
-                            }
-                        }
-
-                        // 3. Top Rated
+                        // 2. Top Rated
                         if (detail.topGames.size >= 3) {
                             SpTitledSection(
                                 title = "Top Rated",
@@ -180,14 +153,27 @@ fun ExploreDeveloperScreen(
                                     topGames = detail.topGames,
                                     onGameSelected = onGameSelected,
                                     modifier = Modifier.testTag("developer_top_rated_section"),
+                                    isDefaultFocusGroup = true,
                                 )
                             }
                         }
 
-                        // 4. Games grid
+                        // 3. Your Stats
+                        if (detail.userStats != null) {
+                            SpTitledSection(title = "Your Stats") {
+                                DeveloperUserStatsCard(
+                                    userStats = detail.userStats,
+                                    totalGames = detail.gameCount,
+                                    onGameSelected = onGameSelected,
+                                    modifier = Modifier.testTag("developer_user_stats"),
+                                )
+                            }
+                        }
+
+                        // 4. All games — the full library entry-point.
                         if (detail.games.isNotEmpty()) {
                             SpTitledSection(
-                                title = "Games",
+                                title = "All games",
                                 titleTrailing = if (detail.games.size > 12 && onNavigateToGames != null) {
                                     {
                                         SpButton(
@@ -201,10 +187,15 @@ fun ExploreDeveloperScreen(
                                 SpGameGrid(
                                     items = detail.games.take(12).mapIndexed { index, game ->
                                         @Composable {
+                                            // Default-focus claim lives on
+                                            // Top Rated; falling back to
+                                            // the first game here would
+                                            // scroll the page on first
+                                            // entry past Top Rated +
+                                            // Your Stats.
                                             Box(
                                                 modifier = Modifier.focusRestoreItem(
                                                     key = "developer_${name}_game_${game.id}",
-                                                    isDefault = index == 0,
                                                 ),
                                             ) {
                                                 SpGridGameCard(
@@ -223,15 +214,59 @@ fun ExploreDeveloperScreen(
                             }
                         }
 
-                        // 5. Your Stats
-                        if (detail.userStats != null) {
-                            SpTitledSection(title = "Your Stats") {
-                                DeveloperUserStatsCard(
-                                    userStats = detail.userStats,
-                                    totalGames = detail.gameCount,
-                                    onGameSelected = onGameSelected,
-                                    modifier = Modifier.testTag("developer_user_stats"),
-                                )
+                        // 5. Connected companies — moved to the bottom
+                        // because the user is mostly here for the games
+                        // (sections 2–4), not the supply-chain trivia.
+                        // Split into two separately-labelled subsections
+                        // so each chip is obviously a publisher OR a
+                        // related developer, not an undifferentiated mix.
+                        if (detail.publishers.isNotEmpty()) {
+                            SpTitledSection(title = "Published by") {
+                                FlowRow(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .testTag("developer_publisher_chips"),
+                                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                                    verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                                ) {
+                                    detail.publishers.forEach { publisher ->
+                                        SpChip(
+                                            text = "${publisher.name} (${publisher.count})",
+                                            onClick = { onPublisherSelected(publisher.name) },
+                                            modifier = Modifier
+                                                .testTag("developer_publisher_chip_${publisher.name}")
+                                                .semantics {
+                                                    contentDescription = "${publisher.name}, ${publisher.count} games"
+                                                    role = Role.Button
+                                                },
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
+                        if (detail.relatedDevelopers.isNotEmpty()) {
+                            SpTitledSection(title = "Related developers") {
+                                FlowRow(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .testTag("developer_related_chips"),
+                                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                                    verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                                ) {
+                                    detail.relatedDevelopers.forEach { related ->
+                                        SpChip(
+                                            text = related.name,
+                                            onClick = { onDeveloperSelected(related.name) },
+                                            modifier = Modifier
+                                                .testTag("developer_related_chip_${related.name}")
+                                                .semantics {
+                                                    contentDescription = "${related.name}, ${related.gameCount} games"
+                                                    role = Role.Button
+                                                },
+                                        )
+                                    }
+                                }
                             }
                         }
                         } // SpSectionList

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExplorePublisherScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExplorePublisherScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.ui.layout.layout
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.runtime.Composable
@@ -33,8 +32,10 @@ import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.components.SpMainContentPadding
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpScreenTopSpacer
+import com.spela.player.presentation.ui.components.SpScrollableContent
 import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.feature.explore.DeveloperCompanyDescription
 import com.spela.player.presentation.ui.feature.explore.DeveloperDetailSkeleton
@@ -74,11 +75,9 @@ fun ExplorePublisherScreen(
 
     SpScreen(modifier = Modifier.testTag("publisher_detail_screen")) {
         CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
-        Column(
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            when {
-                state.isLoading && state.detail == null -> {
+        when {
+            state.isLoading && state.detail == null -> {
+                Column(modifier = Modifier.fillMaxSize()) {
                     if (isGamepad) {
                         SpScreenTopSpacer()
                     } else {
@@ -90,33 +89,24 @@ fun ExplorePublisherScreen(
                     }
                     DeveloperDetailSkeleton()
                 }
+            }
 
-                state.detail != null -> {
-                    val detail = state.detail!!
-                    val horizontalPadding = SpSpacing.ScreenHorizontal
+            state.detail != null -> {
+                val detail = state.detail!!
 
-                    Box(modifier = Modifier.fillMaxSize()) {
+                // Hero-banner page pattern from player/LAYOUT.md.
+                // See matching comment in ExploreDeveloperScreen.
+                SpScrollableContent {
+                    DeveloperHeroBanner(
+                        detail = detail,
+                        modifier = Modifier
+                            .focusRestoreItem(key = "explore_publisher_hero", isDefault = true)
+                            .testTag("publisher_hero_banner"),
+                    )
+                    SpMainContentPadding {
                         SpSectionList(
-                            modifier = Modifier.fillMaxSize().testTag("publisher_detail_content"),
+                            modifier = Modifier.testTag("publisher_detail_content"),
                         ) {
-                            // 0. Hero Banner — full-width edge-to-edge
-                            DeveloperHeroBanner(
-                                detail = detail,
-                                modifier = Modifier
-                                    .focusRestoreItem(key = "explore_publisher_hero", isDefault = true)
-                                    .layout { measurable, constraints ->
-                                        val extraWidth = (horizontalPadding * 2).roundToPx()
-                                        val newConstraints = constraints.copy(
-                                            maxWidth = constraints.maxWidth + extraWidth,
-                                            minWidth = if (constraints.minWidth > 0) constraints.minWidth + extraWidth else 0,
-                                        )
-                                        val placeable = measurable.measure(newConstraints)
-                                        layout(placeable.width, placeable.height) {
-                                            placeable.place(-horizontalPadding.roundToPx(), 0)
-                                        }
-                                    }
-                                    .testTag("publisher_hero_banner"),
-                            )
                             // 1. About (company description)
                             val companyInfo = detail.companyInfo
                             if (companyInfo?.description != null) {
@@ -244,22 +234,25 @@ fun ExplorePublisherScreen(
                                     )
                                 }
                             }
-                        }
-                        // Top bar overlaid on everything — floats over the banner
-                        if (isGamepad) {
-                            SpScreenTopSpacer()
-                        } else {
-                            SpTopBar(
-                                title = "",
-                                showBack = true,
-                                onBack = onBack,
-                                onGradient = true,
-                            )
-                        }
-                    } // Box
-                }
+                        } // SpSectionList
+                    } // SpMainContentPadding
+                } // SpScrollableContent
 
-                else -> {
+                // Top bar overlaid on everything — floats over the banner.
+                if (isGamepad) {
+                    SpScreenTopSpacer()
+                } else {
+                    SpTopBar(
+                        title = "",
+                        showBack = true,
+                        onBack = onBack,
+                        onGradient = true,
+                    )
+                }
+            }
+
+            else -> {
+                Column(modifier = Modifier.fillMaxSize()) {
                     if (isGamepad) {
                         SpScreenTopSpacer()
                     } else {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExplorePublisherScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExplorePublisherScreen.kt
@@ -97,20 +97,26 @@ fun ExplorePublisherScreen(
                 // Hero-banner page pattern from player/LAYOUT.md.
                 // See matching comment in ExploreDeveloperScreen.
                 SpScrollableContent {
+                    // Hero banner is decorative — no focusable descendants
+                    // — see matching comment in ExploreDeveloperScreen.
+                    // Default-focus claim moved to Top Rated.
                     DeveloperHeroBanner(
                         detail = detail,
                         modifier = Modifier
-                            .focusRestoreItem(key = "explore_publisher_hero", isDefault = true)
+                            .focusRestoreItem(key = "explore_publisher_hero")
                             .testTag("publisher_hero_banner"),
                     )
                     SpMainContentPadding {
                         SpSectionList(
                             modifier = Modifier.testTag("publisher_detail_content"),
                         ) {
-                            // 1. About (company description)
+                            // 1. About — entity description (when IGDB has
+                            // one). Heading names the entity type so the
+                            // page is self-identifying. See matching
+                            // section in ExploreDeveloperScreen.
                             val companyInfo = detail.companyInfo
                             if (companyInfo?.description != null) {
-                                SpTitledSection(title = "About") {
+                                SpTitledSection(title = "About this publisher") {
                                     DeveloperCompanyDescription(
                                         companyInfo = companyInfo,
                                         modifier = Modifier.testTag("publisher_company_description_section"),
@@ -118,46 +124,7 @@ fun ExplorePublisherScreen(
                                 }
                             }
 
-                            // 2. Related chips — developers who worked with this publisher,
-                            // and related publishers with similar portfolios.
-                            val hasDevelopers = detail.developers.isNotEmpty()
-                            val hasRelated = detail.relatedPublishers.isNotEmpty()
-                            if (hasDevelopers || hasRelated) {
-                                FlowRow(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .testTag("publisher_related_chips"),
-                                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-                                    verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-                                ) {
-                                    detail.developers.forEach { developer ->
-                                        SpChip(
-                                            text = "${developer.name} (${developer.count})",
-                                            onClick = { onDeveloperSelected(developer.name) },
-                                            modifier = Modifier
-                                                .testTag("publisher_developer_chip_${developer.name}")
-                                                .semantics {
-                                                    contentDescription = "${developer.name}, ${developer.count} games"
-                                                    role = Role.Button
-                                                },
-                                        )
-                                    }
-                                    detail.relatedPublishers.forEach { related ->
-                                        SpChip(
-                                            text = related.name,
-                                            onClick = { onPublisherSelected(related.name) },
-                                            modifier = Modifier
-                                                .testTag("publisher_related_chip_${related.name}")
-                                                .semantics {
-                                                    contentDescription = "${related.name}, ${related.gameCount} games"
-                                                    role = Role.Button
-                                                },
-                                        )
-                                    }
-                                }
-                            }
-
-                            // 3. Top Rated
+                            // 2. Top Rated
                             if (detail.topGames.size >= 3) {
                                 SpTitledSection(
                                     title = "Top Rated",
@@ -179,14 +146,28 @@ fun ExplorePublisherScreen(
                                         topGames = detail.topGames,
                                         onGameSelected = onGameSelected,
                                         modifier = Modifier.testTag("publisher_top_rated_section"),
+                                        isDefaultFocusGroup = true,
                                     )
                                 }
                             }
 
-                            // 4. Games grid
+                            // 3. Your Stats
+                            val userStats = detail.userStats
+                            if (userStats != null) {
+                                SpTitledSection(title = "Your Stats") {
+                                    DeveloperUserStatsCard(
+                                        userStats = userStats,
+                                        totalGames = detail.gameCount,
+                                        onGameSelected = onGameSelected,
+                                        modifier = Modifier.testTag("publisher_user_stats"),
+                                    )
+                                }
+                            }
+
+                            // 4. All games — the full library entry-point.
                             if (detail.games.isNotEmpty()) {
                                 SpTitledSection(
-                                    title = "Games",
+                                    title = "All games",
                                     titleTrailing = if (detail.games.size > 12 && onNavigateToGames != null) {
                                         {
                                             SpButton(
@@ -200,10 +181,11 @@ fun ExplorePublisherScreen(
                                     SpGameGrid(
                                         items = detail.games.take(12).mapIndexed { index, game ->
                                             @Composable {
+                                                // Default-focus claim
+                                                // lives on Top Rated.
                                                 Box(
                                                     modifier = Modifier.focusRestoreItem(
                                                         key = "publisher_${name}_game_${game.id}",
-                                                        isDefault = index == 0,
                                                     ),
                                                 ) {
                                                     SpGridGameCard(
@@ -222,16 +204,60 @@ fun ExplorePublisherScreen(
                                 }
                             }
 
-                            // 5. Your Stats
-                            val userStats = detail.userStats
-                            if (userStats != null) {
-                                SpTitledSection(title = "Your Stats") {
-                                    DeveloperUserStatsCard(
-                                        userStats = userStats,
-                                        totalGames = detail.gameCount,
-                                        onGameSelected = onGameSelected,
-                                        modifier = Modifier.testTag("publisher_user_stats"),
-                                    )
+                            // 5. Connected companies — moved to the bottom
+                            // (visitors are mostly here for games) and
+                            // split into two separately-labelled
+                            // subsections so each chip is obviously a
+                            // developer that this publisher released
+                            // games for OR a publisher with a similar
+                            // portfolio.
+                            if (detail.developers.isNotEmpty()) {
+                                SpTitledSection(title = "Developers") {
+                                    FlowRow(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .testTag("publisher_developer_chips"),
+                                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                                        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                                    ) {
+                                        detail.developers.forEach { developer ->
+                                            SpChip(
+                                                text = "${developer.name} (${developer.count})",
+                                                onClick = { onDeveloperSelected(developer.name) },
+                                                modifier = Modifier
+                                                    .testTag("publisher_developer_chip_${developer.name}")
+                                                    .semantics {
+                                                        contentDescription = "${developer.name}, ${developer.count} games"
+                                                        role = Role.Button
+                                                    },
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (detail.relatedPublishers.isNotEmpty()) {
+                                SpTitledSection(title = "Related publishers") {
+                                    FlowRow(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .testTag("publisher_related_chips"),
+                                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                                        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                                    ) {
+                                        detail.relatedPublishers.forEach { related ->
+                                            SpChip(
+                                                text = related.name,
+                                                onClick = { onPublisherSelected(related.name) },
+                                                modifier = Modifier
+                                                    .testTag("publisher_related_chip_${related.name}")
+                                                    .semantics {
+                                                        contentDescription = "${related.name}, ${related.gameCount} games"
+                                                        role = Role.Button
+                                                    },
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         } // SpSectionList

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreWizardScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreWizardScreen.kt
@@ -37,10 +37,10 @@ import com.spela.player.presentation.ui.components.SpProgressBar
 import com.spela.player.presentation.ui.feature.explore.GameShelf
 import com.spela.player.presentation.ui.feature.explore.GameShelfSkeleton
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
+import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
-import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 
 @Composable
@@ -56,11 +56,9 @@ fun ExploreWizardScreen(
         viewModel.loadWizardSteps()
     }
 
+    SpScreen(modifier = Modifier.testTag("wizard_screen")) {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .spScreenBackground()
-            .testTag("wizard_screen"),
+        modifier = Modifier.fillMaxSize(),
     ) {
         // Top bar with back button
         Row(
@@ -289,5 +287,6 @@ fun ExploreWizardScreen(
                 }
             }
         }
-    }
+    } // Column
+    } // SpScreen
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/FavoritesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/FavoritesScreen.kt
@@ -20,12 +20,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.spela.player.presentation.intent.GameListIntent
-import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.SpEmptyStates
+import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.theme.SpSpacing
-import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.GameListViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -43,7 +43,7 @@ fun FavoritesScreen(
     val focusMemory = rememberFocusMemoryState()
 
     CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
-    Box(modifier = Modifier.fillMaxSize().spScreenBackground()) {
+    SpScreen {
         if (state.isLoading && state.favoriteGames.isEmpty()) {
             Box(
                 modifier = Modifier.fillMaxSize(),
@@ -90,6 +90,6 @@ fun FavoritesScreen(
                 }
             }
         }
-    }
+    } // SpScreen
     } // CompositionLocalProvider
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -73,6 +73,7 @@ import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTextField
+import androidx.compose.ui.text.input.ImeAction
 import com.spela.player.presentation.ui.components.SpTitledSection
 import com.spela.player.presentation.ui.components.social.ActivityEventItem
 import com.spela.player.presentation.ui.components.social.OnlineUsersRow
@@ -539,19 +540,22 @@ private fun DeviceNameBanner(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
                 ) {
+                    val submit = {
+                        if (nameInput.isNotBlank()) {
+                            onSave(nameInput)
+                        }
+                    }
                     SpTextField(
                         value = nameInput,
                         onValueChange = { nameInput = it },
                         placeholder = "My device",
+                        imeAction = ImeAction.Done,
+                        onImeAction = submit,
                         modifier = Modifier.weight(1f),
                     )
                     SpButton(
                         text = "Save",
-                        onClick = {
-                            if (nameInput.isNotBlank()) {
-                                onSave(nameInput)
-                            }
-                        },
+                        onClick = submit,
                         style = SpButtonStyle.Primary,
                         enabled = nameInput.isNotBlank(),
                     )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/PlayLaterScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/PlayLaterScreen.kt
@@ -20,12 +20,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.spela.player.presentation.intent.GameListIntent
-import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.ScreenLoadingIndicator
+import com.spela.player.presentation.ui.components.SpEmptyStates
+import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.rememberLoadingFlashDebounce
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.theme.SpSpacing
-import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.GameListViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -43,7 +43,7 @@ fun PlayLaterScreen(
     val focusMemory = rememberFocusMemoryState()
 
     CompositionLocalProvider(LocalFocusMemory provides focusMemory) {
-    Box(modifier = Modifier.fillMaxSize().spScreenBackground()) {
+    SpScreen {
         if (state.isLoading && state.playLaterGames.isEmpty()) {
             Box(
                 modifier = Modifier.fillMaxSize(),
@@ -90,6 +90,6 @@ fun PlayLaterScreen(
                 }
             }
         }
-    }
+    } // SpScreen
     } // CompositionLocalProvider
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
@@ -15,14 +15,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.components.ShaderPreviewDialog
 import com.spela.player.presentation.ui.components.SpConfirmDialog
 import com.spela.player.presentation.ui.components.SpDialog
+import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpTextField
 import com.spela.player.presentation.ui.components.keymapping.PresetPickerDialog
 import com.spela.player.presentation.ui.feature.library.darken
@@ -80,22 +78,7 @@ fun SettingsScreen(
         SpColor.SecondaryDark.darken(0.82f),
     )
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .drawBehind {
-                val cx = size.width / 2f
-                val cy = size.height / 2f
-                val d = (size.width + size.height) * 0.25f
-                drawRect(
-                    brush = Brush.linearGradient(
-                        colors = gradientColors,
-                        start = Offset(cx - d, cy - d),
-                        end = Offset(cx + d, cy + d),
-                    ),
-                )
-            },
-    ) {
+    SpScreen(gradientColors = gradientColors) {
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             val isWide = maxWidth > LIST_DETAIL_BREAKPOINT.dp
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package com.spela.player.presentation.ui.screen
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpTypography.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpTypography.kt
@@ -4,6 +4,40 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
+/**
+ * Centralised typography tokens for the player UI.
+ *
+ * ## Minimum size floor: 14sp
+ *
+ * Every token defined here is ≥ 14sp. The app's main UI must not use
+ * smaller text — readability on TVs, gaming handhelds, and for users
+ * with imperfect eyesight degrades quickly below that. 16sp is the
+ * default body / title size; 14sp is reserved for the genuinely
+ * smaller tier (labels, supporting metadata, chips).
+ *
+ * If you find yourself wanting smaller text, you almost certainly
+ * want to:
+ *
+ *   1. Move information to a different place in the layout, or
+ *   2. Use [FinePrint] explicitly — the one allowed exception, for
+ *      true disclaimers / legal-style text that the user shouldn't
+ *      need to read often.
+ *
+ * **Do not hardcode `fontSize = N.sp`** outside this file (with the
+ * narrow exception of in-game overlays where dense layouts are
+ * unavoidable — e.g. the secondary keyboard tab labels).
+ *
+ * ## Tier semantics
+ *
+ * - Display: hero / splash banners. Rare.
+ * - Headline: section titles ("Top Rated", "About this developer").
+ * - Title: card titles, list-item primary text.
+ * - Body: paragraphs, descriptions, metadata values.
+ * - Label: buttons, chips, tags, supporting metadata labels.
+ *
+ * Within a tier, *Small / Medium / Large are visual-weight knobs —
+ * they're all readable in the main UI.
+ */
 object SpTypography {
     // Display - for hero sections, splash screens
     val DisplayLarge = TextStyle(
@@ -52,11 +86,13 @@ object SpTypography {
         fontWeight = FontWeight.Medium,
         lineHeight = 20.sp,
     )
+    // 14sp — at the readability floor. Used to be 12sp; bumped per the
+    // app-wide minimum (see kdoc above).
     val TitleSmall = TextStyle(
-        fontSize = 12.sp,
+        fontSize = 14.sp,
         fontWeight = FontWeight.Medium,
-        lineHeight = 16.sp,
-        letterSpacing = 0.5.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp,
     )
 
     // Body - descriptions, paragraphs
@@ -70,10 +106,12 @@ object SpTypography {
         fontWeight = FontWeight.Normal,
         lineHeight = 20.sp,
     )
+    // 14sp — at the readability floor. Used to be 12sp; bumped per the
+    // app-wide minimum (see kdoc above).
     val BodySmall = TextStyle(
-        fontSize = 12.sp,
+        fontSize = 14.sp,
         fontWeight = FontWeight.Normal,
-        lineHeight = 16.sp,
+        lineHeight = 20.sp,
     )
 
     // Label - buttons, chips, tags
@@ -83,16 +121,44 @@ object SpTypography {
         lineHeight = 20.sp,
         letterSpacing = 0.25.sp,
     )
+    // 14sp — at the readability floor. Used to be 12sp; bumped per the
+    // app-wide minimum (see kdoc above).
     val LabelMedium = TextStyle(
-        fontSize = 12.sp,
+        fontSize = 14.sp,
         fontWeight = FontWeight.SemiBold,
-        lineHeight = 16.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.4.sp,
+    )
+    // 14sp — at the readability floor. Used to be 10sp; bumped per the
+    // app-wide minimum (see kdoc above).
+    val LabelSmall = TextStyle(
+        fontSize = 14.sp,
+        fontWeight = FontWeight.Medium,
+        lineHeight = 20.sp,
         letterSpacing = 0.5.sp,
     )
-    val LabelSmall = TextStyle(
-        fontSize = 10.sp,
-        fontWeight = FontWeight.Medium,
-        lineHeight = 14.sp,
-        letterSpacing = 0.5.sp,
+
+    /**
+     * Disclaimer / legal-style fine print. 12sp — the ONE allowed
+     * exception to the 14sp floor.
+     *
+     * Reserved for text that:
+     *
+     *   - The user should be aware of but doesn't need to read in
+     *     daily use (terms-of-service blurbs, attribution footers,
+     *     debug-build markers, ROM hash signatures shown for
+     *     verification, etc.)
+     *   - Is information-dense enough that compressing it down
+     *     actively helps comprehension (e.g. a tabular "this is
+     *     metadata about the metadata" footer).
+     *
+     * If you're tempted to use this for ordinary supporting metadata
+     * (release year, developer name, chip text), use [LabelSmall]
+     * (14sp) instead.
+     */
+    val FinePrint = TextStyle(
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Normal,
+        lineHeight = 16.sp,
     )
 }

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -327,6 +327,17 @@ func main() {
 		go scrapeWorker.Run(workerCtx)
 	}
 
+	// One-shot cleanup: clear stale IGDB metadata stuck on demo-console
+	// games (ADEMO / DDEMO) from before the Pouet routing was added, and
+	// enqueue them for a fresh Pouet scrape. Idempotent — guarded by a
+	// ServerSetting flag, so subsequent restarts are no-ops. See the
+	// kdoc on BackfillDemoConsoleMisscrapes for details.
+	go func() {
+		if err := metaScraper.BackfillDemoConsoleMisscrapes(); err != nil {
+			slog.Warn("demo-console misscrape backfill failed", "error", err)
+		}
+	}()
+
 	// Rebuild variant groups from scratch on startup. This is idempotent —
 	// the result depends only on filenames and IGDB IDs, not on existing
 	// group state. Fixes any corruption from previous runs.

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -361,6 +361,21 @@ var discPattern = regexp.MustCompile(`(?i)[\(\[]\s*(?:disc|disk|cd)\s*(\d+)\s*[\
 // reasons. .ipf files are no longer indexed (see #892).
 var amigaDiscPattern = regexp.MustCompile(`\s([A-Z])$`)
 
+// amigaUnderscoreDiscPattern matches the alternative Amiga floppy
+// convention where each disk is suffixed with `_N` — e.g.
+// "BatmanVuelve_1.adf", "BatmanVuelve_2.adf". Common for ripped
+// demoscene productions where the original naming wasn't preserved.
+//
+// Restricted to 1-2 digit suffixes (`_1`..`_99`) to avoid grabbing
+// dates / serials / version numbers — `Game_2024.adf` (a 4-digit
+// year) and `Tool_v1.adf` won't match. Anchored to end-of-string
+// after extension is stripped.
+//
+// Safety: as with [amigaDiscPattern], a lone match isn't grouped
+// (see `len(files) < 2` guard in the disc-group loop), so a single
+// `Random_1.adf` stays as a standalone game.
+var amigaUnderscoreDiscPattern = regexp.MustCompile(`_(\d{1,2})$`)
+
 // trackPattern matches CD audio track markers in filenames, e.g. "(Track 06)", "(Track 1)".
 // These are companion files referenced by .cue sheets and should not be scanned as standalone games.
 var trackPattern = regexp.MustCompile(`(?i)\(Track\s*\d+\)`)
@@ -742,6 +757,13 @@ func stripAmigaDiscMarker(nameNoExt string) string {
 	return strings.TrimSpace(amigaDiscPattern.ReplaceAllString(nameNoExt, ""))
 }
 
+// stripAmigaUnderscoreDiscMarker removes the `_N` Amiga disc suffix from a
+// filename (extension already stripped). "BatmanVuelve_1" → "BatmanVuelve".
+// Pass-through if no match.
+func stripAmigaUnderscoreDiscMarker(nameNoExt string) string {
+	return strings.TrimSpace(amigaUnderscoreDiscPattern.ReplaceAllString(nameNoExt, ""))
+}
+
 // amigaDiscNumber converts a single uppercase letter to a 1-indexed disc
 // number ("A" → 1, "B" → 2, "E" → 5). Used for sorting Amiga disk sets.
 func amigaDiscNumber(letter string) int {
@@ -1082,6 +1104,17 @@ func (s *Scanner) scanMultiDisc(dir string, consoleMap map[string]*db.Console, f
 			parentDir := filepath.Dir(path)
 			nameNoExt := strings.TrimSuffix(info.Name(), filepath.Ext(info.Name()))
 			baseTitle := stripAmigaDiscMarker(nameNoExt)
+			key := discGroupKey{Dir: parentDir, Title: baseTitle}
+			discGroups[key] = append(discGroups[key], path)
+		} else if ext == ".adf" && amigaUnderscoreDiscPattern.MatchString(strings.TrimSuffix(info.Name(), ext)) {
+			// Amiga floppy alternative: "Title_1.adf" / "Title_2.adf" — `_N` suffix.
+			// Common for ripped demos. The 1-2-digit regex avoids
+			// catching years / serials. Lone matches stay as
+			// standalone games via the `len(files) < 2` guard
+			// downstream.
+			parentDir := filepath.Dir(path)
+			nameNoExt := strings.TrimSuffix(info.Name(), filepath.Ext(info.Name()))
+			baseTitle := stripAmigaUnderscoreDiscMarker(nameNoExt)
 			key := discGroupKey{Dir: parentDir, Title: baseTitle}
 			discGroups[key] = append(discGroups[key], path)
 		}

--- a/server/internal/scanner/scanner_test.go
+++ b/server/internal/scanner/scanner_test.go
@@ -450,6 +450,37 @@ func TestAmigaDiscPattern(t *testing.T) {
 	}
 }
 
+func TestAmigaUnderscoreDiscPattern(t *testing.T) {
+	// `_N` at end of name-without-extension, 1-2 digits. Common for ripped
+	// demoscene productions (e.g. BatmanVuelve_1.adf / BatmanVuelve_2.adf).
+	tests := []struct {
+		nameNoExt string
+		matches   bool
+		stripped  string
+	}{
+		{"BatmanVuelve_1", true, "BatmanVuelve"},
+		{"BatmanVuelve_2", true, "BatmanVuelve"},
+		{"Game_10", true, "Game"},
+		{"Game_99", true, "Game"},
+		// 3+ digits don't match (avoids matching years like _2024).
+		{"Tool_2024", false, "Tool_2024"},
+		{"Demo_1991_release", false, "Demo_1991_release"},
+		// Underscore but no trailing digit.
+		{"Final_Fantasy", false, "Final_Fantasy"},
+		// Mid-string `_N` doesn't anchor.
+		{"Star Trek_02_TNG", false, "Star Trek_02_TNG"},
+		// No underscore at all.
+		{"BatmanVuelve", false, "BatmanVuelve"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.nameNoExt, func(t *testing.T) {
+			assert.Equal(t, tt.matches, amigaUnderscoreDiscPattern.MatchString(tt.nameNoExt))
+			assert.Equal(t, tt.stripped, stripAmigaUnderscoreDiscMarker(tt.nameNoExt))
+		})
+	}
+}
+
 func TestAmigaDiscNumber(t *testing.T) {
 	tests := []struct {
 		letter string

--- a/server/internal/scraper/scraper_pouet.go
+++ b/server/internal/scraper/scraper_pouet.go
@@ -129,6 +129,123 @@ func (s *Scraper) applyPouetMetadata(game *db.Game, prod *pouet.Prod, console db
 	}
 }
 
+// backfillDemoMisscrapeFlag is the [db.ServerSetting] key used to record
+// that [Scraper.BackfillDemoConsoleMisscrapes] has run at least once on
+// this database. The backfill is idempotent over its query (only acts on
+// rows that still have igdb:* on a demo console), but we still gate it on
+// the flag so the work doesn't repeat on every startup once cleared.
+const backfillDemoMisscrapeFlag = "backfill_demo_igdb_misscrape_v1"
+
+// BackfillDemoConsoleMisscrapes clears IGDB-sourced metadata from demo-
+// console games (ADEMO / DDEMO) that have an `igdb:*` scraper ID, then
+// enqueues them for a fresh Pouet-routed scrape.
+//
+// Why: the DemoConsoles → Pouet routing in ScrapeGame was added after
+// some libraries had already been scraped through the IGDB path. The
+// fuzzy-match path in IGDB matches demo filenames (e.g. "Batmanpower
+// (The Goonies) [1989].adf") to real games (Ocean's Batman), and once
+// those bogus matches are saved the routing rule alone won't undo them
+// — re-scrape only runs on user-initiated rescrape or scanner-detected
+// file changes, neither of which fire on a stable library.
+//
+// One-shot via [backfillDemoMisscrapeFlag]: once the flag is set, the
+// backfill is a no-op. This avoids re-correcting an admin's deliberate
+// IGDB-to-demo match (e.g. linking a demo to a base game) after server
+// restarts. Admins who want to re-run the backfill can delete the
+// ServerSetting row.
+func (s *Scraper) BackfillDemoConsoleMisscrapes() error {
+	var setting db.ServerSetting
+	if err := s.DB.Where("key = ?", backfillDemoMisscrapeFlag).First(&setting).Error; err == nil {
+		// Already run on this DB.
+		return nil
+	}
+
+	demoAbbrevs := make([]string, 0, len(DemoConsoles))
+	for abbr := range DemoConsoles {
+		demoAbbrevs = append(demoAbbrevs, abbr)
+	}
+
+	var games []db.Game
+	if err := s.DB.
+		Joins("JOIN consoles ON consoles.id = games.console_id").
+		Where("consoles.abbreviation IN ?", demoAbbrevs).
+		Where("games.scraper_id LIKE 'igdb:%'").
+		Find(&games).Error; err != nil {
+		return fmt.Errorf("querying demo-console misscrapes: %w", err)
+	}
+
+	if len(games) == 0 {
+		// Set the flag so we don't repeat the query on every startup.
+		s.DB.Create(&db.ServerSetting{Key: backfillDemoMisscrapeFlag, Value: "done"})
+		return nil
+	}
+
+	slog.Info("backfilling demo-console misscrapes", "count", len(games))
+
+	ids := make([]uint, 0, len(games))
+	for _, g := range games {
+		ids = append(ids, g.ID)
+	}
+
+	// Clear the IGDB-sourced fields. Mirror the field set that
+	// ScrapeGame's re-scrape path clears, so the next scrape starts
+	// from a clean slate. Title is intentionally left as-is — a
+	// re-scrape with a successful Pouet match will overwrite it, and
+	// for demos with filenames too generic for Pouet to match
+	// (e.g. "BatmanVuelve_1.adf") the existing Title is at least a
+	// hint of the original even if it came from a wrong IGDB match.
+	if err := s.DB.Model(&db.Game{}).
+		Where("id IN ?", ids).
+		Updates(map[string]interface{}{
+			"scraper_id":              "",
+			"cover_url":               "",
+			"screenshot_url":          "",
+			"libretro_cover_url":      "",
+			"igdb_cover_url":          "",
+			"description":             "",
+			"storyline":               "",
+			"developer":               "",
+			"publisher":               "",
+			"genre":                   "",
+			"game_modes":              "",
+			"players":                 0,
+			"total_rating":            0,
+			"total_rating_count":      0,
+			"igdb_user_rating":        0,
+			"igdb_user_rating_count":  0,
+			"time_to_beat_hastily":    0,
+			"time_to_beat_normally":   0,
+			"time_to_beat_completely": 0,
+			"scrape_attempts":         0,
+		}).Error; err != nil {
+		return fmt.Errorf("clearing demo-console misscrape metadata: %w", err)
+	}
+
+	// Drop normalised screenshot + release-date rows for these games
+	// — same as ScrapeGame's re-scrape branch does inline.
+	s.DB.Where("game_id IN ?", ids).Delete(&db.GameScreenshot{})
+	s.DB.Where("game_id IN ?", ids).Delete(&db.GameReleaseDate{})
+
+	// Enqueue for a fresh Pouet scrape. Low priority so user-initiated
+	// scrapes still jump the queue.
+	if s.Queue != nil {
+		if err := s.Queue.EnqueueGames(0, ids, 10); err != nil {
+			slog.Warn("failed to enqueue demo-console misscrapes for re-scrape",
+				"count", len(ids), "error", err)
+		}
+	}
+
+	// Mark done so the next startup is a no-op.
+	if err := s.DB.Create(&db.ServerSetting{
+		Key:   backfillDemoMisscrapeFlag,
+		Value: "done",
+	}).Error; err != nil {
+		slog.Warn("failed to record demo-misscrape backfill flag", "error", err)
+	}
+
+	return nil
+}
+
 // ScrapeGameWithPouetMatch applies metadata from a specific Pouet production ID.
 func (s *Scraper) ScrapeGameWithPouetMatch(game *db.Game, pouetID string) error {
 	prod, err := s.PouetClient.GetProd(pouetID)


### PR DESCRIPTION
Second mega-fix branch from a manual-testing batch. Each commit was validated in hot-reload before being committed.

## Server / scraper

- **`fix(scraper)`: backfill stale IGDB metadata on demo-console games.** 83 records on ADEMO / DDEMO in the deployed library have `igdb:*` scraper IDs from before the DemoConsoles → Pouet routing existed. Examples in the production data: "Batmanpower (The Goonies) [1989].adf" → Ocean's Batman, "Helloween DrStein (Xerox).adf" → IGDB "Hellbent", "Abused (Redline) [1996].adf" → IGDB "Abuse". One-shot, idempotent, guarded by a ServerSetting flag — runs on next startup, clears the bogus fields, enqueues for fresh Pouet scrapes. Re-runnable by `DELETE FROM server_settings WHERE key = 'backfill_demo_igdb_misscrape_v1'`.
- **`feat(scanner)`: recognize Amiga `_N` disc suffix for multi-disc grouping.** Files like `BatmanVuelve_1.adf` / `BatmanVuelve_2.adf` now group into one multi-disc game with an auto-generated `BatmanVuelve.m3u`, like the existing ` A`/` B` convention. Restricted to 1-2 trailing digits + end-of-string + `.adf` only, so years and serials don't false-match.

## Player

- **`fix(player)`: "Name this device" form submits on Enter.** The Home banner's text field had no IME-action wiring.
- **`fix(player)`: game-detail polish — cog moved to actions menu, star + metadata focus.** Cog button beside "..." moved into the actions menu as "Save state settings", only renders for Medium/Large console tiers where the override is meaningful. StarRatingRow stars now have a visible focus ring (shared-interactionSource clickable + gamepadFocusable). MetadataGrid links (Developer / Publisher / Achievements) now save focus so back-nav restores it.
- **`refactor(player)`: 10 screens migrated to SpScreen.** Activity / AllGames / Favorites / PlayLater / ExploreWizard / Collections / CollectionDetail / Settings + ExploreDeveloper / ExplorePublisher were using ad-hoc `Box(fillMaxSize().spScreenBackground())` or hand-rolled gradient `drawBehind`. All now use SpScreen per LAYOUT.md. ExploreDeveloper / ExplorePublisher also rebuilt to match the LAYOUT.md "Screen with hero banner" pattern (SpScrollableContent → HeroBanner edge-to-edge → SpMainContentPadding → SpSectionList).
- **`feat(player)`: publisher/developer screen polish — sections, focus, logo.** Section order: About → Top Rated → Your Stats → All games → Connected companies. "About" headings name the entity type. Chips split into labelled subsections per type. Default-focus claim moved off the (non-focusable) hero banner onto the first Top Rated card. Hero logo container changed to fixed 200×80dp so `ContentScale.Fit` actually scales small logos up.
- **`feat(player)`: viewport-gate default-focus to avoid forward-nav scrolls.** Centralised in `focusRestoreItem`: when `isDefault = true` would land on an off-screen target during forward nav, the focus claim is skipped so the page stays at the top. Back-nav (`Action.Restore`) is unaffected — returning to a screen still scrolls to restore the previously-focused element. One-spot change in FocusMemory.kt benefits every screen.

## Test plan

- [ ] CI green
- [ ] After deploy: existing wrong-Ocean metadata on ADEMO games clears and re-scrapes correctly (visible on next visit; some demos with too-generic filenames will end up unmatched, which is still better than wrong Ocean metadata)
- [ ] `BatmanVuelve_1.adf` + `BatmanVuelve_2.adf` group as a single game with auto-generated m3u
- [ ] Developer / publisher pages load with Top Rated focused (not scrolled to All games), correct section order, logos visible at proper size, "About this developer" / "About this publisher" headings
- [ ] Game-detail "..." menu shows "Save state settings" entry for PS2/N64/etc., absent for NES/GB; rating stars have visible focus
- [ ] Name-this-device form submits on Enter