### PR TITLE
feat(player): route Azahar (3DS) through Vulkan on desktop

### DIFF
--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -340,6 +340,23 @@ static bool environment_callback(unsigned cmd, void *data) {
                     }
                 }
 
+#ifndef __ANDROID__
+                /* Azahar (3DS): force Vulkan on desktop. The WGL/OpenGL path
+                 * crashes; route through the offscreen Vulkan path (#1234).
+                 * Detected via the core's "citra_" option namespace. Android
+                 * keeps GLES (works there), so this is desktop-only. */
+                {
+                    const struct retro_variable *v4 = (const struct retro_variable *)data;
+                    for (; v4->key; v4++) {
+                        if (v4->key && strstr(v4->key, "citra_graphics_api")) {
+                            LOGI("Azahar core detected, forcing Vulkan graphics API");
+                            core_variables_set("citra_graphics_api", "Vulkan");
+                            break;
+                        }
+                    }
+                }
+#endif
+
                 /* ScummVM: sensible default gamepad mapping for the audience
                  * (#859). The core's built-in joypad-to-key defaults are
                  * tuned for the libretro-scummvm dev environment, not for a
@@ -495,6 +512,14 @@ static bool environment_callback(unsigned cmd, void *data) {
              * Other cores: GLES3 on Android, OpenGL Core on desktop. */
             const char *libname = g_core.system_info.library_name;
             bool prefer_vulkan = libname && strstr(libname, "dolphin") != NULL;
+#ifndef __ANDROID__
+            /* Azahar (3DS): the desktop WGL/OpenGL path crashes; use the
+             * offscreen Vulkan path (#1234) instead. Android keeps GLES
+             * (which works there). library_name is "Azahar" (older: "Citra"). */
+            if (libname && (strstr(libname, "Azahar") || strstr(libname, "Citra"))) {
+                prefer_vulkan = true;
+            }
+#endif
 #ifdef __ANDROID__
             if (libname && strstr(libname, "PPSSPP") != NULL) {
                 prefer_vulkan = true;


### PR DESCRIPTION
@
## What

Switches the Azahar (3DS) core from the desktop WGL/OpenGL HW-render path to the **offscreen Vulkan path** (the #1234 surface-caps shim). Two changes, both `#ifndef __ANDROID__` and Azahar-gated:

- `GET_PREFERRED_HW_RENDER` → reports `VULKAN` for Azahar/Citra (was `OPENGL_CORE`)
- `SET_VARIABLES` → forces `citra_graphics_api=Vulkan` when the core declares its `citra_` options

## Why

Verified end-to-end during the #1243 investigation: with this, the Vulkan handshake fully succeeds — HW-render type 6 accepted, context negotiation v2, **Vulkan device created successfully**, renderer initialized. Matches the long-term "proper Vulkan" direction (more cores will need it).

## Honest scope

This does **not** make 3DS playable on its own. Azahar still hits an **unrelated core-side memory-corruption crash** on Windows x64 (indirect `call` through a garbage object pointer, deep in `retro_run` — fully analyzed in #1243), which happens identically on OpenGL and Vulkan. This PR just gets the graphics layer onto Vulkan and is ready for when that upstream core bug is resolved. No regression: Azahar crashed on the GL path too.

Android is untouched (keeps GLES, which works there).

Related: #1243, #1234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@