### PR TITLE
Pill nav gamepad-only (#1187) + Azahar to libretro buildbot (#1188)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InputModeTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InputModeTest.kt
@@ -10,13 +10,13 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * E2E tests for input mode detection (TOUCH vs GAMEPAD).
+ * E2E tests for the in-app InputMode flag (TOUCH vs GAMEPAD).
  *
- * Verifies:
- * - Default mode is touch → tab bar visible
- * - Setting GAMEPAD mode → section indicator appears, tab bar hidden
- * - Setting TOUCH mode → tab bar returns
- * - Focus recovery: D-pad key press populates focus even from unfocused state
+ * Post #1187 InputMode no longer drives the nav style — that's tied to physical
+ * controller presence. InputMode still exists to tell screens whether the user
+ * is doing pointer-style or focus-style navigation (auto-focus, etc.), so these
+ * tests verify that the flag transitions cleanly and crucially that flipping
+ * InputMode by itself does NOT change which navigation widget is rendered.
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
 class InputModeTest {
@@ -35,101 +35,69 @@ class InputModeTest {
         setContent { harness.App() }
         advance(harness)
 
-        // Default mode should be TOUCH
         assertEquals(InputMode.TOUCH, harness.gamepadPortManager.inputMode.value)
 
-        // Tab bar should be visible
         onNodeWithContentDescription("Home").assertExists()
         onNodeWithContentDescription("Consoles").assertExists()
         onNodeWithContentDescription("Settings").assertExists()
 
-        // Section indicator should not exist
         onNodeWithContentDescription("Section indicator").assertDoesNotExist()
     }
 
     @Test
-    fun gamepadModeSwitchesToSectionIndicator() = runComposeUiTest {
+    fun inputModeFlipsDoNotChangeNavStyle() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        // Switch to GAMEPAD mode
+        // No physical controller is connected — toggling InputMode (as keyboard
+        // navigation would) must leave the tab bar visible.
         harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advanceQuick(harness)
 
-        // Section indicator should appear
-        onNodeWithContentDescription("Section indicator").assertExists()
+        onNodeWithContentDescription("Home").assertExists()
+        onNodeWithContentDescription("Section indicator").assertDoesNotExist()
 
-        // Tab bar should be hidden
-        onNodeWithContentDescription("Home").assertDoesNotExist()
-    }
-
-    @Test
-    fun touchModeRestoresTabBar() = runComposeUiTest {
-        val harness = createLoggedInHarness()
-
-        setContent { harness.App() }
-        advance(harness)
-
-        // Switch to GAMEPAD mode
-        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
-        advanceQuick(harness)
-
-        // Verify gamepad mode
-        onNodeWithContentDescription("Section indicator").assertExists()
-        onNodeWithContentDescription("Home").assertDoesNotExist()
-
-        // Switch back to TOUCH mode (simulates touch on content)
         harness.gamepadPortManager.setInputMode(InputMode.TOUCH)
         advanceQuick(harness)
 
-        // Tab bar should return
         onNodeWithContentDescription("Home").assertExists()
-        onNodeWithContentDescription("Consoles").assertExists()
-
-        // Section indicator should be gone
         onNodeWithContentDescription("Section indicator").assertDoesNotExist()
     }
 
     @Test
-    fun inputModeTogglesRepeatedly() = runComposeUiTest {
+    fun inputModeStateTogglesCleanly() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        // Cycle through modes multiple times
         repeat(3) {
             harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
             advanceQuick(harness)
-            onNodeWithContentDescription("Section indicator").assertExists()
-            onNodeWithContentDescription("Home").assertDoesNotExist()
+            assertEquals(InputMode.GAMEPAD, harness.gamepadPortManager.inputMode.value)
 
             harness.gamepadPortManager.setInputMode(InputMode.TOUCH)
             advanceQuick(harness)
-            onNodeWithContentDescription("Home").assertExists()
-            onNodeWithContentDescription("Section indicator").assertDoesNotExist()
+            assertEquals(InputMode.TOUCH, harness.gamepadPortManager.inputMode.value)
         }
     }
 
     @Test
-    fun gamepadModePreservedAcrossScreens() = runComposeUiTest {
+    fun pillIsRetainedAcrossScreensWhenControllerStaysConnected() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        // Enter gamepad mode
-        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        harness.gamepadPortManager.connectDevice(1, "Test Controller")
         advanceQuick(harness)
         onNodeWithContentDescription("Section: Home, active").assertExists()
 
-        // Navigate to a different section
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
         advanceQuick(harness)
 
-        // Should still be in gamepad mode with the section indicator
         onNodeWithContentDescription("Section indicator").assertExists()
         onNodeWithContentDescription("Section: Explore, active").assertExists()
     }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionIndicatorTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionIndicatorTest.kt
@@ -9,8 +9,10 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlin.test.Test
 
 /**
- * E2E tests for the floating section indicator that replaces the bottom tab bar
- * when the user is in gamepad input mode.
+ * E2E tests for the floating section indicator (pill) that replaces the bottom
+ * tab bar when a physical gamepad is connected. See #1187: the pill is tied to
+ * controller presence, not to in-app InputMode, so keyboard + mouse users on
+ * desktop never see it flicker in.
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
 class SectionIndicatorTest {
@@ -29,72 +31,60 @@ class SectionIndicatorTest {
         setContent { harness.App() }
         advance(harness)
 
-        // Bottom nav tabs should be visible
         onNodeWithContentDescription("Home").assertExists()
         onNodeWithContentDescription("Consoles").assertExists()
         onNodeWithContentDescription("Settings").assertExists()
 
-        // Section indicator should not exist
         onNodeWithContentDescription("Section indicator").assertDoesNotExist()
     }
 
     @Test
-    fun sectionIndicatorAppearsOnGamepadInput() = runComposeUiTest {
+    fun sectionIndicatorAppearsWhenGamepadConnects() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        // Switch to gamepad input mode (simulates D-pad press)
-        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        harness.gamepadPortManager.connectDevice(1, "Test Controller")
         advanceQuick(harness)
 
-        // Section indicator should be visible
         onNodeWithContentDescription("Section indicator").assertExists()
-
-        // Bottom nav tabs should be gone
         onNodeWithContentDescription("Home").assertDoesNotExist()
     }
 
     @Test
-    fun gamepadConnectAloneDoesNotShowIndicator() = runComposeUiTest {
+    fun keyboardInputModeAloneDoesNotShowIndicator() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        // Just connecting a gamepad (without D-pad input) should NOT switch nav style
-        harness.gamepadPortManager.connectDevice(1, "Test Controller")
+        // Keyboard nav (arrow keys, [, ]) flips InputMode to GAMEPAD to drive
+        // focus behavior, but with no physical controller connected the nav
+        // style must stay as the tab bar so it doesn't flicker against mouse use.
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advanceQuick(harness)
 
-        // Tab bar should still be visible (touch mode)
         onNodeWithContentDescription("Home").assertExists()
         onNodeWithContentDescription("Consoles").assertExists()
-
-        // Section indicator should not exist
         onNodeWithContentDescription("Section indicator").assertDoesNotExist()
     }
 
     @Test
-    fun sectionIndicatorDisappearsOnTouchInput() = runComposeUiTest {
+    fun sectionIndicatorDisappearsWhenGamepadDisconnects() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        // Enter gamepad mode
-        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        harness.gamepadPortManager.connectDevice(1, "Test Controller")
         advanceQuick(harness)
         onNodeWithContentDescription("Section indicator").assertExists()
 
-        // Switch back to touch mode
-        harness.gamepadPortManager.setInputMode(InputMode.TOUCH)
+        harness.gamepadPortManager.disconnectDevice(1)
         advanceQuick(harness)
 
-        // Section indicator should be gone
         onNodeWithContentDescription("Section indicator").assertDoesNotExist()
-
-        // Bottom nav should be back
         onNodeWithContentDescription("Home").assertExists()
         onNodeWithContentDescription("Consoles").assertExists()
     }
@@ -106,11 +96,9 @@ class SectionIndicatorTest {
         setContent { harness.App() }
         advance(harness)
 
-        // Switch to gamepad mode (we're on Home screen)
-        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        harness.gamepadPortManager.connectDevice(1, "Test Controller")
         advanceQuick(harness)
 
-        // Home should be the active section
         onNodeWithContentDescription("Section: Home, active").assertExists()
         onNodeWithContentDescription("Section: Consoles").assertExists()
         onNodeWithContentDescription("Section: Settings").assertExists()
@@ -123,15 +111,12 @@ class SectionIndicatorTest {
         setContent { harness.App() }
         advance(harness)
 
-        // Switch to gamepad mode
-        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        harness.gamepadPortManager.connectDevice(1, "Test Controller")
         advance(harness)
 
-        // Cycle to next section
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
         advanceQuick(harness)
 
-        // Indicator should show new active section
         onNodeWithContentDescription("Section indicator").assertExists()
         onNodeWithContentDescription("Section: Explore, active").assertExists()
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -94,12 +94,13 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
     ) {
         val navState by navigationViewModel.state.collectAsState()
 
-        // Input mode detection: TOUCH shows tab bar, GAMEPAD shows section indicator
-        val inputMode by gamepadPortManager?.inputMode?.collectAsState()
-            ?: remember { mutableStateOf(InputMode.TOUCH) }
-        val isGamepadMode = inputMode == InputMode.GAMEPAD
+        // Nav style is driven by whether a physical gamepad is connected, not by
+        // the in-app InputMode. Keyboard + mouse users (no gamepad) always see the
+        // tab bar / side rail, so the nav doesn't flicker between styles as they
+        // switch between typing and clicking. See #1187.
         val controllerStatus by gamepadPortManager?.controllerStatus?.collectAsState()
             ?: remember { mutableStateOf(ControllerStatusState.Empty) }
+        val isGamepadMode = controllerStatus.connectedCount > 0
         val sectionIndicatorVisible = isGamepadMode
 
         // Indicator for E2E tests: exposes whether the libretro core is running.

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
@@ -30,20 +30,6 @@ import com.spela.player.libretro.ControllerStatusState
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 
-/**
- * Glyphs for the prev/next-section bumpers shown on either side of the
- * pill. When a controller is connected we use the L1/R1 labels that
- * match the bumper buttons; otherwise we surface the keyboard bindings
- * (`[` / `]`) the GamepadHandler already wires (#1136). This keeps the
- * pill honest about what each user can actually press.
- */
-private data class SectionBumperGlyphs(val prev: String, val next: String) {
-    companion object {
-        val Gamepad = SectionBumperGlyphs(prev = "L1", next = "R1")
-        val Keyboard = SectionBumperGlyphs(prev = "[", next = "]")
-    }
-}
-
 @Composable
 fun SpSectionIndicator(
     activeTab: BottomNavTab,
@@ -52,11 +38,6 @@ fun SpSectionIndicator(
     modifier: Modifier = Modifier,
 ) {
     val animationsEnabled = LocalAnimationsEnabled.current
-    val glyphs = if (controllerStatus.connectedCount > 0) {
-        SectionBumperGlyphs.Gamepad
-    } else {
-        SectionBumperGlyphs.Keyboard
-    }
 
     AnimatedVisibility(
         visible = visible,
@@ -75,7 +56,7 @@ fun SpSectionIndicator(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = glyphs.prev,
+                text = "L1",
                 color = SpColor.OnBackgroundSecondary,
                 fontSize = 12.sp,
             )
@@ -94,7 +75,7 @@ fun SpSectionIndicator(
                 }
             }
             Text(
-                text = glyphs.next,
+                text = "R1",
                 color = SpColor.OnBackgroundSecondary,
                 fontSize = 12.sp,
             )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/BuildbotUrl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/BuildbotUrl.kt
@@ -3,6 +3,18 @@ package com.spela.player.util
 private const val BUILDBOT_BASE = "https://buildbot.libretro.com/nightly"
 
 /**
+ * Cores whose Android nightly is packaged without the `_android` suffix.
+ *
+ * libretro buildbot publishes most Android cores as
+ * `<name>_libretro_android.so` inside `<name>_libretro_android.so.zip`, but
+ * a handful of newer cores (azahar) ship as `<name>_libretro.so` inside
+ * `<name>_libretro.so.zip`. The convention is enforced upstream by the
+ * buildbot config, not by anything we control — when in doubt, HEAD the
+ * two URLs to confirm.
+ */
+private val ANDROID_NO_SUFFIX_CORES = setOf("azahar")
+
+/**
  * Builds the libretro buildbot download URL for a given core name.
  *
  * URL patterns per platform:
@@ -13,7 +25,14 @@ private const val BUILDBOT_BASE = "https://buildbot.libretro.com/nightly"
  */
 fun buildbotCoreUrl(coreName: String, platform: String = currentPlatform(), arch: String = currentArch()): String {
     return when (platform) {
-        "android" -> "$BUILDBOT_BASE/android/latest/$arch/${coreName}_libretro_android.so.zip"
+        "android" -> {
+            val asset = if (coreName in ANDROID_NO_SUFFIX_CORES) {
+                "${coreName}_libretro.so.zip"
+            } else {
+                "${coreName}_libretro_android.so.zip"
+            }
+            "$BUILDBOT_BASE/android/latest/$arch/$asset"
+        }
         "macos" -> "$BUILDBOT_BASE/apple/osx/$arch/latest/${coreName}_libretro.dylib.zip"
         "windows" -> "$BUILDBOT_BASE/windows/$arch/latest/${coreName}_libretro.dll.zip"
         else -> {
@@ -37,10 +56,18 @@ fun resolveDownloadUrl(template: String, platform: String = currentPlatform(), a
 
 /**
  * Returns the expected filename of the extracted core binary.
+ *
+ * Mirrors the buildbot asset naming — cores in [ANDROID_NO_SUFFIX_CORES]
+ * ship as `<name>_libretro.so` on Android too, so the cached on-disk
+ * filename has to match what's inside the zip.
  */
 fun coreFileName(coreName: String, platform: String = currentPlatform()): String {
     return when (platform) {
-        "android" -> "${coreName}_libretro_android.so"
+        "android" -> if (coreName in ANDROID_NO_SUFFIX_CORES) {
+            "${coreName}_libretro.so"
+        } else {
+            "${coreName}_libretro_android.so"
+        }
         "macos" -> "${coreName}_libretro.dylib"
         "windows" -> "${coreName}_libretro.dll"
         else -> "${coreName}_libretro.so"

--- a/player/shared/src/commonTest/kotlin/com/spela/player/util/BuildbotUrlTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/util/BuildbotUrlTest.kt
@@ -84,6 +84,30 @@ class BuildbotUrlTest {
         assertEquals("nestopia_libretro.so", coreFileName("nestopia", "linux"))
     }
 
+    // Azahar Android — libretro buildbot drops the `_android` suffix for this
+    // core specifically. See #1187 and ANDROID_NO_SUFFIX_CORES.
+
+    @Test
+    fun azaharAndroidArm64Url() {
+        assertEquals(
+            "https://buildbot.libretro.com/nightly/android/latest/arm64-v8a/azahar_libretro.so.zip",
+            buildbotCoreUrl("azahar", "android", "arm64-v8a"),
+        )
+    }
+
+    @Test
+    fun azaharAndroidFileName() {
+        assertEquals("azahar_libretro.so", coreFileName("azahar", "android"))
+    }
+
+    @Test
+    fun azaharMacosArm64UnchangedFromConvention() {
+        assertEquals(
+            "https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/azahar_libretro.dylib.zip",
+            buildbotCoreUrl("azahar", "macos", "arm64"),
+        )
+    }
+
     // resolveDownloadUrl — Azahar-style GitHub release templates
 
     private val azaharTemplate =

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -149,6 +149,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Drop the legacy CustomDownloadURL override on the azahar core row so
+	// downloads fall back to the libretro buildbot nightly endpoint. See #1187.
+	if err := db.MigrateAzaharToBuildbot(database); err != nil {
+		slog.Warn("failed to migrate azahar core to buildbot default", "error", err)
+	}
+
 	// Compute LogoAspectRatio for every seeded console by parsing the
 	// embedded SVG's viewBox. Lets the player app size the console-
 	// detail hero logo correctly on first render — without this, the

--- a/server/internal/api/core_handler_test.go
+++ b/server/internal/api/core_handler_test.go
@@ -19,35 +19,6 @@ import (
 
 func itoa(u uint) string { return strconv.FormatUint(uint64(u), 10) }
 
-func TestListCores_AzaharHasDownloadURL(t *testing.T) {
-	_, cfg := setupTestEnv(t)
-	router, cleanup := NewRouter(*cfg)
-	defer cleanup()
-	token := registerAndGetToken(t, router)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/cores", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
-	router.ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusOK, w.Code)
-
-	var cores []map[string]interface{}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cores))
-
-	var azahar map[string]interface{}
-	for _, c := range cores {
-		if c["name"] == "azahar" {
-			azahar = c
-			break
-		}
-	}
-	require.NotNil(t, azahar, "azahar core should be seeded")
-	url, _ := azahar["customDownloadUrl"].(string)
-	assert.Contains(t, url, "github.com/azahar-emu/azahar")
-	assert.Contains(t, url, "{platform}")
-}
-
 func TestListCores_BuildbotCoresHaveNoDownloadURL(t *testing.T) {
 	_, cfg := setupTestEnv(t)
 	router, cleanup := NewRouter(*cfg)
@@ -64,8 +35,11 @@ func TestListCores_BuildbotCoresHaveNoDownloadURL(t *testing.T) {
 	var cores []db.Core
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cores))
 
+	// `azahar` joined this set in #1188 — pre-#1188 it was pinned to a
+	// GitHub release that broke on Apple Silicon and 404'd on Android.
+	// Guard against a regression that re-adds the override.
 	for _, c := range cores {
-		if c.Name == "nestopia" || c.Name == "snes9x" || c.Name == "dolphin" {
+		if c.Name == "nestopia" || c.Name == "snes9x" || c.Name == "dolphin" || c.Name == "azahar" {
 			assert.Empty(t, c.CustomDownloadURL, "buildbot core %s should have no downloadUrl", c.Name)
 		}
 	}
@@ -135,8 +109,10 @@ func TestDownloadCore_BackfillsMetadata(t *testing.T) {
 }
 
 // TestDownloadCore_PinnedCoreCopiesDownloadURL verifies that a core with a
-// populated DownloadURL (pinned cores like azahar) has its DownloadURL
-// copied into SourceURL on the first-serve backfill.
+// populated CustomDownloadURL has it copied into SourceURL on the first-
+// serve metadata backfill. Spela no longer ships any seeded pinned cores
+// (azahar moved to the buildbot default in #1188), so the fixture is a
+// synthetic row written into the DB just for this test.
 func TestDownloadCore_PinnedCoreCopiesDownloadURL(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router, cleanup := NewRouter(*cfg)
@@ -145,12 +121,17 @@ func TestDownloadCore_PinnedCoreCopiesDownloadURL(t *testing.T) {
 
 	require.NoError(t, os.MkdirAll(cfg.CoreDir, 0o755))
 	payload := []byte("pinned-core-bytes")
-	corePath := filepath.Join(cfg.CoreDir, "azahar_libretro.so")
+	corePath := filepath.Join(cfg.CoreDir, "fake_pinned_libretro.so")
 	require.NoError(t, os.WriteFile(corePath, payload, 0o644))
 
-	var core db.Core
-	require.NoError(t, database.Where("name = ?", "azahar").First(&core).Error)
-	require.NotEmpty(t, core.CustomDownloadURL, "seeded azahar core should have a DownloadURL template")
+	pinnedURL := "https://example.test/cores/fake_pinned-{platform}.zip"
+	core := db.Core{
+		Name:              "fake_pinned",
+		DisplayName:       "Fake Pinned Core",
+		Platforms:         "linux",
+		CustomDownloadURL: pinnedURL,
+	}
+	require.NoError(t, database.Create(&core).Error)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/cores/"+itoa(core.ID)+"/download?platform=linux", nil)
@@ -160,8 +141,8 @@ func TestDownloadCore_PinnedCoreCopiesDownloadURL(t *testing.T) {
 
 	var refreshed db.Core
 	require.NoError(t, database.First(&refreshed, core.ID).Error)
-	assert.Equal(t, core.CustomDownloadURL, refreshed.SourceURL,
-		"pinned core's DownloadURL template should be copied to SourceURL on first serve")
+	assert.Equal(t, pinnedURL, refreshed.SourceURL,
+		"pinned core's CustomDownloadURL should be copied to SourceURL on first serve")
 }
 
 // TestHashFileSha256_Errors verifies that hashFileSha256 returns an error

--- a/server/internal/db/azahar_buildbot_migration_test.go
+++ b/server/internal/db/azahar_buildbot_migration_test.go
@@ -1,0 +1,97 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// #1187: live deployments seeded before the buildbot switchover have a
+// stale CustomDownloadURL pinned to a github.com/azahar-emu release that
+// 404s on Android arm64-v8a and ships an Apple Silicon Vulkan crash.
+// MigrateAzaharToBuildbot force-clears that override so the player falls
+// back to the libretro buildbot nightly.
+
+func openAzaharTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&Core{}))
+	return database
+}
+
+func TestMigrateAzaharToBuildbotClearsLegacyURL(t *testing.T) {
+	database := openAzaharTestDB(t)
+
+	require.NoError(t, database.Create(&Core{
+		Name:              "azahar",
+		DisplayName:       "Azahar",
+		Platforms:         "windows,linux,macos,android",
+		Version:           "2125.0.1",
+		CustomDownloadURL: "https://github.com/azahar-emu/azahar/releases/download/2125.0.1/azahar-libretro-{platform}-2125.0.1.zip",
+	}).Error)
+
+	require.NoError(t, MigrateAzaharToBuildbot(database))
+
+	var got Core
+	require.NoError(t, database.Where("name = ?", "azahar").First(&got).Error)
+	require.Equal(t, "", got.CustomDownloadURL, "stale GitHub URL must be cleared so player uses buildbot")
+	require.Equal(t, "", got.Version, "stale pinned version must be cleared")
+}
+
+func TestMigrateAzaharToBuildbotIdempotent(t *testing.T) {
+	database := openAzaharTestDB(t)
+
+	require.NoError(t, database.Create(&Core{
+		Name:              "azahar",
+		DisplayName:       "Azahar",
+		Platforms:         "windows,linux,macos,android",
+		Version:           "2125.0-alpha4",
+		CustomDownloadURL: "https://github.com/azahar-emu/azahar/releases/download/2125.0-alpha4/azahar-libretro-2125.0-alpha4-{platform}.zip",
+	}).Error)
+
+	require.NoError(t, MigrateAzaharToBuildbot(database))
+	require.NoError(t, MigrateAzaharToBuildbot(database))
+
+	var got Core
+	require.NoError(t, database.Where("name = ?", "azahar").First(&got).Error)
+	require.Equal(t, "", got.CustomDownloadURL)
+	require.Equal(t, "", got.Version)
+}
+
+func TestMigrateAzaharToBuildbotNoRow(t *testing.T) {
+	database := openAzaharTestDB(t)
+
+	// Fresh DB with no azahar row — migration must succeed quietly so
+	// startup doesn't fail before SeedCores has had a chance to run.
+	require.NoError(t, MigrateAzaharToBuildbot(database))
+}
+
+func TestMigrateAzaharToBuildbotLeavesCleanRowAlone(t *testing.T) {
+	database := openAzaharTestDB(t)
+
+	require.NoError(t, database.Create(&Core{
+		Name:        "azahar",
+		DisplayName: "Azahar",
+		Platforms:   "windows,linux,macos,android",
+		Sha256:      "deadbeef",
+		SizeBytes:   42,
+	}).Error)
+
+	require.NoError(t, MigrateAzaharToBuildbot(database))
+
+	var got Core
+	require.NoError(t, database.Where("name = ?", "azahar").First(&got).Error)
+	require.Equal(t, "", got.CustomDownloadURL)
+	require.Equal(t, "", got.Version)
+	// Binary metadata is left intact — the server's cached binary may
+	// still be valid (downloaded from a previous buildbot session) and
+	// staleness/freshness is the player's call, not the migration's.
+	require.Equal(t, "deadbeef", got.Sha256)
+	require.Equal(t, int64(42), got.SizeBytes)
+}

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -1251,14 +1252,7 @@ func SeedCores(db *gorm.DB) error {
 		{Name: "gearcoleco", DisplayName: "Gearcoleco", Description: "ColecoVision emulator", Platforms: "windows,linux,macos,android"},
 		{Name: "puae", DisplayName: "PUAE", Description: "Commodore Amiga emulator", Platforms: "windows,linux,macos,android"},
 		{Name: "neocd", DisplayName: "NeoCD", Description: "Neo Geo CD emulator", Platforms: "windows,linux,macos,android"},
-		{
-			Name:        "azahar",
-			DisplayName: "Azahar",
-			Description: "Nintendo 3DS emulator (Citra successor)",
-			Platforms:   "windows,linux,macos,android",
-			Version:     "2125.0.1",
-			CustomDownloadURL: "https://github.com/azahar-emu/azahar/releases/download/2125.0.1/azahar-libretro-{platform}-2125.0.1.zip",
-		},
+		{Name: "azahar", DisplayName: "Azahar", Description: "Nintendo 3DS emulator (Citra successor)", Platforms: "windows,linux,macos,android"},
 		{Name: "scummvm", DisplayName: "ScummVM", Description: "Point-and-click adventure game engine", Platforms: "windows,linux,macos,android"},
 		{Name: "freechaf", DisplayName: "FreeChaF", Description: "Fairchild Channel F emulator", Platforms: "windows,linux,macos,android"},
 		{Name: "o2em", DisplayName: "O2EM", Description: "Magnavox Odyssey 2 / Philips Videopac emulator", Platforms: "windows,linux,macos,android"},
@@ -1310,6 +1304,45 @@ func SeedCores(db *gorm.DB) error {
 		}
 	}
 
+	return nil
+}
+
+// MigrateAzaharToBuildbot clears the legacy CustomDownloadURL / Version
+// override on the azahar core row so downloads fall back to the libretro
+// buildbot nightly endpoint. See #1187.
+//
+// Pre-#1187 the row was seeded with a GitHub release URL pinned to
+// 2125.0-alpha4 (later 2125.0.1). That URL 404'd on Android arm64-v8a
+// — the only Android ABI we support for 3DS — and shipped an Azahar
+// build with a Vulkan tooling_info crash on Apple Silicon. Buildbot
+// publishes fresh nightlies that fix both. SeedCores only backfilled
+// empty rows, so live deployments never picked up the corrected URL;
+// this migration force-clears the override so every existing row joins
+// the buildbot path.
+//
+// Idempotent: once the row is buildbot-default (both fields empty),
+// this is a no-op.
+func MigrateAzaharToBuildbot(database *gorm.DB) error {
+	var azahar Core
+	err := database.Where("name = ?", "azahar").First(&azahar).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("loading azahar core: %w", err)
+	}
+	if azahar.CustomDownloadURL == "" && azahar.Version == "" {
+		return nil
+	}
+	if err := database.Model(&azahar).Updates(map[string]interface{}{
+		"download_url": "",
+		"version":      "",
+	}).Error; err != nil {
+		return fmt.Errorf("clearing azahar override: %w", err)
+	}
+	slog.Info("migrated azahar core to buildbot default",
+		"previous_url", azahar.CustomDownloadURL,
+		"previous_version", azahar.Version)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Two unrelated player/server fixes on the same branch.

### #1187 — Pill nav: trigger on physical gamepad only

The bottom nav was switching between the tab bar and the pill / section indicator based on \`InputMode\`, which flipped to \`GAMEPAD\` on any keyboard navigation. Desktop users with keyboard + mouse saw the nav widget oscillate every other interaction.

Pill is now driven by \`controllerStatus.connectedCount > 0\`. Keyboard shortcuts (\`[\`, \`]\`, Tab) still switch sections — they just don't change which nav widget is rendered. Dropped the \`[\`/\`]\` glyph variant from the pill since the keyboard branch is unreachable now.

### #1188 — 3DS broken everywhere: drop GitHub release pin, use libretro buildbot

Starting a 3DS game crashed/404'd on every platform:

- **Desktop macOS arm64** — cached Azahar 2125.0-alpha4 dylib crashed in \`Vulkan::Instance::CollectToolingInfo()+0x438\` (SIGSEGV pc=0x0; MoltenVK doesn't expose \`vkGetPhysicalDeviceToolPropertiesEXT\` to the libretro context).
- **Android arm64-v8a** — server-served \`CustomDownloadURL\` 404s. \`SeedCores\` only backfills empty rows, so PR #343's bump to 2125.0.1 never reached existing deployments.

Switched Azahar to the libretro buildbot nightly endpoint, same as every other core. Coverage I verified: macOS arm64/x86_64, Linux x86_64, Windows x86_64, Android arm64-v8a. The two unsupported Android ABIs (armeabi-v7a, x86_64) lose 3DS — acceptable, we only target modern hardware for that console.

Azahar's Android buildbot asset is named \`azahar_libretro.so.zip\` (no \`_android\` suffix), unlike every other core. Wired in via a tiny \`ANDROID_NO_SUFFIX_CORES\` set in \`BuildbotUrl.kt\` so the deviation is explicit. Server-side, \`MigrateAzaharToBuildbot\` idempotently clears the stale \`CustomDownloadURL\` / \`Version\` on every startup so live deployments fix themselves on next deploy.

### Operator note (3DS fix only)

Existing desktop installs still hold the crashy dylib in their cores cache. \`isCachedCoreCurrent\` returns null for buildbot-default cores (server has no \`Sha256\` until it serves the binary, which it never does on the buildbot path), so the cached file is kept. One-time manual cleanup per desktop:

\`\`\`
# macOS
rm ~/Library/Application\ Support/Spela/cores/azahar_libretro.dylib
# Linux
rm ~/.local/share/spela/cores/azahar_libretro.so
# Windows
del %APPDATA%\Spela\cores\azahar_libretro.dll
\`\`\`

Android has no cached binary (the 404 prevented one being written), so it just pulls buildbot on next launch.

## Test plan

- [x] \`./gradlew :desktop:desktopTest --tests SectionIndicatorTest --tests InputModeTest --tests GamepadNavigationTest\` — green
- [x] \`./gradlew :shared:desktopTest --tests BuildbotUrlTest\` — green (new Azahar Android URL + filename + macOS-still-standard assertions)
- [x] \`go test ./internal/db/... -run 'Azahar|SeedCores'\` — green (4 new migration tests: clears legacy URL, idempotent, no-row safe, leaves clean rows alone)
- [x] Pre-push hook ran \`go build ./...\` clean
- [ ] Manual: bring up desktop app, run a keyboard-only session, confirm tab bar stays in place across keyboard + mouse alternation
- [ ] Manual: connect a controller, confirm pill appears and shows \`L1\`/\`R1\` (not \`[\`/\`]\`)
- [ ] Manual: after deploy, delete cached Azahar dylib on desktop, start a 3DS game, confirm Vulkan setup completes
- [ ] Manual: on AYN Thor, start a 3DS game, confirm core download succeeds and game launches

Closes #1187, closes #1188.