### PR TITLE
Core download UX: background prefetch + foreground progress sheet (#1192)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/data/repository/CoreUpdateServiceTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/data/repository/CoreUpdateServiceTest.kt
@@ -1,0 +1,250 @@
+package com.spela.player.data.repository
+
+import com.spela.player.desktop.e2e.FakePreferencesRepository
+import com.spela.player.domain.model.LibretroCore
+import com.spela.player.domain.model.UserPreferences
+import com.spela.player.domain.repository.CoreRepository
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [CoreUpdateService]. Lives in desktopTest (rather than
+ * commonTest) so it can reuse the rich [FakePreferencesRepository] from
+ * the existing e2e fakes module — implementing the full
+ * `PreferencesRepository` surface inline for one test would be more
+ * noise than signal.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CoreUpdateServiceTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val scope = CoroutineScope(testDispatcher)
+    private val dispatchers = object : DispatcherProvider {
+        override val main: CoroutineDispatcher = testDispatcher
+        override val io: CoroutineDispatcher = testDispatcher
+        override val default: CoroutineDispatcher = testDispatcher
+    }
+
+    private lateinit var coreRepo: SettableCoreRepository
+    private lateinit var preferences: FakePreferencesRepository
+    private lateinit var service: CoreUpdateService
+
+    @BeforeTest
+    fun setUp() {
+        coreRepo = SettableCoreRepository()
+        preferences = FakePreferencesRepository()
+        service = CoreUpdateService(coreRepo, preferences, dispatchers, scope)
+    }
+
+    @Test
+    fun prefetchOnlyTouchesCachedStaleCores() = runTest(testDispatcher) {
+        coreRepo.cores = listOf(
+            core("nestopia"),
+            core("snes9x"),
+            core("mgba"),
+            core("dolphin"),
+        )
+        // nestopia is cached and stale → should be downloaded.
+        // snes9x is cached and current → skipped.
+        // mgba is cached, server can't decide (null) → skipped per
+        //   tri-state semantics ("can't decide" defers to per-launch check).
+        // dolphin is not cached at all → skipped.
+        coreRepo.cachedCores = setOf("nestopia", "snes9x", "mgba")
+        coreRepo.currentByName["nestopia"] = false
+        coreRepo.currentByName["snes9x"] = true
+        coreRepo.currentByName["mgba"] = null
+
+        service.prefetchStaleCachedCores()
+        advanceUntilIdle()
+
+        assertEquals(listOf("nestopia"), coreRepo.downloadCalls,
+            "only the cached AND explicitly-stale core gets prefetched")
+    }
+
+    @Test
+    fun prefetchNoopsWhenAutoUpdateDisabled() = runTest(testDispatcher) {
+        preferences.preferencesResult = Result.success(
+            UserPreferences(autoUpdateCoresEnabled = false),
+        )
+        coreRepo.cores = listOf(core("nestopia"))
+        coreRepo.cachedCores = setOf("nestopia")
+        coreRepo.currentByName["nestopia"] = false
+
+        service.prefetchStaleCachedCores()
+        advanceUntilIdle()
+
+        assertTrue(coreRepo.downloadCalls.isEmpty(),
+            "auto-update preference off ⇒ no downloads")
+    }
+
+    @Test
+    fun prefetchIsSingleFlightAcrossCalls() = runTest(testDispatcher) {
+        coreRepo.cores = listOf(core("nestopia"))
+        coreRepo.cachedCores = setOf("nestopia")
+        coreRepo.currentByName["nestopia"] = false
+
+        service.prefetchStaleCachedCores()
+        service.prefetchStaleCachedCores()
+        service.prefetchStaleCachedCores()
+        advanceUntilIdle()
+
+        assertEquals(1, coreRepo.downloadCalls.size,
+            "second/third calls within a session must no-op")
+    }
+
+    @Test
+    fun downloadCoreDeduplicatesConcurrentCallers() = runTest(testDispatcher) {
+        coreRepo.cores = listOf(core("nestopia"))
+        coreRepo.gateDownload = true
+
+        val first = service.downloadCore("nestopia", null)
+        val second = service.downloadCore("nestopia", null)
+        assertTrue(first === second, "concurrent callers must share one handle")
+
+        coreRepo.releaseDownload()
+        advanceUntilIdle()
+        assertEquals(1, coreRepo.downloadCalls.size)
+    }
+
+    @Test
+    fun inFlightDownloadIsClearedAfterCompletion() = runTest(testDispatcher) {
+        coreRepo.cores = listOf(core("nestopia"))
+
+        val handle = service.downloadCore("nestopia", null)
+        advanceUntilIdle()
+        assertEquals("/fake/nestopia", handle.await().getOrNull())
+
+        assertNull(service.inFlightDownload("nestopia"),
+            "handle must be removed from the registry post-completion")
+    }
+
+    @Test
+    fun progressByteCountersAreSurfacedThroughHandle() = runTest(testDispatcher) {
+        coreRepo.cores = listOf(core("nestopia"))
+        coreRepo.progressEmissions = listOf(0L to 100L, 50L to 100L, 100L to 100L)
+
+        val handle = service.downloadCore("nestopia", null)
+        advanceUntilIdle()
+
+        val snapshot = handle.progress.value
+        assertEquals(100L, snapshot.bytesDownloaded)
+        assertEquals(100L, snapshot.totalBytes)
+    }
+
+    @Test
+    fun completionSnapshotFlipsToTotalWhenTotalWasKnown() = runTest(testDispatcher) {
+        coreRepo.cores = listOf(core("nestopia"))
+        coreRepo.progressEmissions = listOf(50L to 200L)
+
+        val handle = service.downloadCore("nestopia", null)
+        advanceUntilIdle()
+
+        val snapshot = handle.progress.value
+        assertEquals(200L, snapshot.totalBytes)
+        assertEquals(200L, snapshot.bytesDownloaded)
+    }
+
+    @Test
+    fun prefetchSkipsNeverCachedCoresEvenIfStaleAtServer() = runTest(testDispatcher) {
+        // Bandwidth guardrail: never download a core the user has not
+        // played. Stale-at-server only matters if there's already a
+        // local copy that's wrong.
+        coreRepo.cores = listOf(core("opera"))
+        coreRepo.cachedCores = emptySet()
+        coreRepo.currentByName["opera"] = false
+
+        service.prefetchStaleCachedCores()
+        advanceUntilIdle()
+
+        assertTrue(coreRepo.downloadCalls.isEmpty())
+    }
+
+    @Test
+    fun handleReturnedFromInFlightDownloadIsTheSameAsActiveOne() = runTest(testDispatcher) {
+        coreRepo.cores = listOf(core("nestopia"))
+        coreRepo.gateDownload = true
+
+        val created = service.downloadCore("nestopia", null)
+        val recovered = service.inFlightDownload("nestopia")
+        assertNotNull(recovered)
+        assertTrue(created === recovered,
+            "inFlightDownload must hand back the live registry entry, " +
+                "not a fresh handle")
+
+        coreRepo.releaseDownload()
+        advanceUntilIdle()
+    }
+
+    private fun core(name: String) = LibretroCore(
+        id = name.hashCode().toLong(),
+        name = name,
+        displayName = name.replaceFirstChar { it.uppercase() },
+    )
+}
+
+/**
+ * Test-only [CoreRepository] with knobs for cache state, staleness, and
+ * download gating. The desktop e2e module's [FakeCoreRepository] is too
+ * rigid for these scenarios — its cores list and staleness are fixed.
+ */
+private class SettableCoreRepository : CoreRepository {
+    var cores: List<LibretroCore> = emptyList()
+    var cachedCores: Set<String> = emptySet()
+    val currentByName: MutableMap<String, Boolean?> = mutableMapOf()
+    val downloadCalls = mutableListOf<String>()
+
+    /** Pairs of (bytesDownloaded, totalBytes) emitted in order before the download completes. */
+    var progressEmissions: List<Pair<Long, Long?>> = emptyList()
+
+    /** When true, suspends downloadCore until [releaseDownload] is called. */
+    var gateDownload: Boolean = false
+    private val gate = CompletableDeferred<Unit>()
+
+    fun releaseDownload() {
+        gate.complete(Unit)
+    }
+
+    override suspend fun getAvailableCores(): Result<List<LibretroCore>> = Result.success(cores)
+    override suspend fun getRecommendedCore(gameId: String): Result<LibretroCore> =
+        cores.firstOrNull()?.let { Result.success(it) }
+            ?: Result.failure(IllegalStateException("no cores"))
+
+    override suspend fun downloadCore(
+        coreName: String,
+        customDownloadUrl: String?,
+        onProgress: (bytesDownloaded: Long, totalBytes: Long?) -> Unit,
+    ): Result<String> {
+        downloadCalls.add(coreName)
+        if (gateDownload) gate.await()
+        progressEmissions.forEach { (sent, total) -> onProgress(sent, total) }
+        return Result.success("/fake/$coreName")
+    }
+
+    override suspend fun downloadCoreByHash(
+        coreName: String,
+        sha256: String,
+        onProgress: (bytesDownloaded: Long, totalBytes: Long?) -> Unit,
+    ): Result<String> = Result.success("/fake/$coreName@$sha256")
+
+    override suspend fun getLocalCorePath(coreName: String): String? =
+        if (coreName in cachedCores) "/fake/cores/$coreName" else null
+
+    override suspend fun isCoreCached(coreName: String): Boolean = coreName in cachedCores
+
+    override suspend fun isCachedCoreCurrent(coreName: String): Boolean? =
+        currentByName[coreName]
+
+    override suspend fun getServerCoreSha(coreName: String): String? = null
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -208,8 +208,15 @@ class SpelaTestHarness(
         scope = scope,
     )
 
+    val coreUpdateService = com.spela.player.data.repository.CoreUpdateService(
+        coreRepository = coreRepo,
+        preferencesRepository = preferencesRepo,
+        dispatchers = dispatchers,
+        scope = scope,
+    )
+
     val emulationViewModel = EmulationViewModel(
-        prepareGameUseCase = PrepareGameUseCase(downloadRepo, coreRepo),
+        prepareGameUseCase = PrepareGameUseCase(downloadRepo, coreRepo, coreUpdateService),
         getGameDetailUseCase = GetGameDetailUseCase(gameRepo),
         preferencesRepository = preferencesRepo,
         achievementsRepository = achievementsRepo,

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -598,18 +598,26 @@ class FakeCoreRepository : CoreRepository {
         return Result.success(cores.first())
     }
 
-    override suspend fun downloadCore(coreName: String, customDownloadUrl: String?, onProgress: (Float) -> Unit): Result<String> {
+    override suspend fun downloadCore(
+        coreName: String,
+        customDownloadUrl: String?,
+        onProgress: (bytesDownloaded: Long, totalBytes: Long?) -> Unit,
+    ): Result<String> {
         downloadCalls.add(coreName)
-        onProgress(1f)
+        onProgress(0L, 0L)
         return Result.success("/fake/cores/$coreName")
     }
 
-    override suspend fun downloadCoreByHash(coreName: String, sha256: String, onProgress: (Float) -> Unit): Result<String> {
+    override suspend fun downloadCoreByHash(
+        coreName: String,
+        sha256: String,
+        onProgress: (bytesDownloaded: Long, totalBytes: Long?) -> Unit,
+    ): Result<String> {
         downloadByHashCalls.add(coreName to sha256)
         if (sha256 in prunedHashes) {
             return Result.failure(com.spela.player.domain.repository.CorePrunedException(sha256))
         }
-        onProgress(1f)
+        onProgress(0L, 0L)
         return Result.success("/fake/cores/$coreName@$sha256")
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CoreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CoreRepositoryImpl.kt
@@ -43,7 +43,11 @@ class CoreRepositoryImpl(
         }
     }
 
-    override suspend fun downloadCore(coreName: String, customDownloadUrl: String?, onProgress: (Float) -> Unit): Result<String> = runCatching {
+    override suspend fun downloadCore(
+        coreName: String,
+        customDownloadUrl: String?,
+        onProgress: (bytesDownloaded: Long, totalBytes: Long?) -> Unit,
+    ): Result<String> = runCatching {
         val fileName = coreFileName(coreName)
         val destPath = fileStorage.getCoresDir() + "/$fileName"
         val tempZipPath = "$destPath.zip.tmp"
@@ -58,7 +62,11 @@ class CoreRepositoryImpl(
         try {
             httpClient.prepareGet(url) {
                 onDownload { bytesSentTotal, contentLength ->
-                    if (contentLength != null && contentLength > 0) onProgress(bytesSentTotal.toFloat() / contentLength)
+                    // Ktor reports contentLength=null when the server
+                    // omits Content-Length. Pass it through verbatim so
+                    // the UI can render an indeterminate progress bar
+                    // instead of a misleading 0% / NaN%.
+                    onProgress(bytesSentTotal, contentLength)
                 }
             }.execute { response ->
                 if (!response.status.isSuccess()) {
@@ -87,7 +95,7 @@ class CoreRepositoryImpl(
     override suspend fun downloadCoreByHash(
         coreName: String,
         sha256: String,
-        onProgress: (Float) -> Unit,
+        onProgress: (bytesDownloaded: Long, totalBytes: Long?) -> Unit,
     ): Result<String> = runCatching {
         // Resolve the server-side numeric core id. The versioned endpoint is
         // `/api/cores/{id}/download?sha256=...` and requires the numeric id;
@@ -99,9 +107,7 @@ class CoreRepositoryImpl(
         val (status, body) = apiClient.downloadCoreByHash(
             coreId = core.id.toString(),
             sha256 = sha256,
-            onProgress = { sent, total ->
-                if (total != null && total > 0) onProgress(sent.toFloat() / total)
-            },
+            onProgress = { sent, total -> onProgress(sent, total) },
         )
         if (status == 404) {
             throw CorePrunedException(sha256)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CoreUpdateService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CoreUpdateService.kt
@@ -1,0 +1,199 @@
+package com.spela.player.data.repository
+
+import com.spela.player.domain.repository.CoreRepository
+import com.spela.player.domain.repository.PreferencesRepository
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Mutable byte-counter snapshot exposed by [CoreDownloadHandle]. Mirrors
+ * the underlying `CoreRepository.downloadCore` callback contract — total
+ * may be `null` when the server omits Content-Length.
+ */
+data class CoreDownloadSnapshot(
+    val bytesDownloaded: Long,
+    val totalBytes: Long?,
+)
+
+/**
+ * Handle to an in-flight (or just-completed) core download.
+ *
+ * Two callers may share one handle: the post-login prefetch in
+ * [CoreUpdateService.prefetchStaleCachedCores] kicks off downloads
+ * without observing, then a game-launch path that lands on the same
+ * core during the prefetch reuses the in-flight handle so both see the
+ * same byte counter and the same finished binary. There is never more
+ * than one HTTP fetch for a single core at a time.
+ */
+class CoreDownloadHandle internal constructor(
+    val coreName: String,
+    progressFlow: StateFlow<CoreDownloadSnapshot>,
+    private val deferred: Deferred<Result<String>>,
+) {
+    val progress: StateFlow<CoreDownloadSnapshot> = progressFlow
+
+    /** Suspends until the download completes, then returns its result. */
+    suspend fun await(): Result<String> = deferred.await()
+}
+
+/**
+ * Coordinates core download lifecycles so the post-login prefetch pass
+ * and the per-game-launch download flow don't race each other or
+ * double-fetch the same core. See #1192.
+ *
+ * Single instance per app session (wired as a Koin `single`). Holds a
+ * map of `coreName -> CoreDownloadHandle` for in-flight fetches; the
+ * entry is removed once the download completes (success or failure) so
+ * a subsequent stale-vs-server check on the next game launch can
+ * trigger a fresh download.
+ *
+ * Lifetime:
+ *
+ *   - [prefetchStaleCachedCores] runs at most once per app session
+ *     (gated by [sessionStarted]). Called after login completes —
+ *     re-calls within the same session no-op so the post-login one-
+ *     shot wiring in NavigationViewModel doesn't need to track its
+ *     own "already fired" flag.
+ *
+ *   - [downloadCore] is safe to call repeatedly: it dedupes against the
+ *     in-flight map, so two concurrent callers for the same core share
+ *     one download.
+ *
+ * The service intentionally has no shutdown hook. It owns no resources
+ * outside the injected [scope]; cancelling that scope cancels every
+ * in-flight download.
+ */
+class CoreUpdateService(
+    private val coreRepository: CoreRepository,
+    private val preferencesRepository: PreferencesRepository,
+    private val dispatchers: DispatcherProvider,
+    private val scope: CoroutineScope,
+) {
+    private val mutex = Mutex()
+    private val inFlight = mutableMapOf<String, CoreDownloadHandle>()
+
+    // Guarded by [mutex]. Not atomic because every prefetchStaleCachedCores
+    // path acquires the mutex anyway (via downloadCore) — keeping the flag
+    // under the same lock means we don't need a second synchronization
+    // primitive.
+    private var sessionStarted: Boolean = false
+
+    /**
+     * Returns a deduplicated handle for downloading [coreName]. If a
+     * download is already in flight for the same name, the existing
+     * handle is returned so both callers see the same progress and the
+     * same finished file.
+     *
+     * The download runs on [scope] regardless of who awaits. If no one
+     * awaits, the download still completes (used by the prefetch pass,
+     * which fires-and-forgets).
+     */
+    suspend fun downloadCore(coreName: String, customDownloadUrl: String?): CoreDownloadHandle =
+        mutex.withLock {
+            inFlight[coreName]?.let { return@withLock it }
+
+            val progressFlow = MutableStateFlow(CoreDownloadSnapshot(0L, null))
+            val deferred = scope.async(dispatchers.io) {
+                val result = coreRepository.downloadCore(
+                    coreName = coreName,
+                    customDownloadUrl = customDownloadUrl,
+                    onProgress = { sent, total ->
+                        progressFlow.value = CoreDownloadSnapshot(sent, total)
+                    },
+                )
+                // Belt-and-suspenders: when the HTTP layer never emitted
+                // progress (Content-Length absent OR the body was fully
+                // buffered before any chunk reached us), flag completion
+                // so observers can tear down the sheet. If we DID see a
+                // total, mirror it as the final value so the UI shows
+                // 100% rather than the last mid-flight sample.
+                progressFlow.value = progressFlow.value.let { last ->
+                    val total = last.totalBytes
+                    if (total != null && total > 0) {
+                        CoreDownloadSnapshot(total, total)
+                    } else {
+                        last
+                    }
+                }
+                mutex.withLock { inFlight.remove(coreName) }
+                result
+            }
+            val handle = CoreDownloadHandle(coreName, progressFlow.asStateFlow(), deferred)
+            inFlight[coreName] = handle
+            handle
+        }
+
+    /**
+     * Returns the in-flight handle for [coreName] if a download is
+     * currently running, or `null` otherwise. Game-launch paths use
+     * this to decide whether to reuse a prefetch's download
+     * (subscribing to its progress) or start their own.
+     */
+    suspend fun inFlightDownload(coreName: String): CoreDownloadHandle? =
+        mutex.withLock { inFlight[coreName] }
+
+    /**
+     * Background prefetch: for every locally-cached core, ask the
+     * server for its current per-platform sha256 and silently re-
+     * download anything that's stale. Gated on the user's
+     * `autoUpdateCoresEnabled` preference (default true).
+     *
+     * Idempotent across the app session: only the first call kicks off
+     * the pass; subsequent calls return immediately. The prefetch
+     * launches on [scope] and never blocks the caller.
+     */
+    fun prefetchStaleCachedCores() {
+        scope.launch(dispatchers.io) {
+            val shouldRun = mutex.withLock {
+                if (sessionStarted) false else {
+                    sessionStarted = true
+                    true
+                }
+            }
+            if (!shouldRun) return@launch
+            runPrefetchPass()
+        }
+    }
+
+    private suspend fun runPrefetchPass() {
+        val enabled = runCatching {
+            preferencesRepository.getPreferences().getOrNull()?.autoUpdateCoresEnabled
+        }.getOrNull() ?: true
+        if (!enabled) {
+            println("[CoreUpdateService] prefetch skipped — autoUpdateCoresEnabled is false")
+            return
+        }
+
+        val cores = coreRepository.getAvailableCores().getOrNull() ?: run {
+            println("[CoreUpdateService] prefetch skipped — getAvailableCores failed")
+            return
+        }
+
+        var stale = 0
+        for (core in cores) {
+            // Only cores the user has actually used. New users / never-
+            // played consoles cost zero extra bandwidth.
+            if (coreRepository.getLocalCorePath(core.name) == null) continue
+            // Tri-state: only act on an explicit "false" (server sha
+            // known and differs). `null` means "can't decide" — defer
+            // to the per-launch staleness check rather than guess.
+            if (coreRepository.isCachedCoreCurrent(core.name) != false) continue
+
+            stale++
+            println("[CoreUpdateService] prefetching stale core ${core.name}")
+            // Kick off the download but don't await — the prefetch
+            // pass should complete promptly even if individual cores
+            // take a while.
+            downloadCore(core.name, core.customDownloadUrl)
+        }
+        println("[CoreUpdateService] prefetch pass complete (stale=$stale of ${cores.size} cached/known)")
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -51,6 +51,7 @@ val commonModule = module {
     single<GameRepository> { GameRepositoryImpl(get(), get(), get()) }
     single<SaveDataRepository> { SaveDataRepositoryImpl(get()) }
     single<CoreRepository> { CoreRepositoryImpl(get(), get(), get()) }
+    single { CoreUpdateService(get(), get(), get(), get()) }
     single<DownloadRepository> { DownloadRepositoryImpl(get(), get(), get()) }
     single<ServerRepository> { ServerRepositoryImpl(get(), get(), get()) }
     single<PreferencesRepository> { PreferencesRepositoryImpl(get(), get(), get(), get()) }
@@ -91,7 +92,7 @@ val commonModule = module {
     factory { ToggleFavoriteUseCase(get()) }
     factory { GetPlayLaterGamesUseCase(get()) }
     factory { TogglePlayLaterUseCase(get()) }
-    factory { PrepareGameUseCase(get(), get()) }
+    factory { PrepareGameUseCase(get(), get(), get()) }
     factory { RestoreSessionUseCase(get(), get(), get()) }
     factory { GetOnlineUsersUseCase(get()) }
     factory { GetActivityFeedUseCase(get()) }
@@ -377,6 +378,7 @@ val commonModule = module {
             dispatchers = get(),
             scope = get(),
             biosRepository = get(),
+            coreUpdateService = get(),
         )
     }
     factory {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/CoreDownload.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/CoreDownload.kt
@@ -1,0 +1,24 @@
+package com.spela.player.domain.model
+
+/**
+ * UI-facing snapshot of an in-progress libretro core download. Surfaced
+ * via [com.spela.player.presentation.state.EmulationState.coreDownload]
+ * while a play tap is waiting on a fresh-or-updated core binary. See
+ * #1192.
+ *
+ * [totalBytes] is `null` until the HTTP response carries a Content-Length
+ * header — buildbot always does, but we can't assume that for every
+ * `CustomDownloadURL` so the sheet has to handle the indeterminate case
+ * gracefully. When `null`, callers should render an indeterminate
+ * progress bar; when known, [fraction] is derivable as
+ * `bytesDownloaded / totalBytes`.
+ */
+data class CoreDownloadProgress(
+    val coreName: String,
+    val coreDisplayName: String,
+    val bytesDownloaded: Long,
+    val totalBytes: Long?,
+) {
+    val fraction: Float?
+        get() = totalBytes?.takeIf { it > 0 }?.let { bytesDownloaded.toFloat() / it }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/CoreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/CoreRepository.kt
@@ -15,7 +15,23 @@ class CorePrunedException(sha256: String) : RuntimeException(
 interface CoreRepository {
     suspend fun getAvailableCores(): Result<List<LibretroCore>>
     suspend fun getRecommendedCore(gameId: String): Result<LibretroCore>
-    suspend fun downloadCore(coreName: String, customDownloadUrl: String? = null, onProgress: (Float) -> Unit = {}): Result<String>
+
+    /**
+     * Downloads the latest binary for [coreName].
+     *
+     * [onProgress] receives raw byte counters as they're observed from
+     * the underlying HTTP stream. `totalBytes` may be `null` for hosts
+     * that don't send a Content-Length header; the UI should render an
+     * indeterminate state in that case. Fires zero or more times during
+     * the download and is not guaranteed to fire at all (e.g. when the
+     * payload is fully buffered before any download progress reaches the
+     * client). See #1192.
+     */
+    suspend fun downloadCore(
+        coreName: String,
+        customDownloadUrl: String? = null,
+        onProgress: (bytesDownloaded: Long, totalBytes: Long?) -> Unit = { _, _ -> },
+    ): Result<String>
 
     /**
      * Downloads a specific historical build of [coreName] identified by
@@ -26,7 +42,11 @@ interface CoreRepository {
      *
      * Part of #555 Phase 3 core history retention.
      */
-    suspend fun downloadCoreByHash(coreName: String, sha256: String, onProgress: (Float) -> Unit = {}): Result<String>
+    suspend fun downloadCoreByHash(
+        coreName: String,
+        sha256: String,
+        onProgress: (bytesDownloaded: Long, totalBytes: Long?) -> Unit = { _, _ -> },
+    ): Result<String>
 
     suspend fun getLocalCorePath(coreName: String): String?
     suspend fun isCoreCached(coreName: String): Boolean

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
@@ -6,11 +6,9 @@ import com.spela.player.domain.repository.CorePrunedException
 import com.spela.player.domain.repository.CoreRepository
 import com.spela.player.domain.repository.DownloadRepository
 import com.spela.player.util.currentPlatform
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 
 /**
  * Classifies why (if at all) the player might want to surface a

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
@@ -1,9 +1,16 @@
 package com.spela.player.domain.usecase
 
+import com.spela.player.data.repository.CoreUpdateService
+import com.spela.player.domain.model.CoreDownloadProgress
 import com.spela.player.domain.repository.CorePrunedException
 import com.spela.player.domain.repository.CoreRepository
 import com.spela.player.domain.repository.DownloadRepository
 import com.spela.player.util.currentPlatform
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 
 /**
  * Classifies why (if at all) the player might want to surface a
@@ -119,6 +126,7 @@ private val ANDROID_CORE_SUBSTITUTIONS = mapOf(
 class PrepareGameUseCase(
     private val downloadRepository: DownloadRepository,
     private val coreRepository: CoreRepository,
+    private val coreUpdateService: CoreUpdateService,
 ) {
     /** Warning copy shown to the user when the session's pinned core is no longer on the server. */
     private val prunedWarning =
@@ -145,6 +153,18 @@ class PrepareGameUseCase(
         sessionHasSaves: Boolean = false,
         skipCoreDecisionPrompt: Boolean = false,
         rehearsalCrashPending: Boolean = false,
+        /**
+         * Optional progress sink for the unpinned-core download path.
+         * Receives a non-null [CoreDownloadProgress] while a download is
+         * in flight (including reused prefetch downloads), then `null`
+         * once the binary is on disk. Caller is expected to surface this
+         * as a foreground sheet — see #1192.
+         *
+         * Not invoked for the version-pinned download path: that path is
+         * tied to a save-state replay and the user is already waiting on
+         * a known-good binary, not browsing.
+         */
+        onCoreDownload: (CoreDownloadProgress?) -> Unit = {},
     ): Result<PrepareGameResult> {
         println("[PrepareGame] invoke(gameId=$gameId)")
         val gamePath = downloadRepository.getLocalGamePath(gameId)
@@ -278,7 +298,7 @@ class PrepareGameUseCase(
             if (error is CorePrunedException) {
                 println("[PrepareGame] Pinned core $pinnedCoreSha256 pruned — falling back to latest")
                 val fallbackPath = coreRepository.getLocalCorePath(coreName)
-                    ?: coreRepository.downloadCore(coreName, customDownloadUrl).getOrElse {
+                    ?: downloadWithProgress(coreName, core.displayName, customDownloadUrl, onCoreDownload).getOrElse {
                         return Result.failure(it)
                     }
                 // When the user explicitly locked this session to the
@@ -334,7 +354,7 @@ class PrepareGameUseCase(
         val shouldCheckStaleness = autoUpdateCoresEnabled && cached != null
         val corePath = if (shouldCheckStaleness && coreRepository.isCachedCoreCurrent(coreName) == false) {
             println("[PrepareGame] Cached $coreName is stale vs server — redownloading")
-            coreRepository.downloadCore(coreName, customDownloadUrl).getOrElse {
+            downloadWithProgress(coreName, core.displayName, customDownloadUrl, onCoreDownload).getOrElse {
                 // Re-download failed: fall back to the stale cache rather
                 // than stranding the user. The game still runs; saves
                 // made here might not load on a fresh install, but that's
@@ -348,7 +368,7 @@ class PrepareGameUseCase(
                 cached
             } else {
                 println("[PrepareGame] No cached core — downloading $coreName")
-                coreRepository.downloadCore(coreName, customDownloadUrl).getOrElse {
+                downloadWithProgress(coreName, core.displayName, customDownloadUrl, onCoreDownload).getOrElse {
                     println("[PrepareGame] downloadCore FAILED: ${it::class.simpleName}: ${it.message}")
                     return Result.failure(it)
                 }.also { println("[PrepareGame] downloadCore succeeded → $it") }
@@ -364,6 +384,56 @@ class PrepareGameUseCase(
                 coreDisplayName = core.displayName.ifEmpty { coreName },
             ),
         )
+    }
+
+    /**
+     * Runs a deduplicated core download through [CoreUpdateService] while
+     * surfacing progress to [onCoreDownload]. When a prefetch pass is
+     * already downloading the same core, both callers share one HTTP
+     * fetch and one progress stream — see #1192.
+     *
+     * Wrapped in [coroutineScope] so the progress collector lives only
+     * as long as the await; cancelling the outer prepareGame call
+     * propagates to both the download and the collector.
+     */
+    private suspend fun downloadWithProgress(
+        coreName: String,
+        coreDisplayName: String,
+        customDownloadUrl: String?,
+        onCoreDownload: (CoreDownloadProgress?) -> Unit,
+    ): Result<String> = coroutineScope {
+        val handle = coreUpdateService.downloadCore(coreName, customDownloadUrl)
+        val displayName = coreDisplayName.ifEmpty { coreName }
+        // Push an initial indeterminate tick so the sheet renders the
+        // moment we know we're going to download — before the HTTP
+        // layer reports the first byte.
+        onCoreDownload(
+            CoreDownloadProgress(
+                coreName = coreName,
+                coreDisplayName = displayName,
+                bytesDownloaded = 0L,
+                totalBytes = null,
+            ),
+        )
+
+        val progressJob = handle.progress
+            .onEach { snapshot ->
+                onCoreDownload(
+                    CoreDownloadProgress(
+                        coreName = coreName,
+                        coreDisplayName = displayName,
+                        bytesDownloaded = snapshot.bytesDownloaded,
+                        totalBytes = snapshot.totalBytes,
+                    ),
+                )
+            }
+            .launchIn(this)
+        try {
+            handle.await()
+        } finally {
+            progressJob.cancel()
+            onCoreDownload(null)
+        }
     }
 
     /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
@@ -24,6 +24,7 @@ class NavigationViewModel(
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
     private val biosRepository: BiosRepository? = null,
+    private val coreUpdateService: com.spela.player.data.repository.CoreUpdateService? = null,
 ) {
     private val _state = MutableStateFlow(NavigationState())
     val state: StateFlow<NavigationState> = _state.asStateFlow()
@@ -287,6 +288,13 @@ class NavigationViewModel(
                         }
                     }
                 }
+
+                // Background prefetch of stale cached cores — keeps the
+                // user off the foreground download path when buildbot
+                // has rolled out a new nightly since they last played.
+                // The service single-flights internally so re-calls per
+                // session no-op. See #1192.
+                coreUpdateService?.prefetchStaleCachedCores()
             }
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -195,6 +195,15 @@ data class EmulationState(
      * issue. #555 Phase 3.
      */
     val coreVersionWarning: String? = null,
+    /**
+     * Snapshot of an in-progress core download. Non-null while
+     * PrepareGameUseCase is fetching (or awaiting a prefetch of) a
+     * fresh-or-updated libretro core; null otherwise. The Emulation UI
+     * renders a foreground sheet while this is non-null so the user
+     * gets a "downloading Azahar — 12 / 38 MB" surface instead of an
+     * opaque loading spinner. See #1192.
+     */
+    val coreDownload: com.spela.player.domain.model.CoreDownloadProgress? = null,
     val fps: Float = 0f,
     val frameTime: Float = 0f,
     val isFastForward: Boolean = false,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -413,6 +413,16 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
                             }
                         }
 
+                        // Core download progress sheet — replaces the
+                        // pre-#1192 opaque loading spinner with a
+                        // foreground modal carrying "Updating Azahar —
+                        // 12 / 38 MB". Non-null when prepareGameUseCase
+                        // is fetching a fresh/updated core (including
+                        // when reusing an in-flight prefetch).
+                        emulationState.coreDownload?.let { progress ->
+                            com.spela.player.presentation.ui.feature.coreupdate.CoreDownloadSheet(progress)
+                        }
+
                         // Missing BIOS dialog (AC 4.3)
                         if (emulationState.showMissingBiosDialog) {
                             com.spela.player.presentation.ui.feature.gamedetail.MissingBiosDialog(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/coreupdate/CoreDownloadSheet.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/coreupdate/CoreDownloadSheet.kt
@@ -1,0 +1,90 @@
+package com.spela.player.presentation.ui.feature.coreupdate
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.spela.player.domain.model.CoreDownloadProgress
+import com.spela.player.presentation.ui.components.SpDownloadProgressBar
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Foreground sheet rendered while [com.spela.player.presentation.state.EmulationState.coreDownload]
+ * is non-null. Replaces the pre-#1192 opaque loading spinner with a
+ * blocking modal that names which core is downloading, how big it is,
+ * and how far along we are.
+ *
+ * Non-dismissable: the user can't bypass an in-progress core download
+ * because the emulator can't start without the binary. The back press
+ * already cancels the play action upstream — we intentionally don't add
+ * a cancel button here in v1 (would require teardown of a partial file
+ * and the existing play-cancel path doesn't propagate that yet).
+ *
+ * Reuses `SpDownloadProgressBar` so the indeterminate-and-determinate
+ * transitions match the rest of the app (game downloads, save uploads).
+ */
+@Composable
+fun CoreDownloadSheet(progress: CoreDownloadProgress) {
+    Dialog(
+        onDismissRequest = { /* non-dismissable while download is in flight */ },
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.85f)
+                .clip(RoundedCornerShape(SpSpacing.RadiusPill))
+                .background(SpColor.SurfaceElevated)
+                .padding(SpSpacing.XLarge)
+                .testTag("core_download_sheet"),
+        ) {
+            Text(
+                text = "Updating ${progress.coreDisplayName}",
+                style = SpTypography.HeadlineMedium,
+                color = SpColor.OnBackground,
+            )
+            Spacer(Modifier.height(SpSpacing.Small))
+            Text(
+                text = "A newer build of the emulator core is available — fetching now so saves stay compatible.",
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackgroundSecondary,
+            )
+            Spacer(Modifier.height(SpSpacing.XLarge))
+
+            // SpDownloadProgressBar takes a Float fraction in [0, 1]
+            // with a -1f sentinel for indeterminate. Match that contract
+            // so the bar behaves identically to the rest of the app's
+            // download surfaces.
+            val fraction = progress.fraction ?: -1f
+            val total = progress.totalBytes ?: 0L
+            SpDownloadProgressBar(
+                progress = fraction,
+                bytesDownloaded = progress.bytesDownloaded,
+                totalBytes = total,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(Modifier.height(SpSpacing.Default))
+            Text(
+                text = "This might take a minute on slow connections.",
+                style = SpTypography.LabelSmall,
+                color = SpColor.OnBackgroundTertiary,
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -1022,6 +1022,13 @@ class EmulationViewModel(
                 sessionHasSaves = hasSaves,
                 skipCoreDecisionPrompt = skipCoreDecisionPrompt,
                 rehearsalCrashPending = crashPending,
+                onCoreDownload = { progress ->
+                    // Progress callback fires on the dispatcher running
+                    // prepareGameUseCase (typically io). State updates on
+                    // _state are thread-safe via MutableStateFlow's atomic
+                    // CAS, so we don't need to hop to the main dispatcher.
+                    _state.update { it.copy(coreDownload = progress) }
+                },
             ).fold(
                 onSuccess = { prepared ->
                     val gamePath = prepared.gamePath

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/domain/usecase/PrepareGameUseCaseTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/domain/usecase/PrepareGameUseCaseTest.kt
@@ -1,17 +1,51 @@
 package com.spela.player.domain.usecase
 
+import com.spela.player.data.repository.CoreUpdateService
 import com.spela.player.domain.model.DownloadProgress
 import com.spela.player.domain.model.DownloadedGame
 import com.spela.player.domain.model.LibretroCore
+import com.spela.player.domain.model.ShaderPreset
+import com.spela.player.domain.model.UserPreferences
 import com.spela.player.domain.repository.CorePrunedException
 import com.spela.player.domain.repository.CoreRepository
 import com.spela.player.domain.repository.DownloadRepository
+import com.spela.player.domain.repository.PreferencesRepository
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+
+/**
+ * Constructs a [PrepareGameUseCase] backed by the supplied [core] plus a
+ * lightweight [CoreUpdateService] wired to the test scope. The service
+ * isn't exercised here — these tests pin the use case's own decision
+ * branches, and CoreUpdateService is covered separately in
+ * CoreUpdateServiceTest (#1192). The presence of the service is purely
+ * to satisfy the constructor.
+ */
+private fun TestScope.buildPrepareGameUseCase(
+    core: CoreRepository,
+    downloads: DownloadRepository = FakeDownloadRepository(),
+): PrepareGameUseCase {
+    val dispatchers = object : DispatcherProvider {
+        override val main: CoroutineDispatcher = Dispatchers.Unconfined
+        override val io: CoroutineDispatcher = Dispatchers.Unconfined
+        override val default: CoroutineDispatcher = Dispatchers.Unconfined
+    }
+    val updateService = CoreUpdateService(
+        coreRepository = core,
+        preferencesRepository = StubPreferencesRepository(),
+        dispatchers = dispatchers,
+        scope = this.backgroundScope,
+    )
+    return PrepareGameUseCase(downloads, core, updateService)
+}
 
 /**
  * Regression coverage for the Phase 2 cache-invalidation branch in
@@ -31,7 +65,7 @@ class PrepareGameUseCaseTest {
             local = "/local/core.so",
             isCurrent = null, // "don't know" branch
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(gameId = "g1").getOrThrow()
 
@@ -45,7 +79,7 @@ class PrepareGameUseCaseTest {
             local = "/local/core.so",
             isCurrent = true,
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(gameId = "g1").getOrThrow()
 
@@ -60,7 +94,7 @@ class PrepareGameUseCaseTest {
             isCurrent = false, // stale branch
             downloadResult = Result.success("/local/core-refreshed.so"),
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(gameId = "g1").getOrThrow()
 
@@ -75,7 +109,7 @@ class PrepareGameUseCaseTest {
             isCurrent = false,
             downloadResult = Result.failure(RuntimeException("network down")),
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(gameId = "g1").getOrThrow()
 
@@ -91,7 +125,7 @@ class PrepareGameUseCaseTest {
             local = "/local/core.so",
             isCurrent = false, // server thinks local is stale …
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         // … but the user has opted out of auto-updates. We must not
         // call downloadCore; the locally cached binary stays in use.
@@ -117,7 +151,7 @@ class PrepareGameUseCaseTest {
             isCurrent = false,
             serverSha = "bb".repeat(32), // 64 chars, differs from pin
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -137,7 +171,7 @@ class PrepareGameUseCaseTest {
             isCurrent = false,
             serverSha = "bb".repeat(32),
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -157,7 +191,7 @@ class PrepareGameUseCaseTest {
             isCurrent = false,
             serverSha = "bb".repeat(32),
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -177,7 +211,7 @@ class PrepareGameUseCaseTest {
             isCurrent = false,
             serverSha = "bb".repeat(32),
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -199,7 +233,7 @@ class PrepareGameUseCaseTest {
             isCurrent = true,
             serverSha = pinned, // server matches pin — no drift
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -219,7 +253,7 @@ class PrepareGameUseCaseTest {
             isCurrent = null,
             serverSha = null, // network failure / server hasn't fingerprinted
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -244,7 +278,7 @@ class PrepareGameUseCaseTest {
             isCurrent = false,
             serverSha = "bb".repeat(32),
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -270,7 +304,7 @@ class PrepareGameUseCaseTest {
             local = "/local/core.so",
             isCurrent = true,
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -297,7 +331,7 @@ class PrepareGameUseCaseTest {
             isCurrent = false,
             serverSha = "bb".repeat(32),
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -322,7 +356,7 @@ class PrepareGameUseCaseTest {
             local = "/local/core.so",
             isCurrent = true,
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -350,7 +384,7 @@ class PrepareGameUseCaseTest {
             // binary is no longer in the server's history.
             hashDownloadResult = Result.failure(CorePrunedException("aa".repeat(32))),
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -377,7 +411,7 @@ class PrepareGameUseCaseTest {
             isCurrent = true,
             hashDownloadResult = Result.failure(CorePrunedException("aa".repeat(32))),
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -405,7 +439,7 @@ class PrepareGameUseCaseTest {
             isCurrent = true,
             hashDownloadResult = Result.failure(CorePrunedException("aa".repeat(32))),
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -428,7 +462,7 @@ class PrepareGameUseCaseTest {
             isCurrent = false,
             serverSha = "bb".repeat(32),
         )
-        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+        val useCase = buildPrepareGameUseCase(core)
 
         val result = useCase.invoke(
             gameId = "g1",
@@ -487,7 +521,7 @@ private class FakeCoreRepository(
     override suspend fun downloadCore(
         coreName: String,
         customDownloadUrl: String?,
-        onProgress: (Float) -> Unit,
+        onProgress: (bytesDownloaded: Long, totalBytes: Long?) -> Unit,
     ): Result<String> {
         downloadCoreCalls++
         return downloadResult
@@ -496,7 +530,7 @@ private class FakeCoreRepository(
     override suspend fun downloadCoreByHash(
         coreName: String,
         sha256: String,
-        onProgress: (Float) -> Unit,
+        onProgress: (bytesDownloaded: Long, totalBytes: Long?) -> Unit,
     ): Result<String> = hashDownloadResult
 
     override suspend fun getLocalCorePath(coreName: String): String? = local
@@ -505,4 +539,43 @@ private class FakeCoreRepository(
 
     override suspend fun isCachedCoreCurrent(coreName: String): Boolean? = isCurrent
     override suspend fun getServerCoreSha(coreName: String): String? = serverSha
+}
+
+/**
+ * Minimum-viable [PreferencesRepository] for tests that only need
+ * [getPreferences] (used by [CoreUpdateService] to gate its prefetch
+ * pass). Every other method throws so an accidental dependency in a
+ * future test surfaces loudly rather than returning a silent default.
+ */
+private class StubPreferencesRepository : PreferencesRepository {
+    override suspend fun getPreferences(): Result<UserPreferences> =
+        Result.success(UserPreferences())
+
+    override suspend fun updatePreferences(
+        showPerformanceOverlay: Boolean?,
+        autoSaveEnabled: Boolean?,
+        autoLoadSaveEnabled: Boolean?,
+        autoUpdateCoresEnabled: Boolean?,
+        selectedShader: String?,
+        selectedTheme: String?,
+        consoleShaders: Map<String, String>?,
+        consoleSaveStatePolicies: Map<String, String>?,
+        gameSaveStatePolicies: Map<String, String>?,
+        defaultSecondScreenPage: String?,
+    ): Result<UserPreferences> = error("unused")
+
+    override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
+    override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) = Unit
+    override fun getAllDeviceShaderOverrides(): Map<String, ShaderPreset> = emptyMap()
+    override suspend fun syncDeviceShaderOverrides() = Unit
+    override suspend fun resolveShader(consoleId: String): ShaderPreset = ShaderPreset.NONE
+    override suspend fun pushDeviceShaderOverridesToServer() = Unit
+    override suspend fun syncKeyMappingsFromServer() = Unit
+    override suspend fun pushKeyMappingsToServer() = Unit
+    override fun getOrientationLock(): String = "auto"
+    override fun setOrientationLock(mode: String) = Unit
+    override fun getControlTab(consoleId: String): String = "gamepad"
+    override fun setControlTab(consoleId: String, tab: String) = Unit
+    override fun getConsoleListGrouping(): String = "generation"
+    override fun setConsoleListGrouping(grouping: String) = Unit
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -237,8 +237,8 @@ class StubDownloadRepository : DownloadRepository {
 class StubCoreRepository : CoreRepository {
     override suspend fun getAvailableCores() = Result.success(emptyList<LibretroCore>())
     override suspend fun getRecommendedCore(gameId: String) = Result.success(LibretroCore(id = 1, name = "nestopia", displayName = "Nestopia"))
-    override suspend fun downloadCore(coreName: String, customDownloadUrl: String?, onProgress: (Float) -> Unit) = Result.success("/path/to/core.so")
-    override suspend fun downloadCoreByHash(coreName: String, sha256: String, onProgress: (Float) -> Unit) = Result.success("/path/to/core.so")
+    override suspend fun downloadCore(coreName: String, customDownloadUrl: String?, onProgress: (bytesDownloaded: Long, totalBytes: Long?) -> Unit) = Result.success("/path/to/core.so")
+    override suspend fun downloadCoreByHash(coreName: String, sha256: String, onProgress: (bytesDownloaded: Long, totalBytes: Long?) -> Unit) = Result.success("/path/to/core.so")
     override suspend fun getLocalCorePath(coreName: String): String = "/path/to/core.so"
     override suspend fun isCoreCached(coreName: String) = true
     override suspend fun isCachedCoreCurrent(coreName: String): Boolean? = null
@@ -847,10 +847,17 @@ class EmulationViewModelTestBuilder {
             scope = vmScope,
         )
 
+        val emulationStubCoreRepo = StubCoreRepository()
         return EmulationViewModel(
             prepareGameUseCase = PrepareGameUseCase(
                 downloadRepository = StubDownloadRepository(),
-                coreRepository = StubCoreRepository(),
+                coreRepository = emulationStubCoreRepo,
+                coreUpdateService = com.spela.player.data.repository.CoreUpdateService(
+                    coreRepository = emulationStubCoreRepo,
+                    preferencesRepository = preferencesRepository,
+                    dispatchers = dispatchers,
+                    scope = vmScope,
+                ),
             ),
             getGameDetailUseCase = GetGameDetailUseCase(gameRepository = gameRepository),
             preferencesRepository = preferencesRepository,


### PR DESCRIPTION
## Summary

Closes the "is the app frozen?" UX gap when launching a game whose core needs to be downloaded.

### Background prefetch — `CoreUpdateService`

New service coordinates core download lifecycles so the post-login prefetch pass and per-game-launch download flow don't race or double-fetch the same core. Holds an in-flight registry keyed by core name; concurrent callers share one HTTP fetch and one progress \`StateFlow\`.

\`prefetchStaleCachedCores()\` runs once per app session after login. For every locally-cached core, asks the server for its current per-platform sha (via the #1190 platform-aware manifest) and silently redownloads anything explicitly stale. Gated on \`autoUpdateCoresEnabled\` (default true). New users / never-cached cores pay zero extra bandwidth. Wired into \`NavigationViewModel.restoreSession()\` next to the existing BIOS sync.

### Foreground download sheet

\`CoreRepository.downloadCore\`'s progress callback now surfaces raw byte counters — \`(bytesDownloaded: Long, totalBytes: Long?) -> Unit\` — so the UI can render "12 MB / 38 MB" instead of a percentage. The bytes were already available from ktor's \`onDownload\` hook; the old \`(Float) -> Unit\` callback discarded them.

\`prepareGameUseCase\` takes a new optional \`onCoreDownload\` sink. When a prefetch is already running for the same core, the play path reuses the in-flight \`CoreDownloadHandle\` so the user sees the prefetch's progress rather than a parallel download.

\`EmulationViewModel\` mirrors the progress into a new \`EmulationState.coreDownload\` field. \`SpelaApp\` renders \`CoreDownloadSheet\` (full-width modal \`Dialog\`, non-dismissable, reuses \`SpDownloadProgressBar\` for visual parity with game/save downloads) while that field is non-null. Sheet auto-hides on completion.

When the HTTP layer reports unknown totals, the sheet renders the indeterminate variant of \`SpDownloadProgressBar\` — same shape Spela uses everywhere else for unknown-size downloads.

## Test plan

- [x] \`go test ./...\` — server suite green (15 packages, includes the unchanged \`internal/cores\` from #1190)
- [x] \`./gradlew :desktop:desktopTest --tests CoreUpdateServiceTest\` — 9 new tests green covering cached-stale prefetch targeting, \`autoUpdateCoresEnabled\` gating, single-flight per session, concurrent caller deduplication, in-flight registry cleanup, byte counters surfaced through the handle, completion mirroring \`totalBytes\` onto \`bytesDownloaded\` when known, never-cached cores skipped, \`inFlightDownload\` returning the same instance as the live entry
- [x] \`./gradlew :shared:desktopTest\` — green (existing suite, no regressions to shared module)
- [ ] Manual: launch a 3DS game on a device with no cached Azahar — confirm the sheet renders "Updating Azahar" + a determinate bar reaching 100%, then the emulator starts
- [ ] Manual: kill the local cache for a non-3DS core (e.g. \`rm \$CORE_DIR/nestopia_libretro.so\`), restart the app, confirm the background prefetch pulls a fresh copy without blocking the dashboard
- [ ] Manual: with auto-update toggled off in settings, confirm the prefetch pass no-ops on next app launch

## Notes

- Two of the existing \`./gradlew :desktop:desktopTest\` classes failed locally with "could not find any node" errors during my full-suite run (CreateChallengeTest, ControllerStatusIndicatorTest, GameDetailCommunitySectionsTest, GamepadNavigationTest, SessionsUiTest, ShareSessionMenuTest). None touch \`CoreUpdateService\`, \`prepareGameUseCase\` progress wiring, or \`EmulationState.coreDownload\`. The pattern matches the documented "local-only \`advance(harness)\` undercount under fork contention" flake category in \`docs/desktop-test-flakes.md\` (CI uses different gating and is unaffected). Letting CI verify.

Closes #1192.