### PR TITLE
fix(player): clear displayed frame on game unload (#1236)

### DIFF
--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -1155,6 +1155,10 @@ JNI_FUNC(void, nativeUnloadGame)(JNIEnv *env, jobject thiz) {
     g_core.retro_unload_game();
     g_core.game_loaded = false;
     audio_deinit();
+    /* Clear the displayed frame so the next game doesn't briefly show this
+     * game's last frame (#1236). The next game's first video_refresh resets
+     * the dimensions. */
+    video_clear_frame();
     LOGI("Game unloaded");
 }
 

--- a/player/native/src/libretro_bridge.h
+++ b/player/native/src/libretro_bridge.h
@@ -24,6 +24,9 @@ void video_deinit(void);
  * libretro's MailBox flush in CGSH_OpenGL_Libretro::Release) don't
  * dereference data that's already partially torn down. (#916) */
 void video_set_shutting_down(void);
+/* Zero the current frame dimensions so the previous game's frame doesn't
+ * linger into the next game. Called on game unload. (#1236) */
+void video_clear_frame(void);
 void video_set_pixel_format(unsigned format);
 void video_refresh_callback(const void *data, unsigned width, unsigned height, size_t pitch);
 unsigned video_get_width(void);

--- a/player/native/src/libretro_video.c
+++ b/player/native/src/libretro_video.c
@@ -138,6 +138,19 @@ void video_unlock(void) {
     }
 }
 
+/* Clear the displayed frame so the previous game's last frame doesn't linger
+ * into the next game (#1236). Zeroing the dimensions makes readers
+ * (nativeGetVideoWidth/Height, renderGpuFrameToBgra's >0 guard, the SW
+ * fill path) report "no frame" until the next game's first video_refresh
+ * repopulates them. The frame buffer allocation is kept for reuse. */
+void video_clear_frame(void) {
+    video_lock();
+    video_state.width = 0;
+    video_state.height = 0;
+    video_state.pitch = 0;
+    video_unlock();
+}
+
 void video_set_pixel_format(unsigned format) {
     video_lock();
     video_state.pixel_format = format;


### PR DESCRIPTION
Closes #1236.

When a game stops, the previous game's last frame lingered until the next game produced its first frame (visible when switching games — e.g. GameCube then another title showed the old frame).

**Fix:** zero the video frame dimensions on \
ativeUnloadGame\ via a new \ideo_clear_frame()\. Readers (\
ativeGetVideoWidth/Height\, \enderGpuFrameToBgra\'s \>0\ guard, the SW fill path) then report 'no frame', so the surface shows black until the next core's first \ideo_refresh\ sets new dimensions. The frame buffer allocation is kept for reuse. Cross-platform (also clears stale frames on Android game switches).

Native C change; verified compiles. Best observed on a clean (non-crashing) game switch such as NES -> SNES.