### PR TITLE
perf(player): render desktop CRT/scanline/LCD shaders on the GPU (#1209)

### DIFF
--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopEmulationSurface.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopEmulationSurface.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.spela.player.domain.model.ShaderPreset
-import com.spela.player.presentation.ui.feature.shader.drawShaderOverlay
 import com.spela.player.presentation.ui.feature.shader.filterQuality
 import com.spela.player.presentation.viewmodel.LibretroAnalog
 import com.spela.player.presentation.viewmodel.LibretroButtons
@@ -248,6 +247,11 @@ private fun DrawScope.drawScaledBitmap(bitmap: ImageBitmap, shader: ShaderPreset
     val dstSize = IntSize(dstWidth, dstHeight)
     val srcSize = IntSize(bitmap.width, bitmap.height)
 
+    // CRT / scanlines / LCD render as a single GPU fragment pass (#1209) instead
+    // of per-frame Compose geometry that scaled with output resolution. Returns
+    // false for pass-through presets and on failure, where we draw plainly.
+    if (drawWithDesktopShader(bitmap, shader, dstOffset, dstSize, srcSize)) return
+
     drawImage(
         image = bitmap,
         srcOffset = IntOffset.Zero,
@@ -256,8 +260,6 @@ private fun DrawScope.drawScaledBitmap(bitmap: ImageBitmap, shader: ShaderPreset
         dstSize = dstSize,
         filterQuality = shader.filterQuality(),
     )
-
-    drawShaderOverlay(shader, dstOffset, dstSize, srcSize)
 }
 
 /**

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopShaderEffect.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopShaderEffect.kt
@@ -1,0 +1,136 @@
+package com.spela.player.libretro
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asSkiaBitmap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import com.spela.player.domain.model.ShaderPreset
+import org.jetbrains.skia.FilterTileMode
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.Paint
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.RuntimeEffect
+import org.jetbrains.skia.RuntimeShaderBuilder
+import org.jetbrains.skia.SamplingMode
+
+/**
+ * GPU post-processing shaders for the desktop emulation surface.
+ *
+ * The shared [com.spela.player.presentation.ui.feature.shader.drawShaderOverlay]
+ * draws CRT/scanline/LCD effects as Compose geometry (hundreds of drawLine calls
+ * + a radial gradient) every frame — its cost scales with output resolution and
+ * collapses to single-digit FPS at fullscreen (#1209). On desktop we instead run
+ * a single Skia [RuntimeEffect] (SkSL) fragment pass over the output, which is
+ * GPU-bound and effectively free even at 4K.
+ *
+ * Ports of the native GLSL presets in `native/shaders/`. The `image` child shader
+ * samples the source frame in source-pixel space; `coord` arrives in output-local
+ * space (the rect is drawn translated to the destination origin).
+ */
+private const val SCANLINES_SKSL = """
+uniform shader image;
+uniform float2 uResolution;
+uniform float2 uTexSize;
+half4 main(float2 coord) {
+    float2 uv = coord / uResolution;
+    half4 color = image.eval(uv * uTexSize);
+    float p = fract(uv.y * uTexSize.y);
+    float mask = smoothstep(0.0, 0.35, p) * smoothstep(1.0, 0.65, p);
+    mask = mix(0.7, 1.0, mask);
+    return half4(color.rgb * half(mask), color.a);
+}
+"""
+
+private const val CRT_SKSL = """
+uniform shader image;
+uniform float2 uResolution;
+uniform float2 uTexSize;
+half4 main(float2 coord) {
+    float2 uv = coord / uResolution;
+    half4 color = image.eval(uv * uTexSize);
+    float p = fract(uv.y * uTexSize.y);
+    float sl = smoothstep(0.0, 0.3, p) * smoothstep(1.0, 0.7, p);
+    sl = mix(0.6, 1.0, sl);
+    float2 c = uv - 0.5;
+    float dist = length(c) * 1.414;
+    float vignette = clamp(1.0 - dist * dist * 0.5, 0.0, 1.0);
+    float m = sl * vignette;
+    return half4(color.rgb * half(m), color.a);
+}
+"""
+
+private const val LCD_SKSL = """
+uniform shader image;
+uniform float2 uResolution;
+uniform float2 uTexSize;
+half4 main(float2 coord) {
+    float2 uv = coord / uResolution;
+    half4 color = image.eval(uv * uTexSize);
+    float2 pp = fract(uv * uTexSize);
+    float ex = 0.1;
+    float ey = 0.15;
+    float px = smoothstep(0.0, ex, pp.x) * smoothstep(1.0, 1.0 - ex, pp.x);
+    float py = smoothstep(0.0, ey, pp.y) * smoothstep(1.0, 1.0 - ey, pp.y);
+    float grid = mix(0.5, 1.0, px * py);
+    return half4(color.rgb * half(grid), color.a);
+}
+"""
+
+/** SkSL source for presets rendered via a fragment shader, or null for the
+ *  pass-through / filter-only presets (NONE / BILINEAR / SHARP_BILINEAR). */
+internal fun ShaderPreset.desktopSksl(): String? = when (this) {
+    ShaderPreset.SCANLINES -> SCANLINES_SKSL
+    ShaderPreset.CRT_SIMPLE -> CRT_SKSL
+    ShaderPreset.LCD_GRID -> LCD_SKSL
+    ShaderPreset.NONE, ShaderPreset.BILINEAR, ShaderPreset.SHARP_BILINEAR -> null
+}
+
+/** Compiled-effect cache, keyed by SkSL source (compiling is the costly step). */
+private val effectCache = HashMap<String, RuntimeEffect>()
+
+/**
+ * Draws [bitmap] into the destination rect with [shader]'s fragment effect.
+ * Returns true if it handled drawing; false for pass-through presets or on
+ * failure (the caller should then fall back to a plain [DrawScope.drawImage]).
+ */
+internal fun DrawScope.drawWithDesktopShader(
+    bitmap: ImageBitmap,
+    shader: ShaderPreset,
+    dstOffset: IntOffset,
+    dstSize: IntSize,
+    srcSize: IntSize,
+): Boolean {
+    val sksl = shader.desktopSksl() ?: return false
+    if (dstSize.width <= 0 || dstSize.height <= 0) return false
+    return try {
+        val effect = effectCache.getOrPut(sksl) { RuntimeEffect.makeForShader(sksl) }
+        val image = Image.makeFromBitmap(bitmap.asSkiaBitmap())
+        // Nearest sampling — these presets layer on top of a pixel-perfect base.
+        val imageShader = image.makeShader(
+            FilterTileMode.CLAMP,
+            FilterTileMode.CLAMP,
+            SamplingMode.DEFAULT,
+            null,
+        )
+        val builder = RuntimeShaderBuilder(effect).apply {
+            uniform("uResolution", dstSize.width.toFloat(), dstSize.height.toFloat())
+            uniform("uTexSize", srcSize.width.toFloat(), srcSize.height.toFloat())
+            child("image", imageShader)
+        }
+        val paint = Paint().apply { this.shader = builder.makeShader(null) }
+        drawIntoCanvas { canvas ->
+            val nc = canvas.nativeCanvas
+            nc.save()
+            nc.translate(dstOffset.x.toFloat(), dstOffset.y.toFloat())
+            nc.drawRect(Rect.makeWH(dstSize.width.toFloat(), dstSize.height.toFloat()), paint)
+            nc.restore()
+        }
+        true
+    } catch (e: Throwable) {
+        println("[Shader] desktop RuntimeEffect failed (${e.message}); using plain draw")
+        false
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/DesktopShaderEffectTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/DesktopShaderEffectTest.kt
@@ -1,0 +1,27 @@
+package com.spela.player.libretro
+
+import com.spela.player.domain.model.ShaderPreset
+import org.jetbrains.skia.RuntimeEffect
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class DesktopShaderEffectTest {
+
+    @Test
+    fun effectPresetsHaveCompilableSksl() {
+        listOf(ShaderPreset.SCANLINES, ShaderPreset.CRT_SIMPLE, ShaderPreset.LCD_GRID).forEach { preset ->
+            val sksl = preset.desktopSksl()
+            assertNotNull(sksl, "$preset should provide SkSL")
+            // Throws on invalid SkSL — guards against shader syntax regressions.
+            RuntimeEffect.makeForShader(sksl)
+        }
+    }
+
+    @Test
+    fun passThroughPresetsHaveNoSksl() {
+        listOf(ShaderPreset.NONE, ShaderPreset.BILINEAR, ShaderPreset.SHARP_BILINEAR).forEach { preset ->
+            assertNull(preset.desktopSksl(), "$preset should not use a fragment shader")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the fullscreen FPS collapse with shaders enabled on desktop. Closes #1209.

## Root cause (confirmed)
The shared `drawShaderOverlay` renders CRT/scanlines/LCD as **per-frame Compose geometry** — hundreds of full-width `drawLine` calls (one per source row/col) plus a `radialGradient` fill for CRT — over the entire output. That cost scales with output resolution, so windowed is fine but fullscreen (4K) drops to single-digit FPS. Verified on Windows: NES/SNES with a shader stutter at fullscreen; with shader = NONE it's smooth.

## Fix
On desktop, render these presets as a **single Skia `RuntimeEffect` (SkSL) fragment pass** over the output — GPU-bound and effectively free even at 4K.
- New `DesktopShaderEffect.kt`: SkSL ports of the native GLSL presets (scanlines / CRT / LCD), a compiled-effect cache, and `drawWithDesktopShader`.
- `DesktopEmulationSurface.drawScaledBitmap` uses it for CRT/SCANLINES/LCD; pass-through presets (NONE/BILINEAR/SHARP_BILINEAR) and any failure fall back to the existing plain `drawImage`.
- The shared `drawShaderOverlay` is **untouched** — still used by Android and the shader preview.

## Testing
- Unit test `DesktopShaderEffectTest`: each effect preset's SkSL compiles via `RuntimeEffect.makeForShader` (guards against shader syntax regressions) and pass-through presets have no SkSL.
- Full desktop suite green locally.
- ⚠️ **Visual verification pending**: the SkSL is ported 1:1 from the existing GLSL, but the on-screen look (and the fullscreen FPS recovery) should be eyeballed on a real desktop run. Safe to iterate — pass-through presets are unchanged and there's a graceful fallback.
