### PR TITLE
fix(player): stop Azahar (3DS) crash from GET_SENSOR_INTERFACE env collision

### DIFF
--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -149,6 +149,20 @@ static void *hw_get_proc_address(const char *sym) {
  * We handle the subset of environment commands needed for basic operation.
  */
 static bool environment_callback(unsigned cmd, void *data) {
+    /* GET_SENSOR_INTERFACE (25 | RETRO_ENVIRONMENT_EXPERIMENTAL = 0x10019) must
+     * be intercepted by its FULL value, BEFORE the base_cmd masking below. The
+     * mask (cmd & 0xFFFF) maps 0x10019 -> 25, which collides with our local
+     * RETRO_ENVIRONMENT_SET_CONTROLLER_PORT_DEVICE_ENV (25); that case returns
+     * true WITHOUT populating the retro_sensor_interface out-param. The core
+     * (Azahar/3DS) then stores the uninitialized {set_sensor_state,
+     * get_sensor_input} function pointers and later calls the garbage
+     * set_sensor_state(port, ENABLE, rate) -> hard crash on desktop (the
+     * uninitialized stack happened to be zero on Android, hiding it there).
+     * We don't expose host motion sensors, so decline cleanly: the core keeps
+     * its null sensor callbacks and motion is simply disabled. (#1237, #1243) */
+    if (cmd == (25u | 0x10000u)) {
+        return false;
+    }
     /* Mask off RETRO_ENVIRONMENT_EXPERIMENTAL (0x10000) so experimental
      * commands like GET_HW_RENDER_INTERFACE match our case labels. */
     unsigned base_cmd = cmd & 0xFFFF;


### PR DESCRIPTION
## The bug

3DS games (Azahar core) crashed on launch on desktop — `EXCEPTION_ACCESS_VIOLATION` deep in `retro_run`, an indirect call through a garbage function pointer. The crash #1237 / #1243 chased for a long time.

## Root cause — a libretro command-number collision

`environment_callback` masks every command with `cmd & 0xFFFF` so EXPERIMENTAL commands match plain case labels (e.g. `GET_HW_RENDER_INTERFACE`). But our trimmed `libretro.h` also defines a **local** constant `RETRO_ENVIRONMENT_SET_CONTROLLER_PORT_DEVICE_ENV = 25`, while the real `RETRO_ENVIRONMENT_GET_SENSOR_INTERFACE` is `25 | EXPERIMENTAL` = `0x10019`.

So `GET_SENSOR_INTERFACE` masked to `25` and matched the controller-port case, which returned **true without populating** the caller's `retro_sensor_interface` out-param. Azahar then stored the **uninitialized** sensor function pointers and later called the garbage `set_sensor_state(port, ENABLE, rate)` → crash. (The `rate` arg `0x3c` = 60 in the crash registers confirmed it.)

On Android the uninitialized stack happened to be zero (the null-guard hid it); on desktop the stack garbage was non-zero, so it crashed every launch.

## Fix

Intercept `GET_SENSOR_INTERFACE` by its **full** value before masking and decline it cleanly (we expose no host motion sensors). The core keeps its null sensor callbacks; motion is simply disabled — no crash. 14 lines, no behavior change for any other command.

## Verification

Ocarina of Time 3D now boots and renders (400×480) on the desktop player — confirmed both **in-process** (the real app) and via a standalone native host harness built to pinpoint the fault with symbols (that harness is what cracked it; see #1243). Earlier eliminations (firmware, graphics backend, JIT, stack size, etc.) are all documented on #1243.

Closes #1237. Closes #1243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
