### PR TITLE
fix(player): per-console & console-list UI fixes (#1216 #1217 #1218)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ConsoleDetailBrowseSectionTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ConsoleDetailBrowseSectionTest.kt
@@ -8,6 +8,7 @@ import com.spela.player.presentation.ui.TestTags
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 /**
  * Desktop E2E tests for the console detail screen changes from #1095:
@@ -169,6 +170,42 @@ class ConsoleDetailBrowseSectionTest {
         advanceQuick(harness)
 
         onNodeWithTag(TestTags.CONSOLE_ADMIN_MENU_SETTINGS).assertIsDisplayed()
+    }
+
+    // ─────────────────────────────────────────────────
+    // Console settings button (available to all users)
+    // ─────────────────────────────────────────────────
+
+    @Test
+    fun consoleSettingsButtonVisibleForNonAdmin() = runComposeUiTest {
+        val harness = createHarness()
+        // Default FakeAuthRepository returns role "player" — non-admin
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        advanceFully(harness)
+
+        onNodeWithTag(TestTags.CONSOLE_SETTINGS_BUTTON).assertIsDisplayed()
+    }
+
+    @Test
+    fun consoleSettingsButtonNavigatesToConsoleSettings() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        advanceFully(harness)
+
+        onNodeWithTag(TestTags.CONSOLE_SETTINGS_BUTTON).performClick()
+        advance(harness)
+
+        assertEquals(
+            SpScreen.ConsoleSettings("nes"),
+            harness.navigationViewModel.state.value.currentScreen,
+            "Console settings button should navigate to ConsoleSettings(\"nes\")",
+        )
     }
 
     // ─────────────────────────────────────────────────

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
@@ -133,6 +133,35 @@ class SettingsConsoleNavigationTest {
     }
 
     @Test
+    fun backFromConsoleSettingsReturnsToPerConsoleNotGeneral() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToSettings(harness)
+        navigateToControlsCategory(harness)
+
+        // Into a console's settings...
+        onNodeWithText("Nintendo Entertainment System").performClick()
+        advance(harness)
+        assertEquals(
+            SpScreen.ConsoleSettings("nes"),
+            harness.navigationViewModel.state.value.currentScreen,
+        )
+
+        // ...then Back. We should return to the Per-Console list, not General.
+        harness.navigationViewModel.onIntent(NavigationIntent.GoBack)
+        advance(harness)
+
+        assertEquals(
+            SpScreen.Settings,
+            harness.navigationViewModel.state.value.currentScreen,
+        )
+        // The console rows are only rendered in the Per-Console category content;
+        // before the rememberSaveable fix this reset to General and the rows were gone.
+        onNodeWithText("Nintendo Entertainment System").assertIsDisplayed()
+    }
+
+    @Test
     fun consoleSettingsRowsHaveArrowIcon() = runComposeUiTest {
         val harness = createLoggedInHarness()
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/TestTags.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/TestTags.kt
@@ -67,6 +67,7 @@ object TestTags {
     const val CONSOLE_BROWSE_ALL_CTA = "console_browse_all_cta"
     const val CONSOLE_ADMIN_MENU_BUTTON = "console_admin_menu_button"
     const val CONSOLE_ADMIN_MENU_SETTINGS = "console_admin_menu_settings"
+    const val CONSOLE_SETTINGS_BUTTON = "console_settings_button"
 
     // Game detail — primary CTA changes label between Play / Resume / Download
     // depending on save + cache state. Tests should target the tag, not the

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -242,6 +242,7 @@ internal fun ConsoleCard(
                 SpImage(
                     model = console.iconUrl,
                     contentDescription = null,
+                    staggerMs = 0L, // eager: bounded console list, no request stagger
                     modifier = Modifier.fillMaxSize(),
                 )
             } else {
@@ -458,6 +459,7 @@ private fun ConsoleHeroBannerContent(
                 SpImage(
                     model = console.iconUrl,
                     contentDescription = null,
+                    staggerMs = 0L, // eager: bounded console list, no request stagger
                     modifier = Modifier.size(224.dp),
                 )
             } else {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleListSort.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleListSort.kt
@@ -1,0 +1,13 @@
+package com.spela.player.presentation.ui.screen
+
+import com.spela.player.domain.model.Console
+
+/**
+ * Ordering for flat console lists (e.g. the Per-Console settings list):
+ * alphabetical by name, case-insensitive.
+ *
+ * Note: the main Consoles library screen intentionally groups consoles by
+ * generation/manufacturer and is not affected by this.
+ */
+internal fun List<Console>.sortedForConsoleList(): List<Console> =
+    sortedBy { it.name.lowercase() }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -334,6 +334,15 @@ fun ConsoleScreen(
                 onGradient = true,
                 onBack = onBack,
                 actions = {
+                    // Console settings (controls, shaders, …) — available to every
+                    // user since these are per-user, per-console preferences.
+                    SpIconButton(
+                        icon = Icons.Filled.Settings,
+                        contentDescription = "Console settings",
+                        onGradient = true,
+                        onClick = onNavigateToConsoleSettings,
+                        modifier = Modifier.testTag(TestTags.CONSOLE_SETTINGS_BUTTON),
+                    )
                     if (state.isAdmin) {
                         var adminMenuExpanded by remember { mutableStateOf(false) }
                         Box {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
@@ -282,7 +282,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.consolesContent(
 ) {
     if (state.consoles.isNotEmpty()) {
         items(
-            items = state.consoles,
+            items = state.consoles.sortedForConsoleList(),
             key = { "console_${it.id}" },
         ) { console ->
             SpCard(
@@ -300,6 +300,9 @@ private fun androidx.compose.foundation.lazy.LazyListScope.consolesContent(
                         SpImage(
                             model = console.iconUrl,
                             contentDescription = null,
+                            // Eager load: the console list is short and bounded, so
+                            // skip the request stagger to avoid logos popping in.
+                            staggerMs = 0L,
                             modifier = Modifier.size(32.dp).alpha(0.7f),
                         )
                     } else {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -57,10 +59,14 @@ fun SettingsScreen(
         keyMappingViewModel?.onIntent(KeyMappingIntent.LoadMapping("__default__"))
     }
 
-    // Selected category state
-    var selectedCategory by remember { mutableStateOf(SettingsCategory.GENERAL) }
-    // On phones, null means showing the category list
-    var showingDetail by remember { mutableStateOf(false) }
+    // Selected category state. Saveable so it survives forward+back navigation
+    // (e.g. into a console's settings and back) instead of resetting to General.
+    var selectedCategory by rememberSaveable(
+        stateSaver = Saver(save = { it.name }, restore = { SettingsCategory.valueOf(it) }),
+    ) { mutableStateOf(SettingsCategory.GENERAL) }
+    // On phones, false means showing the category list. Also saveable so we
+    // return to the detail (not the list) after navigating back.
+    var showingDetail by rememberSaveable { mutableStateOf(false) }
 
     // Dialogs (shared across all categories)
     SettingsDialogs(

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/ui/screen/ConsoleListSortTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/ui/screen/ConsoleListSortTest.kt
@@ -1,0 +1,31 @@
+package com.spela.player.presentation.ui.screen
+
+import com.spela.player.domain.model.Console
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConsoleListSortTest {
+
+    private fun console(name: String) =
+        Console(id = name.lowercase(), name = name, abbreviation = name.take(3), gameCount = 0)
+
+    @Test
+    fun sortsAlphabeticallyCaseInsensitive() {
+        val input = listOf(
+            console("Super Nintendo"),
+            console("atari 2600"),
+            console("Nintendo 64"),
+            console("Dreamcast"),
+        )
+        val sorted = input.sortedForConsoleList().map { it.name }
+        assertEquals(
+            listOf("atari 2600", "Dreamcast", "Nintendo 64", "Super Nintendo"),
+            sorted,
+        )
+    }
+
+    @Test
+    fun emptyListStaysEmpty() {
+        assertEquals(0, emptyList<Console>().sortedForConsoleList().size)
+    }
+}


### PR DESCRIPTION
## Summary
A batch of per-console / console-list UI fixes found during Windows testing. Each commit is one issue with E2E/unit tests.

Closes #1218, #1217, #1216.

## Changes

### #1218 — Back from console settings returned to "General"
`SettingsScreen` kept `selectedCategory` / `showingDetail` in plain `remember`, so navigating into a console's settings and back reset the screen to the General category. Switched to `rememberSaveable` so the active category (and the phone detail state) survive forward+back navigation.
- Test: `SettingsConsoleNavigationTest.backFromConsoleSettingsReturnsToPerConsoleNotGeneral`.

### #1217 — Per-Console list unsorted + logos popping in
- Sort the Per-Console settings list alphabetically by name (case-insensitive) via a small tested helper `sortedForConsoleList()`.
- Eager-load console logos: they used `SpImage`'s random 0–1000ms request stagger (right for big game grids, wrong for a short bounded console list). Pass `staggerMs = 0L` in the Per-Console list and the console-card watermarks.
- The main Consoles library screen keeps its intentional generation/manufacturer grouping (only its logos are eager-loaded).
- Test: `ConsoleListSortTest` (unit).

### #1216 — No "Console settings" button on the console screen
Per-console controls/shaders were only reachable via the **admin-only** overflow menu. Added an always-visible "Console settings" button (navigates to `ConsoleSettings(consoleId)`) — these are per-user, per-console preferences, so they shouldn't be admin-gated. The admin overflow menu is unchanged.
- Tests: `ConsoleDetailBrowseSectionTest.consoleSettingsButtonVisibleForNonAdmin` + `…NavigatesToConsoleSettings`.

## Testing
Full desktop suite green locally (`:shared:desktopTest` + `:desktop:desktopTest`).

## Not included
- #1219 (per-console shader not persisted) — deferred; it's in the preferences persistence layer (see investigation comment on the issue).
- #1215 (title bar +30% padding) — trivial constant tweak, not E2E-verifiable; can fold into the title-bar follow-up.
