### PR TITLE
feat(player): desktop gamepad navigation + usage-based nav style (#1205)

### DIFF
--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.window.rememberWindowState
 import com.spela.player.di.commonModule
 import com.spela.player.di.platformModule
 import com.spela.player.libretro.DesktopGamepadPoller
+import com.spela.player.libretro.DesktopGamepadSynth
+import com.spela.player.presentation.ui.gamepad.InputModeClassifier
 import com.spela.player.presentation.App
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.navigation.NavigationIntent
@@ -40,6 +42,10 @@ fun main(args: Array<String>) {
     startKoin {
         modules(commonModule, platformModule())
     }
+
+    // Attribute synthesized gamepad key events to the gamepad (not the keyboard)
+    // so the control method in use drives the nav style. See DesktopGamepadSynth.
+    InputModeClassifier.isKeyboardNavFromGamepad = { DesktopGamepadSynth.wasRecent() }
 
     // Start gamepad poller (SDL2)
     val gamepadPoller = getKoin().get<DesktopGamepadPoller>()

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ControllerStatusIndicatorTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ControllerStatusIndicatorTest.kt
@@ -3,25 +3,24 @@ package com.spela.player.desktop.e2e
 import androidx.compose.ui.test.*
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.ui.gamepad.InputMode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlin.test.Test
 
 /**
- * E2E tests for the controller status indicator.
+ * E2E tests for the controller status indicator (connected-player dots).
  *
- * Since #1187 the nav style is driven by *physical controller connection*
- * (`controllerStatus.connectedCount > 0`): connecting a controller puts the app
- * into gamepad mode, which hides the side rail / bottom bar and shows the
- * floating `SpSectionIndicator` pill. When 2+ controllers are connected
- * (`isMultiplayer`), the pill additionally renders an `SpControllerStatusRow`
- * of connected-player dots with `showEmptySlots = false` — so each connected
- * port exposes a "Player N connected" / "Player N active" content description,
- * and empty ports render nothing.
+ * The dots render inside the floating `SpSectionIndicator` pill, shown in
+ * gamepad navigation mode (`InputMode.GAMEPAD`; see `resolveGamepadNavStyle`).
+ * With 2+ controllers (`isMultiplayer`) the pill renders an
+ * `SpControllerStatusRow` with `showEmptySlots = false` — each connected port
+ * exposes a "Player N connected" / "Player N active" content description, and
+ * empty ports render nothing. These tests drive gamepad mode (via the harness
+ * factory) to exercise that row.
  *
- * (The older `SpControllerStatusCard`-in-rail and bottom-bar mini-pill became
- * unreachable when #1187 gated the rail/bottom-bar on `!isGamepadMode`; the
- * section-indicator dots are now the live controller-status surface. See #1198.)
+ * (A separate bottom-bar mini-pill surfaces controller status for
+ * touch/keyboard users with 2+ controllers; it is not covered here.)
  *
  * Tests verify:
  * - No player dots with 0 or 1 controller (not multiplayer)
@@ -36,6 +35,9 @@ class ControllerStatusIndicatorTest {
         val harness = SpelaTestHarness(StandardTestDispatcher())
         harness.authRepo.preSetTokens()
         harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        // The connected-player dots live in the gamepad-mode section pill, so
+        // exercise these tests in gamepad input mode.
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         return harness
     }
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InputModeTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InputModeTest.kt
@@ -12,11 +12,10 @@ import kotlin.test.assertEquals
 /**
  * E2E tests for the in-app InputMode flag (TOUCH vs GAMEPAD).
  *
- * Post #1187 InputMode no longer drives the nav style — that's tied to physical
- * controller presence. InputMode still exists to tell screens whether the user
- * is doing pointer-style or focus-style navigation (auto-focus, etc.), so these
- * tests verify that the flag transitions cleanly and crucially that flipping
- * InputMode by itself does NOT change which navigation widget is rendered.
+ * InputMode reflects the control method currently in use and DOES drive the nav
+ * style (see `resolveGamepadNavStyle`): GAMEPAD -> section pill, TOUCH -> tab
+ * bar, regardless of controller connection. These tests verify the flag
+ * transitions cleanly and that it drives which navigation widget is rendered.
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
 class InputModeTest {
@@ -45,20 +44,20 @@ class InputModeTest {
     }
 
     @Test
-    fun inputModeFlipsDoNotChangeNavStyle() = runComposeUiTest {
+    fun inputModeDrivesNavStyle() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        // No physical controller is connected — toggling InputMode (as keyboard
-        // navigation would) must leave the tab bar visible.
+        // GAMEPAD usage shows the section pill (and hides the tab bar)...
         harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advanceQuick(harness)
 
-        onNodeWithContentDescription("Home").assertExists()
-        onNodeWithContentDescription("Section indicator").assertDoesNotExist()
+        onNodeWithContentDescription("Section indicator").assertExists()
+        onNodeWithContentDescription("Home").assertDoesNotExist()
 
+        // ...switching back to TOUCH (keyboard/mouse) restores the tab bar.
         harness.gamepadPortManager.setInputMode(InputMode.TOUCH)
         advanceQuick(harness)
 
@@ -85,13 +84,13 @@ class InputModeTest {
     }
 
     @Test
-    fun pillIsRetainedAcrossScreensWhenControllerStaysConnected() = runComposeUiTest {
+    fun pillIsRetainedAcrossSectionsInGamepadMode() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        harness.gamepadPortManager.connectDevice(1, "Test Controller")
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advanceQuick(harness)
         onNodeWithContentDescription("Section: Home, active").assertExists()
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionIndicatorTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionIndicatorTest.kt
@@ -10,9 +10,12 @@ import kotlin.test.Test
 
 /**
  * E2E tests for the floating section indicator (pill) that replaces the bottom
- * tab bar when a physical gamepad is connected. See #1187: the pill is tied to
- * controller presence, not to in-app InputMode, so keyboard + mouse users on
- * desktop never see it flicker in.
+ * tab bar in gamepad navigation mode.
+ *
+ * Nav style follows the control method currently IN USE (see
+ * `resolveGamepadNavStyle`): the pill shows when [InputMode] is GAMEPAD and the
+ * tab bar shows for TOUCH (keyboard/mouse/touch) — regardless of whether a
+ * controller is connected.
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
 class SectionIndicatorTest {
@@ -25,7 +28,7 @@ class SectionIndicatorTest {
     }
 
     @Test
-    fun bottomNavVisibleWhenNoGamepad() = runComposeUiTest {
+    fun bottomNavVisibleInTouchMode() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
@@ -39,13 +42,13 @@ class SectionIndicatorTest {
     }
 
     @Test
-    fun sectionIndicatorAppearsWhenGamepadConnects() = runComposeUiTest {
+    fun sectionIndicatorAppearsWhenUsingGamepad() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        harness.gamepadPortManager.connectDevice(1, "Test Controller")
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advanceQuick(harness)
 
         onNodeWithContentDescription("Section indicator").assertExists()
@@ -53,16 +56,16 @@ class SectionIndicatorTest {
     }
 
     @Test
-    fun keyboardInputModeAloneDoesNotShowIndicator() = runComposeUiTest {
+    fun touchInputKeepsTabBarEvenWithControllerConnected() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        // Keyboard nav (arrow keys, [, ]) flips InputMode to GAMEPAD to drive
-        // focus behavior, but with no physical controller connected the nav
-        // style must stay as the tab bar so it doesn't flicker against mouse use.
-        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        // A controller is connected, but the user is navigating with keyboard/mouse
+        // (TOUCH). Nav style follows usage, so the tab bar stays and the pill does not show.
+        harness.gamepadPortManager.connectDevice(1, "Test Controller")
+        harness.gamepadPortManager.setInputMode(InputMode.TOUCH)
         advanceQuick(harness)
 
         onNodeWithContentDescription("Home").assertExists()
@@ -71,22 +74,22 @@ class SectionIndicatorTest {
     }
 
     @Test
-    fun sectionIndicatorDisappearsWhenGamepadDisconnects() = runComposeUiTest {
+    fun switchingBetweenInputMethodsTogglesNavStyle() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        harness.gamepadPortManager.connectDevice(1, "Test Controller")
+        // Use gamepad -> pill.
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advanceQuick(harness)
         onNodeWithContentDescription("Section indicator").assertExists()
 
-        harness.gamepadPortManager.disconnectDevice(1)
+        // Switch back to keyboard/mouse -> tab bar.
+        harness.gamepadPortManager.setInputMode(InputMode.TOUCH)
         advanceQuick(harness)
-
         onNodeWithContentDescription("Section indicator").assertDoesNotExist()
         onNodeWithContentDescription("Home").assertExists()
-        onNodeWithContentDescription("Consoles").assertExists()
     }
 
     @Test
@@ -96,7 +99,7 @@ class SectionIndicatorTest {
         setContent { harness.App() }
         advance(harness)
 
-        harness.gamepadPortManager.connectDevice(1, "Test Controller")
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advanceQuick(harness)
 
         onNodeWithContentDescription("Section: Home, active").assertExists()
@@ -111,7 +114,7 @@ class SectionIndicatorTest {
         setContent { harness.App() }
         advance(harness)
 
-        harness.gamepadPortManager.connectDevice(1, "Test Controller")
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advance(harness)
 
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection)

--- a/player/native/src/gamepad_sdl2.c
+++ b/player/native/src/gamepad_sdl2.c
@@ -89,6 +89,12 @@ JNIEXPORT jboolean JNICALL Java_com_spela_player_libretro_LibretroJni_nativeGame
     (void)env; (void)obj;
     if (initialized) return JNI_TRUE;
 
+    /* Run joystick device detection on SDL's own internal thread so hot-plug
+     * add/remove events are delivered even though this app never pumps a Win32
+     * message loop on the UI thread. Without this, controllers connected AFTER
+     * launch are never detected on Windows. Must be set before SDL_Init. */
+    SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
+
     if (SDL_Init(SDL_INIT_GAMECONTROLLER) < 0) {
         return JNI_FALSE;
     }
@@ -129,7 +135,15 @@ JNIEXPORT jobjectArray JNICALL Java_com_spela_player_libretro_LibretroJni_native
         switch (event.type) {
             case SDL_CONTROLLERDEVICEADDED: {
                 int device_index = event.cdevice.which;
-                if (SDL_IsGameController(device_index) && num_controllers < MAX_CONTROLLERS) {
+                /* Dedup: SDL also posts ADDED for controllers already opened at
+                 * init (open_controllers), which would otherwise open the same
+                 * physical device twice and assign it two ports. */
+                SDL_JoystickID new_id = SDL_JoystickGetDeviceInstanceID(device_index);
+                int already_open = 0;
+                for (int k = 0; k < num_controllers; k++) {
+                    if (controller_instance_ids[k] == new_id) { already_open = 1; break; }
+                }
+                if (!already_open && SDL_IsGameController(device_index) && num_controllers < MAX_CONTROLLERS) {
                     SDL_GameController *gc = SDL_GameControllerOpen(device_index);
                     if (gc) {
                         controllers[num_controllers] = gc;
@@ -169,9 +183,18 @@ JNIEXPORT jobjectArray JNICALL Java_com_spela_player_libretro_LibretroJni_native
     jmethodID ctor = (*env)->GetMethodID(env, stateClass, "<init>", "(ILjava/lang/String;[Z[I)V");
     if (!ctor) return NULL;
 
-    jobjectArray result = (*env)->NewObjectArray(env, num_controllers, stateClass, NULL);
+    /* Count attached controllers so the returned array has no null slots. A
+     * momentarily-detached controller (e.g. a wireless pad dropping) would
+     * otherwise leave a null element that the Kotlin poller NPEs on. */
+    int attached_count = 0;
+    for (int i = 0; i < num_controllers; i++) {
+        if (controllers[i] && SDL_GameControllerGetAttached(controllers[i])) attached_count++;
+    }
+
+    jobjectArray result = (*env)->NewObjectArray(env, attached_count, stateClass, NULL);
     if (!result) return NULL;
 
+    int out_index = 0;
     for (int i = 0; i < num_controllers; i++) {
         SDL_GameController *gc = controllers[i];
         if (!gc || !SDL_GameControllerGetAttached(gc)) continue;
@@ -209,7 +232,8 @@ JNIEXPORT jobjectArray JNICALL Java_com_spela_player_libretro_LibretroJni_native
 
         /* Create GamepadState object */
         jobject stateObj = (*env)->NewObject(env, stateClass, ctor, controllerId, jname, buttons, axes);
-        (*env)->SetObjectArrayElement(env, result, i, stateObj);
+        (*env)->SetObjectArrayElement(env, result, out_index, stateObj);
+        out_index++;
 
         /* Clean up local refs */
         (*env)->DeleteLocalRef(env, jname);

--- a/player/run-desktop.ps1
+++ b/player/run-desktop.ps1
@@ -1,0 +1,64 @@
+<#
+.SYNOPSIS
+  Launch the Spela desktop player on Windows with the full native-build environment.
+
+.DESCRIPTION
+  Building/running the desktop app needs: the MSVC x64 dev environment (for the
+  native libretro bridge), JDK, Vulkan SDK, the Android SDK (the Gradle build
+  configures the :android module unconditionally), SDL2 (desktop gamepad), and
+  Git Bash on PATH (the native shader step shells out to bash). It also needs the
+  built native dir on PATH so the Windows loader can resolve SDL2.dll, a
+  dependency of spela-libretro.dll.
+
+  This script wires all of that up and then runs `gradlew :desktop:run`.
+  Any extra arguments are forwarded to Gradle (e.g. --info, --game <id>).
+
+.NOTES
+  SDL2: set $env:SDL2_DIR to the SDL2 'cmake' dir to override auto-detection.
+  Auto-detection looks for %USERPROFILE%\SDL2\SDL2-*\cmake.
+#>
+param([Parameter(ValueFromRemainingArguments = $true)] [string[]] $GradleArgs)
+
+$ErrorActionPreference = 'Stop'
+$playerDir = $PSScriptRoot
+
+# --- MSVC x64 developer environment (Build Tools needs -products *) ---
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $vswhere)) { throw "vswhere not found. Install Visual Studio Build Tools (C++ workload)." }
+$vsPath = & $vswhere -latest -products * -property installationPath
+if (-not $vsPath) { throw "No Visual Studio / Build Tools installation found." }
+Import-Module (Join-Path $vsPath 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll')
+Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64' | Out-Null
+
+# --- JDK / Vulkan / Android from machine/user env ---
+$env:JAVA_HOME  = [System.Environment]::GetEnvironmentVariable('JAVA_HOME', 'Machine')
+$env:VULKAN_SDK = [System.Environment]::GetEnvironmentVariable('VULKAN_SDK', 'Machine')
+if (-not $env:ANDROID_HOME) {
+    $env:ANDROID_HOME = [System.Environment]::GetEnvironmentVariable('ANDROID_HOME', 'User')
+}
+
+# --- SDL2 (override with $env:SDL2_DIR; else auto-detect under %USERPROFILE%\SDL2) ---
+if (-not $env:SDL2_DIR) {
+    $sdl2Root = Get-ChildItem "$env:USERPROFILE\SDL2\SDL2-*" -Directory -ErrorAction SilentlyContinue |
+        Sort-Object Name -Descending | Select-Object -First 1
+    if ($sdl2Root) { $env:SDL2_DIR = Join-Path $sdl2Root.FullName 'cmake' }
+}
+if ($env:SDL2_DIR) {
+    $env:CMAKE_PREFIX_PATH = Split-Path $env:SDL2_DIR -Parent
+} else {
+    Write-Warning "SDL2 not found; gamepad support will be disabled. Set `$env:SDL2_DIR to enable it."
+}
+
+# --- PATH: native build dir (for SDL2.dll at runtime) + Git Bash (for shader step) ---
+$nativeDir = Join-Path $playerDir 'desktop\build\native'
+$gitBin = 'C:\Program Files\Git\bin'
+$env:Path = "$nativeDir;$gitBin;$env:Path"
+
+Write-Host "JAVA_HOME=$env:JAVA_HOME"
+Write-Host "VULKAN_SDK=$env:VULKAN_SDK"
+Write-Host "ANDROID_HOME=$env:ANDROID_HOME"
+Write-Host "SDL2_DIR=$env:SDL2_DIR"
+Write-Host "--- launching :desktop:run ---"
+
+Set-Location $playerDir
+& .\gradlew.bat :desktop:run --console=plain @GradleArgs

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -75,7 +75,9 @@ import com.spela.player.presentation.ui.gamepad.GamepadHandler
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalIsForwardNavigation
 import com.spela.player.presentation.ui.gamepad.LocalIsTabSwitch
+import com.spela.player.presentation.ui.gamepad.InputModeClassifier
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
+import com.spela.player.presentation.ui.gamepad.resolveGamepadNavStyle
 import com.spela.player.presentation.ui.components.LocalScrapeService
 import com.spela.player.presentation.ui.theme.SpelaTheme
 import androidx.compose.runtime.CompositionLocalProvider
@@ -88,19 +90,20 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
     val currentTheme by settingsViewModel.selectedTheme.collectAsState()
 
     SpelaTheme(theme = currentTheme) {
+    val inputMode = gamepadPortManager?.inputMode?.collectAsState()?.value ?: InputMode.TOUCH
     CompositionLocalProvider(
         LocalScrapeService provides scrapeService,
-        LocalInputMode provides (gamepadPortManager?.inputMode?.collectAsState()?.value ?: InputMode.TOUCH),
+        LocalInputMode provides inputMode,
     ) {
         val navState by navigationViewModel.state.collectAsState()
 
-        // Nav style is driven by whether a physical gamepad is connected, not by
-        // the in-app InputMode. Keyboard + mouse users (no gamepad) always see the
-        // tab bar / side rail, so the nav doesn't flicker between styles as they
-        // switch between typing and clicking. See #1187.
+        // Nav style follows the control method currently in USE (gamepad -> L1/R1
+        // section pill; keyboard/mouse/touch -> tab bar / side rail), regardless of
+        // what is connected. The policy is centralized in resolveGamepadNavStyle()
+        // — change the behavior there.
         val controllerStatus by gamepadPortManager?.controllerStatus?.collectAsState()
             ?: remember { mutableStateOf(ControllerStatusState.Empty) }
-        val isGamepadMode = controllerStatus.connectedCount > 0
+        val isGamepadMode = resolveGamepadNavStyle(inputMode, controllerStatus)
         val sectionIndicatorVisible = isGamepadMode
 
         // Indicator for E2E tests: exposes whether the libretro core is running.
@@ -164,7 +167,14 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
             onPreviousSection = if (isGamepadScreen) {
                 { navigationViewModel.onIntent(NavigationIntent.PreviousSection) }
             } else null,
-            onGamepadInput = { gamepadPortManager?.setInputMode(InputMode.GAMEPAD) },
+            onGamepadInput = {
+                // On desktop, real keyboard nav and synthesized gamepad nav are
+                // indistinguishable here; the classifier tells them apart so the
+                // control method in use drives InputMode (and thus the nav style).
+                gamepadPortManager?.setInputMode(
+                    if (InputModeClassifier.isKeyboardNavFromGamepad()) InputMode.GAMEPAD else InputMode.TOUCH
+                )
+            },
             focusResetKey = Pair(navState.activeTab, navState.currentScreen),
             isGoingBack = navState.isGoingBack,
         ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/InputModeClassifier.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/InputModeClassifier.kt
@@ -1,0 +1,20 @@
+package com.spela.player.presentation.ui.gamepad
+
+/**
+ * Decides whether a keyboard-style navigation event (arrow keys, Enter, Escape,
+ * etc. reaching [GamepadHandler]) should count as **gamepad** input or as
+ * **real keyboard** input — which in turn drives [InputMode].
+ *
+ * This matters only on desktop, where gamepad navigation is implemented as
+ * *synthesized* key events (see desktop `GamepadUiNavigator`): a real keyboard
+ * press and a gamepad press are otherwise indistinguishable at the Compose
+ * layer. Desktop installs a classifier that returns true only when the event
+ * was just synthesized by the gamepad poller.
+ *
+ * Default is `true` (treat keyboard nav as gamepad), which preserves the
+ * Android behavior where these events genuinely originate from the controller.
+ */
+object InputModeClassifier {
+    @Volatile
+    var isKeyboardNavFromGamepad: () -> Boolean = { true }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/NavStylePolicy.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/NavStylePolicy.kt
@@ -1,0 +1,27 @@
+package com.spela.player.presentation.ui.gamepad
+
+import com.spela.player.libretro.ControllerStatusState
+
+/**
+ * Single source of truth for the navigation *style*: whether the UI shows the
+ * gamepad style (L1/R1 section pill + focus navigation) or the touch/desktop
+ * style (bottom tab bar / side rail).
+ *
+ * **Current policy — by control method in USE:** the gamepad style shows when
+ * the last input came from a gamepad ([inputMode] == GAMEPAD); using the
+ * keyboard, mouse, or touch shows the tab bar — regardless of whether a
+ * controller is connected.
+ *
+ * This is intentionally the *only* place the policy lives so it's a one-line
+ * change. Alternatives, for reference:
+ *  - **Controller presence** (the #1187 behavior): `controllerStatus.connectedCount > 0`
+ *  - **Presence AND usage:** `controllerStatus.connectedCount > 0 && inputMode == InputMode.GAMEPAD`
+ *  - **Usage only** (current): `inputMode == InputMode.GAMEPAD`
+ *
+ * [controllerStatus] is passed in (unused by the current policy) so switching to
+ * a presence-based policy needs no call-site changes.
+ */
+fun resolveGamepadNavStyle(
+    inputMode: InputMode,
+    @Suppress("UNUSED_PARAMETER") controllerStatus: ControllerStatusState,
+): Boolean = inputMode == InputMode.GAMEPAD

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/di/PlatformModule.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/di/PlatformModule.kt
@@ -122,17 +122,16 @@ actual fun platformModule(): Module = module {
     single<PlatformSecondaryDisplay> { DesktopSecondaryDisplay() }
     single {
         val navViewModel = get<NavigationViewModel>()
-        val emulationState = get<kotlinx.coroutines.flow.MutableStateFlow<com.spela.player.presentation.state.EmulationState>>()
         DesktopGamepadPoller(
             jni = get(),
             gamepadPortManager = get(),
             controller = get(),
             navigationEventBus = get<NavigationEventBus>(),
-            isEmulationActive = {
-                navViewModel.state.value.showInGameOverlay &&
-                    emulationState.value.isRunning &&
-                    !emulationState.value.showOverlay
-            },
+            // UI-navigation synth only applies in the app menus. While a game is
+            // open (showInGameOverlay), GamepadHandler is disabled, so synth keys
+            // can't drive focus and would leak into the emulator — suppress them.
+            // The gamepad still controls the game via the poller's button routing.
+            isInGame = { navViewModel.state.value.showInGameOverlay },
         )
     }
     single {

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
@@ -1,12 +1,12 @@
 package com.spela.player.libretro
 
-import com.spela.player.presentation.navigation.NavigationEvent
 import com.spela.player.presentation.navigation.NavigationEventBus
 import com.spela.player.presentation.viewmodel.LibretroButtons
 import com.spela.player.presentation.viewmodel.LibretroController
+import java.util.concurrent.Executors
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -23,7 +23,8 @@ class DesktopGamepadPoller(
     private val gamepadPortManager: GamepadPortManager,
     private val controller: LibretroController,
     private val navigationEventBus: NavigationEventBus? = null,
-    private val isEmulationActive: () -> Boolean = { false },
+    /** True while a game is open; suppresses UI-navigation synth (see [GamepadUiNavigator]). */
+    private val isInGame: () -> Boolean = { false },
 ) {
     companion object {
         private const val POLL_INTERVAL_MS = 8L // ~120 Hz
@@ -39,26 +40,31 @@ class DesktopGamepadPoller(
 
         /** Trigger threshold to consider as digital press. */
         private const val TRIGGER_THRESHOLD = 8000
-
-        /** SDL GameController button indices for shoulder buttons. */
-        private const val SDL_BUTTON_LEFT_SHOULDER = 9
-        private const val SDL_BUTTON_RIGHT_SHOULDER = 10
     }
 
     private var pollJob: Job? = null
     private var initialized = false
 
+    /**
+     * SDL must be initialized and polled from the SAME thread — its event pump
+     * (which delivers controller hot-plug events) is thread-affine. A coroutine
+     * on Dispatchers.IO hops threads across delay(), which silently breaks
+     * hot-plug detection. Pin everything to one dedicated thread.
+     */
+    private val pollDispatcher = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "spela-gamepad-poller").apply { isDaemon = true }
+    }.asCoroutineDispatcher()
+
     /** SDL controller IDs currently tracked, mapped to port manager device IDs. */
     private val knownControllers = mutableSetOf<Int>()
 
-    /** Edge detection for shoulder buttons in UI navigation mode. */
-    private var prevLeftShoulder = false
-    private var prevRightShoulder = false
+    /** Translates controller input into UI navigation key events (menus only). */
+    private val uiNavigator = GamepadUiNavigator(navigationEventBus, isInGame)
 
     fun start(scope: CoroutineScope) {
         if (pollJob != null) return
 
-        pollJob = scope.launch(Dispatchers.IO) {
+        pollJob = scope.launch(pollDispatcher) {
             initialized = jni.nativeGamepadInit()
             if (!initialized) {
                 println("[GamepadPoller] SDL2 gamepad init failed (SDL2 may not be available)")
@@ -140,22 +146,7 @@ class DesktopGamepadPoller(
             }
         }
 
-        // UI navigation: emit shoulder button events when not in emulation
-        if (!isEmulationActive() && navigationEventBus != null && states.isNotEmpty()) {
-            val first = states[0]
-            val leftShoulder = first.buttons.getOrNull(SDL_BUTTON_LEFT_SHOULDER) == true
-            val rightShoulder = first.buttons.getOrNull(SDL_BUTTON_RIGHT_SHOULDER) == true
-
-            if (leftShoulder && !prevLeftShoulder) {
-                navigationEventBus.emit(NavigationEvent.PreviousSection)
-            }
-            if (rightShoulder && !prevRightShoulder) {
-                navigationEventBus.emit(NavigationEvent.NextSection)
-            }
-
-            prevLeftShoulder = leftShoulder
-            prevRightShoulder = rightShoulder
-        }
+        uiNavigator.handle(states)
 
         // Detect disconnections
         val disconnected = knownControllers - currentIds

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
@@ -1,6 +1,7 @@
 package com.spela.player.libretro
 
 import com.spela.player.presentation.navigation.NavigationEventBus
+import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.viewmodel.LibretroButtons
 import com.spela.player.presentation.viewmodel.LibretroController
 import java.util.concurrent.Executors
@@ -59,7 +60,11 @@ class DesktopGamepadPoller(
     private val knownControllers = mutableSetOf<Int>()
 
     /** Translates controller input into UI navigation key events (menus only). */
-    private val uiNavigator = GamepadUiNavigator(navigationEventBus, isInGame)
+    private val uiNavigator = GamepadUiNavigator(
+        navigationEventBus = navigationEventBus,
+        isInGame = isInGame,
+        onGamepadInput = { gamepadPortManager.setInputMode(InputMode.GAMEPAD) },
+    )
 
     fun start(scope: CoroutineScope) {
         if (pollJob != null) return

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadSynth.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadSynth.kt
@@ -1,0 +1,22 @@
+package com.spela.player.libretro
+
+/**
+ * Lets Compose tell synthesized gamepad key events apart from real keyboard
+ * input. [GamepadUiNavigator] calls [mark] right before it injects a synthetic
+ * key; [wasRecent] stays true for a short window afterward. The desktop
+ * `InputModeClassifier` uses this so gamepad navigation keeps the app in GAMEPAD
+ * input mode while genuine keyboard input falls through to TOUCH.
+ */
+object DesktopGamepadSynth {
+    /** How long after a synth a key event is still attributed to the gamepad. */
+    private const val WINDOW_NANOS = 120_000_000L // 120 ms
+
+    @Volatile
+    private var lastSynthNanos = 0L
+
+    fun mark() {
+        lastSynthNanos = System.nanoTime()
+    }
+
+    fun wasRecent(): Boolean = (System.nanoTime() - lastSynthNanos) < WINDOW_NANOS
+}

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadUiNavigator.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadUiNavigator.kt
@@ -28,6 +28,12 @@ class GamepadUiNavigator(
      */
     private val isInGame: () -> Boolean,
     /**
+     * Called once per poll frame in which the gamepad produced any UI-navigation
+     * input. Used to set the app's input mode to GAMEPAD (which drives the nav
+     * style). No-op by default.
+     */
+    private val onGamepadInput: () -> Unit = {},
+    /**
      * Key-event sink. Defaults to an AWT [Robot] that synthesizes real key
      * presses; tests inject a fake to assert the button -> key-code mapping and
      * auto-repeat timing without a real Robot.
@@ -41,6 +47,12 @@ class GamepadUiNavigator(
          */
         private const val REPEAT_INITIAL_DELAY_TICKS = 45 // ~360ms at the 8ms poll rate
         private const val REPEAT_INTERVAL_TICKS = 8       // ~64ms between repeats
+
+        /** Libretro button ids that count as UI navigation input. */
+        private val NAV_BUTTONS = intArrayOf(
+            LibretroButtons.UP, LibretroButtons.DOWN, LibretroButtons.LEFT, LibretroButtons.RIGHT,
+            LibretroButtons.B, LibretroButtons.A, LibretroButtons.L, LibretroButtons.R,
+        )
     }
 
     private var prevLeftShoulder = false
@@ -74,6 +86,11 @@ class GamepadUiNavigator(
             return
         }
         val first = states[0]
+
+        // Any gamepad nav input this frame means the user is driving the UI with
+        // the controller -> switch the app to GAMEPAD input mode (drives nav style).
+        val anyNavInput = NAV_BUTTONS.any { first.buttons.getOrNull(it) == true }
+        if (anyNavInput) onGamepadInput()
 
         // L1/R1 -> section switching (via the navigation bus).
         // buttons is indexed by libretro button id, so use L (10) / R (11).
@@ -127,6 +144,9 @@ class GamepadUiNavigator(
 
     /** Emits a synthesized key press+release via the injected sink or the AWT Robot. */
     private fun synthKey(keyCode: Int) {
+        // Mark so the desktop InputModeClassifier attributes the resulting key
+        // event to the gamepad (keeps GAMEPAD mode) rather than to a real keyboard.
+        DesktopGamepadSynth.mark()
         val sink = synthesizeKey
         if (sink != null) {
             sink(keyCode)

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadUiNavigator.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadUiNavigator.kt
@@ -1,0 +1,142 @@
+package com.spela.player.libretro
+
+import com.spela.player.presentation.navigation.NavigationEvent
+import com.spela.player.presentation.navigation.NavigationEventBus
+import com.spela.player.presentation.viewmodel.LibretroButtons
+import java.awt.Robot
+import java.awt.event.KeyEvent
+
+/**
+ * Translates player-1 gamepad input into UI navigation when not in a game:
+ * L1/R1 switch sections (via the navigation bus), the d-pad drives focus with
+ * keyboard-style auto-repeat, and the face buttons confirm/back.
+ *
+ * Everything is emitted as synthesized key events so the existing keyboard-based
+ * `GamepadHandler` is the single navigation layer in the UI (parity with how
+ * Android's MainActivity feeds gamepad input into Compose).
+ *
+ * Kept separate from [DesktopGamepadPoller] so it has no native (JNI) dependency
+ * and can be unit-tested directly with an injected key sink.
+ */
+class GamepadUiNavigator(
+    private val navigationEventBus: NavigationEventBus?,
+    /**
+     * True whenever a game is open (the in-game screen/overlay is showing).
+     * UI navigation is suppressed then: `GamepadHandler` is disabled in-game, so
+     * synth keys can't drive menu focus and would leak into the emulator. The
+     * gamepad still controls the game directly via the poller's button routing.
+     */
+    private val isInGame: () -> Boolean,
+    /**
+     * Key-event sink. Defaults to an AWT [Robot] that synthesizes real key
+     * presses; tests inject a fake to assert the button -> key-code mapping and
+     * auto-repeat timing without a real Robot.
+     */
+    private val synthesizeKey: ((Int) -> Unit)? = null,
+) {
+    companion object {
+        /**
+         * D-pad auto-repeat timing, in poll ticks (one tick per poll). Mirrors the
+         * keyboard / Android feel: an initial hold delay, then a steady repeat.
+         */
+        private const val REPEAT_INITIAL_DELAY_TICKS = 45 // ~360ms at the 8ms poll rate
+        private const val REPEAT_INTERVAL_TICKS = 8       // ~64ms between repeats
+    }
+
+    private var prevLeftShoulder = false
+    private var prevRightShoulder = false
+    private var prevConfirm = false
+    private var prevBack = false
+
+    /** Poll ticks each d-pad direction has been held (0 = released), for auto-repeat. */
+    private val dpadHoldTicks = mutableMapOf(
+        LibretroButtons.UP to 0,
+        LibretroButtons.DOWN to 0,
+        LibretroButtons.LEFT to 0,
+        LibretroButtons.RIGHT to 0,
+    )
+
+    /** Lazily-created AWT Robot used when no [synthesizeKey] sink is injected. */
+    private val defaultRobot: Robot? by lazy {
+        try {
+            Robot()
+        } catch (e: Exception) {
+            println("[GamepadUiNavigator] AWT Robot unavailable; UI gamepad navigation disabled: ${e.message}")
+            null
+        }
+    }
+
+    /** Processes one poll frame of controller [states] (player 1 = `states[0]`). */
+    fun handle(states: Array<GamepadState>) {
+        if (isInGame() || navigationEventBus == null || states.isEmpty()) {
+            // Reset auto-repeat so a held direction doesn't carry into a game.
+            dpadHoldTicks.keys.forEach { dpadHoldTicks[it] = 0 }
+            return
+        }
+        val first = states[0]
+
+        // L1/R1 -> section switching (via the navigation bus).
+        // buttons is indexed by libretro button id, so use L (10) / R (11).
+        val leftShoulder = first.buttons.getOrNull(LibretroButtons.L) == true
+        val rightShoulder = first.buttons.getOrNull(LibretroButtons.R) == true
+        if (leftShoulder && !prevLeftShoulder) {
+            navigationEventBus.emit(NavigationEvent.PreviousSection)
+        }
+        if (rightShoulder && !prevRightShoulder) {
+            navigationEventBus.emit(NavigationEvent.NextSection)
+        }
+        prevLeftShoulder = leftShoulder
+        prevRightShoulder = rightShoulder
+
+        // D-pad -> arrow keys with hold-to-repeat. Confirm (bottom face button =
+        // RETRO_B) -> Enter and back (right face button = RETRO_A) -> Escape are
+        // single-press only.
+        repeatOnHold(first, LibretroButtons.UP, KeyEvent.VK_UP)
+        repeatOnHold(first, LibretroButtons.DOWN, KeyEvent.VK_DOWN)
+        repeatOnHold(first, LibretroButtons.LEFT, KeyEvent.VK_LEFT)
+        repeatOnHold(first, LibretroButtons.RIGHT, KeyEvent.VK_RIGHT)
+        prevConfirm = synthOnEdge(first, LibretroButtons.B, prevConfirm, KeyEvent.VK_ENTER)
+        prevBack = synthOnEdge(first, LibretroButtons.A, prevBack, KeyEvent.VK_ESCAPE)
+    }
+
+    /**
+     * Fires [keyCode] for a directional button with keyboard-style auto-repeat:
+     * once on the initial press, then (after [REPEAT_INITIAL_DELAY_TICKS]) every
+     * [REPEAT_INTERVAL_TICKS] ticks while held.
+     */
+    private fun repeatOnHold(state: GamepadState, buttonId: Int, keyCode: Int) {
+        val pressed = state.buttons.getOrNull(buttonId) == true
+        if (!pressed) {
+            dpadHoldTicks[buttonId] = 0
+            return
+        }
+        val held = dpadHoldTicks.getValue(buttonId)
+        val fire = held == 0 ||
+            (held >= REPEAT_INITIAL_DELAY_TICKS &&
+                (held - REPEAT_INITIAL_DELAY_TICKS) % REPEAT_INTERVAL_TICKS == 0)
+        if (fire) synthKey(keyCode)
+        dpadHoldTicks[buttonId] = held + 1
+    }
+
+    /** Synthesizes [keyCode] on the rising edge of a button (press only, not held). */
+    private fun synthOnEdge(state: GamepadState, buttonId: Int, prev: Boolean, keyCode: Int): Boolean {
+        val pressed = state.buttons.getOrNull(buttonId) == true
+        if (pressed && !prev) synthKey(keyCode)
+        return pressed
+    }
+
+    /** Emits a synthesized key press+release via the injected sink or the AWT Robot. */
+    private fun synthKey(keyCode: Int) {
+        val sink = synthesizeKey
+        if (sink != null) {
+            sink(keyCode)
+            return
+        }
+        val robot = defaultRobot ?: return
+        try {
+            robot.keyPress(keyCode)
+            robot.keyRelease(keyCode)
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadUiNavigatorTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadUiNavigatorTest.kt
@@ -1,0 +1,115 @@
+package com.spela.player.libretro
+
+import com.spela.player.presentation.navigation.NavigationEvent
+import com.spela.player.presentation.navigation.NavigationEventBus
+import com.spela.player.presentation.viewmodel.LibretroButtons
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import java.awt.event.KeyEvent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GamepadUiNavigatorTest {
+
+    private val keys = mutableListOf<Int>()
+    private val bus = NavigationEventBus()
+    private var inGame = false
+    private val nav = GamepadUiNavigator(
+        navigationEventBus = bus,
+        isInGame = { inGame },
+        synthesizeKey = { keys.add(it) },
+    )
+
+    /** A one-frame controller state with the given libretro button ids pressed. */
+    private fun pressed(vararg buttonIds: Int): Array<GamepadState> {
+        val buttons = BooleanArray(16)
+        buttonIds.forEach { buttons[it] = true }
+        return arrayOf(GamepadState(0, "Test Controller", buttons, IntArray(6)))
+    }
+
+    private val released = arrayOf(GamepadState(0, "Test Controller", BooleanArray(16), IntArray(6)))
+
+    @Test
+    fun dpadDirectionsMapToArrowKeys() {
+        nav.handle(pressed(LibretroButtons.UP)); nav.handle(released)
+        nav.handle(pressed(LibretroButtons.DOWN)); nav.handle(released)
+        nav.handle(pressed(LibretroButtons.LEFT)); nav.handle(released)
+        nav.handle(pressed(LibretroButtons.RIGHT)); nav.handle(released)
+
+        assertEquals(
+            listOf(KeyEvent.VK_UP, KeyEvent.VK_DOWN, KeyEvent.VK_LEFT, KeyEvent.VK_RIGHT),
+            keys,
+        )
+    }
+
+    @Test
+    fun confirmMapsToEnterAndBackMapsToEscape() {
+        // RETRO_B (0) = bottom face button = confirm; RETRO_A (8) = right = back.
+        nav.handle(pressed(LibretroButtons.B)); nav.handle(released)
+        nav.handle(pressed(LibretroButtons.A)); nav.handle(released)
+
+        assertEquals(listOf(KeyEvent.VK_ENTER, KeyEvent.VK_ESCAPE), keys)
+    }
+
+    @Test
+    fun confirmDoesNotRepeatWhileHeld() {
+        repeat(100) { nav.handle(pressed(LibretroButtons.B)) }
+        assertEquals(listOf(KeyEvent.VK_ENTER), keys)
+    }
+
+    @Test
+    fun dpadAutoRepeatsAfterInitialDelay() {
+        // Tick 0 fires immediately; no repeat through the initial-delay window.
+        repeat(45) { nav.handle(pressed(LibretroButtons.RIGHT)) }
+        assertEquals(1, keys.size, "only the initial press should have fired during the delay")
+
+        // First repeat fires once the hold passes the initial delay.
+        nav.handle(pressed(LibretroButtons.RIGHT))
+        assertEquals(2, keys.size)
+
+        // Then one more repeat per interval.
+        repeat(8) { nav.handle(pressed(LibretroButtons.RIGHT)) }
+        assertEquals(3, keys.size)
+
+        keys.forEach { assertEquals(KeyEvent.VK_RIGHT, it) }
+    }
+
+    @Test
+    fun releasingResetsAutoRepeat() {
+        nav.handle(pressed(LibretroButtons.RIGHT)) // fire 1
+        nav.handle(released)                        // reset
+        nav.handle(pressed(LibretroButtons.RIGHT)) // fire 2 (fresh press, not a repeat)
+        assertEquals(2, keys.size)
+    }
+
+    @Test
+    fun noSynthWhileInGame() {
+        inGame = true
+        repeat(10) { nav.handle(pressed(LibretroButtons.RIGHT)) }
+        assertTrue(keys.isEmpty())
+    }
+
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    @Test
+    fun shouldersEmitSectionEventsUsingCorrectButtonIndices() = runTest {
+        val received = mutableListOf<NavigationEvent>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            bus.events.collect { received.add(it) }
+        }
+
+        // L (10) -> previous, R (11) -> next. Guards against the old bug that read
+        // indices 9/10 (X / L1) instead of the libretro L/R ids.
+        nav.handle(pressed(LibretroButtons.R)); nav.handle(released)
+        nav.handle(pressed(LibretroButtons.L)); nav.handle(released)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(NavigationEvent.NextSection, NavigationEvent.PreviousSection),
+            received,
+        )
+        job.cancel()
+    }
+}


### PR DESCRIPTION
## Summary
Brings **desktop gamepad navigation to parity with Android**, and makes the navigation style follow the **control method currently in use**. Developed/tested on Windows.

Closes #1205. Also fixes #1210.

## What's included

### Desktop gamepad navigation (`fadc8d29`)
- SDL2 wired into the desktop native bridge. `SDL_HINT_JOYSTICK_THREAD` so controllers hot-plugged after launch are detected on Windows; dedup `CONTROLLERDEVICEADDED`; compact poll array with no null slots (**fixes #1210**, a poller-thread NPE on momentary controller detach).
- New `GamepadUiNavigator`: d-pad → arrow keys with keyboard-style **auto-repeat**, bottom face button → Enter, right → Escape, L1/R1 → sections. Implemented as **synthesized key events** so the existing keyboard-based `GamepadHandler` stays the single UI navigation layer.
- Synth is suppressed whenever a game is open (`showInGameOverlay`), so it never leaks into the emulator.
- Fixed a latent bug: L1/R1 were reading the wrong button indices (X/L1 instead of libretro L/R).
- Unit test for the button→key mapping, auto-repeat timing, and gating.

### Usage-based nav style (`fbedff22`)
- The section pill vs. tab bar now follows the input method **in use** (gamepad → pill; keyboard/mouse/touch → tabs), not physical controller presence. Connecting a controller no longer forces the pill; using it does, and touching the keyboard/mouse switches back — even while it stays connected.
- Policy centralized in `resolveGamepadNavStyle()` with alternatives documented inline, so it's a one-line change later.
- `InputModeClassifier` + `DesktopGamepadSynth` distinguish real keyboard input from the desktop gamepad's synthesized keys (default preserves Android behavior).
- Updated `InputModeTest` / `SectionIndicatorTest` / `ControllerStatusIndicatorTest` for the new policy.

### Tooling (`cd2ab36e`)
- `player/run-desktop.ps1`: one-command Windows launch (MSVC env + JDK/Vulkan/Android SDK + SDL2 + PATH, then `:desktop:run`).

## Testing
- Full desktop suite green (`:shared:desktopTest` + `:desktop:desktopTest`, 821 tests).
- Manually verified on Windows with an 8BitDo Ultimate 2 controller: hot-plug, menu navigation + auto-repeat, no in-game leak, and the pill/tabs switching by control method in use.

## Not included (follow-ups)
- In-game overlay (Save/Load) gamepad navigation on desktop (#1211).
- Other Windows issues found while testing: #1203 (GameCube black screen), #1204 (title bar), #1206 (save upload hang), #1207/#1208 (BIOS), #1209 (fullscreen FPS).
