### PR TITLE
fix(player): GameCube/Dolphin black screen + crash on Windows via offscreen Vulkan surface caps (#1203, #1214)

### DIFF
--- a/player/native/src/gpu_renderer_vulkan.c
+++ b/player/native/src/gpu_renderer_vulkan.c
@@ -2530,14 +2530,24 @@ static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL wrapped_vkGetInstanceProcAddr(
     if (strcmp(pName, "vkEnumerateDeviceExtensionProperties") == 0) {
         return (PFN_vkVoidFunction)wrapped_vkEnumerateDeviceExtensionProperties;
     }
-    if (strcmp(pName, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR") == 0) {
-        return (PFN_vkVoidFunction)wrapped_vkGetPhysicalDeviceSurfaceCapabilitiesKHR;
-    }
     if (strcmp(pName, "vkGetDeviceProcAddr") == 0) {
         return (PFN_vkVoidFunction)wrapped_vkGetDeviceProcAddr;
     }
 
     PFN_vkVoidFunction result = vkGetInstanceProcAddr(instance, pName);
+
+    /* Surface capabilities. With a real surface (on-screen, e.g. Android) use
+     * the real-driver wrapper that forces IDENTITY transform (#916). In
+     * offscreen mode the instance has no VK_KHR_surface, so `result` is NULL
+     * and we fall through to the synthesized stub below — which reports
+     * supportedUsageFlags including COLOR_ATTACHMENT (what a real surface
+     * reports; cf. RetroArch passing its real vk_surface to create_device2).
+     * Previously we ALWAYS used the real-driver wrapper; querying the real
+     * driver with the dummy offscreen surface returned no COLOR_ATTACHMENT on
+     * Windows, so Dolphin's Vulkan swap-chain creation failed and then crashed
+     * (#1203 / #1214). */
+    if (result && strcmp(pName, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR") == 0)
+        return (PFN_vkVoidFunction)wrapped_vkGetPhysicalDeviceSurfaceCapabilitiesKHR;
 
     /* Provide stubs for surface functions that return NULL in offscreen mode */
     if (!result) {


### PR DESCRIPTION
Fixes the GameCube/Dolphin **black screen** and **crash** on Windows. Verified live: Metroid Prime boots and renders at ~60fps via Vulkan, no crash. Closes #1203. Closes #1214.

## Root cause
On Windows, DolphinLibretro's Vulkan backend brings up its own swapchain and queries `vkGetPhysicalDeviceSurfaceCapabilitiesKHR`. In our offscreen HW-render mode we hand the core a dummy `VkSurfaceKHR` (`0xDEADBEEF`) and shim the surface functions. But `wrapped_vkGetInstanceProcAddr` returned the **real-driver** caps wrapper unconditionally — so the query hit the real driver with the dummy surface. On Windows that returned `supportedUsageFlags` **without** `COLOR_ATTACHMENT`, so Dolphin's swapchain creation failed (`VKSwapChain.cpp: swap chain does not support usage as color attachment`) and it then crashed with `EXCEPTION_ACCESS_VIOLATION` in `retro_run`. macOS (MoltenVK) and Android were unaffected.

## Fix
In offscreen mode (no real `VK_KHR_surface`, so the real proc addr is `NULL`) return the **synthesized stub** caps, which already report `supportedUsageFlags` including `COLOR_ATTACHMENT` — the same thing a real surface reports. RetroArch's reference path passes its real `vk_surface` to `create_device2`, so the core gets real caps; offscreen, we synthesize the equivalent. The real-driver wrapper (which forces IDENTITY transform for PPSSPP-on-Android, #916) is kept only when a real surface exists.

One file: `gpu_renderer_vulkan.c` — `wrapped_vkGetInstanceProcAddr`.

## Why this matters beyond GameCube
This is the proper Vulkan HW-render offscreen path. More cores use Vulkan (Citra/3DS, PPSSPP, paraLLEl-RDP), so fixing the offscreen caps shim unblocks them on Windows too.

## Testing
Native C change to the Vulkan offscreen shim; not representable in the desktop fake-repo harness. Verified manually on Windows (GameCube renders + steady 60fps, clean exit). Linux CI builds the native lib (compile check). macOS/Android paths unchanged (real-surface wrapper retained).
