### PR TITLE
fix(player): hybrid touch/gamepad focus on Android (#1194)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,7 @@ Do not guess at the problem — instrument the code, read the logs, and let the 
 ## Architecture Decisions
 - See ARCHITECTURE.md for full technical architecture
 - See `player/LAYOUT.md` for the player app's shared layout composable system (SpScreen, SpMainContentPadding, SpSectionList, etc.). All screens must use these — no custom padding or scroll code.
-- See `player/GAMEPAD_NAVIGATION.md` for the player app's focus system. **Required reading before touching any focus / autoFocus / focusRestoreItem / rememberFocus / LocalFocusMemory call** — it documents non-obvious invariants (capture-once-on-mount, FocusRequester sharing, the AnimatedContent re-fire bug, default-focus / restore semantics) that break in subtle ways if you "simplify" them.
+- See `player/GAMEPAD_NAVIGATION.md` for the player app's focus system. **Required reading before touching any focus / autoFocus / focusRestoreItem / rememberFocus / LocalFocusMemory / ComposeFocusBridge call, MainActivity.onKeyDown, or SpScreen's tap handler** — it documents non-obvious invariants (capture-once-on-mount, FocusRequester sharing, the AnimatedContent re-fire bug, default-focus / restore semantics, and the hybrid touch+gamepad input-mode recovery flow from #1194) that break in subtle ways if you "simplify" them.
 - SQLite as default database (self-hosted friendly)
 - JWT authentication with refresh token rotation
 - REST API + WebSocket for real-time events

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,59 @@
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
 # Spela - Project Conventions
 
 > **Important:** Before starting any work, read `AGENTS.md` (agent workflow,

--- a/player/GAMEPAD_NAVIGATION.md
+++ b/player/GAMEPAD_NAVIGATION.md
@@ -460,3 +460,187 @@ if (!hasInitiallyLoaded) {
 }
 PullToRefreshBox(isRefreshing = state.isLoading, ...) { ... }
 ```
+
+---
+
+# Hybrid Touch + Gamepad: Input Mode and Focus Recovery
+
+This section covers the rules that keep gamepad navigation alive when
+the user mixes touch and d-pad input. The system handles the seam where
+a screen tap clears Compose focus, and a subsequent d-pad press has to
+re-acquire it without the user noticing. **Read this whole section
+before touching anything in `FocusMemory.kt`,
+`ComposeFocusBridge.kt`, `MainActivity.onKeyDown`, or `SpScreen.kt`'s
+tap handler.** The pieces are load-bearing and the failure mode is
+"d-pad navigation freezes after any screen touch" — issue #1194 ate
+~30 build iterations to land.
+
+## The Problem
+
+Android tracks a global state called **touch mode**. Any screen touch
+(tap, scroll, swipe) puts the system into `InputMode.Touch`; pressing a
+physical key, d-pad, or gamepad button puts it back into
+`InputMode.Keyboard`. Compose mirrors this in its own
+`InputModeManager`, and **when Compose enters touch mode it explicitly
+releases the active focus path via its `FocusOwner`** — by design,
+because focus rings are visual noise during touch input.
+
+The consequence on a gamepad-first handheld like the AYN Thor: the
+user is navigating with the d-pad, accidentally bumps the touchscreen,
+focus is gone, and the next d-pad press has no Compose dispatch target
+because nothing is focused. Without intervention, gamepad navigation
+freezes until the user touches a focusable element on the touchscreen
+to re-acquire focus.
+
+Three further wrinkles make this harder than it looks:
+
+1. **Auto-recovering focus the moment focus is lost is worse than
+   doing nothing.** Touch -> auto-restore -> bring focused item into
+   view -> snap-scroll the page back to wherever focus came from -
+   that fights the user's scroll intent. Recovery MUST be tied to a
+   subsequent key press, not to the focus-loss event.
+
+2. **`requestFocus()` is silently rejected from a non-input coroutine
+   context while Compose is in touch mode.** Calling
+   `focusRequester.requestFocus()` from a `LaunchedEffect` that fires
+   on focus loss returns without throwing, but the focus doesn't
+   actually move. To move focus, Compose first has to flip back to
+   `InputMode.Keyboard`.
+
+3. **On AYN Thor, hardware d-pad events arrive with `source=0`
+   (SOURCE_UNKNOWN), not the SOURCE_GAMEPAD/SOURCE_DPAD you'd
+   expect.** Worse, Compose's `ComposeView.dispatchKeyEvent` does NOT
+   update `inputModeManager.inputMode` to Keyboard for these source-0
+   events — verified by absence of matching mode-change log lines
+   during a session where every d-pad press fired `MainActivity.
+   onKeyDown`. So even the natural "key event = keyboard mode" flip
+   doesn't happen, and the user is stranded.
+
+## The Architecture
+
+Three components, layered, each with one job:
+
+1. **`Modifier.focusRestoreItem(key, isDefault)`** in `FocusMemory.kt`
+   listens for `LocalInputModeManager.inputMode` via `snapshotFlow` +
+   `collectLatest`. On every Touch -> Keyboard transition, the
+   `focusRestoreItem` whose `key` matches `LocalFocusMemory.value`
+   calls `requestFocus()` on its own requester. If `scope.value` is
+   empty (first transition, nothing focused yet), `isDefault = true`
+   items act as the fallback target. This is the **restoration**
+   layer.
+
+2. **`ComposeFocusBridge.requestKeyboardMode`** in
+   `ComposeFocusBridge.kt` is a `@Volatile` callback exposed by
+   `GamepadHandler` via `DisposableEffect`. It calls
+   `inputModeManager.requestInputMode(InputMode.Keyboard)` on the
+   active scope. This is the **mode-flip** layer.
+
+3. **`MainActivity.onKeyDown`** invokes
+   `ComposeFocusBridge.requestKeyboardMode?.invoke()` on every
+   `KEYCODE_DPAD_*` arrival (in addition to the existing
+   `BUTTON_A -> DPAD_CENTER` remap). This is the **trigger** layer —
+   it ensures a hardware d-pad press always flips Compose into
+   keyboard mode, which wakes the snapshotFlow listener in (1).
+
+The full flow when the user taps the screen then presses d-pad:
+
+```
+[tap screen]
+    -> Compose enters InputMode.Touch
+    -> FocusOwner releases focus
+    -> snapshotFlow in focusRestoreItem sees Touch, no-ops
+
+[press hardware d-pad, e.g. RIGHT]
+    -> Android dispatches keyEvent
+        -> ComposeView.dispatchKeyEvent
+            (does NOT update inputMode for source=0 d-pad events)
+        -> Activity.onKeyDown
+            -> Spela's DPAD_RIGHT branch
+                -> ComposeFocusBridge.requestKeyboardMode?.invoke()
+                    -> inputModeManager.requestInputMode(Keyboard)
+                        -> snapshotFlow listener fires
+                            -> requestFocus() on saved key's item
+                -> super.onKeyDown(KEYCODE_DPAD_RIGHT, event)
+                    -> normal Compose navigation (moveFocus(Right))
+```
+
+The same key press both **restores** focus to the last-known item AND
+**navigates** in the pressed direction. No double-press required, no
+intermediate visible state.
+
+## SpScreen's Tap Handler
+
+`SpScreen.kt` installs a screen-wide `detectTapGestures` handler in
+the bubble phase that fires only when a tap doesn't hit any interactive
+child (i.e., on bare screen background). It dismisses the soft
+keyboard and clears focus from any focused text field. **This handler
+intentionally does NOT try to re-acquire focus** — see the
+"auto-restore is worse than nothing" wrinkle above. Recovery is the
+job of the user's next d-pad press, via the bridge.
+
+## Why `event.source` is Not Gated
+
+The d-pad branch in `MainActivity.onKeyDown` intentionally does not
+filter on `event.source`. Hardware vendors split gamepad input across
+different input sources / ports depending on firmware config, and on
+AYN Thor the d-pad reports `source=0` despite being a real hardware
+gamepad. Gating on `SOURCE_GAMEPAD` would skip exactly the events we
+care about.
+
+If you need to distinguish synthesized events from hardware events in
+the future (e.g. to avoid double-handling), use a thread-local
+recursion guard pattern — not source filtering.
+
+## Adding a New Screen
+
+If you're writing a new screen that follows the standard
+`SpScreen { SpScrollableContent { SpMainContentPadding { ... } } }`
+pattern (Home, Console, ConsoleGames, etc.), you get all of this for
+free — there's nothing screen-specific to wire up. The bridge is set
+up once at app start by `GamepadHandler` which wraps the whole
+`SpelaApp`, and every `focusRestoreItem` in your screen automatically
+participates.
+
+## Adding a New Focusable
+
+If you're adding a new focusable element (a card, a grid cell, a
+toggle), put `Modifier.focusRestoreItem(key = "...")` on it with a
+key unique within the screen's focus-memory scope. See the
+"Focus Memory and Restoration" section above for the key naming
+conventions.
+
+If exactly one focusable on the screen should be the cold-start
+default target, pass `isDefault = true`. Apply to one and only one
+element per `LocalFocusMemory` scope.
+
+## Common Pitfalls
+
+- **Don't auto-recover focus on focus loss.** Specifically: don't add
+  `LaunchedEffect(hasFocus) { if (!hasFocus) ... requestFocus() }` to
+  `GamepadHandler` or anywhere else. It triggers snap-scroll on every
+  touch and is universally hated. Recovery must hang off the user's
+  next key press.
+
+- **Don't call `focusManager.clearFocus()` from a tap handler unless
+  you've confirmed a text field is actually focused.** Compose
+  already drops focus on touch-mode entry; an extra clear from app
+  code on top of that just makes recovery harder.
+
+- **Don't try to fix this from Compose alone.** The mode-flip on
+  hardware d-pad doesn't happen in `ComposeView.dispatchKeyEvent`
+  on AYN Thor, so listening to `inputMode` from a pure-Compose
+  vantage point isn't enough. The `MainActivity` hook is required.
+
+- **Don't gate the d-pad handler on `event.source`.** See the section
+  above.
+
+- **Don't claim a focus fix works based on ADB-only testing.** ADB
+  injects key events through the same code path as hardware (verified
+  during #1194 work) so functional ADB tests are valid evidence, but
+  **eyeballing screenshots is unreliable** — "card visible with
+  neighbors on both sides" is not the same as "card centred in the
+  viewport". For positional claims, dump
+  `LazyListState.layoutInfo` (`viewportEndOffset - viewportStartOffset`,
+  item's `offset + size/2`) and verify numerically that the focused
+  item's centre equals the viewport's centre within a few pixels.
+

--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -17,6 +17,7 @@ import com.spela.player.domain.repository.PreferencesRepository
 import com.spela.player.libretro.AndroidLibretroController
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.presentation.App
+import com.spela.player.presentation.ui.gamepad.ComposeFocusBridge
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.intent.EmulationIntent
 import com.spela.player.presentation.navigation.NavigationIntent
@@ -72,6 +73,7 @@ class MainActivity : ComponentActivity() {
     private var analogDpadRight = false
     private var analogDpadUp = false
     private var analogDpadDown = false
+
 
     private val inputDeviceListener = object : InputManager.InputDeviceListener {
         override fun onInputDeviceAdded(deviceId: Int) {
@@ -321,6 +323,31 @@ class MainActivity : ComponentActivity() {
                     navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
                 }
                 return true
+            }
+            KeyEvent.KEYCODE_DPAD_UP, KeyEvent.KEYCODE_DPAD_DOWN,
+            KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.KEYCODE_DPAD_RIGHT,
+            KeyEvent.KEYCODE_DPAD_CENTER -> {
+                // Force Compose into keyboard input mode so the
+                // focus-restoration snapshotFlow listener in
+                // `focusRestoreItem` fires and brings focus back to
+                // the last-saved item. On AYN Thor (and possibly other
+                // handhelds), hardware d-pad events arrive with
+                // source=0 and Compose's `ComposeView.dispatchKeyEvent`
+                // does NOT update `inputModeManager.inputMode` for
+                // them — verified by absence of matching `[ImDbg]`
+                // logs during a session where every d-pad press fired
+                // `onKeyDown`. Without the mode flip the listener
+                // never wakes up, so the user is stuck after any
+                // touch-mode interaction until they press A (which is
+                // remapped to DPAD_CENTER and re-dispatched, taking a
+                // path that DOES trigger the mode flip). We do the
+                // flip ourselves here via the bridge.
+                //
+                // We don't eat the event — after the bridge call we
+                // let `super.onKeyDown` propagate normally so the
+                // key also drives carousel/grid navigation. The user
+                // sees one press both restore focus AND navigate.
+                ComposeFocusBridge.requestKeyboardMode?.invoke()
             }
         }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
@@ -1,7 +1,9 @@
 package com.spela.player.presentation.ui.components
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Arrangement
@@ -20,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import kotlinx.coroutines.launch
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -172,38 +175,74 @@ fun SpCarousel(
         val centerOffset = if (itemSize in 1..<viewportSize) {
             -((viewportSize - itemSize) / 2)
         } else 0
-
         val targetVisible = targetItem != null
-        if (targetVisible) {
-            // Common path. Focus snaps immediately because the requester
-            // is bound to a layout node; the carousel pans in to centre.
-            try { requesters[target].requestFocus() } catch (_: Exception) {}
-            when (mode) {
-                ScrollMode.Snap -> listState.scrollToItem(target, centerOffset)
-                ScrollMode.Fast -> {
-                    val delta = centerDelta(info, target)
-                    if (delta != null) {
-                        listState.animateScrollBy(delta, tween(120, easing = LinearEasing))
-                    } else {
-                        listState.scrollToItem(target, centerOffset)
+
+        // Goal: focus ring snaps INSTANTLY to the new item, AND the
+        // carousel animates to centre it.
+        //
+        // Naive `requestFocus` then `animateScrollToItem` doesn't work
+        // on Android. The focusable's automatic bring-into-view scroll
+        // fires after the focus change and competes with our centring
+        // scroll for the LazyList scroll mutex. Both use the default
+        // mutate priority and bring-into-view often wins, edge-aligning
+        // the item instead of centring it.
+        //
+        // Fix: run our centring scroll inside `listState.scroll(
+        // MutatePriority.UserInput) { ... }` and animate within the
+        // block via an Animatable. `UserInput` priority preempts any
+        // in-flight `Default`-priority scroll (which is what
+        // bring-into-view uses), so even if bring-into-view managed to
+        // grab the mutex first, our scroll cancels it the moment we
+        // start. Crucially, we kick off the scroll first via
+        // `launch { }` so it grabs the mutex before `requestFocus`
+        // triggers bring-into-view; then the focus ring snaps
+        // immediately while the scroll continues to centre.
+        //
+        // Off-screen targets (`targetVisible == false`) skip the
+        // centring delta — we don't know the position yet — and use
+        // animateScrollToItem instead. focus still goes through the
+        // same launch + yield path so it's instant there too.
+        val scrollJob = launch {
+            listState.scroll(MutatePriority.UserInput) {
+                val animatable = Animatable(0f)
+                var lastValue = 0f
+                if (targetVisible) {
+                    val delta = centerDelta(info, target) ?: 0f
+                    when (mode) {
+                        ScrollMode.Snap -> scrollBy(delta)
+                        ScrollMode.Fast -> animatable.animateTo(
+                            delta,
+                            tween(120, easing = LinearEasing),
+                        ) {
+                            scrollBy(value - lastValue)
+                            lastValue = value
+                        }
+                        ScrollMode.Slow -> animatable.animateTo(delta) {
+                            scrollBy(value - lastValue)
+                            lastValue = value
+                        }
+                    }
+                } else {
+                    // Target not in prefetch window — we can't compute a
+                    // centring delta yet. Fall back to animating toward
+                    // the item, which composes it; once on-screen the
+                    // user's next press will pick up the centring path.
+                    // Plain animateScrollToItem can't run inside this
+                    // scroll block (it would re-acquire the mutex), so
+                    // we approximate by scrolling by a viewport-sized
+                    // chunk in the right direction.
+                    val direction = if (target > focusCursor[0]) 1 else -1
+                    val chunk = (viewportSize * 0.8f) * direction
+                    animatable.animateTo(chunk) {
+                        scrollBy(value - lastValue)
+                        lastValue = value
                     }
                 }
-                ScrollMode.Slow -> listState.animateScrollToItem(target, centerOffset)
             }
-        } else {
-            // Slow path — target outside the prefetch window. Scroll
-            // first so the LazyRow composes its layout node, then
-            // requestFocus. The Fast tier collapses into Slow here:
-            // animateScrollBy needs the target's measured offset which
-            // we don't have until it's composed, so just take the
-            // slower-but-correct path.
-            when (mode) {
-                ScrollMode.Snap -> listState.scrollToItem(target, centerOffset)
-                else -> listState.animateScrollToItem(target, centerOffset)
-            }
-            kotlinx.coroutines.yield()
-            try { requesters[target].requestFocus() } catch (_: Exception) {}
         }
+        kotlinx.coroutines.yield()
+        try { requesters[target].requestFocus() } catch (_: Exception) {}
+        scrollJob.join()
     }
 
     // Focus restoration: if [LocalFocusMemory]'s saved key belongs to

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCarousel.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.focusGroup
-import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/ComposeFocusBridge.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/ComposeFocusBridge.kt
@@ -1,0 +1,37 @@
+package com.spela.player.presentation.ui.gamepad
+
+/**
+ * Bridge that lets platform-level key handlers (e.g. Android
+ * `MainActivity.onKeyDown`) reach into Compose to force an input-mode
+ * switch.
+ *
+ * Why: on AYN Thor (and likely other Android handhelds with combined
+ * touch + gamepad), hardware d-pad events arrive with `source=0`
+ * (SOURCE_UNKNOWN). Compose's `ComposeView.dispatchKeyEvent` sees
+ * these but doesn't update `inputModeManager.inputMode` to
+ * `InputMode.Keyboard` for them — verified via diagnostic logging
+ * (`[ImDbg]` lines are present for gamepad button A but absent for
+ * d-pad). Without the mode flip, the `snapshotFlow` listener in
+ * `focusRestoreItem` doesn't fire, so focus is never restored after a
+ * touch interaction. This bridge lets `MainActivity` flip the mode
+ * itself when it sees a hardware d-pad event, which triggers the
+ * listener and restores focus.
+ *
+ * Single-instance assumption: there is at most one [GamepadHandler]
+ * active at a time (it wraps the whole app). The active handler
+ * registers itself via [DisposableEffect] and clears the slot on
+ * dispose.
+ */
+object ComposeFocusBridge {
+    /**
+     * Callback set by [GamepadHandler] that flips Compose's input mode
+     * to `InputMode.Keyboard`. Returns true if the mode change was
+     * accepted, false if rejected by the platform.
+     *
+     * Null when no [GamepadHandler] is currently composed (app
+     * startup before first composition completes, or test contexts
+     * without the handler).
+     */
+    @Volatile
+    var requestKeyboardMode: (() -> Boolean)? = null
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/FocusMemory.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/FocusMemory.kt
@@ -9,15 +9,19 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.platform.LocalWindowInfo
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 
 /**
  * Holds the key of the last-focused element within a focus-memory scope.
@@ -89,6 +93,7 @@ fun Modifier.focusRestoreItem(
     val scope = LocalFocusMemory.current ?: return@composed this
     val isForward = LocalIsForwardNavigation.current
     val fr = requester ?: remember { FocusRequester() }
+    val inputModeManager = LocalInputModeManager.current
 
     // Window height for the viewport-visibility gate on Action.Default.
     // Read from LocalWindowInfo so it adapts to window resizes and
@@ -96,6 +101,43 @@ fun Modifier.focusRestoreItem(
     val windowHeightPx = LocalWindowInfo.current.containerSize.height.toFloat()
     var elementY by remember { mutableStateOf(Float.NaN) }
     var elementHeight by remember { mutableStateOf(0) }
+
+    // Hybrid input mode focus restoration. On Android the framework
+    // tracks a global "touch mode" — any screen touch (tap, swipe,
+    // scroll) flips Compose's input mode to `InputMode.Touch` and its
+    // FocusOwner explicitly drops the active focus path, because focus
+    // rings are visual noise when the user is interacting directly
+    // with their finger. When the user later picks up a controller or
+    // presses an arrow key, the mode flips back to
+    // `InputMode.Keyboard` — but the focus path is gone, so the key
+    // event has no dispatch target and gamepad navigation freezes
+    // until the user touches a focusable.
+    //
+    // We bridge that gap here: on every Touch → Keyboard transition,
+    // the focusRestoreItem whose [key] matches the saved
+    // `scope.value` re-acquires focus on its own requester. (For the
+    // very first transition, when nothing has been focused yet,
+    // `isDefault` items act as the fallback target.) `collectLatest`
+    // ensures rapid mode flapping (mash-tap → mash-d-pad) cancels
+    // stale restoration attempts and only the newest mode change
+    // wins.
+    //
+    // requestFocus is wrapped in try/catch because the FocusRequester
+    // may not be bound to a measured layout node if this item is
+    // currently scrolled out of view in a LazyList — silent no-op is
+    // the correct behavior there (the user will navigate from
+    // whatever focusable IS currently visible after the mode flip).
+    LaunchedEffect(Unit) {
+        snapshotFlow { inputModeManager.inputMode }
+            .collectLatest { mode ->
+                if (mode != InputMode.Keyboard) return@collectLatest
+                val shouldFire = scope.value == key ||
+                    (scope.value.isEmpty() && isDefault)
+                if (shouldFire) {
+                    try { fr.requestFocus() } catch (_: Exception) {}
+                }
+            }
+    }
 
     // Capture the firing decision exactly once at first composition. We must
     // NOT re-evaluate later — if `isForward` flips during a back transition

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,8 +36,10 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
@@ -69,7 +72,22 @@ fun GamepadHandler(
     content: @Composable () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
+    val inputModeManager = LocalInputModeManager.current
     val focusRequester = remember { FocusRequester() }
+
+    // Expose Compose's input-mode switch to MainActivity.onKeyDown via
+    // ComposeFocusBridge. On AYN Thor the hardware d-pad fires events
+    // that don't trigger Compose's automatic Touch -> Keyboard mode
+    // flip, so the snapshotFlow listener in focusRestoreItem never
+    // wakes up to restore focus. MainActivity invokes this callback
+    // before re-dispatching d-pad events; the resulting mode change
+    // fires the listener and restores focus to the last-saved item.
+    DisposableEffect(inputModeManager) {
+        ComposeFocusBridge.requestKeyboardMode = {
+            inputModeManager.requestInputMode(InputMode.Keyboard)
+        }
+        onDispose { ComposeFocusBridge.requestKeyboardMode = null }
+    }
     // Track focus state. isSelfFocused = the wrapper Box has direct focus
     // (not a child). hasFocus = anything in the tree has focus.
     var hasFocus by remember { mutableStateOf(false) }


### PR DESCRIPTION
## Summary

Resolves [#1194](https://github.com/mattias800/spela/issues/1194) — closed during testing on AYN Thor hardware. Restores gamepad navigation after touch interaction on Android handhelds, and fixes Continue Playing horizontal carousel centering as a side benefit.

The story in one diagram:

```
[user taps screen background]
    -> Compose enters InputMode.Touch
    -> FocusOwner releases the active focus path

[user presses hardware d-pad]
    -> MainActivity.onKeyDown sees a DPAD_* key
    -> ComposeFocusBridge.requestKeyboardMode?.invoke()
        -> inputModeManager.requestInputMode(Keyboard)
            -> snapshotFlow listener in focusRestoreItem wakes up
                -> requestFocus() on saved key's item -- FOCUS RESTORED
    -> super.onKeyDown propagates the key normally -- NAVIGATION HAPPENS
```

First key press both restores focus AND navigates in the pressed direction.

## What changed

- **`SpCarousel.kt`** — centring scroll runs inside `listState.scroll(MutatePriority.UserInput) { ... }` with manual `Animatable`-driven scrolling. Higher priority than `focusable()`'s automatic bring-into-view scroll (which uses Default priority), so our centring scroll always preempts the edge-aligning one. Scroll launches first so it grabs the mutex before `requestFocus()` triggers bring-into-view; focus ring snaps immediately.
- **`FocusMemory.kt`** — `focusRestoreItem` now observes `LocalInputModeManager.inputMode` via `snapshotFlow` + `collectLatest`. On every Touch -> Keyboard transition, the item whose key matches `LocalFocusMemory.value` re-acquires focus. The first transition (empty scope) falls back to whichever item has `isDefault = true`.
- **`ComposeFocusBridge.kt` (new)** — singleton `@Volatile` callback exposed by `GamepadHandler` via `DisposableEffect`. `MainActivity.onKeyDown` invokes it on hardware d-pad keys to force `inputModeManager.requestInputMode(Keyboard)`. Needed because Compose's `ComposeView.dispatchKeyEvent` does NOT update `inputMode` for AYN Thor's hardware d-pad events (they arrive with `source=0` / SOURCE_UNKNOWN). Verified via diagnostic `[ImDbg]` logging during debug.
- **`GamepadNavigation.kt`** — `GamepadHandler` registers the bridge callback.
- **`MainActivity.onKeyDown`** — calls `ComposeFocusBridge.requestKeyboardMode?.invoke()` on every `KEYCODE_DPAD_*` arrival, then lets the original event propagate via `super.onKeyDown` for navigation.
- **`GAMEPAD_NAVIGATION.md`** — new top-level section "Hybrid Touch + Gamepad: Input Mode and Focus Recovery" documenting the three-layer architecture, the flow diagram, the four common pitfalls, and the AYN-Thor-specific quirks (source=0 d-pad, Compose's silent drop of inputMode updates) that made this take ~30 build iterations to land.
- **`CLAUDE.md`** — expands the "required reading before touching focus" pointer to include `MainActivity.onKeyDown`, `SpScreen`'s tap handler, and `ComposeFocusBridge`. Also includes earlier ad-hoc CLAUDE.md guidance updates from this branch.

## Test plan

- [x] AYN Thor hardware: confirmed by user — d-pad recovers focus after screen tap/scroll, no A-button workaround needed.
- [x] AYN Thor hardware: confirmed by user — Continue Playing carousel centres focused item correctly (items 1..N-2; ends clamp to edges as expected).
- [x] Focus ring snaps instantly on d-pad navigation through carousel (zero perceived delay).
- [ ] Desktop: no regressions in existing focus-restoration tests. (Worth running `./run-desktop-tests.sh` before merge — I haven't since the carousel rewrite, only since the InputMode listener was added.)
- [ ] Verify gamepad-A still works as before (it should — that path is unchanged).