### PR TITLE
test(player): repair desktop e2e suite after #1187 nav redesign

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ControllerStatusIndicatorTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ControllerStatusIndicatorTest.kt
@@ -6,24 +6,28 @@ import com.spela.player.presentation.navigation.SpScreen
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 /**
  * E2E tests for the controller status indicator.
  *
- * The Compose UI test window is wide enough to trigger LABELED_RAIL layout (> 840dp),
- * so the SpNavigationRail with SpControllerStatusCard is what's on screen.  The card:
- *   - Is only shown when 2+ controllers are connected (isMultiplayer = true)
- *   - Has contentDescription "$connectedCount controllers connected"
- *   - Navigates to Settings on click
- *   - Renders all 4 port dots (showEmptySlots = true), including disconnected slots
+ * Since #1187 the nav style is driven by *physical controller connection*
+ * (`controllerStatus.connectedCount > 0`): connecting a controller puts the app
+ * into gamepad mode, which hides the side rail / bottom bar and shows the
+ * floating `SpSectionIndicator` pill. When 2+ controllers are connected
+ * (`isMultiplayer`), the pill additionally renders an `SpControllerStatusRow`
+ * of connected-player dots with `showEmptySlots = false` — so each connected
+ * port exposes a "Player N connected" / "Player N active" content description,
+ * and empty ports render nothing.
+ *
+ * (The older `SpControllerStatusCard`-in-rail and bottom-bar mini-pill became
+ * unreachable when #1187 gated the rail/bottom-bar on `!isGamepadMode`; the
+ * section-indicator dots are now the live controller-status surface. See #1198.)
  *
  * Tests verify:
- * - Visibility rules (hidden with 0 or 1 controller, visible with 2+)
- * - Card disappears when dropping back to 1 controller
- * - Individual dot content descriptions for connected ports
- * - Click navigates to Settings
- * - Disconnect and reconnect behaviour
+ * - No player dots with 0 or 1 controller (not multiplayer)
+ * - Connected-player dots appear with 2+ controllers
+ * - Dots update on drop-to-one, disconnect, and reconnect
+ * - Only connected ports render (no empty-slot dots)
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
 class ControllerStatusIndicatorTest {
@@ -38,117 +42,98 @@ class ControllerStatusIndicatorTest {
     // ---- Visibility ----
 
     @Test
-    fun hiddenWithNoControllers() = runComposeUiTest {
+    fun noPlayerDotsWithoutControllers() = runComposeUiTest {
         val harness = createLoggedInHarness()
         setContent { harness.App() }
         advance(harness)
 
-        // No pill when there are zero controllers
-        onNodeWithContentDescription("0 controllers connected").assertDoesNotExist()
+        // No controllers → not gamepad mode, no controller dots anywhere.
+        onNodeWithContentDescription("Player 1 connected").assertDoesNotExist()
     }
 
     @Test
-    fun hiddenWithOneController() = runComposeUiTest {
-        val harness = createLoggedInHarness()
-        setContent { harness.App() }
-        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
-        advance(harness)
-
-        // Still no pill — one controller does not trigger multiplayer mode
-        onNodeWithContentDescription("1 controllers connected").assertDoesNotExist()
-    }
-
-    @Test
-    fun visibleWithTwoControllers() = runComposeUiTest {
+    fun noPlayerDotsWithOneController() = runComposeUiTest {
         val harness = createLoggedInHarness()
         setContent { harness.App() }
         harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
-        harness.gamepadPortManager.connectDevice(2, "DualSense")
         advance(harness)
 
-        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
+        // One controller enters gamepad mode (section indicator shows) but is
+        // not multiplayer, so the pill renders no controller dots.
+        onNodeWithContentDescription("Player 1 connected").assertDoesNotExist()
     }
 
     @Test
-    fun disappearsWhenDroppingToOneController() = runComposeUiTest {
+    fun playerDotsVisibleWithTwoControllers() = runComposeUiTest {
         val harness = createLoggedInHarness()
         setContent { harness.App() }
         harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
         harness.gamepadPortManager.connectDevice(2, "DualSense")
         advance(harness)
 
-        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 1 connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
+    }
+
+    @Test
+    fun playerDotsDisappearWhenDroppingToOneController() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        onNodeWithContentDescription("Player 1 connected").assertIsDisplayed()
 
         harness.gamepadPortManager.disconnectDevice(2)
         advance(harness)
 
-        // Pill gone — back to single-controller (non-multiplayer)
-        onNodeWithContentDescription("2 controllers connected").assertDoesNotExist()
-        onNodeWithContentDescription("1 controllers connected").assertDoesNotExist()
+        // Back to a single controller — no longer multiplayer, dots gone.
+        onNodeWithContentDescription("Player 1 connected").assertDoesNotExist()
+        onNodeWithContentDescription("Player 2 connected").assertDoesNotExist()
     }
 
     // ---- Dot States ----
 
     @Test
-    fun connectedDotsShowCorrectState() = runComposeUiTest {
+    fun onlyConnectedPortsRenderDots() = runComposeUiTest {
         val harness = createLoggedInHarness()
         setContent { harness.App() }
         harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
         harness.gamepadPortManager.connectDevice(2, "DualSense")
         advance(harness)
 
-        // The navigation-rail card renders all 4 slots (showEmptySlots = true)
+        // The section-indicator row uses showEmptySlots = false, so only the
+        // two connected ports render. Ports 3 and 4 show nothing.
         onNodeWithContentDescription("Player 1 connected").assertIsDisplayed()
         onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
-        // Slots 3 and 4 are empty and shown as not connected
-        onNodeWithContentDescription("Player 3 not connected").assertIsDisplayed()
-        onNodeWithContentDescription("Player 4 not connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 3 not connected").assertDoesNotExist()
+        onNodeWithContentDescription("Player 4 not connected").assertDoesNotExist()
     }
 
     @Test
-    fun reportingActivityDoesNotBreakConnectedState() = runComposeUiTest {
-        // The active dot state uses a real-clock 300ms timeout, making it too
-        // fragile to assert a specific "active" state in the test harness.
-        // This test verifies that reporting activity does not cause an error
-        // or break the connected state of the other port.
+    fun reportingActivityKeepsOtherPortConnected() = runComposeUiTest {
+        // Reporting input on one port must not error or break the connected
+        // state of the other port. (The active-dot state uses a 300ms timeout;
+        // after a normal advance it has lapsed back to connected, which is the
+        // stable thing to assert.)
         val harness = createLoggedInHarness()
         setContent { harness.App() }
         harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
         harness.gamepadPortManager.connectDevice(2, "DualSense")
         advance(harness)
 
-        // Report activity on port 0 (Player 1) — should not crash or break state
         harness.gamepadPortManager.reportActivity(0)
-        advanceQuick(harness)
+        advance(harness)
 
-        // The indicator is still visible and both ports still exist
-        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 1 connected").assertIsDisplayed()
         onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
-    }
-
-    // ---- Navigation ----
-
-    @Test
-    fun clickingCardNavigatesToSettings() = runComposeUiTest {
-        val harness = createLoggedInHarness()
-        setContent { harness.App() }
-        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
-        harness.gamepadPortManager.connectDevice(2, "DualSense")
-        advance(harness)
-
-        onNodeWithContentDescription("2 controllers connected").performClick()
-        advance(harness)
-
-        assertEquals(
-            SpScreen.Settings.route,
-            harness.navigationViewModel.state.value.currentScreen.route,
-        )
     }
 
     // ---- Disconnect/Reconnect ----
 
     @Test
-    fun disconnectedPortShowsAsNotConnected() = runComposeUiTest {
+    fun disconnectedPortDropsItsDot() = runComposeUiTest {
         val harness = createLoggedInHarness()
         setContent { harness.App() }
         harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
@@ -156,17 +141,14 @@ class ControllerStatusIndicatorTest {
         harness.gamepadPortManager.connectDevice(3, "Pro Controller")
         advance(harness)
 
-        onNodeWithContentDescription("3 controllers connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 1 connected").assertIsDisplayed()
 
-        // Disconnect P1
+        // Disconnect P1 (frees port 0). Still multiplayer (ports 1 and 2 stay),
+        // so the pill keeps showing dots — but only for the connected ports.
         harness.gamepadPortManager.disconnectDevice(1)
         advance(harness)
 
-        // Still multiplayer; card shows 2 connected controllers
-        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
-        // P1 slot is now empty — the card shows it as "not connected" (showEmptySlots = true)
-        onNodeWithContentDescription("Player 1 not connected").assertIsDisplayed()
-        // P2 and P3 stay connected
+        onNodeWithContentDescription("Player 1 connected").assertDoesNotExist()
         onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
         onNodeWithContentDescription("Player 3 connected").assertIsDisplayed()
     }
@@ -183,12 +165,10 @@ class ControllerStatusIndicatorTest {
         harness.gamepadPortManager.disconnectDevice(1)
         advance(harness)
 
-        // Reconnect — may get a different device ID
+        // Reconnect — may get a different device ID, reclaims the freed port 0.
         harness.gamepadPortManager.connectDevice(99, "Xbox Controller")
         advance(harness)
 
-        // Port 0 is reclaimed; back to 2 controllers
-        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
         onNodeWithContentDescription("Player 1 connected").assertIsDisplayed()
         onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
     }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadConfigTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadConfigTest.kt
@@ -102,9 +102,16 @@ class GamepadConfigTest {
         harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
         advance(harness)
 
-        // Report activity AFTER advance so the 500ms timeout hasn't expired
+        // Report activity, then advance virtual time by LESS than the 500ms
+        // activity window (REFRESH_INTERVAL is 200ms) so the config VM's refresh
+        // loop recomputes isActive while the input is still fresh. The harness
+        // injects the test scheduler as the clock, so this is deterministic —
+        // advancing a full second (as advance/advanceQuick do) would push past
+        // the window and read inactive. See #1198.
         harness.gamepadPortManager.reportActivity(0)
-        advanceQuick(harness)
+        harness.testDispatcher.scheduler.advanceTimeBy(300)
+        harness.testDispatcher.scheduler.runCurrent()
+        waitForIdle()
 
         // The activity indicator should be active
         onAllNodesWithContentDescription("Activity indicator active").assertCountEquals(1)

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadNavigationTest.kt
@@ -14,10 +14,14 @@ import kotlin.test.Test
  * Verifies component focusability and directional focus navigation
  * for gaming handheld support.
  *
- * Note: D-pad input triggers gamepad mode which hides the bottom tab bar
- * and shows the section indicator. Tab bar interaction via D-pad is therefore
- * not possible — section cycling (L1/R1) is tested in SectionIndicatorTest
- * and SectionNavigationTest.
+ * Note: since #1187 the nav style (side rail / bottom bar vs. section
+ * indicator pill) is driven by *physical controller connection*
+ * (`controllerStatus.connectedCount > 0`), not by `InputMode`. Tests that
+ * exercise d-pad navigation at a screen-edge boundary must therefore
+ * connect a controller so the side rail is hidden — otherwise the rail
+ * sits to the left of the content and `DirectionLeft` moves focus into it.
+ * Section cycling (L1/R1) is tested in SectionIndicatorTest and
+ * SectionNavigationTest.
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
 class GamepadNavigationTest {
@@ -90,7 +94,11 @@ class GamepadNavigationTest {
         setContent { harness.App() }
         advance(harness)
 
-        // Enter gamepad mode and navigate to Consoles
+        // Connect a controller so the app is in gamepad mode and the side rail
+        // is hidden (post-#1187). Without this the rail sits to the left of the
+        // grid and DirectionLeft would move focus into the rail instead of
+        // staying on the leftmost card.
+        harness.gamepadPortManager.connectDevice(1, "Test Controller")
         harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         harness.navigationViewModel.onIntent(
             NavigationIntent.NavigateTo(SpScreen.Consoles)
@@ -247,7 +255,10 @@ class GamepadNavigationTest {
         setContent { harness.App() }
         advance(harness)
 
-        // Enter gamepad mode and go to Consoles
+        // Connect a controller so the app is in gamepad mode and the side rail
+        // is hidden (post-#1187) — otherwise focus recovery / moveFocus(Next)
+        // lands on a rail tab instead of the console grid.
+        harness.gamepadPortManager.connectDevice(1, "Test Controller")
         harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection) // Explore
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection) // Consoles

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -167,7 +167,11 @@ class SpelaTestHarness(
     val presenceService = PresenceService(fakeApiClient, stubEngineFactory, dispatchers, scope)
 
     val keyMappingRepo = FakeKeyMappingRepository()
-    val gamepadPortManager = GamepadPortManager(keyMappingRepo, scope)
+    val gamepadPortManager = GamepadPortManager(
+        keyMappingRepo,
+        scope,
+        nowMs = { testDispatcher.scheduler.currentTime },
+    )
 
     // Achievement fakes are exposed so tests can drive the popup wiring:
     // set `achievementsRepo.raTokenResult = Result.success(...)` to enable
@@ -269,6 +273,7 @@ class SpelaTestHarness(
         gamepadPortManager = gamepadPortManager,
         dispatchers = dispatchers,
         scope = scope,
+        nowMs = { testDispatcher.scheduler.currentTime },
     )
 
     val socialRepo = FakeSocialRepository()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
@@ -24,6 +24,12 @@ import kotlin.time.Clock
 class GamepadPortManager(
     private val keyMappingRepository: KeyMappingRepository,
     private val scope: CoroutineScope? = null,
+    /**
+     * Wall-clock source in epoch milliseconds. Defaults to the system clock.
+     * Tests inject a virtual clock (the test scheduler's `currentTime`) so the
+     * activity-timeout window is deterministic instead of racing real time.
+     */
+    private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
     companion object {
         const val MAX_PORTS = 8
@@ -109,7 +115,7 @@ class GamepadPortManager(
     fun reportActivity(port: Int) {
         if (port < 0 || port >= MAX_PORTS) return
         if (!occupiedPorts[port]) return
-        lastActivityMs[port] = Clock.System.now().toEpochMilliseconds()
+        lastActivityMs[port] = nowMs()
         _portActivity.value = buildActivityMap()
         emitControllerStatus()
     }
@@ -303,7 +309,7 @@ class GamepadPortManager(
     }
 
     private fun emitControllerStatus() {
-        val now = Clock.System.now().toEpochMilliseconds()
+        val now = nowMs()
         _controllerStatus.value = ControllerStatusState.fromPortData(
             occupiedPorts = occupiedPorts.copyOf(),
             lastActivityMs = lastActivityMs.copyOf(),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModel.kt
@@ -35,6 +35,12 @@ class GamepadConfigViewModel(
     private val gamepadPortManager: GamepadPortManager,
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
+    /**
+     * Wall-clock source in epoch milliseconds. Defaults to the system clock.
+     * Tests inject a virtual clock so the activity-timeout window is
+     * deterministic rather than racing real time against the test scheduler.
+     */
+    private val nowMs: () -> Long = { kotlin.time.Clock.System.now().toEpochMilliseconds() },
 ) {
     companion object {
         private const val ACTIVITY_TIMEOUT_MS = 500L
@@ -78,7 +84,7 @@ class GamepadConfigViewModel(
     private fun refreshState() {
         val assignments = gamepadPortManager.assignments.value
         val activity = gamepadPortManager.portActivity.value
-        val now = kotlin.time.Clock.System.now().toEpochMilliseconds()
+        val now = nowMs()
 
         val portAssignments = assignments.map { assignment ->
             val lastActivity = activity[assignment.port] ?: 0L


### PR DESCRIPTION
Closes #1198.

## Summary

`player/run-desktop-tests.sh` (`:desktop:desktopTest`) had **9 deterministic failures** plus the documented intermittent `GamepadConfigTest` activity flake. CI only runs `:shared:desktopTest`, so these went unflagged. All trace to recent UI changes — #1187 ("pill nav gamepad-only") and #1106 (console grouping chips).

| | Before | After |
|---|---|---|
| `:shared:desktopTest` | 650 / 0 fail | 650 / 0 fail |
| `:desktop:desktopTest` | 822 / **9 fail** | 821 / **0 fail** |

(821 = 822 − 1; the unreachable-feature `clickingCardNavigatesToSettings` test was removed.)

## Root causes & fixes

### `ControllerStatusIndicatorTest` (7) — tested an unreachable surface
#1187 gates the side rail / bottom bar on `!isGamepadMode` (zero controllers) and `SpControllerStatusCard` on `isMultiplayer` (≥2 controllers) — mutually exclusive, so the in-rail card and the bottom-bar mini-pill are now **dead code**. The live controller-status surface post-#1187 is the connected-player dots in `SpSectionIndicator` (`showEmptySlots = false`). Rewrote the test to verify that surface ("Player N connected" dots appear with 2+ controllers, hidden with 0–1, update on disconnect/reconnect). This also adds coverage that was previously missing for the section-indicator path.

### `GamepadNavigationTest` (2) — `setInputMode(GAMEPAD)` no longer hides the rail
`focusDoesNotWrapOnDirectionLeftAtBoundary` and `dpadRecoversFocusAfterSectionSwitch` set `InputMode.GAMEPAD` but didn't connect a controller. Pre-#1187 that hid the side rail; post-#1187 the rail style follows *controller connection*, so the rail stayed visible to the left of the console grid and `DirectionLeft` / `moveFocus(Next)` moved focus into it. (Confirmed with a focus dump: connecting a controller moves the NES card from x=221 → x=15.) Fix: connect a controller so the tests exercise real gamepad mode.

### `GamepadConfigTest.activityIndicatorShowsActiveAfterInput` — real-clock vs virtual-time flake
`GamepadPortManager.reportActivity` / `emitControllerStatus` and `GamepadConfigViewModel.refreshState` computed the 300ms/500ms "active" window with `Clock.System.now()` (real wall-clock), but the harness drives virtual time, so the window expired under load (observed: an 11.8 s run). Injected a defaulted `nowMs: () -> Long = { Clock.System.now()… }` time source into both classes — **production default = system clock, behavior unchanged**; the harness passes the test scheduler's virtual clock and the test advances 300 ms within the window.

## Dead code flagged (follow-up, not in this PR)
Per CLAUDE.md (mention dead code, don't delete pre-existing): the unreachable `SpControllerStatusCard`-in-rail and bottom-bar mini-pill, plus the lost "navigate to controller settings" affordance and aggregate "N controllers connected" accessibility label, are documented in #1198 for a product/UX decision.

## Test plan
- [x] `./run-desktop-tests.sh` — `:shared` 650/0, `:desktop` 821/0.
- [x] `GamepadConfigTest` deterministic across 3 reruns (`--rerun-tasks`).
- [x] `GamepadNavigationTest` 10/10, `ControllerStatusIndicatorTest` 8/8 in isolation.

## Review note
The automated code-reviewer agent hit a session/rate limit before producing a review; I performed a self-review against the diff (clock-injection completeness, defaulted-param caller safety, advance-timing determinism, coverage parity, no leftover diagnostics). No UI/composable code changed, so the design-system (ui-agent) gate is N/A.