### PR TITLE
fix(server): accept comma/apostrophe/&/! in BIOS download filename validation (#1208)

### DIFF
--- a/server/internal/api/bios_special_chars_test.go
+++ b/server/internal/api/bios_special_chars_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// neoGeoPocketBiosName is a real No-Intro-style BIOS filename with spaces,
+// brackets, parentheses and a comma — the case from #1208.
+const neoGeoPocketBiosName = "[BIOS] SNK NeoGeo Pocket (Japan, Europe) (En).bin"
+
+// TestGetBiosFile_SpecialCharNameNotValidationError reproduces #1208: a BIOS
+// filename containing a comma (and brackets/parens/spaces) must not be
+// rejected by the path-param character whitelist with a 422. When the file
+// is absent the correct answer is a plain 404, same as any other missing
+// BIOS, not "validation failed".
+func TestGetBiosFile_SpecialCharNameNotValidationError(t *testing.T) {
+	_, database, router := setupBiosTestEnv(t)
+	token := createBiosTestUser(t, database, "user")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/bios/"+url.PathEscape(neoGeoPocketBiosName), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusUnprocessableEntity, w.Code,
+		"special-character BIOS name must not fail path validation (#1208)")
+	assert.Equal(t, http.StatusNotFound, w.Code,
+		"absent BIOS should return a plain 404")
+}
+
+// TestGetBiosFile_SpecialCharNameServesWhenPresent confirms the end-to-end
+// path: a present BIOS file with special characters in its name is served.
+func TestGetBiosFile_SpecialCharNameServesWhenPresent(t *testing.T) {
+	store, database, router := setupBiosTestEnv(t)
+	token := createBiosTestUser(t, database, "user")
+
+	require.NoError(t, os.WriteFile(filepath.Join(store.BiosDir, neoGeoPocketBiosName), []byte("ngp bios"), 0644))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/bios/"+url.PathEscape(neoGeoPocketBiosName), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "ngp bios", w.Body.String())
+}

--- a/server/internal/api/huma_bios.go
+++ b/server/internal/api/huma_bios.go
@@ -25,7 +25,7 @@ type ListBiosFilesOutput struct {
 
 // DeleteBiosFileInput is the input for DELETE /api/admin/bios/{filename}.
 type DeleteBiosFileInput struct {
-	Filename string `path:"filename" pattern:"^[A-Za-z0-9._()\\[\\] +-]+$" maxLength:"128" doc:"BIOS file name."`
+	Filename string `path:"filename" pattern:"^[A-Za-z0-9._()\\[\\],'&! +-]+$" maxLength:"128" doc:"BIOS file name."`
 }
 
 // DeleteBiosFileOutput wraps the delete success message.

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -143,7 +143,7 @@ type CoreDownloadInput struct {
 
 // BiosDownloadInput is the input for GET /api/bios/{filename}.
 type BiosDownloadInput struct {
-	Filename string `path:"filename" pattern:"^[A-Za-z0-9._()\\[\\] +-]+$" maxLength:"128" doc:"BIOS file name."`
+	Filename string `path:"filename" pattern:"^[A-Za-z0-9._()\\[\\],'&! +-]+$" maxLength:"128" doc:"BIOS file name."`
 }
 
 // BiosArchiveDownloadInput is the input for GET /api/bios/archive/{filename}.
@@ -151,7 +151,7 @@ type BiosDownloadInput struct {
 // server returns a zip of `<biosDir>/<SubDir>/` so the client can extract
 // the directory tree on the device.
 type BiosArchiveDownloadInput struct {
-	Filename string `path:"filename" pattern:"^[A-Za-z0-9._()\\[\\] +-]+$" maxLength:"128" doc:"Sentinel filename of the bundle entry (matches registry FileName)."`
+	Filename string `path:"filename" pattern:"^[A-Za-z0-9._()\\[\\],'&! +-]+$" maxLength:"128" doc:"Sentinel filename of the bundle entry (matches registry FileName)."`
 }
 
 // SessionSaveDownloadInput is the input for GET /api/sessions/{id}/saves/{saveId}.
@@ -216,7 +216,7 @@ type BrandingLogoInput struct{}
 // under a download-friendly name without changing the served bytes.
 type GameDownloadInput struct {
 	ID       string `path:"id" pattern:"^[0-9]+$" maxLength:"20" doc:"Game ID."`
-	Filename string `path:"filename" required:"false" pattern:"^[A-Za-z0-9._()\\[\\] +-]+$" maxLength:"128" doc:"Optional download filename — server ignores it; lets clients control the saved filename."`
+	Filename string `path:"filename" required:"false" pattern:"^[A-Za-z0-9._()\\[\\],'&! +-]+$" maxLength:"128" doc:"Optional download filename — server ignores it; lets clients control the saved filename."`
 	Format   string `query:"format" required:"false" doc:"'zip' to force ZIP packaging for multi-file disc games. Default is .tar (or single-file passthrough)."`
 }
 


### PR DESCRIPTION
Closes #1208.

## Root cause
The path-param whitelist `^[A-Za-z0-9._()\[\] +-]+\$` allowed spaces, brackets and parentheses but **not commas**. So a real No-Intro-style BIOS name like:

`[BIOS] SNK NeoGeo Pocket (Japan, Europe) (En).bin`

failed Huma path validation with **422 'validation failed'** before the handler could even check existence — instead of the plain **404** that plain-named missing BIOS files return.

## Fix
Broaden the character class to also allow `, ' & !` — all common in ROM/BIOS filenames — across the four download path params that shared the identical pattern (BIOS download, BIOS archive, game download, admin BIOS delete). No path separators, colon or drive chars are added, so directory traversal stays blocked (`TestGetBiosFile_PathTraversal` still passes).

## Tests
- `TestGetBiosFile_SpecialCharNameNotValidationError` — an absent special-char BIOS now returns **404, not 422**.
- `TestGetBiosFile_SpecialCharNameServesWhenPresent` — a present special-char BIOS is served end-to-end.

Both fail before, pass after; existing BIOS tests (incl. path-traversal + MD5 mismatch) still pass.

Note: the file in the report isn't in the server BIOS registry, so it still 404s — but now correctly. Surfacing missing optional BIOS to the user is the separate #1207.