### PR TITLE
test(player): wait/click GameDetail CTA by testTag, not stale label text

### DIFF
--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -2001,15 +2001,17 @@ fun ComposeRule.navigateToN64Game() {
         scrollToAndTapText("Banjo-Kazooie")
     }
 
-    // Wait for the GameDetail primary CTA. The label depends on local
-    // state: "Download" pre-download, "Play" post-download with no save,
-    // "Resume" once a save exists. After a previous test already ran the
-    // game, "Download" is gone — accept any of the three.
+    // Wait for the GameDetail primary CTA to render. It's either the Download
+    // button (pre-download) or the play button (post-download, label "Play" /
+    // "Resume" / "New game" / "Continue"). Poll for either stable testTag, not
+    // label text — "New game" (downloaded but unplayed) matched none of the old
+    // text checks.
     pollUntil(timeoutMillis = TIMEOUT_LONG) {
         try {
-            onAllNodesWithText("Download", substring = false).fetchSemanticsNodes().isNotEmpty() ||
-                onAllNodesWithText("Play", substring = false).fetchSemanticsNodes().isNotEmpty() ||
-                onAllNodesWithText("Resume", substring = false).fetchSemanticsNodes().isNotEmpty()
+            onAllNodes(hasTestTag(com.spela.player.presentation.ui.TestTags.GAME_DETAIL_DOWNLOAD_BUTTON))
+                .fetchSemanticsNodes().isNotEmpty() ||
+                onAllNodes(hasTestTag(com.spela.player.presentation.ui.TestTags.GAME_DETAIL_PLAY_BUTTON))
+                    .fetchSemanticsNodes().isNotEmpty()
         } catch (_: Exception) { false }
     }
 }
@@ -2020,13 +2022,13 @@ fun ComposeRule.navigateToN64GameAndPlay() {
     // N64 core (mupen64plus_next) takes longer to initialize than NES (nestopia).
     // It needs to download the core binary, set up GL/Vulkan context, and load a larger ROM.
     // On emulators this can take 60+ seconds for the first run (core download + init).
-    // If saves exist, the button is "Resume"; otherwise "Play"
-    val hasResume = onAllNodesWithText("Resume", substring = true)
-        .fetchSemanticsNodes().isNotEmpty()
-    if (hasResume) {
-        onNodeWithText("Resume").performClick()
-    } else {
-        onNodeWithText("Play").performClick()
+    // Click the play CTA via its stable testTag — the label is "Resume" with a
+    // save, else "Play" / "New game", and onNodeWithText("Play") misses the
+    // "New game" label an unplayed in-library game shows. OnClick action, not a
+    // synthetic touch, so it isn't dropped on the AYN Thor's secondary display.
+    // See clickNodeByTag / startGameAndWait.
+    if (!clickNodeByTag(com.spela.player.presentation.ui.TestTags.GAME_DETAIL_PLAY_BUTTON)) {
+        onAllNodes(hasTestTag(com.spela.player.presentation.ui.TestTags.GAME_DETAIL_PLAY_BUTTON))[0].performClick()
     }
     // Wait for the "Game running" semantic marker which is always on the primary display,
     // regardless of touch controls visibility, physical controller, or dual-screen mode.
@@ -2288,12 +2290,16 @@ fun ComposeRule.downloadGameIfNeeded() {
             onNodeWithText("Download", substring = false).performClick()
         }
         waitForIdle()
-        // After download, button becomes "Play", "Resume", or "New Game"
-        // ROM download can be slow on emulator — use 60s timeout
+        // After download the Download button is replaced by the play CTA, whose
+        // label varies — "Play", "Resume", "New game", or "Continue". Poll for
+        // its stable testTag, not label text: an in-library *unplayed* game reads
+        // "New game", which the old "Play"/"Resume" text poll never matched, so
+        // download-required tests (e.g. the N64/Banjo flow) timed out after 60s.
+        // ROM download can be slow on emulator / large ROMs — keep the 60s timeout.
         pollUntil(timeoutMillis = 60_000) {
             try {
-                onAllNodesWithText("Play", substring = false).fetchSemanticsNodes().isNotEmpty() ||
-                    onAllNodesWithText("Resume", substring = false).fetchSemanticsNodes().isNotEmpty()
+                onAllNodes(hasTestTag(com.spela.player.presentation.ui.TestTags.GAME_DETAIL_PLAY_BUTTON))
+                    .fetchSemanticsNodes().isNotEmpty()
             } catch (_: Exception) { false }
         }
         android.util.Log.d("E2E_NAV", "downloadGameIfNeeded: Download complete")

--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -806,8 +806,13 @@ fun ComposeRule.clickNodeByTag(tag: String): Boolean {
             }
             waitForIdle()
             return true
-        } catch (_: Exception) {
+        } catch (_: Throwable) {
             // Tree busy / node detached mid-resolution — try the other tree.
+            // Catch Throwable, not just Exception: a node present at the
+            // fetchSemanticsNodes check above can vanish before the indexed
+            // fetch (screen transition), and fetchSemanticsNode() then throws
+            // AssertionError ("can't retrieve node at index 0") — an Error, not
+            // an Exception. Leaking it would defeat this method's Boolean contract.
         }
     }
     return false
@@ -2277,9 +2282,14 @@ fun ComposeRule.assertTagNotVisible(tag: String) {
 }
 
 fun ComposeRule.downloadGameIfNeeded() {
-    // Use Compose tree — UiAutomator accessibility tree can be stale after navigation
+    // Gate on the Download button's testTag, not "Download" label text. Text can
+    // false-positive / linger while the actual CTA has already flipped, and it
+    // must agree with the clickNodeByTag(DOWNLOAD_BUTTON) below. Absent tag
+    // (game already downloaded) → skip straight to play. (Compose tree, not
+    // UiAutomator — the accessibility tree can be stale after navigation.)
     val hasDownload = try {
-        onAllNodesWithText("Download", substring = false).fetchSemanticsNodes().isNotEmpty()
+        onAllNodes(hasTestTag(com.spela.player.presentation.ui.TestTags.GAME_DETAIL_DOWNLOAD_BUTTON))
+            .fetchSemanticsNodes().isNotEmpty()
     } catch (_: Exception) { false }
 
     if (hasDownload) {


### PR DESCRIPTION
## Summary

The Android E2E download→play navigation helpers waited for / clicked the GameDetail primary CTA by **label text** ("Play"/"Resume"). An in-library game that's been **downloaded yet never played** shows **"New game"** (a played-then-cleared one can show "Continue"), so none of the text checks matched — the poll ran the full timeout and the test failed before ever reaching `loadGame`.

Reproduced by `HwRenderTest` (N64/Banjo-Kazooie): the 16 MB ROM downloaded fully, then `downloadGameIfNeeded` timed out after 60s at `TestHelpers.kt:2293`. Found while diagnosing the NES `retro_load_game` blocker (which turned out to be a bad local test ROM, not app code).

## Fix

Three coupled spots in the same flow now use the **stable testTags** (`GAME_DETAIL_PLAY_BUTTON` / `GAME_DETAIL_DOWNLOAD_BUTTON`) — the label-agnostic approach `startGameAndWait()` already uses — and the play CTA is clicked via `clickNodeByTag` (OnClick action, not a synthetic touch the AYN Thor secondary display drops):

- `navigateToN64Game()` — detail-loaded wait
- `downloadGameIfNeeded()` — post-download wait
- `navigateToN64GameAndPlay()` — play-CTA click

Same family as the NavigationTest stale-text fix (#1198/#1199) and the AYN Thor tap-delivery fix (#1201).

## Testing

- `:android:compileDebugAndroidTestKotlin` passes.
- End-to-end on the AYN Thor (N64/Banjo `HwRenderTest`) to be run once the device is free; the manual NES path is already confirmed working with a good ROM.

Closes #1239