### PR TITLE
fix(player): transparent title bar on Windows/Linux via JBR WindowDecorations (#1204)

### DIFF
--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
@@ -139,19 +139,40 @@ private var isJbrTitleBarActive = false
  * Gracefully degrades to standard title bar on non-JBR JDKs (dev mode).
  */
 private fun applyJbrTransparentTitleBar(window: java.awt.Window) {
-    if (!System.getProperty("java.vendor").orEmpty().contains("JetBrains", ignoreCase = true)) {
-        return
-    }
     try {
-        val rootPane = (window as? javax.swing.JFrame)?.rootPane ?: return
-        rootPane.putClientProperty("jetbrains.awt.customTitleBar.enabled", true)
-        rootPane.putClientProperty("jetbrains.awt.transparentTitleBarAppearance", true)
-        val bg = java.awt.Color(10, 10, 16) // #0A0A10 — fallback before Compose renders
+        // JBR custom title bar API, called reflectively so non-JBR JDKs degrade
+        // gracefully (getWindowDecorations() is absent/returns null off JBR).
+        val jbr = Class.forName("com.jetbrains.JBR")
+        val windowDecorations = jbr.getMethod("getWindowDecorations").invoke(null)
+        if (windowDecorations == null) {
+            println("[TitleBar] JBR WindowDecorations unavailable — standard title bar")
+            return
+        }
+        // Invoke via the PUBLIC interfaces — the runtime impl class is a synthetic
+        // module-private type and reflecting on it throws IllegalAccessException.
+        val wdInterface = Class.forName("com.jetbrains.WindowDecorations")
+        val ctbInterface = Class.forName("com.jetbrains.WindowDecorations\$CustomTitleBar")
+        val titleBar = wdInterface.getMethod("createCustomTitleBar").invoke(windowDecorations)
+        ctbInterface.getMethod("setHeight", java.lang.Float.TYPE).invoke(titleBar, 32f)
+        // setCustomTitleBar is overloaded ((Frame, ..), (Dialog, ..)) and the param
+        // types vary by JBR version, so match the overload to the actual arg types.
+        val setMethod = wdInterface.methods.firstOrNull { m ->
+            m.name == "setCustomTitleBar" && m.parameterCount == 2 &&
+                m.parameterTypes[0].isInstance(window) && m.parameterTypes[1].isInstance(titleBar)
+        } ?: run {
+            println("[TitleBar] no matching setCustomTitleBar overload — standard title bar")
+            return
+        }
+        setMethod.invoke(windowDecorations, window, titleBar)
+
+        val bg = java.awt.Color(10, 10, 16) // #0A0A10 — fallback behind the transparent bar
         window.background = bg
-        rootPane.background = bg
-        window.contentPane.background = bg
+        (window as? javax.swing.JFrame)?.let {
+            it.rootPane.background = bg
+            it.contentPane.background = bg
+        }
         isJbrTitleBarActive = true
-    } catch (_: Exception) {
-        // Graceful degradation — standard title bar
+    } catch (e: Throwable) {
+        println("[TitleBar] JBR custom title bar failed: $e")
     }
 }

--- a/player/run-desktop.ps1
+++ b/player/run-desktop.ps1
@@ -16,6 +16,13 @@
 .NOTES
   SDL2: set $env:SDL2_DIR to the SDL2 'cmake' dir to override auto-detection.
   Auto-detection looks for %USERPROFILE%\SDL2\SDL2-*\cmake.
+
+  Title bar: the transparent title bar on Windows/Linux requires the JetBrains
+  Runtime (JBR). This script runs on JBR if found (override with $env:SPELA_JBR,
+  else auto-detected under %USERPROFILE%\jbr\jbr-*); otherwise it falls back to
+  the machine JDK and the title bar is opaque (dev only — release builds package
+  JBR). Download a JBR build from https://cache-redirector.jetbrains.com/intellij-jbr/
+  and unpack it under %USERPROFILE%\jbr\.
 #>
 param([Parameter(ValueFromRemainingArguments = $true)] [string[]] $GradleArgs)
 
@@ -30,8 +37,22 @@ if (-not $vsPath) { throw "No Visual Studio / Build Tools installation found." }
 Import-Module (Join-Path $vsPath 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll')
 Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64' | Out-Null
 
-# --- JDK / Vulkan / Android from machine/user env ---
-$env:JAVA_HOME  = [System.Environment]::GetEnvironmentVariable('JAVA_HOME', 'Machine')
+# --- JDK: prefer the JetBrains Runtime so the window gets a transparent title
+#     bar (same as release builds; see applyJbrTransparentTitleBar in Main.kt).
+#     Override with $env:SPELA_JBR; else auto-detect %USERPROFILE%\jbr\jbr-*.
+#     Falls back to the machine JDK (opaque title bar) if no JBR is present. ---
+$jbr = $env:SPELA_JBR
+if (-not $jbr) {
+    $jbrDir = Get-ChildItem "$env:USERPROFILE\jbr\jbr-*" -Directory -ErrorAction SilentlyContinue |
+        Sort-Object Name -Descending | Select-Object -First 1
+    if ($jbrDir) { $jbr = $jbrDir.FullName }
+}
+if ($jbr -and (Test-Path (Join-Path $jbr 'bin\java.exe'))) {
+    $env:JAVA_HOME = $jbr
+} else {
+    $env:JAVA_HOME = [System.Environment]::GetEnvironmentVariable('JAVA_HOME', 'Machine')
+    Write-Warning "JetBrains Runtime not found; using $env:JAVA_HOME (title bar will be opaque). Set `$env:SPELA_JBR or unpack a JBR under %USERPROFILE%\jbr\."
+}
 $env:VULKAN_SDK = [System.Environment]::GetEnvironmentVariable('VULKAN_SDK', 'Machine')
 if (-not $env:ANDROID_HOME) {
     $env:ANDROID_HOME = [System.Environment]::GetEnvironmentVariable('ANDROID_HOME', 'User')


### PR DESCRIPTION
## Summary
Fixes the transparent window title bar on **Windows/Linux**. Closes #1204.

## Root cause
The desktop title bar was wired through `jetbrains.awt.customTitleBar.enabled` / `jetbrains.awt.transparentTitleBarAppearance` **client properties**, which the JetBrains Runtime ignores — so the title bar was never actually transparent on Windows/Linux. macOS was unaffected because it uses the JDK-agnostic `apple.awt.*` properties. This meant the bar was opaque both in dev *and* in release (which already packages JBR).

## Fix
- `Main.kt`: use the real JBR API — `JBR.getWindowDecorations().setCustomTitleBar(window, customTitleBar)` — invoked **reflectively** so non-JBR JDKs degrade gracefully (the title bar just stays standard). The `setCustomTitleBar` overload is matched to the window type at runtime (`(Frame, …)` for Compose's `ComposeWindow`).
- `run-desktop.ps1`: launch the dev app on the **JetBrains Runtime** (auto-detected under `%USERPROFILE%\jbr\jbr-*`, or `$env:SPELA_JBR`), falling back to the machine JDK (opaque, with a warning). This makes the dev window match release, which already uses JBR for Windows/Linux.

Net effect: transparent title bar now works on Windows/Linux in **both** dev (JBR launcher) and release (already JBR). CI stays on Temurin (no JBR download → avoids the GitHub API rate limit that originally pushed CI off JBR, #125).

## Testing
- Full desktop suite green (`:shared:desktopTest` + `:desktop:desktopTest`).
- Manually verified on Windows (JBR 21.0.11): title bar is transparent (gradient shows through), window controls (min/max/close) and dragging work, and content isn't clipped under the bar.

## Note
`applyJbrTransparentTitleBar` is reflective desktop entry-point code against a JBR-only API; it can't be meaningfully unit-tested without a JBR runtime, so it's covered by manual verification.
