### PR TITLE
fix(player): surface emulation load errors in logs/tests; clearer message

### DIFF
--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -2398,8 +2398,27 @@ fun ComposeRule.startGameAndWait() {
             }
             .flatten().filterIsInstance<String>().take(20)
     } catch (_: Exception) { emptyList() }
-    android.util.Log.d("E2E_GAMEPLAY", "Game did not start. Visible contentDescriptions sample: $lastDesc")
-    throw IllegalStateException("Game did not start within 20 seconds")
+    // Surface the actual emulation error so the failure is actionable
+    // without reading screenshots. EmulationViewModel and the native
+    // bridge log it ("[Emulation] EXCEPTION during emulation start: ...",
+    // "retro_load_game failed"); read it back from logcat — the same
+    // mechanism the start-detection above uses.
+    val emulationError = try {
+        device.executeShellCommand("logcat -d -s System.out:I SpelaLibretro:I -t 800")
+            .lineSequence()
+            .lastOrNull { line ->
+                line.contains("EXCEPTION during emulation start") ||
+                    line.contains("retro_load_game failed") ||
+                    line.contains("Failed to load game")
+            }
+            ?.replace(Regex("^.*?(System\\.out|SpelaLibretro):\\s*"), "")
+            ?.trim()
+    } catch (_: Exception) { null }
+    android.util.Log.d("E2E_GAMEPLAY", "Game did not start. emulationError='$emulationError' visible=$lastDesc")
+    throw IllegalStateException(
+        "Game did not start within 20 seconds" +
+            (emulationError?.let { " — emulation error (from logcat): \"$it\"" } ?: ""),
+    )
 }
 
 fun ComposeRule.openOverlay() {

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
@@ -134,7 +134,14 @@ class AndroidLibretroController(
 
     override fun loadGame(gamePath: String) {
         if (!jni.nativeLoadGame(gamePath)) {
-            throw RuntimeException("Failed to load game: $gamePath")
+            // retro_load_game returned false. The core rejected the ROM —
+            // see the `[core]` lines in logcat (tag SpelaLibretro) for the
+            // core's own reason. Common causes: unsupported/corrupt ROM,
+            // wrong core for the file, or missing BIOS.
+            throw RuntimeException(
+                "the emulator core could not load this game (it may be an " +
+                    "unsupported or corrupt ROM): $gamePath",
+            )
         }
         targetFps = jni.nativeGetTargetFps()
         if (targetFps <= 0) targetFps = 60.0


### PR DESCRIPTION
Refs #1200.

When a game fails to load on the player, the error was only visible as an on-screen red banner ("Failed to start emulation: Failed to load game: <path>") — diagnosing the AYN Thor core-load failure meant reading a screenshot.

## Changes
- **`AndroidLibretroController.loadGame`** — clearer exception message: "the emulator core could not load this game (it may be an unsupported or corrupt ROM): <path>", plus a comment pointing at the `[core]` logcat lines (tag `SpelaLibretro`) for the core's own reason.
- **`startGameAndWait`** (E2E helper) — on the "Game did not start within 20s" timeout, read the emulation error back from logcat (`System.out` + `SpelaLibretro`, same mechanism the start-detection already uses) and append it to the thrown message.

The error was already logged by `EmulationViewModel` (`println("[Emulation] EXCEPTION during emulation start: …")`); the test just wasn't surfacing it.

## Before / after (test failure message)
Before: `Game did not start within 20 seconds`
After: `Game did not start within 20 seconds — emulation error (from logcat): "[Emulation] EXCEPTION during emulation start: RuntimeException: the emulator core could not load this game …: …/Super Mario Bros.nes"`

Verified on the AYN Thor.