### PR TITLE
feat(search): platform-code hint in global search

### DIFF
--- a/server/internal/api/huma_search_social.go
+++ b/server/internal/api/huma_search_social.go
@@ -126,10 +126,20 @@ func (h *SearchHandler) HumaSearch(ctx context.Context, in *SearchInput) (*Searc
 		limit = 5
 	}
 
+	// Multi-token queries may include a platform abbreviation that
+	// prioritises (but doesn't filter) that platform's games — e.g.
+	// "jurassic park nes" or "nes jurassic park". The hint is dropped
+	// only for the games search; the other categories continue to
+	// search the full query so a user typing "nes" gets the NES
+	// console hit in the consoles tab too. See [extractConsoleHint].
+	gameQuery, priorityAbbr := h.extractConsoleHint(query)
+
 	escapedQuery := escapeLikePattern(query)
 	likePattern := "%" + escapedQuery + "%"
 
-	games := h.searchGames(likePattern, limit)
+	gamesLikePattern := "%" + escapeLikePattern(gameQuery) + "%"
+
+	games := h.searchGames(gamesLikePattern, limit, priorityAbbr)
 	consoles := h.searchConsoles(likePattern, limit)
 	developers := h.searchDevelopers(likePattern, limit)
 	publishers := h.searchPublishers(likePattern, limit)

--- a/server/internal/api/search_handler.go
+++ b/server/internal/api/search_handler.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"fmt"
 	"log/slog"
 	"math"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -90,8 +92,82 @@ type SearchFranchiseResult struct {
 // likeEscape is the ESCAPE clause fragment used in all LIKE queries.
 const likeEscape = " ESCAPE '\\'"
 
+// consoleAbbrSafe restricts what may be inlined into the CASE expression
+// used by [SearchHandler.searchGames] when applying a platform-code
+// priority. Real console abbreviations are A-Z 0-9 only (NES, SNES, GBA,
+// A52, GG, etc.); this regex rejects anything else as a guard against
+// future bugs that might let raw user text slip into priorityAbbr.
+var consoleAbbrSafe = regexp.MustCompile(`^[A-Z0-9]{1,16}$`)
+
+// extractConsoleHint pulls a single console-abbreviation token out of a
+// multi-token search query so callers can prioritise (not filter)
+// matching games. Lets users type "jurassic park nes" or "nes jurassic
+// park" and have NES results float to the top.
+//
+// Rules:
+//   - One-token queries are returned unchanged. ("nes" alone keeps the
+//     existing behaviour: searches every category for "nes" and finds
+//     the NES console.)
+//   - For multi-token queries, the first token whose lower-cased form
+//     exactly matches a Console.Abbreviation (case-insensitive) is
+//     stripped from the query; that abbreviation becomes the hint.
+//   - If stripping leaves fewer than two characters of query, the hint
+//     is dropped and the original query is returned — we don't want
+//     "DS Dark Souls" → search for nothing if the user was reaching
+//     for the regular search.
+//   - If no token matches, the original query is returned with empty hint.
+//
+// Returns the (potentially-stripped) cleaned query and the canonical
+// upper-case abbreviation of the matched console, or empty string if
+// none.
+func (h *SearchHandler) extractConsoleHint(query string) (cleanedQuery string, priorityAbbr string) {
+	tokens := strings.Fields(query)
+	if len(tokens) < 2 {
+		return query, ""
+	}
+
+	var consoleAbbrs []string
+	if err := h.DB.Model(&db.Console{}).
+		Where("deleted_at IS NULL").
+		Pluck("abbreviation", &consoleAbbrs).Error; err != nil {
+		return query, ""
+	}
+	abbrSet := make(map[string]string, len(consoleAbbrs))
+	for _, a := range consoleAbbrs {
+		abbrSet[strings.ToLower(a)] = a
+	}
+
+	matched := ""
+	remaining := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		if matched == "" {
+			if canonical, ok := abbrSet[strings.ToLower(t)]; ok {
+				matched = canonical
+				continue
+			}
+		}
+		remaining = append(remaining, t)
+	}
+
+	if matched == "" {
+		return query, ""
+	}
+
+	cleaned := strings.Join(remaining, " ")
+	if len(cleaned) < 2 {
+		// User typed something like "nes" with stray whitespace, or
+		// "nes a". Leaving them with a single-character query is
+		// useless. Fall back to the original.
+		return query, ""
+	}
+	return cleaned, matched
+}
+
 // searchGames searches for games matching the query, excluding soft-deleted entries.
-func (h *SearchHandler) searchGames(likePattern string, limit int) SearchCategoryResult[SearchGameResult] {
+//
+// When priorityAbbr is non-empty, games on that console float to the top
+// of the result list without filtering out other consoles' results.
+func (h *SearchHandler) searchGames(likePattern string, limit int, priorityAbbr string) SearchCategoryResult[SearchGameResult] {
 	type gameRow struct {
 		ID          uint
 		Title       string
@@ -112,11 +188,34 @@ func (h *SearchHandler) searchGames(likePattern string, limit int) SearchCategor
 		Count(&total)
 
 	var rows []gameRow
-	if err := h.DB.
+	q := h.DB.
 		Table("games").
 		Select("games.id, games.title, games.cover_url, consoles.name as console_name, consoles.abbreviation as console_abbr, games.developer, games.genre, consoles.cover_aspect").
 		Joins("JOIN consoles ON consoles.id = games.console_id").
-		Where(likeClause, likePattern).
+		Where(likeClause, likePattern)
+
+	// Priority-console hint: matching console first, then alphabetical
+	// within each bucket. Implemented via a CASE expression on the
+	// abbreviation column so SQLite can short-circuit the comparison
+	// per row without an extra subquery.
+	//
+	// priorityAbbr is sourced from extractConsoleHint, which only
+	// returns values it found in the consoles table — never user
+	// input — so inlining it into the SQL string is safe. Belt-and-
+	// braces: a regex sanity check rejects anything that isn't the
+	// alphanumeric / underscore form abbreviations actually use, so a
+	// future bug that lets user text leak in can't become injection.
+	// (Parameter binding via gorm.Expr / gorm.Order doesn't survive
+	// — GORM's Order() falls through to fmt.Sprintf and drops the
+	// Vars.)
+	if priorityAbbr != "" && consoleAbbrSafe.MatchString(priorityAbbr) {
+		q = q.Order(fmt.Sprintf(
+			"CASE WHEN UPPER(consoles.abbreviation) = '%s' THEN 0 ELSE 1 END",
+			strings.ToUpper(priorityAbbr),
+		))
+	}
+
+	if err := q.
 		Order("games.title ASC").
 		Limit(limit).
 		Scan(&rows).Error; err != nil {

--- a/server/internal/api/search_handler_test.go
+++ b/server/internal/api/search_handler_test.go
@@ -395,6 +395,112 @@ func TestSearch_RequiresAuth(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
+// TestSearch_PlatformCodeHintBoostsMatchingConsole covers the "jurassic
+// park nes" pattern: a multi-token query containing a console
+// abbreviation prioritises games on that console without filtering out
+// other consoles' results.
+func TestSearch_PlatformCodeHintBoostsMatchingConsole(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+
+	var snes, nes, gba db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snes).Error)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nes).Error)
+	require.NoError(t, database.Where("abbreviation = ?", "GBA").First(&gba).Error)
+
+	// Same title across three platforms — alphabetical order without
+	// the hint would put SNES before NES (S > N is false; actually
+	// SNES sorts after NES alphabetically by title which is identical,
+	// so order would come down to whatever the ORM returns).
+	// With a NES hint, NES must surface first regardless of SNES /
+	// GBA being in the result set.
+	titles := []db.Game{
+		{ConsoleID: snes.ID, Title: "Jurassic Park", FileName: "jp.smc", FilePath: "/roms/snes/jp.smc"},
+		{ConsoleID: nes.ID, Title: "Jurassic Park", FileName: "jp.nes", FilePath: "/roms/nes/jp.nes"},
+		{ConsoleID: gba.ID, Title: "Jurassic Park", FileName: "jp.gba", FilePath: "/roms/gba/jp.gba"},
+	}
+	for i := range titles {
+		require.NoError(t, database.Create(&titles[i]).Error)
+	}
+
+	cases := []struct {
+		name   string
+		query  string
+		expect string
+	}{
+		{"suffix", "jurassic park nes", "nes"},
+		{"prefix", "nes jurassic park", "nes"},
+		{"mixed case", "Jurassic Park NES", "nes"},
+		{"uppercase abbrev", "JURASSIC PARK NES", "nes"},
+		// Different console — make sure the hint is being read, not
+		// hard-coded.
+		{"snes hint", "jurassic park snes", "snes"},
+		{"gba hint", "jurassic park gba", "gba"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, resp := searchGet(t, router, token,
+				"/api/search?q="+url.QueryEscape(tc.query))
+			require.Equal(t, http.StatusOK, code)
+			require.GreaterOrEqual(t, len(resp.Games.Results), 3,
+				"all three platform variants should still be in the result set (hint priortises, doesn't filter)")
+			assert.Equal(t, tc.expect, resp.Games.Results[0].ConsoleID,
+				"first result should be on the hinted console")
+		})
+	}
+}
+
+// TestSearch_PlatformCodeHintSingleTokenStillSearchesEverything verifies
+// the "user typed just `nes` alone" case isn't stripped to an empty
+// query. A single token shouldn't trigger console-hint extraction; the
+// token has to remain in the games-title LIKE pattern.
+func TestSearch_PlatformCodeHintSingleTokenStillSearchesEverything(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+
+	var nes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nes).Error)
+
+	// A game whose title contains "nes" — confirms the unmodified
+	// single-token query still runs the LIKE search instead of being
+	// stripped to nothing by the hint extractor.
+	g := db.Game{ConsoleID: nes.ID, Title: "Jonesy NES", FileName: "jn.nes", FilePath: "/roms/nes/jn.nes"}
+	require.NoError(t, database.Create(&g).Error)
+
+	code, resp := searchGet(t, router, token, "/api/search?q=nes")
+	require.Equal(t, http.StatusOK, code)
+	assert.NotEmpty(t, resp.Games.Results,
+		"single-token query should not strip the token; it should LIKE-match game titles")
+}
+
+// TestSearch_PlatformCodeHintDoesNotFilterOtherConsoles asserts the
+// "don't filter out other platforms" contract from the spec.
+func TestSearch_PlatformCodeHintDoesNotFilterOtherConsoles(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+
+	var snes, gba db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snes).Error)
+	require.NoError(t, database.Where("abbreviation = ?", "GBA").First(&gba).Error)
+
+	// "Final Fantasy" exists only on SNES and GBA. User types
+	// "final fantasy nes" — no NES game matches the title, but the
+	// result must still include SNES + GBA results, not be empty.
+	for i, c := range []db.Console{snes, gba} {
+		g := db.Game{
+			ConsoleID: c.ID,
+			Title:     "Final Fantasy",
+			FileName:  fmt.Sprintf("ff-%d.rom", i),
+			FilePath:  fmt.Sprintf("/roms/ff-%d.rom", i),
+		}
+		require.NoError(t, database.Create(&g).Error)
+	}
+
+	code, resp := searchGet(t, router, token,
+		"/api/search?q="+url.QueryEscape("final fantasy nes"))
+	require.Equal(t, http.StatusOK, code)
+	assert.Equal(t, 2, len(resp.Games.Results),
+		"NES hint must not filter out SNES + GBA results when no NES title matches")
+}
+
 func TestSearch_LimitDefaultsAndBounds(t *testing.T) {
 	database, router, token := setupSearchEnv(t)
 


### PR DESCRIPTION
Fifth mega-fix branch — one fix so far.

## `0b25a267` — global search platform-code priority

Cmd+K queries containing a console abbreviation now boost matching-platform games to the top without filtering other platforms out. Works at either end of the query — \`jurassic park nes\` and \`nes jurassic park\` both prioritise NES results.

- New \`extractConsoleHint\` helper plucks console abbreviations from the DB and looks for an exact token match in the query. Single-token queries are unchanged (so \`nes\` alone still searches every category normally).
- \`searchGames\` accepts a \`priorityAbbr\` parameter; when non-empty it adds an extra \`ORDER BY CASE WHEN UPPER(consoles.abbreviation) = '<abbr>' THEN 0 ELSE 1 END\` ahead of the alphabetical sort. SQLite short-circuits the comparison per row.
- \`consoleAbbrSafe\` regex (\`^[A-Z0-9]{1,16}$\`) gates the SQL inlining. The abbr already comes from the consoles table (never user input), but the regex is a defence-in-depth check in case a future bug lets user text leak in. (gorm.Expr / parameter binding don't survive \`Order()\` — it falls through to fmt.Sprintf and drops the Vars.)

Test coverage:
- \`TestSearch_PlatformCodeHintBoostsMatchingConsole\` — 6 sub-cases: suffix, prefix, mixed case, uppercase, two different platform codes
- \`TestSearch_PlatformCodeHintSingleTokenStillSearchesEverything\` — \`nes\` alone isn't stripped
- \`TestSearch_PlatformCodeHintDoesNotFilterOtherConsoles\` — \"final fantasy nes\" still returns SNES + GBA results when no NES title matches

## Test plan

- [ ] CI green
- [ ] Cmd+K \`jurassic park nes\` → NES Jurassic Park at the top, other platforms still listed below
- [ ] Cmd+K \`nes jurassic park\` → same result (order-independent)
- [ ] Cmd+K \`nes\` alone → still finds the NES console and title-contains matches