### PR TITLE
fix(player): skip centerOnFocus scroll in touch input mode (#1196)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/CenterOnFocus.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/CenterOnFocus.kt
@@ -14,8 +14,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalInputModeManager
 import com.spela.player.presentation.ui.components.LocalScrollState
 
 /**
@@ -88,8 +90,21 @@ fun Modifier.centerOnFocus(
 
     if (scrollState == null && lazyGridInfo == null && lazyListInfo == null) return@composed this
 
+    val inputModeManager = LocalInputModeManager.current
+
     LaunchedEffect(isFocused) {
         if (!isFocused) return@LaunchedEffect
+
+        // Centring-on-focus is a gamepad / arrow-key affordance — it
+        // pulls the focused element to the viewport centre so the user
+        // can see what they just navigated to with the d-pad. When the
+        // focus change comes from a pointer (mouse click, touch tap,
+        // `ComposeUiTest.performClick`), the element is already on
+        // screen by definition, so there's nothing to scroll TO — and
+        // running a scroll here has been observed to drop the
+        // accompanying click action on Compose Multiplatform 1.10
+        // (see #1196). Skip when the input mode is Touch.
+        if (inputModeManager.inputMode != InputMode.Keyboard) return@LaunchedEffect
 
         val now = System.currentTimeMillis()
         val isRapid = now - lastFocusTime < 100


### PR DESCRIPTION
Closes #1196 (partial — fixes 14 of 24 failing desktop e2e tests).

## Summary

When \`Modifier.gamepadFocusable\` (via \`centerOnFocus\`) was applied to a clickable element nested in a scrollable container, \`performClick\` from \`ComposeUiTest\` silently dropped the OnClick semantic action — the click handler never fired. This explained the bulk of the desktop \`:desktop:desktopTest\` failures reported in #1196.

Verified by running the full desktop suite:

| | Before | After |
|---|---|---|
| Total | 822 tests, 24 failures | 829 tests, **10 failures** |
| SessionsUiTest | 3 fail | **all pass** |
| ShareSessionMenuTest | 3 fail | **all pass** |
| CreateChallengeTest | 7 fail | **all pass** |
| GameDetailCommunitySectionsTest | 1 fail | **all pass** |

The remaining 10 failures (ControllerStatusIndicatorTest, GamepadConfigTest, GamepadNavigationTest) are unrelated to popup-click — they're pre-existing state-propagation and focus-traversal bugs that don't share a root cause and will need separate diagnosis.

## Root cause

\`centerOnFocus\`'s \`LaunchedEffect(isFocused)\` fires the moment a click triggers focus on the element. Its \`animateScrollTo(targetScroll)\` then runs in the same focus frame and something in Compose Multiplatform 1.10's pointer-event pipeline drops the OnClick that's in-flight on the same element. Removing the scroll (verified during investigation by replacing the body with \`return@LaunchedEffect\`) restores the click — confirming the scroll is the trigger, not the LaunchedEffect itself or the modifier ordering.

## Fix

Centring-on-focus is a gamepad / arrow-key affordance — it pulls the focused element to the viewport centre so the user can see what they just navigated to with the d-pad. When the focus change comes from a pointer (mouse click, touch tap, \`ComposeUiTest.performClick\`), the element is already on screen by definition, so there's nothing to scroll TO.

Gate the scroll on \`LocalInputModeManager.current.inputMode == InputMode.Keyboard\` so it runs for gamepad / keyboard focus changes only:

\`\`\`kotlin
LaunchedEffect(isFocused) {
    if (!isFocused) return@LaunchedEffect
    if (inputModeManager.inputMode != InputMode.Keyboard) return@LaunchedEffect
    // ... scroll math + animateScrollTo
}
\`\`\`

Side note: this is consistent with how the Android focus-recovery in #1194 already establishes the input mode — hardware d-pad presses flip the mode to Keyboard via \`ComposeFocusBridge\`, so AYN Thor gamepad navigation still centres on focus correctly. Mouse + touch + \`performClick\` all set the mode to Touch, which now skips the scroll.

## Investigation path (for the curious)

Documented in detail on #1196. Short version: built a layered \`MinimalDropdownTest\` covering vanilla \`Material3 Button + DropdownMenu\`, the \`SpIconButton\` Box-merge structure, the full \`SpInnerCard\`-wrapped \`SpIconButton\`, etc. — all 7 layers passed in isolation. The bug only manifested in the full \`SessionsUiTest\` context, but by stripping \`SpIconButton\` modifier-by-modifier inside the real \`SessionsSection\`, narrowed it to \`gamepadFocusable\`, then to \`centerOnFocus\` specifically, then to the scroll inside its \`LaunchedEffect\`.

## Test plan

- [x] \`./run-desktop-tests.sh\` — 829 tests, 10 failures (the 10 remaining are unrelated, listed above).
- [x] All 14 previously-popup-click-failing tests now pass.
- [ ] Manual sanity-check on AYN Thor that gamepad-driven centring-on-focus still works the same way as before (gamepad input is Keyboard mode → scroll path unchanged).