### PR TITLE
Server-side libretro buildbot poller for automatic core updates (#1190)

### DIFF
--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/CoresApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/CoresApi.kt
@@ -85,10 +85,11 @@ open class CoresApi : ApiClient {
      * Get fingerprint for a core binary
      * Returns sha256 + size + fetched-at for the server&#39;s current cached binary of a core. Players use this to decide whether their locally cached copy is stale without re-downloading the binary itself.
      * @param id Core row ID (not core name).
+     * @param platform Player&#39;s &lt;platform&gt;-&lt;arch&gt; tag. Optional; omit for the legacy core-wide manifest. (optional)
      * @return CoreManifestResponse
      */
     @Suppress("UNCHECKED_CAST")
-    open suspend fun getCoreManifest(id: kotlin.String): HttpResponse<CoreManifestResponse> {
+    open suspend fun getCoreManifest(id: kotlin.String, platform: kotlin.String? = null): HttpResponse<CoreManifestResponse> {
 
         val localVariableAuthNames = listOf<String>()
 
@@ -96,6 +97,7 @@ open class CoresApi : ApiClient {
             io.ktor.client.utils.EmptyContent
 
         val localVariableQuery = mutableMapOf<String, List<String>>()
+        platform?.apply { localVariableQuery["platform"] = listOf("$platform") }
         val localVariableHeaders = mutableMapOf<String, String>()
 
         val localVariableConfig = RequestConfig<kotlin.Any?>(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -864,13 +864,18 @@ class SpelaApiClient(
         return coresApi.listCores().body()
     }
 
-    suspend fun getCoreManifest(coreId: Long): com.spela.client.models.CoreManifestResponse {
+    suspend fun getCoreManifest(coreId: Long, platformArch: String? = null): com.spela.client.models.CoreManifestResponse {
         // The server's `/api/cores/{id}/manifest` path-id was changed
         // from int64 to a regex-validated string (`^[0-9]+$`) in the
         // OpenAPI schema, so the generated client now expects a String.
         // The numeric `coreId` we hold internally is still semantically
         // a row PK — encoding it as decimal preserves the URL shape.
-        return coresApi.getCoreManifest(coreId.toString()).body()
+        //
+        // platformArch is the `<currentPlatform()>-<currentArch()>` tag
+        // used by the per-platform staleness path (#1190). When null the
+        // server falls back to the legacy Core-wide fingerprint, so older
+        // callers keep working unchanged.
+        return coresApi.getCoreManifest(coreId.toString(), platformArch).body()
     }
 
     suspend fun getRecommendedCore(gameId: String): com.spela.player.domain.model.LibretroCore {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CoreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CoreRepositoryImpl.kt
@@ -8,6 +8,8 @@ import com.spela.player.domain.repository.CoreRepository
 import com.spela.player.util.FileStorage
 import com.spela.player.util.buildbotCoreUrl
 import com.spela.player.util.coreFileName
+import com.spela.player.util.currentArch
+import com.spela.player.util.currentPlatform
 import com.spela.player.util.extractFirstZipEntry
 import com.spela.player.util.resolveDownloadUrl
 import io.ktor.client.*
@@ -149,7 +151,14 @@ class CoreRepositoryImpl(
             apiClient.getAvailableCores().firstOrNull { it.name == coreName }?.id
         }.getOrNull() ?: return null
 
-        val manifest = runCatching { apiClient.getCoreManifest(coreId) }.getOrNull()
+        // Pass our runtime platform-arch so the server returns the
+        // per-platform fingerprint that matches the binary this device
+        // actually downloaded from buildbot. Without this the server
+        // falls back to its single Core.Sha256, which conflates every
+        // platform and breaks staleness for any device whose ABI isn't
+        // the last one to be admin-refreshed. See #1190.
+        val platformArch = "${currentPlatform()}-${currentArch()}"
+        val manifest = runCatching { apiClient.getCoreManifest(coreId, platformArch) }.getOrNull()
             ?: return null
 
         // Empty sha == the server has not fingerprinted this core

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spela/server/internal/auth"
 	"github.com/spela/server/internal/bios"
 	"github.com/spela/server/internal/cheats"
+	"github.com/spela/server/internal/cores"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/igdb"
 	"github.com/spela/server/internal/retroachievements"
@@ -260,6 +261,27 @@ func main() {
 
 	// Auto-download missing BIOS files at startup (non-blocking)
 	bios.StartAutoDownload(store.BiosDir, database)
+
+	// Libretro buildbot poller: keeps per-platform core fingerprints
+	// fresh so the player's staleness check can drive auto-updates of
+	// buildbot-default cores. Disabled via SPELA_DISABLE_CORE_POLLER=1
+	// for tests and air-gapped installs. See #1190.
+	if os.Getenv("SPELA_DISABLE_CORE_POLLER") == "" {
+		interval := 24 * time.Hour
+		var setting db.ServerSetting
+		if err := database.Where("key = ?", "core_poll_interval_hours").First(&setting).Error; err == nil {
+			if hours, err := strconv.Atoi(setting.Value); err == nil && hours > 0 {
+				interval = time.Duration(hours) * time.Hour
+			}
+		}
+		poller := cores.NewPoller(database, cores.PollerOptions{
+			CoreDir:  coreDir,
+			Interval: interval,
+		})
+		go poller.Run(workerCtx)
+	} else {
+		slog.Info("core buildbot poller disabled by SPELA_DISABLE_CORE_POLLER")
+	}
 
 	// Auto-import cheat codes on first boot (non-blocking)
 	cheats.StartAutoImport(database)

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -59,7 +59,7 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.TokenBlacklist{}, &db.LoginAttempt{},
 		&db.SystemEventCategory{},
 		&db.SystemEvent{},
-		&db.ServerSetting{}, &db.Core{},
+		&db.ServerSetting{}, &db.Core{}, &db.CorePlatformBinary{},
 		&db.ConsoleShaderPreference{},
 		&db.ConsoleSaveStatePolicy{},
 		&db.GameSaveStatePolicy{},

--- a/server/internal/api/core_handler.go
+++ b/server/internal/api/core_handler.go
@@ -248,19 +248,18 @@ func (h *CoreHandler) RefreshCoreMetadata(core *db.Core, platform string) (CoreR
 
 	changed := old != sum
 	if changed {
-		meta := map[string]interface{}{
-			"core":        core.Name,
-			"old_sha256":  old,
-			"new_sha256":  sum,
-			"size_bytes":  size,
-			"platform":    platform,
-			"source_url":  core.SourceURL,
-			"trigger":     "admin_refresh",
-		}
 		db.RecordOperationalEvent(h.DB, db.SystemEventInput{
 			EventType: db.SystemEventCoreUpdated,
 			Reason:    fmt.Sprintf("core %q binary replaced: %s → %s", core.Name, shortSha(old), shortSha(sum)),
-			Metadata:  meta,
+			Metadata: db.CoreUpdatedMetadata{
+				Core:         core.Name,
+				PlatformArch: platform,
+				OldSha256:    old,
+				NewSha256:    sum,
+				SizeBytes:    size,
+				SourceURL:    core.SourceURL,
+				Trigger:      "admin_refresh",
+			},
 		})
 	}
 

--- a/server/internal/api/core_handler_test.go
+++ b/server/internal/api/core_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/spela/server/internal/auth"
 	"github.com/spela/server/internal/db"
@@ -266,6 +267,87 @@ func TestGetCoreManifest_RequiresAuth(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/cores/"+itoa(core.ID)+"/manifest", nil)
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestGetCoreManifest_PerPlatformBinaryWinsOverCoreFields verifies the
+// platform-aware path: when ?platform=<platform-arch> matches a
+// CorePlatformBinary row, its sha/size win over the Core row's legacy
+// single-value fields. The player drives this with currentPlatform-arch
+// so its staleness check sees the right fingerprint for its own runtime.
+// See #1190.
+func TestGetCoreManifest_PerPlatformBinaryWinsOverCoreFields(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	var core db.Core
+	require.NoError(t, database.Where("name = ?", "nestopia").First(&core).Error)
+	// Seed the legacy Core fields with one set of values, the per-platform
+	// row with a different set — the platform-aware response must pick
+	// the per-platform values.
+	require.NoError(t, database.Model(&core).Updates(map[string]interface{}{
+		"sha256":     "legacycoresha",
+		"size_bytes": int64(100),
+		"source_url": "https://example.test/legacy",
+	}).Error)
+	now := time.Now().UTC()
+	require.NoError(t, database.Create(&db.CorePlatformBinary{
+		CoreID:       core.ID,
+		PlatformArch: "linux-x86_64",
+		Sha256:       "perPlatformSha",
+		SizeBytes:    200,
+		FetchedAt:    &now,
+		SourceURL:    "https://example.test/per-platform",
+	}).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/cores/"+itoa(core.ID)+"/manifest?platform=linux-x86_64", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var manifest struct {
+		Sha256    string `json:"sha256"`
+		SizeBytes int64  `json:"sizeBytes"`
+		SourceURL string `json:"sourceUrl"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &manifest))
+	assert.Equal(t, "perPlatformSha", manifest.Sha256)
+	assert.Equal(t, int64(200), manifest.SizeBytes)
+	assert.Equal(t, "https://example.test/per-platform", manifest.SourceURL)
+}
+
+// TestGetCoreManifest_FallsBackWhenPlatformNotPolled verifies that asking
+// for a platform that the poller hasn't covered yet falls back to the
+// legacy Core fields instead of 404-ing — clients shouldn't have to
+// special-case "manifest exists but not for my platform".
+func TestGetCoreManifest_FallsBackWhenPlatformNotPolled(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	var core db.Core
+	require.NoError(t, database.Where("name = ?", "nestopia").First(&core).Error)
+	require.NoError(t, database.Model(&core).Updates(map[string]interface{}{
+		"sha256":     "fallbacksha",
+		"size_bytes": int64(50),
+	}).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/cores/"+itoa(core.ID)+"/manifest?platform=windows-x86_64", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var manifest struct {
+		Sha256    string `json:"sha256"`
+		SizeBytes int64  `json:"sizeBytes"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &manifest))
+	assert.Equal(t, "fallbacksha", manifest.Sha256)
+	assert.Equal(t, int64(50), manifest.SizeBytes)
 }
 
 // TestRefreshCore_PicksUpReplacedBinary is the canonical #555 Phase 2b

--- a/server/internal/api/huma_core.go
+++ b/server/internal/api/huma_core.go
@@ -25,6 +25,12 @@ type ListCoresOutput struct {
 // CoreManifestInput is the input for GET /api/cores/{id}/manifest.
 type CoreManifestInput struct {
 	ID string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Core row ID (not core name)."`
+	// PlatformArch selects the per-platform CorePlatformBinary row to
+	// fingerprint against — e.g. `linux-x86_64`, `macos-arm64`,
+	// `android-arm64-v8a`. Clients should pass `${currentPlatform()}-${currentArch()}`.
+	// When empty, the response falls back to the legacy single Core.Sha256
+	// for admin-tool compatibility. See #1190.
+	PlatformArch string `query:"platform" required:"false" maxLength:"64" pattern:"^[a-z0-9_-]*$" doc:"Player's <platform>-<arch> tag. Optional; omit for the legacy core-wide manifest."`
 }
 
 // CoreManifestResponse is the lightweight fingerprint payload players fetch
@@ -121,6 +127,20 @@ func (h *CoreHandler) HumaListCores(_ context.Context, _ *ListCoresInput) (*List
 }
 
 // HumaGetCoreManifest is the huma handler for GET /api/cores/{id}/manifest.
+//
+// Resolution order:
+//
+//   1. If the request carries a PlatformArch and a CorePlatformBinary row
+//      exists for (core, platform), return that row's fingerprint. This is
+//      the path the player takes for staleness checks (#1190).
+//   2. Otherwise, fall back to the Core row's own Sha256 / etc. — the
+//      legacy single-binary view kept for admin tooling and any caller
+//      that doesn't know about per-platform rows.
+//
+// Fallback is intentional: a request that names a platform we haven't
+// polled yet should still get *something* useful back (typically empty),
+// rather than 404-ing and forcing the client to handle "manifest exists
+// but not for my platform" specially.
 func (h *CoreHandler) HumaGetCoreManifest(_ context.Context, in *CoreManifestInput) (*CoreManifestOutput, error) {
 	parsedID, err := strconv.ParseUint(in.ID, 10, 64)
 	if err != nil {
@@ -128,11 +148,29 @@ func (h *CoreHandler) HumaGetCoreManifest(_ context.Context, in *CoreManifestInp
 	}
 	var core db.Core
 	if err := h.DB.First(&core, uint(parsedID)).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, huma.Error404NotFound("core not found")
 		}
 		return nil, huma.Error500InternalServerError("failed to fetch core")
 	}
+
+	if in.PlatformArch != "" {
+		var binary db.CorePlatformBinary
+		err := h.DB.Where("core_id = ? AND platform_arch = ?", core.ID, in.PlatformArch).First(&binary).Error
+		if err == nil {
+			return &CoreManifestOutput{Body: CoreManifestResponse{
+				Sha256:    binary.Sha256,
+				SizeBytes: binary.SizeBytes,
+				FetchedAt: binary.FetchedAt,
+				SourceURL: binary.SourceURL,
+			}}, nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, huma.Error500InternalServerError("failed to fetch core platform binary")
+		}
+		// fall through to legacy Core fields
+	}
+
 	return &CoreManifestOutput{Body: CoreManifestResponse{
 		Sha256:    core.Sha256,
 		SizeBytes: core.SizeBytes,

--- a/server/internal/cores/buildbot.go
+++ b/server/internal/cores/buildbot.go
@@ -1,0 +1,158 @@
+// Package cores provides the libretro-buildbot polling worker that keeps
+// the server's per-platform core fingerprints fresh. See #1190.
+//
+// The package's responsibilities split cleanly:
+//
+//   - buildbot.go: URL composition. Mirrors player/.../util/BuildbotUrl.kt
+//     so the server and the client agree on where to fetch each (core,
+//     platform, arch) tuple from. Pure functions, no side effects.
+//
+//   - poller.go: the worker itself. Iterates buildbot-default cores on
+//     a schedule, fetches each platform binary, compares sha256 against
+//     the CorePlatformBinary row, writes through on change, and emits
+//     audit events.
+//
+// New cores that follow the standard libretro packaging convention need
+// no code changes here — adding a Core row to the seed is enough. The
+// only file that needs touching is androidNoSuffixCores when a core
+// ships an Android nightly without the `_android` suffix in its asset
+// name (today: just azahar).
+package cores
+
+import (
+	"fmt"
+	"strings"
+)
+
+const buildbotBase = "https://buildbot.libretro.com/nightly"
+
+// androidNoSuffixCores names libretro cores whose Android nightly is
+// packaged without the `_android` suffix. Buildbot publishes most Android
+// cores as `<name>_libretro_android.so` inside `<name>_libretro_android.so.zip`
+// but a handful (azahar) ship as `<name>_libretro.so` inside
+// `<name>_libretro.so.zip`. The convention is set upstream — when adding
+// a new entry here, HEAD both URL shapes against buildbot to confirm.
+//
+// Kept in sync with the player's commonMain ANDROID_NO_SUFFIX_CORES set
+// in BuildbotUrl.kt.
+var androidNoSuffixCores = map[string]struct{}{
+	"azahar": {},
+}
+
+// PlatformArch is the player's runtime platform tag concatenated with
+// its CPU arch, e.g. "linux-x86_64", "macos-arm64", "android-arm64-v8a".
+// Used as the primary key column on CorePlatformBinary and as the
+// `?platform=` query parameter on the manifest endpoint.
+type PlatformArch struct {
+	Platform string // "linux" | "macos" | "windows" | "android"
+	Arch     string // arch-as-the-player-reports-it
+}
+
+// String returns the canonical "<platform>-<arch>" form persisted to the
+// CorePlatformBinary.PlatformArch column.
+func (p PlatformArch) String() string {
+	return p.Platform + "-" + p.Arch
+}
+
+// ParsePlatformArch splits a "<platform>-<arch>" tag back into its
+// components. Returns an error when the tag is malformed; production
+// callers should treat that as a bad-request signal rather than a
+// best-effort parse.
+func ParsePlatformArch(s string) (PlatformArch, error) {
+	idx := strings.Index(s, "-")
+	if idx <= 0 || idx == len(s)-1 {
+		return PlatformArch{}, fmt.Errorf("cores: malformed platform tag %q (want <platform>-<arch>)", s)
+	}
+	return PlatformArch{Platform: s[:idx], Arch: s[idx+1:]}, nil
+}
+
+// DefaultPollMatrix is the canonical set of (platform, arch) tuples the
+// server polls buildbot for. It mirrors the platforms Spela's player
+// ships on, with the carve-out from #1188 that Android only targets
+// arm64-v8a (the other two ABIs aren't built by buildbot for any of the
+// HW-render-heavy cores we care about).
+var DefaultPollMatrix = []PlatformArch{
+	{Platform: "linux", Arch: "x86_64"},
+	{Platform: "linux", Arch: "aarch64"},
+	{Platform: "macos", Arch: "arm64"},
+	{Platform: "macos", Arch: "x86_64"},
+	{Platform: "windows", Arch: "x86_64"},
+	{Platform: "android", Arch: "arm64-v8a"},
+}
+
+// MatrixForPlatforms filters DefaultPollMatrix down to the tuples whose
+// platform appears in the comma-separated list (matching Core.Platforms).
+// Returns an empty slice when the input is empty or has no overlap with
+// the matrix.
+func MatrixForPlatforms(platformsCSV string) []PlatformArch {
+	if platformsCSV == "" {
+		return nil
+	}
+	wanted := make(map[string]struct{})
+	for _, p := range strings.Split(platformsCSV, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			wanted[p] = struct{}{}
+		}
+	}
+	out := make([]PlatformArch, 0, len(DefaultPollMatrix))
+	for _, m := range DefaultPollMatrix {
+		if _, ok := wanted[m.Platform]; ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// BuildbotURL returns the libretro buildbot download URL for a given
+// (coreName, platform, arch). Mirrors the player's buildbotCoreUrl
+// helper — when one moves, the other must too.
+//
+// URL shapes:
+//
+//	android: /nightly/android/latest/{arch}/{name}_libretro_android.so.zip
+//	         (or {name}_libretro.so.zip when coreName is in androidNoSuffixCores)
+//	macos:   /nightly/apple/osx/{arch}/latest/{name}_libretro.dylib.zip
+//	linux:   /nightly/linux/{buildbotArch}/latest/{name}_libretro.so.zip
+//	         (arm64 → aarch64; otherwise pass-through)
+//	windows: /nightly/windows/{arch}/latest/{name}_libretro.dll.zip
+func BuildbotURL(coreName, platform, arch string) string {
+	switch platform {
+	case "android":
+		asset := fmt.Sprintf("%s_libretro_android.so.zip", coreName)
+		if _, ok := androidNoSuffixCores[coreName]; ok {
+			asset = fmt.Sprintf("%s_libretro.so.zip", coreName)
+		}
+		return fmt.Sprintf("%s/android/latest/%s/%s", buildbotBase, arch, asset)
+	case "macos":
+		return fmt.Sprintf("%s/apple/osx/%s/latest/%s_libretro.dylib.zip", buildbotBase, arch, coreName)
+	case "windows":
+		return fmt.Sprintf("%s/windows/%s/latest/%s_libretro.dll.zip", buildbotBase, arch, coreName)
+	default: // linux + anything else falls back to linux conventions
+		buildbotArch := arch
+		if arch == "arm64" {
+			buildbotArch = "aarch64"
+		}
+		return fmt.Sprintf("%s/linux/%s/latest/%s_libretro.so.zip", buildbotBase, buildbotArch, coreName)
+	}
+}
+
+// CoreBinaryFilename returns the filename of the extracted core binary
+// once unzipped from a buildbot download. Mirrors the player's
+// coreFileName — same naming convention has to live on both ends so
+// the server stores it under the name the client expects.
+func CoreBinaryFilename(coreName, platform string) string {
+	switch platform {
+	case "android":
+		if _, ok := androidNoSuffixCores[coreName]; ok {
+			return coreName + "_libretro.so"
+		}
+		return coreName + "_libretro_android.so"
+	case "macos":
+		return coreName + "_libretro.dylib"
+	case "windows":
+		return coreName + "_libretro.dll"
+	default:
+		return coreName + "_libretro.so"
+	}
+}

--- a/server/internal/cores/buildbot_test.go
+++ b/server/internal/cores/buildbot_test.go
@@ -1,0 +1,125 @@
+package cores
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Mirrors player/shared/src/commonTest/.../util/BuildbotUrlTest.kt — the
+// player and the server must agree on every URL the poller writes
+// through to a CorePlatformBinary row. If a player ever fetches from a
+// URL the server didn't poll, staleness goes wrong silently.
+
+func TestBuildbotURL_StandardConvention(t *testing.T) {
+	cases := []struct {
+		name     string
+		core     string
+		platform string
+		arch     string
+		want     string
+	}{
+		{"macos arm64", "nestopia", "macos", "arm64",
+			"https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/nestopia_libretro.dylib.zip"},
+		{"macos x86_64", "snes9x", "macos", "x86_64",
+			"https://buildbot.libretro.com/nightly/apple/osx/x86_64/latest/snes9x_libretro.dylib.zip"},
+		{"android arm64-v8a", "nestopia", "android", "arm64-v8a",
+			"https://buildbot.libretro.com/nightly/android/latest/arm64-v8a/nestopia_libretro_android.so.zip"},
+		{"linux x86_64", "mupen64plus_next", "linux", "x86_64",
+			"https://buildbot.libretro.com/nightly/linux/x86_64/latest/mupen64plus_next_libretro.so.zip"},
+		{"linux arm64 → aarch64", "nestopia", "linux", "arm64",
+			"https://buildbot.libretro.com/nightly/linux/aarch64/latest/nestopia_libretro.so.zip"},
+		{"windows x86_64", "mgba", "windows", "x86_64",
+			"https://buildbot.libretro.com/nightly/windows/x86_64/latest/mgba_libretro.dll.zip"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, BuildbotURL(c.core, c.platform, c.arch))
+		})
+	}
+}
+
+// Azahar deviates: its Android nightly is shipped as `azahar_libretro.so.zip`
+// (no _android suffix). Both the URL and the unzipped filename follow the
+// same exception. See #1188 and ANDROID_NO_SUFFIX_CORES.
+func TestBuildbotURL_AzaharAndroidNoSuffix(t *testing.T) {
+	assert.Equal(t,
+		"https://buildbot.libretro.com/nightly/android/latest/arm64-v8a/azahar_libretro.so.zip",
+		BuildbotURL("azahar", "android", "arm64-v8a"),
+	)
+	assert.Equal(t, "azahar_libretro.so", CoreBinaryFilename("azahar", "android"))
+}
+
+func TestBuildbotURL_AzaharNonAndroidUnchanged(t *testing.T) {
+	// Azahar's macOS / Linux / Windows nightlies follow the standard
+	// convention. The deviation is Android-only.
+	assert.Equal(t,
+		"https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/azahar_libretro.dylib.zip",
+		BuildbotURL("azahar", "macos", "arm64"),
+	)
+	assert.Equal(t, "azahar_libretro.dylib", CoreBinaryFilename("azahar", "macos"))
+}
+
+func TestCoreBinaryFilename(t *testing.T) {
+	assert.Equal(t, "nestopia_libretro.dylib", CoreBinaryFilename("nestopia", "macos"))
+	assert.Equal(t, "nestopia_libretro_android.so", CoreBinaryFilename("nestopia", "android"))
+	assert.Equal(t, "nestopia_libretro.so", CoreBinaryFilename("nestopia", "linux"))
+	assert.Equal(t, "nestopia_libretro.dll", CoreBinaryFilename("nestopia", "windows"))
+}
+
+func TestPlatformArch_RoundTrip(t *testing.T) {
+	cases := []string{
+		"linux-x86_64",
+		"linux-aarch64",
+		"macos-arm64",
+		"macos-x86_64",
+		"windows-x86_64",
+		"android-arm64-v8a", // multi-dash arch — parser keeps everything after the first dash
+	}
+	for _, s := range cases {
+		t.Run(s, func(t *testing.T) {
+			p, err := ParsePlatformArch(s)
+			require.NoError(t, err)
+			assert.Equal(t, s, p.String())
+		})
+	}
+}
+
+func TestPlatformArch_ParseRejectsMalformed(t *testing.T) {
+	for _, bad := range []string{"", "linux", "-x86_64", "linux-"} {
+		t.Run("bad/"+bad, func(t *testing.T) {
+			_, err := ParsePlatformArch(bad)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestMatrixForPlatforms(t *testing.T) {
+	t.Run("empty input → empty matrix", func(t *testing.T) {
+		assert.Empty(t, MatrixForPlatforms(""))
+	})
+
+	t.Run("subset → only matching tuples", func(t *testing.T) {
+		got := MatrixForPlatforms("linux,macos")
+		// linux × {x86_64, aarch64} + macos × {arm64, x86_64} = 4 tuples
+		assert.Len(t, got, 4)
+		for _, p := range got {
+			assert.Contains(t, []string{"linux", "macos"}, p.Platform)
+		}
+	})
+
+	t.Run("full seed shape", func(t *testing.T) {
+		got := MatrixForPlatforms("windows,linux,macos,android")
+		assert.Equal(t, len(DefaultPollMatrix), len(got))
+	})
+
+	t.Run("unknown platform is dropped, not errored", func(t *testing.T) {
+		got := MatrixForPlatforms("linux,emacs")
+		// emacs is filtered out, linux's two arches survive
+		assert.Len(t, got, 2)
+		for _, p := range got {
+			assert.Equal(t, "linux", p.Platform)
+		}
+	})
+}

--- a/server/internal/cores/poller.go
+++ b/server/internal/cores/poller.go
@@ -1,0 +1,441 @@
+package cores
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/safehttp"
+	"gorm.io/gorm"
+)
+
+// downloadMaxBytes caps the size of any single buildbot fetch so a runaway
+// asset (or a server that streams forever) can't OOM the process. The
+// largest current libretro core sits at ~50 MB; 200 MB gives us 4x headroom
+// without trusting upstream to be sane.
+const downloadMaxBytes = 200 * 1024 * 1024
+
+// PollerOptions configures the buildbot poller. CoreDir is the directory
+// where the server writes per-platform binaries — same directory the
+// admin upload path already uses. PollMatrix is the (platform, arch) set
+// to poll for each buildbot-default core; defaults to DefaultPollMatrix
+// when unset. Interval is the gap between full poll cycles; jittered so
+// every server pinned to the libretro buildbot doesn't hit it at the
+// same second.
+type PollerOptions struct {
+	CoreDir    string
+	PollMatrix []PlatformArch
+	Interval   time.Duration
+
+	// HTTPClient is used for all outbound buildbot fetches. Defaults to
+	// safehttp.NewClient(60s) when nil — production should leave it nil.
+	// Tests override it to inject httptest.Server URLs.
+	HTTPClient *http.Client
+
+	// BaseURLOverride replaces the buildbot host for tests. When non-empty,
+	// `https://buildbot.libretro.com/nightly` is rewritten to this base.
+	// Production must leave it empty.
+	BaseURLOverride string
+
+	// Clock returns the current time. Defaults to time.Now when nil; tests
+	// substitute a fixed clock so FetchedAt assertions are stable.
+	Clock func() time.Time
+}
+
+// Poller is the background worker that keeps CorePlatformBinary rows in
+// sync with libretro buildbot nightlies. Construct via NewPoller and run
+// via Run(ctx). Safe to start at most once per process.
+type Poller struct {
+	db   *gorm.DB
+	opts PollerOptions
+}
+
+// NewPoller constructs a Poller with sensible defaults filled in.
+func NewPoller(database *gorm.DB, opts PollerOptions) *Poller {
+	if opts.HTTPClient == nil {
+		opts.HTTPClient = safehttp.NewClient(60 * time.Second)
+	}
+	if len(opts.PollMatrix) == 0 {
+		opts.PollMatrix = DefaultPollMatrix
+	}
+	if opts.Interval <= 0 {
+		opts.Interval = 24 * time.Hour
+	}
+	if opts.Clock == nil {
+		opts.Clock = func() time.Time { return time.Now().UTC() }
+	}
+	return &Poller{db: database, opts: opts}
+}
+
+// Run starts the poll loop. Blocks until ctx is cancelled.
+//
+// Cadence: initial sleep of ~5 minutes (so a freshly booted server isn't
+// bandwidth-spiky during startup), then RunOnce + sleep(interval+jitter)
+// in a loop. Errors from RunOnce are logged and swallowed — the worker
+// MUST stay alive across transient failures or one bad buildbot day
+// permanently disables auto-updates.
+func (p *Poller) Run(ctx context.Context) {
+	slog.Info("cores: buildbot poller started",
+		"interval", p.opts.Interval,
+		"matrix_size", len(p.opts.PollMatrix),
+	)
+
+	// Initial delay; randomized so a fleet of servers booted in lockstep
+	// (Kubernetes rolling restart) doesn't pummel buildbot at once.
+	initialDelay := 5*time.Minute + jitter(60*time.Second)
+	select {
+	case <-ctx.Done():
+		slog.Info("cores: buildbot poller shutting down before first run")
+		return
+	case <-time.After(initialDelay):
+	}
+
+	for {
+		if err := p.RunOnce(ctx); err != nil {
+			slog.Warn("cores: poll cycle errored", "error", err)
+		}
+		wait := p.opts.Interval + jitter(p.opts.Interval/10)
+		select {
+		case <-ctx.Done():
+			slog.Info("cores: buildbot poller shutting down")
+			return
+		case <-time.After(wait):
+		}
+	}
+}
+
+// RunOnce executes a single poll pass: for every buildbot-default Core
+// row, for every (platform, arch) in PollMatrix that the core declares
+// it supports, fetch the buildbot URL, compare sha256, write through on
+// change. Exported so admin tooling can trigger a poll without waiting
+// for the next scheduled cycle.
+func (p *Poller) RunOnce(ctx context.Context) error {
+	if err := os.MkdirAll(p.opts.CoreDir, 0o755); err != nil {
+		return fmt.Errorf("cores: ensuring CoreDir: %w", err)
+	}
+
+	var cores []db.Core
+	// Only poll cores that don't have a CustomDownloadURL override —
+	// pinned cores have their own update flow (admin upload + manual
+	// refresh) and the poller would race against it.
+	err := p.db.
+		Where("download_url = '' OR download_url IS NULL").
+		Where("platforms <> ''").
+		Find(&cores).Error
+	if err != nil {
+		return fmt.Errorf("cores: listing buildbot-default cores: %w", err)
+	}
+
+	for _, core := range cores {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		for _, pa := range MatrixForPlatforms(core.Platforms) {
+			if !inMatrix(pa, p.opts.PollMatrix) {
+				continue
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			p.pollOne(ctx, core, pa)
+		}
+	}
+	return nil
+}
+
+func (p *Poller) pollOne(ctx context.Context, core db.Core, pa PlatformArch) {
+	url := p.urlFor(core.Name, pa)
+	log := slog.With("core", core.Name, "platform", pa.String(), "url", url)
+
+	body, err := p.fetchZipBody(ctx, url)
+	if err != nil {
+		p.emitFailure(core, pa, url, err)
+		log.Warn("cores: buildbot fetch failed", "error", err)
+		return
+	}
+	defer body.cleanup()
+
+	binary, err := extractCoreFromZip(body.path, core.Name, pa.Platform)
+	if err != nil {
+		p.emitFailure(core, pa, url, err)
+		log.Warn("cores: zip extract failed", "error", err)
+		return
+	}
+	defer os.Remove(binary.path)
+
+	sum, size, err := hashAndSize(binary.path)
+	if err != nil {
+		p.emitFailure(core, pa, url, err)
+		log.Warn("cores: hashing extracted binary failed", "error", err)
+		return
+	}
+
+	var existing db.CorePlatformBinary
+	err = p.db.
+		Where("core_id = ? AND platform_arch = ?", core.ID, pa.String()).
+		First(&existing).Error
+	rowExists := err == nil
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		log.Warn("cores: loading per-platform binary row failed", "error", err)
+		return
+	}
+
+	if rowExists && existing.Sha256 == sum {
+		log.Debug("cores: buildbot binary unchanged", "sha256", shortSha(sum))
+		return
+	}
+
+	dstDir := filepath.Join(p.opts.CoreDir, pa.String())
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		log.Warn("cores: creating per-platform core dir failed", "dir", dstDir, "error", err)
+		return
+	}
+	dst := filepath.Join(dstDir, CoreBinaryFilename(core.Name, pa.Platform))
+	if err := os.Rename(binary.path, dst); err != nil {
+		// Cross-device move (temp dir on a different fs from CoreDir):
+		// fall back to copy + remove. The defer will clean up the original.
+		if err := copyFile(binary.path, dst); err != nil {
+			log.Warn("cores: writing core binary to disk failed", "dst", dst, "error", err)
+			return
+		}
+	} else {
+		// Rename succeeded — defer's Remove will silently no-op on a
+		// missing path, so we don't need to nil out binary.path.
+	}
+
+	now := p.opts.Clock()
+	old := existing.Sha256
+	row := db.CorePlatformBinary{
+		CoreID:       core.ID,
+		PlatformArch: pa.String(),
+		FilePath:     dst,
+		Sha256:       sum,
+		SizeBytes:    size,
+		FetchedAt:    &now,
+		SourceURL:    url,
+	}
+	if rowExists {
+		row.ID = existing.ID
+		row.CreatedAt = existing.CreatedAt
+		if err := p.db.Save(&row).Error; err != nil {
+			log.Warn("cores: persisting per-platform binary row failed", "error", err)
+			return
+		}
+	} else {
+		if err := p.db.Create(&row).Error; err != nil {
+			log.Warn("cores: creating per-platform binary row failed", "error", err)
+			return
+		}
+	}
+
+	db.RecordOperationalEvent(p.db, db.SystemEventInput{
+		EventType: db.SystemEventCoreUpdated,
+		Reason: fmt.Sprintf("core %q (%s) replaced: %s → %s",
+			core.Name, pa.String(), shortSha(old), shortSha(sum)),
+		Metadata: db.CoreUpdatedMetadata{
+			Core:         core.Name,
+			PlatformArch: pa.String(),
+			OldSha256:    old,
+			NewSha256:    sum,
+			SizeBytes:    size,
+			SourceURL:    url,
+			Trigger:      "buildbot_poll",
+		},
+	})
+	log.Info("cores: buildbot binary updated",
+		"old_sha256", shortSha(old),
+		"new_sha256", shortSha(sum),
+		"size_bytes", size,
+	)
+}
+
+// urlFor composes the buildbot URL for (coreName, pa). Honors the
+// BaseURLOverride hook used by tests.
+func (p *Poller) urlFor(coreName string, pa PlatformArch) string {
+	u := BuildbotURL(coreName, pa.Platform, pa.Arch)
+	if p.opts.BaseURLOverride != "" {
+		// BuildbotURL always starts with `https://buildbot.libretro.com/nightly`
+		// (constant in this package), so a fixed-prefix swap is safe.
+		return p.opts.BaseURLOverride + u[len(buildbotBase):]
+	}
+	return u
+}
+
+func (p *Poller) emitFailure(core db.Core, pa PlatformArch, url string, err error) {
+	db.RecordOperationalEvent(p.db, db.SystemEventInput{
+		EventType: db.SystemEventCoreUpdateFailed,
+		Reason:    fmt.Sprintf("buildbot poll failed for %q (%s): %s", core.Name, pa.String(), err.Error()),
+		Metadata: db.CoreUpdateFailedMetadata{
+			Core:         core.Name,
+			PlatformArch: pa.String(),
+			URL:          url,
+			Error:        err.Error(),
+		},
+	})
+}
+
+// fetchedBody owns the temp file holding a downloaded zip plus a cleanup
+// that removes it. Callers must defer cleanup() after a successful fetch.
+type fetchedBody struct {
+	path    string
+	cleanup func()
+}
+
+func (p *Poller) fetchZipBody(ctx context.Context, url string) (fetchedBody, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fetchedBody{}, fmt.Errorf("building request: %w", err)
+	}
+	resp, err := p.opts.HTTPClient.Do(req)
+	if err != nil {
+		return fetchedBody{}, fmt.Errorf("buildbot GET: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fetchedBody{}, fmt.Errorf("buildbot GET: HTTP %d", resp.StatusCode)
+	}
+
+	tmp, err := os.CreateTemp("", "buildbot-zip-*.zip")
+	if err != nil {
+		return fetchedBody{}, fmt.Errorf("temp file: %w", err)
+	}
+	path := tmp.Name()
+	cleanup := func() { _ = os.Remove(path) }
+
+	written, err := io.Copy(tmp, io.LimitReader(resp.Body, downloadMaxBytes+1))
+	if cerr := tmp.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
+		cleanup()
+		return fetchedBody{}, fmt.Errorf("writing zip body: %w", err)
+	}
+	if written > downloadMaxBytes {
+		cleanup()
+		return fetchedBody{}, fmt.Errorf("zip body exceeded %d-byte cap (got %d)", downloadMaxBytes, written)
+	}
+	return fetchedBody{path: path, cleanup: cleanup}, nil
+}
+
+type extractedBinary struct {
+	path string
+}
+
+// extractCoreFromZip pulls the core's .so/.dylib/.dll out of the buildbot
+// zip and writes it to a fresh temp file. Returns an error when the zip
+// doesn't carry exactly the expected filename — defensive against an
+// upstream re-layout that would otherwise install the wrong file.
+func extractCoreFromZip(zipPath, coreName, platform string) (extractedBinary, error) {
+	z, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return extractedBinary{}, fmt.Errorf("open zip: %w", err)
+	}
+	defer z.Close()
+
+	wantName := CoreBinaryFilename(coreName, platform)
+	for _, f := range z.File {
+		if filepath.Base(f.Name) != wantName {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return extractedBinary{}, fmt.Errorf("open zip entry %q: %w", f.Name, err)
+		}
+		defer rc.Close()
+
+		tmp, err := os.CreateTemp("", "buildbot-bin-*")
+		if err != nil {
+			return extractedBinary{}, fmt.Errorf("temp file: %w", err)
+		}
+		written, err := io.Copy(tmp, io.LimitReader(rc, downloadMaxBytes+1))
+		if cerr := tmp.Close(); err == nil {
+			err = cerr
+		}
+		if err != nil {
+			_ = os.Remove(tmp.Name())
+			return extractedBinary{}, fmt.Errorf("extracting %q: %w", f.Name, err)
+		}
+		if written > downloadMaxBytes {
+			_ = os.Remove(tmp.Name())
+			return extractedBinary{}, fmt.Errorf("extracted entry %q exceeded %d-byte cap", f.Name, downloadMaxBytes)
+		}
+		return extractedBinary{path: tmp.Name()}, nil
+	}
+	return extractedBinary{}, fmt.Errorf("zip missing %q (got %d entries)", wantName, len(z.File))
+}
+
+func hashAndSize(path string) (string, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	n, err := io.Copy(h, f)
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(h.Sum(nil)), n, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// jitter returns a random duration in [0, max]. Used to spread poll
+// cadence across server fleets and to mask request bursts to buildbot.
+//
+// max may be zero (the early-startup path passes opts.Interval/10 which
+// becomes 0 for tiny intervals in tests); in that case we return 0
+// rather than panicking on rand.Int63n(0).
+func jitter(max time.Duration) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(max)))
+}
+
+func inMatrix(pa PlatformArch, matrix []PlatformArch) bool {
+	for _, m := range matrix {
+		if m == pa {
+			return true
+		}
+	}
+	return false
+}
+
+// shortSha mirrors api.shortSha (kept private to that package) so the
+// poller's audit-event Reason lines render identically.
+func shortSha(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	if len(s) < 12 {
+		return s
+	}
+	return s[:12]
+}

--- a/server/internal/cores/poller_test.go
+++ b/server/internal/cores/poller_test.go
@@ -1,0 +1,289 @@
+package cores
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/safehttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// fakeBuildbot serves a zipped libretro binary at the expected nightly
+// path layout, optionally swapping bytes between rounds so the poller
+// observes a sha change on the second pass.
+type fakeBuildbot struct {
+	server *httptest.Server
+
+	// served counts hits so tests can assert the poller fanned out to
+	// every (platform, arch) tuple instead of, say, polling only linux.
+	served int64
+
+	// payload is the bytes to wrap inside the zip on the NEXT request.
+	// Tests rotate this between RunOnce calls to simulate a buildbot
+	// nightly being republished.
+	payload []byte
+
+	// statusCode lets the test simulate buildbot failures (5xx, etc.) on
+	// the next request. Zero means 200.
+	statusCode int
+}
+
+func newFakeBuildbot(payload []byte) *fakeBuildbot {
+	fb := &fakeBuildbot{payload: payload}
+	fb.server = httptest.NewServer(http.HandlerFunc(fb.handle))
+	return fb
+}
+
+func (fb *fakeBuildbot) URL() string { return fb.server.URL }
+func (fb *fakeBuildbot) Close()      { fb.server.Close() }
+
+func (fb *fakeBuildbot) handle(w http.ResponseWriter, r *http.Request) {
+	atomic.AddInt64(&fb.served, 1)
+	if fb.statusCode != 0 && fb.statusCode != http.StatusOK {
+		w.WriteHeader(fb.statusCode)
+		return
+	}
+	// Derive the inner filename from the asset name. URL shapes:
+	//   /nightly/android/latest/{arch}/{name}_libretro_android.so.zip
+	//   /nightly/apple/osx/{arch}/latest/{name}_libretro.dylib.zip
+	//   /nightly/linux/{arch}/latest/{name}_libretro.so.zip
+	//   /nightly/windows/{arch}/latest/{name}_libretro.dll.zip
+	//
+	// The asset's basename minus `.zip` is what we put inside the archive.
+	base := filepath.Base(r.URL.Path)
+	if !strings.HasSuffix(base, ".zip") {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	inner := strings.TrimSuffix(base, ".zip")
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	f, err := zw.Create(inner)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if _, err := f.Write(fb.payload); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := zw.Close(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/zip")
+	_, _ = w.Write(buf.Bytes())
+}
+
+func openPollerTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&db.Core{}, &db.CorePlatformBinary{}, &db.SystemEvent{}, &db.SystemEventCategory{}))
+	// system event recorder pre-fills category rows from a private map; we
+	// don't need that here because the poller's RecordOperationalEvent path
+	// looks up the category by code and inserts the row lazily.
+	return database
+}
+
+func newPollerForTest(t *testing.T, database *gorm.DB, fb *fakeBuildbot, matrix []PlatformArch) (*Poller, string) {
+	t.Helper()
+	coreDir := t.TempDir()
+	safehttp.SetAllowPrivateForTest(true)
+	t.Cleanup(func() { safehttp.SetAllowPrivateForTest(false) })
+
+	p := NewPoller(database, PollerOptions{
+		CoreDir:         coreDir,
+		PollMatrix:      matrix,
+		Interval:        time.Hour, // unused by RunOnce
+		HTTPClient:      &http.Client{Timeout: 5 * time.Second},
+		BaseURLOverride: fb.URL(),
+		Clock:           func() time.Time { return time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC) },
+	})
+	return p, coreDir
+}
+
+func sha256Hex(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// linuxOnly is a small matrix that keeps tests fast while still exercising
+// the multi-arch dimension (linux × {x86_64, aarch64}).
+var linuxOnlyMatrix = []PlatformArch{
+	{Platform: "linux", Arch: "x86_64"},
+	{Platform: "linux", Arch: "aarch64"},
+}
+
+func TestPoller_PopulatesFreshPerPlatformRows(t *testing.T) {
+	database := openPollerTestDB(t)
+	require.NoError(t, database.Create(&db.Core{
+		Name:      "nestopia",
+		Platforms: "linux",
+	}).Error)
+
+	payload := []byte("nestopia-libretro-binary-bytes")
+	fb := newFakeBuildbot(payload)
+	defer fb.Close()
+
+	p, coreDir := newPollerForTest(t, database, fb, linuxOnlyMatrix)
+	require.NoError(t, p.RunOnce(context.Background()))
+
+	var rows []db.CorePlatformBinary
+	require.NoError(t, database.Order("platform_arch ASC").Find(&rows).Error)
+	require.Len(t, rows, 2, "one row per (core, platform-arch) tuple")
+
+	wantSha := sha256Hex(payload)
+	for _, row := range rows {
+		assert.Equal(t, wantSha, row.Sha256, "row sha must match payload sha")
+		assert.Equal(t, int64(len(payload)), row.SizeBytes)
+		require.NotNil(t, row.FetchedAt)
+		// FilePath should land under {CoreDir}/{platform-arch}/<name>_libretro.so
+		assert.True(t, strings.HasPrefix(row.FilePath, filepath.Join(coreDir, row.PlatformArch)+string(filepath.Separator)),
+			"FilePath %q should live under %q", row.FilePath, filepath.Join(coreDir, row.PlatformArch))
+		// SourceURL should preserve the buildbot path layout. The
+		// BaseURLOverride substitutes the host, so we assert on the
+		// path tail rather than the full URL.
+		assert.Contains(t, row.SourceURL, "/linux/")
+		assert.Contains(t, row.SourceURL, "/latest/nestopia_libretro.so.zip")
+		// And the file should actually be on disk with the right bytes.
+		on, err := os.ReadFile(row.FilePath)
+		require.NoError(t, err)
+		assert.Equal(t, payload, on)
+	}
+}
+
+func TestPoller_NoOpWhenShaUnchanged(t *testing.T) {
+	database := openPollerTestDB(t)
+	require.NoError(t, database.Create(&db.Core{
+		Name:      "nestopia",
+		Platforms: "linux",
+	}).Error)
+
+	payload := []byte("steady-bytes")
+	fb := newFakeBuildbot(payload)
+	defer fb.Close()
+
+	p, _ := newPollerForTest(t, database, fb, linuxOnlyMatrix)
+	require.NoError(t, p.RunOnce(context.Background()))
+	require.NoError(t, p.RunOnce(context.Background()))
+
+	// Second pass must not produce a second core_updated event for any
+	// row; both rows should still hold the original sha.
+	var events []db.SystemEvent
+	require.NoError(t, database.Where("event_type = ?", db.SystemEventCoreUpdated).Find(&events).Error)
+	assert.Len(t, events, 2, "one event per platform on the FIRST pass; second pass is a no-op")
+}
+
+func TestPoller_EmitsCoreUpdatedOnChange(t *testing.T) {
+	database := openPollerTestDB(t)
+	require.NoError(t, database.Create(&db.Core{
+		Name:      "nestopia",
+		Platforms: "linux",
+	}).Error)
+
+	v1 := []byte("nightly-build-001")
+	v2 := []byte("nightly-build-002-bigger-payload")
+	fb := newFakeBuildbot(v1)
+	defer fb.Close()
+
+	p, _ := newPollerForTest(t, database, fb, linuxOnlyMatrix)
+	require.NoError(t, p.RunOnce(context.Background()))
+	fb.payload = v2
+	require.NoError(t, p.RunOnce(context.Background()))
+
+	var rows []db.CorePlatformBinary
+	require.NoError(t, database.Find(&rows).Error)
+	for _, row := range rows {
+		assert.Equal(t, sha256Hex(v2), row.Sha256, "row should track the latest poll")
+	}
+
+	var events []db.SystemEvent
+	require.NoError(t, database.Where("event_type = ?", db.SystemEventCoreUpdated).Order("id ASC").Find(&events).Error)
+	require.Len(t, events, 4, "two platforms × two updates (initial create + version bump)")
+
+	// Spot-check the metadata on the latest event — Trigger must say
+	// buildbot_poll, not admin_refresh.
+	last := events[len(events)-1]
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal([]byte(last.Metadata), &meta))
+	assert.Equal(t, "nestopia", meta["core"])
+	assert.Equal(t, "buildbot_poll", meta["trigger"])
+	assert.Equal(t, sha256Hex(v2), meta["newSha256"])
+}
+
+func TestPoller_EmitsCoreUpdateFailedOnHTTPError(t *testing.T) {
+	database := openPollerTestDB(t)
+	require.NoError(t, database.Create(&db.Core{
+		Name:      "nestopia",
+		Platforms: "linux",
+	}).Error)
+
+	fb := newFakeBuildbot([]byte("ignored-because-status-is-503"))
+	fb.statusCode = http.StatusServiceUnavailable
+	defer fb.Close()
+
+	p, _ := newPollerForTest(t, database, fb, linuxOnlyMatrix)
+	require.NoError(t, p.RunOnce(context.Background()))
+
+	var failures []db.SystemEvent
+	require.NoError(t, database.Where("event_type = ?", db.SystemEventCoreUpdateFailed).Find(&failures).Error)
+	assert.Len(t, failures, 2, "one failure event per (core, platform) tuple")
+
+	// And the row should NOT have been created — we don't write through
+	// on a failed fetch.
+	var rows []db.CorePlatformBinary
+	require.NoError(t, database.Find(&rows).Error)
+	assert.Empty(t, rows)
+}
+
+func TestPoller_SkipsCoresWithCustomDownloadURL(t *testing.T) {
+	database := openPollerTestDB(t)
+	require.NoError(t, database.Create(&db.Core{
+		Name:              "pinned",
+		Platforms:         "linux",
+		CustomDownloadURL: "https://example.test/pinned-{platform}.zip",
+	}).Error)
+	require.NoError(t, database.Create(&db.Core{
+		Name:      "buildbot_core",
+		Platforms: "linux",
+	}).Error)
+
+	fb := newFakeBuildbot([]byte("buildbot-bytes"))
+	defer fb.Close()
+
+	p, _ := newPollerForTest(t, database, fb, linuxOnlyMatrix)
+	require.NoError(t, p.RunOnce(context.Background()))
+
+	// Only the buildbot_core's rows should exist — pinned cores own
+	// their own update path and the poller must not race against admin
+	// uploads.
+	var rows []db.CorePlatformBinary
+	require.NoError(t, database.Find(&rows).Error)
+	require.Len(t, rows, 2)
+	var buildbotCore db.Core
+	require.NoError(t, database.Where("name = ?", "buildbot_core").First(&buildbotCore).Error)
+	for _, row := range rows {
+		assert.Equal(t, buildbotCore.ID, row.CoreID, "every row must belong to buildbot_core, not pinned")
+	}
+}

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -161,6 +161,7 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&RefreshToken{},
 		&ServerSetting{},
 		&Core{},
+		&CorePlatformBinary{},
 		&ConsoleShaderPreference{},
 		&ConsoleKeyMappingPreference{},
 		&ConsoleSaveStatePolicy{},

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -405,10 +405,15 @@ const (
 	SystemEventAPICredentialsInvalid   = "api_credentials_invalid"
 	SystemEventEmulatorJSLoadFailed    = "emulatorjs_load_failed"
 	// Emitted when the server observes a new sha256 for a core binary —
-	// either an admin-triggered force-refresh or (future) a background
-	// buildbot poll. Metadata carries old_sha256 and new_sha256 so the
-	// audit trail shows which version replaced which. See #555 Phase 2.
+	// either an admin-triggered force-refresh or a background buildbot
+	// poll. Metadata carries old_sha256 and new_sha256 so the audit trail
+	// shows which version replaced which. See #555 Phase 2 and #1190.
 	SystemEventCoreUpdated = "core_updated"
+	// Emitted by the libretro buildbot poller when a (core, platform)
+	// fetch fails — HTTP error, zip parse failure, hash mismatch, etc.
+	// Lets admins notice when buildbot goes down or shifts URL layouts.
+	// Metadata: CoreUpdateFailedMetadata. See #1190.
+	SystemEventCoreUpdateFailed = "core_update_failed"
 	// Emitted by the BIOS auto-downloader when an entry fails to fetch
 	// or extract — HTTP error, non-200 status, MD5 mismatch, archive
 	// extraction failure, filesystem error. Lets admins notice when
@@ -436,6 +441,7 @@ var AllSystemEventTypes = []string{
 	SystemEventAPICredentialsInvalid,
 	SystemEventEmulatorJSLoadFailed,
 	SystemEventCoreUpdated,
+	SystemEventCoreUpdateFailed,
 	SystemEventBIOSDownloadFailed,
 }
 
@@ -458,6 +464,7 @@ var SystemEventTypeCategory = map[string]string{
 	SystemEventAPICredentialsInvalid:   CategoryOperational,
 	SystemEventEmulatorJSLoadFailed:    CategoryOperational,
 	SystemEventCoreUpdated:             CategoryOperational,
+	SystemEventCoreUpdateFailed:        CategoryOperational,
 	SystemEventBIOSDownloadFailed:      CategoryOperational,
 }
 
@@ -966,10 +973,45 @@ type Core struct {
 	// whenever it downloads or serves a core for the first time. See #555.
 	// Nullable pointer for FetchedAt so admin UI can distinguish "never
 	// fetched" from "fetched long ago".
+	//
+	// These fields are platform-ambiguous — they describe whichever binary
+	// happens to live at FilePath on this server. For multi-platform
+	// fingerprinting (used by the buildbot poller and the per-platform
+	// staleness check on the player), see CorePlatformBinary. The manifest
+	// endpoint falls back to these when no per-platform row exists, so
+	// existing admin upload flows keep working without changes.
 	Sha256    string     `gorm:"size:64" json:"sha256"`    // hex sha256 of the cached binary
 	SizeBytes int64      `json:"sizeBytes"`                // byte length of the cached binary
 	FetchedAt *time.Time `json:"fetchedAt"`                // when the binary was last downloaded
 	SourceURL string     `gorm:"size:1024" json:"sourceUrl"` // URL we pulled the binary from
+}
+
+// CorePlatformBinary is the per-(core, platform) fingerprint that the
+// libretro buildbot poller maintains. See #1190.
+//
+// `Core.Sha256` and friends describe ONE binary — whatever lives at
+// `Core.FilePath` on this server. That works for admin-uploaded pinned
+// cores but breaks for buildbot-default cores where each platform has
+// its own distinct binary on disk; a single Sha256 means the last
+// platform polled wins and every other platform's player thrashes
+// (sha mismatch → redownload → next poll cycle's sha mismatch → ...).
+//
+// Each row pins one (core, platform-arch) tuple: the file the poller
+// stored to disk, its sha256, its size, and when it was fetched.
+// PlatformArch follows the player's `${currentPlatform()}-${currentArch()}`
+// convention — e.g. `linux-x86_64`, `macos-arm64`, `android-arm64-v8a`.
+type CorePlatformBinary struct {
+	ID           uint           `gorm:"primarykey" json:"id"`
+	CreatedAt    time.Time      `json:"createdAt"`
+	UpdatedAt    time.Time      `json:"updatedAt"`
+	DeletedAt    gorm.DeletedAt `gorm:"index" json:"-"`
+	CoreID       uint           `gorm:"uniqueIndex:idx_core_platform;not null" json:"coreId"`
+	PlatformArch string         `gorm:"uniqueIndex:idx_core_platform;size:64;not null" json:"platformArch"`
+	FilePath     string         `gorm:"size:1024" json:"-"`
+	Sha256       string         `gorm:"size:64" json:"sha256"`
+	SizeBytes    int64          `json:"sizeBytes"`
+	FetchedAt    *time.Time     `json:"fetchedAt"`
+	SourceURL    string         `gorm:"size:1024" json:"sourceUrl"`
 }
 
 // CheatCode represents a cheat code for a specific game.

--- a/server/internal/db/system_event_metadata.go
+++ b/server/internal/db/system_event_metadata.go
@@ -72,3 +72,29 @@ type BIOSDownloadFailedMetadata struct {
 	URL       string `json:"url"`
 	Error     string `json:"error"`
 }
+
+// CoreUpdatedMetadata is the metadata shape for SystemEventCoreUpdated.
+// Emitted whenever the server observes a new sha256 for a core binary —
+// admin-triggered refresh, or a buildbot poll that landed a new nightly.
+// Trigger discriminates the two so the audit trail tells the story.
+type CoreUpdatedMetadata struct {
+	Core         string `json:"core"`
+	PlatformArch string `json:"platformArch,omitempty"` // empty for legacy admin-refresh that doesn't carry one
+	OldSha256    string `json:"oldSha256"`
+	NewSha256    string `json:"newSha256"`
+	SizeBytes    int64  `json:"sizeBytes"`
+	SourceURL    string `json:"sourceUrl"`
+	Trigger      string `json:"trigger"` // "admin_refresh" | "buildbot_poll"
+}
+
+// CoreUpdateFailedMetadata is the metadata shape for
+// SystemEventCoreUpdateFailed. Emitted by the buildbot poller when a
+// fetch or unzip fails — analogous to BIOSDownloadFailedMetadata. Lets
+// admins notice when upstream goes down or shifts the URL layout
+// without tailing container logs. See #1190.
+type CoreUpdateFailedMetadata struct {
+	Core         string `json:"core"`
+	PlatformArch string `json:"platformArch"`
+	URL          string `json:"url"`
+	Error        string `json:"error"`
+}

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -12272,7 +12272,10 @@ export interface operations {
     };
     getCoreManifest: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Player's <platform>-<arch> tag. Optional; omit for the legacy core-wide manifest. */
+                platform?: string;
+            };
             header?: never;
             path: {
                 /** @description Core row ID (not core name). */

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -16023,6 +16023,18 @@
               "pattern": "^[0-9]+$",
               "type": "string"
             }
+          },
+          {
+            "description": "Player's \u003cplatform\u003e-\u003carch\u003e tag. Optional; omit for the legacy core-wide manifest.",
+            "explode": false,
+            "in": "query",
+            "name": "platform",
+            "schema": {
+              "description": "Player's \u003cplatform\u003e-\u003carch\u003e tag. Optional; omit for the legacy core-wide manifest.",
+              "maxLength": 64,
+              "pattern": "^[a-z0-9_-]*$",
+              "type": "string"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
## Summary

Closes the auto-update gap for buildbot-default cores. Pre-this-PR: the player downloaded a buildbot binary on first run and then kept it forever (server's `Sha256` was empty for buildbot cores → `isCachedCoreCurrent` returned null → the staleness branch fell through to "use cached"). New libretro nightlies never reached players who had already cached the core.

### What changed

**Schema — `CorePlatformBinary` table** (commit 1)

The existing `Core.Sha256` / `SizeBytes` / `FetchedAt` / `FilePath` / `SourceURL` describes a single binary. Each platform actually has its own distinct buildbot binary, so a multi-platform poller can't faithfully feed that single column without thrashing.

New `core_platform_binaries` table keyed by `(CoreID, PlatformArch)` carries per-platform fingerprints. `PlatformArch` follows the player's `${currentPlatform()}-${currentArch()}` convention — `linux-x86_64`, `linux-aarch64`, `macos-arm64`, `macos-x86_64`, `windows-x86_64`, `android-arm64-v8a`.

`GET /api/cores/{id}/manifest` now accepts an optional `?platform=` parameter. When passed and the row exists → per-platform fingerprint. Otherwise → fall back to `Core.Sha256` so admin tooling and any caller that doesn't know about per-platform rows keeps working.

Also added typed `CoreUpdatedMetadata` / `CoreUpdateFailedMetadata` event structs and a new `SystemEventCoreUpdateFailed` event type.

**Poller — `server/internal/cores/`** (commit 2)

- `buildbot.go`: URL + filename composition that mirrors the player's `BuildbotUrl.kt`, including the azahar Android quirk (`ANDROID_NO_SUFFIX_CORES`). `DefaultPollMatrix` lists every (platform, arch) tuple we serve.
- `poller.go`: `NewPoller` + `Run(ctx)`. Initial 5min jittered delay so boot isn't bandwidth-spiky, then `RunOnce` + ticker at the `core_poll_interval_hours` `ServerSetting` (default 24h, jittered by `interval/10`). Iterates buildbot-default cores; for each (platform, arch) it fetches via `safehttp.NewClient(60s)`, unzips, hashes, compares against the row, writes through on change. Failures emit `SystemEventCoreUpdateFailed` and continue.
- 200 MB cap per fetch (biggest core ~50 MB; 4x headroom). Temp file → `os.Rename` into `{CoreDir}/{platform-arch}/{name}_libretro{ext}`, with cross-device fallback. `SPELA_DISABLE_CORE_POLLER=1` env-var disables.
- Player update: `getServerCoreSha` passes `${currentPlatform()}-${currentArch()}` on the manifest call so the server returns this device's per-platform fingerprint. Generated OpenAPI client regenerated to expose the new query parameter.

### Net effect

Existing desktop installs holding old buildbot binaries from before this change still benefit: once the poller has populated a `CorePlatformBinary` row, the player's existing staleness check sees a sha mismatch on the next game launch and re-downloads. No manual file deletion required, no player-side migration.

## Test plan

- [x] `go test ./...` — full server suite green (15 packages, including new `internal/cores` and updated `internal/api` + `internal/db`)
- [x] `./gradlew :shared-api:compileKotlinDesktop :shared:compileKotlinDesktop` — player compiles with regenerated client
- [x] `./gradlew :shared:desktopTest` — green
- [x] Pre-push hook ran `go build ./...` clean
- [x] New poller tests: fresh per-platform row creation, no-op on unchanged sha, `core_updated` event on republish, `core_update_failed` on HTTP 5xx, pinned cores (`CustomDownloadURL` set) are skipped
- [x] New manifest tests: `?platform=<platform-arch>` returns the per-platform row when set; falls back to `Core.Sha256` when the row doesn't exist
- [ ] Manual: after deploy, watch logs for the first scheduled `cores: buildbot binary updated` lines for each (core, platform-arch) tuple
- [ ] Manual: verify a player whose cached core predates the poll cycle picks up the new binary on next game launch
- [ ] Optional follow-up: admin "poll now" endpoint that calls `Poller.RunOnce` ad-hoc — was an open question on the issue, not done in this PR

Closes #1190.