### PR TITLE
feat(player): desktop gamepad overlay nav, window drag, focus-on-connect, compact toggle (#1211 #1228 #1229 #1232)

### DIFF
--- a/docs/compose-desktop-transparent-window.md
+++ b/docs/compose-desktop-transparent-window.md
@@ -1,0 +1,201 @@
+# Building a borderless / transparent–title-bar desktop app (Compose Multiplatform)
+
+A field guide for creating cross-platform desktop apps that have **no visible app
+bar** — the app's own content (gradient, header, controls) extends edge-to-edge to
+the top of the window and shows *through* a transparent native title bar, like Spela.
+
+This is deceptively tricky. The OS still owns the window frame; you're making it
+transparent and drawing under it, then patching back the behaviours you lost
+(dragging, content not colliding with the native caption buttons). The mechanism is
+**different on each platform**, and the Windows path has two non-obvious traps that
+cost real debugging time. Read this before reaching for `undecorated = true`.
+
+> **Don't use `undecorated = true`** unless you intend to re-implement the entire
+> window frame yourself (drag, resize from all 8 edges, snap, maximize, native
+> min/max/close buttons, per-OS conventions). Keeping the native frame and just
+> making the title bar transparent is far less work and feels native.
+
+---
+
+## The model
+
+| Platform | Mechanism | Caption buttons | Draggable by default? |
+|---|---|---|---|
+| **macOS** | `apple.awt.*` rootPane client properties (OpenJDK) | top-**left** (traffic lights) | **Yes** |
+| **Windows** | JetBrains Runtime (JBR) `WindowDecorations.CustomTitleBar` | top-**right** | **No** — must opt in (see traps) |
+| **Linux** | JBR `WindowDecorations.CustomTitleBar` | WM-dependent | Yes (WM handles it) |
+
+Two consequences fall out of this table immediately:
+
+1. **Caption buttons live in opposite corners** (macOS left, Windows right). Any
+   interactive content you place in the *same* top corner as the buttons will
+   collide with them. Inset that content (see "Content inset" below).
+2. **Only Windows needs a manual drag fix.** Gate the Windows-specific code behind
+   an `isWindows` check so you don't disturb the working macOS/Linux behaviour.
+
+---
+
+## macOS
+
+Set three client properties on the window's `rootPane` (do it in a `LaunchedEffect`
+inside the `Window {}` composable, where `window` is in scope):
+
+```kotlin
+window.rootPane.putClientProperty("apple.awt.fullWindowContent", true)   // draw under the title bar
+window.rootPane.putClientProperty("apple.awt.transparentTitleBar", true) // make it transparent
+window.rootPane.putClientProperty("apple.awt.windowTitleVisible", false) // hide the title text
+// Opaque fallback color shown for the split second before Compose first renders:
+val bg = java.awt.Color(10, 10, 16)
+window.background = bg; window.rootPane.background = bg; window.contentPane.background = bg
+```
+
+macOS handles dragging itself. Nothing else to do. Traffic lights stay top-left.
+
+---
+
+## Windows / Linux (JetBrains Runtime)
+
+The transparent title bar comes from JBR's `WindowDecorations.CustomTitleBar`. Call
+it **reflectively** so the app still launches on a non-JBR JDK (dev machines,
+`./gradlew run` off a stock JDK) — `com.jetbrains.JBR` simply won't be present and
+you degrade to a normal title bar instead of crashing.
+
+```kotlin
+val jbr = Class.forName("com.jetbrains.JBR")
+val windowDecorations = jbr.getMethod("getWindowDecorations").invoke(null) ?: return // not JBR
+val wdInterface  = Class.forName("com.jetbrains.WindowDecorations")
+val ctbInterface = Class.forName("com.jetbrains.WindowDecorations\$CustomTitleBar")
+
+val titleBar = wdInterface.getMethod("createCustomTitleBar").invoke(windowDecorations)
+ctbInterface.getMethod("setHeight", java.lang.Float.TYPE).invoke(titleBar, 32f)
+
+// setCustomTitleBar is overloaded ((Frame, ..) / (Dialog, ..)) and the param types
+// vary by JBR version — match the overload to the actual window/title-bar types
+// instead of hard-coding a signature (reflecting the impl class throws
+// IllegalAccessException; use the PUBLIC interfaces).
+val setMethod = wdInterface.methods.first { m ->
+    m.name == "setCustomTitleBar" && m.parameterCount == 2 &&
+        m.parameterTypes[0].isInstance(window) && m.parameterTypes[1].isInstance(titleBar)
+}
+setMethod.invoke(windowDecorations, window, titleBar)
+```
+
+**Packaging:** this only works when the app actually runs on JBR. Bundle JBR with
+your distribution (`jpackage`/Conveyor/etc.). In CI, downloading the JBR runtime can
+hit rate limits on the download host — cache it or pin a mirror.
+
+**The native caption buttons are not app-resizable.** Their *height* tracks
+`setHeight`; their *width* is owned by the OS. So "make the buttons narrower" isn't
+available — change the height, or inset your content, instead.
+
+### Trap 1 — the window won't drag (Windows)
+
+Symptom: on Windows the window can't be moved by its top strip at all. Cause:
+Compose renders into one big opaque heavyweight surface that covers the whole
+window, so Windows hit-tests the entire title-bar strip as *client area* and never
+starts a drag.
+
+Fix: overlay an invisible strip across the top and, on each pointer event, tell JBR
+the region is **caption** (non-client) via `forceHitTest(false)`. Windows then
+handles a press there as a window drag — and the native min/max/close buttons keep
+working, because they're caption too, so you can cover the full width.
+
+```kotlin
+// captured when you create the title bar:
+val forceHitTest = ctbInterface.getMethod("forceHitTest", java.lang.Boolean.TYPE)
+fun markDraggable() = forceHitTest.invoke(titleBar, false) // false = non-client = caption/draggable
+
+// in the Window content, ON TOP of your app content, Windows only:
+if (isWindows && titleBarActive) {
+    Box(
+        Modifier.align(Alignment.TopStart).fillMaxWidth().height(titleBarInset)
+            .onPointerEvent(PointerEventType.Move)  { markDraggable() }
+            .onPointerEvent(PointerEventType.Enter) { markDraggable() }
+            .onPointerEvent(PointerEventType.Press) { markDraggable() }
+    )
+}
+```
+
+> **`forceHitTest` must be called synchronously during event dispatch.** Use
+> `Modifier.onPointerEvent` (fires inside Compose's dispatch, within the AWT event),
+> **not** `Modifier.pointerInput { awaitPointerEvent() }` — the coroutine resumes
+> *after* the OS hit-test window has passed, so the call is ignored and dragging
+> silently doesn't work. This is the single most time-wasting trap here.
+
+`forceHitTest(true)` = client (your app handles it, no drag); `forceHitTest(false)`
+= caption (OS handles drag / native buttons). For interactive content you place
+*inside* the strip, call `forceHitTest(true)` over it so clicks reach your control.
+
+### Trap 2 — the activation flag must be Compose state
+
+JBR setup runs in a `LaunchedEffect` (it needs the AWT `window`), i.e. **after** the
+first composition. If you store "is the custom title bar active?" in a plain
+`var`, the composable that reads it (your drag strip, your inset calc) captures
+`false` at first composition and **never recomposes** — so the drag strip is never
+even added to the tree. Back it with `mutableStateOf` so flipping it triggers
+recomposition:
+
+```kotlin
+private val titleBarActiveState = mutableStateOf(false)
+private var titleBarActive: Boolean
+    get() = titleBarActiveState.value
+    set(v) { titleBarActiveState.value = v }
+```
+
+(We chased "drag does nothing" for a while before realizing the strip wasn't being
+composed at all — no amount of `forceHitTest` tuning helps if the handler isn't in
+the tree.)
+
+---
+
+## Content inset — keep interactive content off the native buttons
+
+The whole point is full-bleed content, so your **background must reach the top
+edge** (draw it with `Modifier.drawBehind`/`background` on a full-size root). But
+**interactive** content at the top must not sit under the native caption buttons.
+
+Provide the title-bar height as a `CompositionLocal` and have screens offset their
+top content by it:
+
+```kotlin
+val LocalTitleBarInset = compositionLocalOf { 0.dp } // 0 on platforms w/o a custom bar
+
+val titleBarInset = when {
+    isMacOS -> 28.dp
+    (isWindows || isLinux) && titleBarActive -> 32.dp   // == setHeight
+    else -> 0.dp
+}
+CompositionLocalProvider(LocalTitleBarInset provides titleBarInset) { App() }
+```
+
+Rules of thumb:
+- Background/gradient: full-bleed to the top (draw before/under the inset).
+- Top bars, and any top-corner icons/actions: pad down by `LocalTitleBarInset`.
+- Put this inset in **one** place per screen. It's easy to end up applying it in a
+  top-bar component *and* a per-screen padding *and* a content padding and get
+  double/triple gaps. Centralize it (e.g. a single `ScreenTopSpacer` primitive that
+  every screen uses) rather than sprinkling `LocalTitleBarInset.current` everywhere.
+- Remember the corner asymmetry: a top-**right** action overlaps Windows buttons;
+  a top-**left** one overlaps macOS traffic lights.
+
+---
+
+## Checklist for a new app
+
+- [ ] `Window {}` with the native frame (NOT `undecorated`).
+- [ ] macOS: the three `apple.awt.*` rootPane properties + opaque fallback bg.
+- [ ] Windows/Linux: reflective JBR `CustomTitleBar`, `setHeight`, overload-matched
+      `setCustomTitleBar`; degrade gracefully off JBR.
+- [ ] Bundle JBR in the Windows/Linux distribution.
+- [ ] Activation flag backed by `mutableStateOf` (Trap 2).
+- [ ] Windows drag strip via `onPointerEvent` + `forceHitTest(false)`, gated to
+      `isWindows` (Trap 1).
+- [ ] `LocalTitleBarInset` provided; top content inset by it, background full-bleed.
+- [ ] Test on the platform you're NOT developing on — the mechanisms differ and
+      bugs are platform-specific (dragging, button overlap).
+
+## Reference implementation
+
+`player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt`
+(`applyJbrTransparentTitleBar`, the drag strip, `titleBarInset`) and
+`LocalTitleBarInset.kt`.

--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
@@ -1,11 +1,20 @@
 @file:Suppress("DEPRECATION")
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
 
 package com.spela.player.desktop
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.res.loadSvgPainter
 import androidx.compose.ui.res.useResource
 import androidx.compose.ui.unit.Density
@@ -109,11 +118,36 @@ fun main(args: Array<String>) {
         // through the transparent title bar.
         val titleBarInset = when {
             isMacOS -> 28.dp
-            (isWindows || isLinux) && isJbrTitleBarActive -> 42.dp
+            (isWindows || isLinux) && isJbrTitleBarActive -> 32.dp
             else -> 0.dp
         }
-        CompositionLocalProvider(LocalTitleBarInset provides titleBarInset) {
-            App()
+        Box(Modifier.fillMaxSize()) {
+            CompositionLocalProvider(LocalTitleBarInset provides titleBarInset) {
+                App()
+            }
+
+            // Windows: the JBR custom title bar reserves a transparent top strip,
+            // but Compose's heavyweight surface covers it, so by default the OS
+            // hit-tests the whole strip as client area and the window can't be
+            // dragged (#1228). Overlay an invisible strip that, on each pointer
+            // event, calls forceHitTest(false) to mark the region as caption —
+            // Windows then handles a press there as a window drag (and the native
+            // min/max/close buttons keep working, since they're caption too).
+            // (Linux/macOS title bars remain natively draggable — Windows only.)
+            if (isWindows && isJbrTitleBarActive) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .fillMaxWidth()
+                        .height(titleBarInset)
+                        // forceHitTest must run synchronously during event
+                        // dispatch (onPointerEvent), not from a pointerInput
+                        // coroutine which fires too late for the OS hit test.
+                        .onPointerEvent(PointerEventType.Move) { jbrMarkTitleBarDraggable() }
+                        .onPointerEvent(PointerEventType.Enter) { jbrMarkTitleBarDraggable() }
+                        .onPointerEvent(PointerEventType.Press) { jbrMarkTitleBarDraggable() },
+                )
+            }
         }
 
         // Auto-start a game when --game <gameId> is passed on the command line.
@@ -130,8 +164,33 @@ fun main(args: Array<String>) {
     }
 }
 
-/** Track whether JBR title bar was successfully applied. */
-private var isJbrTitleBarActive = false
+/** Track whether JBR title bar was successfully applied. Backed by Compose
+ *  state so the (async) activation in applyJbrTransparentTitleBar triggers
+ *  recomposition — otherwise the drag strip / inset never re-evaluate. */
+private val isJbrTitleBarActiveState = androidx.compose.runtime.mutableStateOf(false)
+private var isJbrTitleBarActive: Boolean
+    get() = isJbrTitleBarActiveState.value
+    set(value) { isJbrTitleBarActiveState.value = value }
+
+/** The JBR CustomTitleBar instance + its forceHitTest method, captured so the
+ *  Compose drag strip can mark the top region as draggable (#1228). */
+private var jbrTitleBar: Any? = null
+private var jbrForceHitTestMethod: java.lang.reflect.Method? = null
+
+/**
+ * Mark the current pointer position in the title-bar strip as non-client
+ * (caption), so Windows treats a press there as a window drag / native caption
+ * button rather than passing it to the (opaque) Compose surface. Must be called
+ * on each pointer event over the strip. No-op off JBR.
+ */
+private fun jbrMarkTitleBarDraggable() {
+    val tb = jbrTitleBar ?: return
+    val m = jbrForceHitTestMethod ?: return
+    try {
+        m.invoke(tb, false)
+    } catch (_: Throwable) {
+    }
+}
 
 /**
  * Apply transparent title bar via JetBrains Runtime (JBR) custom title bar API.
@@ -153,7 +212,17 @@ private fun applyJbrTransparentTitleBar(window: java.awt.Window) {
         val wdInterface = Class.forName("com.jetbrains.WindowDecorations")
         val ctbInterface = Class.forName("com.jetbrains.WindowDecorations\$CustomTitleBar")
         val titleBar = wdInterface.getMethod("createCustomTitleBar").invoke(windowDecorations)
-        ctbInterface.getMethod("setHeight", java.lang.Float.TYPE).invoke(titleBar, 42f)
+        ctbInterface.getMethod("setHeight", java.lang.Float.TYPE).invoke(titleBar, 32f)
+        // Capture for the Compose drag strip (#1228). forceHitTest(false) marks a
+        // point as non-client (caption) so the OS handles drag / native buttons.
+        jbrTitleBar = titleBar
+        jbrForceHitTestMethod = try {
+            ctbInterface.getMethod("forceHitTest", java.lang.Boolean.TYPE)
+        } catch (e: NoSuchMethodException) {
+            println("[TitleBar] forceHitTest not found; methods=" +
+                ctbInterface.methods.joinToString { it.name })
+            null
+        }
         // setCustomTitleBar is overloaded ((Frame, ..), (Dialog, ..)) and the param
         // types vary by JBR version, so match the overload to the actual arg types.
         val setMethod = wdInterface.methods.firstOrNull { m ->

--- a/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformEmulationSurface.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformEmulationSurface.android.kt
@@ -20,6 +20,9 @@ actual fun PlatformEmulationSurface(
     selectedShader: ShaderPreset,
     modifier: Modifier,
     onEscapePressed: (() -> Unit)?,
+    // Unused on Android — the overlay is navigated via the platform back gesture
+    // and Android's own gamepad key dispatch (#1211 is a desktop-input fix).
+    overlayVisible: Boolean,
 ) {
     val androidController = controller as? AndroidLibretroController ?: return
     val emulationViewModel: EmulationViewModel = koinInject()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -105,6 +106,17 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
             ?: remember { mutableStateOf(ControllerStatusState.Empty) }
         val isGamepadMode = resolveGamepadNavStyle(inputMode, controllerStatus)
         val sectionIndicatorVisible = isGamepadMode
+
+        // When a controller is connected, flip Compose into keyboard input mode so
+        // the current screen's default focusRestoreItem grabs focus and the focus
+        // ring is visible immediately — instead of nothing being focused until the
+        // first d-pad press (#1229). Compose's input mode is independent of the
+        // app's gamepad/touch nav style; using the mouse flips it back to Touch.
+        val inputModeManager = LocalInputModeManager.current
+        val hasController = controllerStatus.connectedCount > 0
+        LaunchedEffect(hasController) {
+            if (hasController) inputModeManager.requestInputMode(androidx.compose.ui.input.InputMode.Keyboard)
+        }
 
         // Indicator for E2E tests: exposes whether the libretro core is running.
         // Tests wait for "Core idle" instead of Thread.sleep after exiting games.

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -156,15 +156,25 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
             navigationViewModel.onIntent(NavigationIntent.GoBack)
         }
 
+        // The in-game pause overlay (Save/Load/Resume menu) is rendered while a
+        // game is open. Re-enable focus navigation for it so the gamepad can
+        // drive the menu (#1211): GamepadHandler is normally disabled in-game so
+        // the pad drives the emulator, but with the overlay open the emulation
+        // surface yields its keys and we want d-pad -> focus + A -> activate.
+        val inGameOverlayOpen = navState.showInGameOverlay && coreIdleState.showOverlay
         GamepadHandler(
-            enabled = !navState.showInGameOverlay,
-            onBack = if (isGamepadScreen) {
+            enabled = !navState.showInGameOverlay || inGameOverlayOpen,
+            onBack = if (inGameOverlayOpen) {
+                // A / Escape resumes (closes the overlay) rather than navigating.
+                { emulationViewModel.onIntent(EmulationIntent.ToggleOverlay) }
+            } else if (isGamepadScreen) {
                 { navigationViewModel.onIntent(NavigationIntent.GoBack) }
             } else null,
-            onNextSection = if (isGamepadScreen) {
+            // Section switching is meaningless while the pause overlay owns input.
+            onNextSection = if (isGamepadScreen && !inGameOverlayOpen) {
                 { navigationViewModel.onIntent(NavigationIntent.NextSection) }
             } else null,
-            onPreviousSection = if (isGamepadScreen) {
+            onPreviousSection = if (isGamepadScreen && !inGameOverlayOpen) {
                 { navigationViewModel.onIntent(NavigationIntent.PreviousSection) }
             } else null,
             onGamepadInput = {
@@ -394,6 +404,7 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
                             onEscapePressed = {
                                 emulationViewModel.onIntent(EmulationIntent.ToggleOverlay)
                             },
+                            overlayVisible = emulationState.showOverlay,
                         )
 
                         // Error overlay: shown when emulation fails to start

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSegmentedControl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSegmentedControl.kt
@@ -7,9 +7,12 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -98,7 +101,11 @@ fun <T> SpSegmentedControl(
         }
         Row(
             modifier = Modifier
-                .height(48.dp) // Material touch-target minimum
+                .height(36.dp) // Compact: a secondary filter, not a primary action
+                // Wrap to content width (left-aligned) instead of stretching to
+                // the parent's full width; segments stay equal via weight(1f)
+                // within the intrinsic width of the widest label.
+                .width(IntrinsicSize.Max)
                 .clip(outerShape)
                 .background(trackBackground)
                 .border(1.dp, trackBorder, outerShape)
@@ -170,6 +177,10 @@ private fun SpSegmentedControlSegment(
 
     Box(
         modifier = modifier
+            // Fill the track height so the selected pill matches the container
+            // instead of shrinking to the text's line height (which varies by
+            // platform — caused round-looking segments on Windows).
+            .fillMaxHeight()
             .padding(2.dp)
             .clip(innerShape)
             .background(background)
@@ -193,7 +204,7 @@ private fun SpSegmentedControlSegment(
     ) {
         Text(
             text = option.label,
-            style = SpTypography.LabelMedium,
+            style = SpTypography.LabelSmall,
             color = textColor,
         )
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformEmulationSurface.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformEmulationSurface.kt
@@ -13,6 +13,9 @@ import com.spela.player.presentation.viewmodel.LibretroController
  * [selectedShader] controls the video filter applied to the rendered frame.
  * [onEscapePressed] is invoked on Desktop when the user presses the Escape key.
  * On Android this parameter is unused (back is handled by PlatformBackHandler).
+ * [overlayVisible] is true while the in-game pause overlay is shown; on Desktop
+ * the surface then yields keyboard/gamepad input and focus so the overlay menu
+ * can be navigated (#1211). Unused on Android.
  */
 @Composable
 expect fun PlatformEmulationSurface(
@@ -20,4 +23,5 @@ expect fun PlatformEmulationSurface(
     selectedShader: ShaderPreset = ShaderPreset.NONE,
     modifier: Modifier = Modifier,
     onEscapePressed: (() -> Unit)? = null,
+    overlayVisible: Boolean = false,
 )

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/di/PlatformModule.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/di/PlatformModule.kt
@@ -17,6 +17,7 @@ import com.spela.player.libretro.LibretroJni
 import com.spela.player.libretro.desktopDefaultRetroMapping
 import com.spela.player.presentation.secondarydisplay.PlatformSecondaryDisplay
 import com.spela.player.platform.DesktopFileStorage
+import com.spela.player.presentation.viewmodel.EmulationViewModel
 import com.spela.player.presentation.viewmodel.LibretroController
 import com.spela.player.util.FileStorage
 import io.ktor.client.*
@@ -122,6 +123,7 @@ actual fun platformModule(): Module = module {
     single<PlatformSecondaryDisplay> { DesktopSecondaryDisplay() }
     single {
         val navViewModel = get<NavigationViewModel>()
+        val emuViewModel = get<EmulationViewModel>()
         DesktopGamepadPoller(
             jni = get(),
             gamepadPortManager = get(),
@@ -131,7 +133,15 @@ actual fun platformModule(): Module = module {
             // open (showInGameOverlay), GamepadHandler is disabled, so synth keys
             // can't drive focus and would leak into the emulator — suppress them.
             // The gamepad still controls the game via the poller's button routing.
-            isInGame = { navViewModel.state.value.showInGameOverlay },
+            //
+            // EXCEPTION: when the in-game pause overlay is open (showOverlay),
+            // GamepadHandler is re-enabled (see SpelaApp) and the emulation
+            // surface yields its keys, so the synth must run to drive focus
+            // through the overlay menu. (#1211)
+            isInGame = {
+                navViewModel.state.value.showInGameOverlay &&
+                    !emuViewModel.state.value.showOverlay
+            },
         )
     }
     single {

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopEmulationSurface.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopEmulationSurface.kt
@@ -70,6 +70,7 @@ fun DesktopEmulationSurface(
     onEscapePressed: (() -> Unit)? = null,
     keyMapping: Map<Int, Int>? = null,
     gamepadPortManager: GamepadPortManager? = null,
+    overlayVisible: Boolean = false,
 ) {
     val effectiveMapping = remember(keyMapping) {
         keyMapping ?: defaultKeyMapping
@@ -107,7 +108,10 @@ fun DesktopEmulationSurface(
 
     // Request focus so we receive key events, and periodically re-request
     // to recover from any focus-stealing UI elements (e.g. overlays).
-    LaunchedEffect(Unit) {
+    // While the in-game pause overlay is open we deliberately stop grabbing
+    // focus so the overlay menu can hold it and be navigated (#1211).
+    LaunchedEffect(overlayVisible) {
+        if (overlayVisible) return@LaunchedEffect
         while (true) {
             focusRequester.requestFocus()
             delay(500)
@@ -127,7 +131,9 @@ fun DesktopEmulationSurface(
                 .fillMaxSize()
                 .background(Color.Black)
                 .focusRequester(focusRequester)
-                .focusable()
+                // Non-focusable while the overlay is open so focus stays in the
+                // overlay menu rather than bouncing back to the surface (#1211).
+                .focusable(enabled = !overlayVisible)
                 .pointerInput(controller) {
                     // Forward Compose pointer events to the libretro
                     // RETRO_DEVICE_MOUSE pipeline (#857). Mirror of the
@@ -179,6 +185,10 @@ fun DesktopEmulationSurface(
                     }
                 }
                 .onPreviewKeyEvent { event ->
+                    // While the pause overlay is open, yield all keys so the
+                    // overlay menu's focus navigation (and its own Escape/back
+                    // handling) gets them instead of the emulator (#1211).
+                    if (overlayVisible) return@onPreviewKeyEvent false
                     // Handle Escape key to toggle overlay
                     if (event.key == Key.Escape && event.type == KeyEventType.KeyDown) {
                         onEscapePressed?.invoke()

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/MetalOffscreenSurface.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/MetalOffscreenSurface.kt
@@ -64,6 +64,7 @@ fun MetalOffscreenSurface(
     onEscapePressed: (() -> Unit)? = null,
     keyMapping: Map<Int, Int>? = null,
     gamepadPortManager: GamepadPortManager? = null,
+    overlayVisible: Boolean = false,
 ) {
     val effectiveMapping = remember(keyMapping) {
         keyMapping ?: defaultMetalKeyMapping
@@ -89,8 +90,10 @@ fun MetalOffscreenSurface(
         }
     }
 
-    // Request focus for keyboard input
-    LaunchedEffect(Unit) {
+    // Request focus for keyboard input. Yield while the pause overlay is open
+    // so its menu can hold focus and be navigated (#1211).
+    LaunchedEffect(overlayVisible) {
+        if (overlayVisible) return@LaunchedEffect
         while (true) {
             focusRequester.requestFocus()
             delay(500)
@@ -172,8 +175,11 @@ fun MetalOffscreenSurface(
                     controller.gpuResize(size.width, size.height)
                 }
                 .focusRequester(focusRequester)
-                .focusable()
+                // Non-focusable + key-yielding while the overlay is open so its
+                // menu owns focus and input (#1211).
+                .focusable(enabled = !overlayVisible)
                 .onPreviewKeyEvent { event ->
+                    if (overlayVisible) return@onPreviewKeyEvent false
                     if (event.key == Key.Escape && event.type == KeyEventType.KeyDown) {
                         onEscapePressed?.invoke()
                         return@onPreviewKeyEvent true

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformEmulationSurface.desktop.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformEmulationSurface.desktop.kt
@@ -26,6 +26,7 @@ actual fun PlatformEmulationSurface(
     selectedShader: ShaderPreset,
     modifier: Modifier,
     onEscapePressed: (() -> Unit)?,
+    overlayVisible: Boolean,
 ) {
     val desktopController = controller as? DesktopLibretroController ?: return
 
@@ -99,6 +100,7 @@ actual fun PlatformEmulationSurface(
             onEscapePressed = onEscapePressed,
             keyMapping = keyMapping,
             gamepadPortManager = gamepadPortManager,
+            overlayVisible = overlayVisible,
         )
     } else {
         // Fallback: software rendering via Compose Canvas + Skia
@@ -109,6 +111,7 @@ actual fun PlatformEmulationSurface(
             onEscapePressed = onEscapePressed,
             keyMapping = keyMapping,
             gamepadPortManager = gamepadPortManager,
+            overlayVisible = overlayVisible,
         )
     }
 }


### PR DESCRIPTION
A batch of desktop (Windows-focused) UX fixes found during manual testing, all verified live on Windows with an 8BitDo controller. Closes #1211, #1228, #1229, #1232.

## #1211 — Gamepad navigation for the in-game pause overlay (desktop)
Previously the gamepad could navigate app menus but not the in-game Save/Load/Resume overlay: while a game is open the synth is suppressed, `GamepadHandler` is disabled, and the emulation surface consumes keys. Now, **only while the pause overlay is open**:
- the poller's `isInGame` returns false so the d-pad→arrows / B→Enter / A→Escape synth drives the menu;
- `GamepadHandler` is re-enabled (arrows move focus, A/Escape resumes, L1/R1 section-switch suppressed);
- `PlatformEmulationSurface` gains an `overlayVisible` flag; the desktop surfaces (`DesktopEmulationSurface`, `MetalOffscreenSurface`) then yield key events + focus so the overlay owns input.

All new behavior is gated on the overlay being open, so active gameplay and menu navigation are unchanged. Android passes `overlayVisible` through unused (it already handles overlay nav).

## #1228 — Windows window not draggable + title-bar height
The JBR custom title bar's transparent strip is covered by Compose's opaque surface, so Windows hit-tested the whole strip as client area and the window couldn't be dragged. Fix: an invisible top strip calls JBR `forceHitTest(false)` **synchronously** via `onPointerEvent` (a `pointerInput` coroutine fires too late for the OS hit test), marking the region as caption — Windows then handles drag, and native min/max/close still work. Also made `isJbrTitleBarActive` reactive Compose state so the strip/inset actually compose after the async title-bar activation. Title-bar height set to **32** (reverts the #1215 42px bump, per design). Windows-only; macOS/Linux unchanged.

## #1229 — Focus ring on controller connect
When a controller is connected, flip Compose into keyboard input mode so the current screen's default `focusRestoreItem` grabs focus immediately — the focus ring is visible right away instead of only after the first d-pad press. Independent of the gamepad/touch nav style (using the mouse flips it back to touch).

## #1232 — Compact, content-width console grouping toggle
The `SpSegmentedControl` ("Generation / Manufacturer") looked round + full-width on Windows. Fixes: segments `fillMaxHeight` (the selected pill matched the text line-height before, which varies per platform → round on Windows); track 48→36 + `LabelSmall` so it reads as a secondary filter; `IntrinsicSize.Max` so it wraps content left-aligned instead of stretching full-width.

## Docs
`docs/compose-desktop-transparent-window.md` — a guide for building borderless/transparent-title-bar Compose Desktop apps (per-platform mechanisms, the two Windows drag traps, content-inset pattern, JBR packaging, checklist).

## Testing
Manually verified on Windows with controller + mouse: overlay gamepad nav, window drag, button height, focus-on-connect, and the toggle look. Full desktop suite green locally; existing CI (Go/Player/Web unit tests) covers regressions. The in-game overlay path and JBR window chrome aren't representable in the fake-repo desktop harness, so those rely on the manual verification above.

## Not included
Intermittent #1230 (Activity crash) and #1231 (Collections JSON) — filed separately, need a captured stack trace to act on.
