### PR TITLE
fix(server): persist per-console shader re-selected after clearing to none (#1219)

### DIFF
--- a/server/internal/api/console_shader_preference_test.go
+++ b/server/internal/api/console_shader_preference_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdatePreferences_ConsoleShaderResetAfterClear reproduces #1219:
+// selecting a per-console shader, clearing it to "none" (a soft-delete),
+// then selecting a shader again must persist. Before the fix the
+// re-select hit the (user_id, console_id) unique index against the
+// soft-deleted row, the Create failed silently, and the shader "reset"
+// when the user left and returned to the console settings screen.
+func TestUpdatePreferences_ConsoleShaderResetAfterClear(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	putShader := func(shader string) map[string]interface{} {
+		body, _ := json.Marshal(map[string]interface{}{
+			"consoleShaders": map[string]string{"nes": shader},
+		})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+		var prefs map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs))
+		return prefs
+	}
+
+	putShader("crt-simple")
+	putShader("none") // clears (soft-delete)
+	prefs := putShader("lcd-grid")
+
+	shaders, ok := prefs["consoleShaders"].(map[string]interface{})
+	require.True(t, ok, "consoleShaders missing from PUT response")
+	assert.Equal(t, "lcd-grid", shaders["nes"], "re-selected shader must persist after a clear")
+
+	// And it survives a fresh GET (the "leave and return" the user saw reset).
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/preferences", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var prefs2 map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs2))
+	shaders = prefs2["consoleShaders"].(map[string]interface{})
+	assert.Equal(t, "lcd-grid", shaders["nes"], "re-selected shader must survive a GET after a clear")
+}

--- a/server/internal/api/huma_user_mutations.go
+++ b/server/internal/api/huma_user_mutations.go
@@ -249,10 +249,19 @@ func (h *UserHandler) HumaUpdatePreferences(ctx context.Context, in *UpdatePrefe
 				h.DB.Where("user_id = ? AND console_id = ?", uid, console.ID).
 					Delete(&db.ConsoleShaderPreference{})
 			} else {
+				// Unscoped lookup so a previously soft-deleted row (from
+				// clearing the shader to "none") is revived in place. A
+				// scoped First would miss it and the subsequent Create
+				// would hit the (user_id, console_id) unique index and
+				// silently fail, dropping the new selection (#1219).
+				// Mirrors the ConsoleKeyMapping / ConsoleSaveStatePolicy
+				// upserts below.
 				var existing db.ConsoleShaderPreference
-				result := h.DB.Where("user_id = ? AND console_id = ?", uid, console.ID).First(&existing)
+				result := h.DB.Unscoped().Where("user_id = ? AND console_id = ?", uid, console.ID).First(&existing)
 				if result.Error == nil {
-					h.DB.Model(&existing).Update("shader", shader)
+					existing.Shader = shader
+					existing.DeletedAt = gorm.DeletedAt{}
+					h.DB.Unscoped().Save(&existing)
 				} else {
 					h.DB.Create(&db.ConsoleShaderPreference{
 						UserID:    uid,


### PR DESCRIPTION
Closes #1219.

## Root cause
`ConsoleShaderPreference` is **soft-deleted** (`DeletedAt`) when a console's shader is set to `none`, and the table has a unique index on `(user_id, console_id)`. The re-select path used a **scoped** `First`/`Create`: the scoped `First` skips the soft-deleted row, then `Create` collides with it on the unique index. That error was ignored, so the new selection was **silently dropped** — the shader appeared to reset when the user left and returned to the console settings screen.

The sibling per-console upserts (`ConsoleKeyMappingPreference`, `ConsoleSaveStatePolicy`) already avoid this with **Unscoped revival**; the shader upsert was the odd one out.

## Fix
Upsert via `Unscoped()`: revive the existing row in place (set `Shader`, clear `DeletedAt`) instead of creating a new one. Idempotent and consistent with the other two.

## Test
`TestUpdatePreferences_ConsoleShaderResetAfterClear` — set shader → clear to `none` → re-select → assert it persists via PUT response and a fresh GET. Confirmed **failing before** (re-selected shader came back `nil`) and **passing after**. Existing shader tests still pass.

Server-only change; not reproducible via the player E2E fakes (fixed fake repo). Full `go test ./...` has some pre-existing **Windows-only** filesystem/path failures (readonly-dir, path separators) unrelated to this change — filing separately; Linux CI is the gate.