### PR TITLE
chore(player): out-of-process core-host debug harness + #1243 postmortem docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,13 @@ This is especially important for:
 
 Do not guess at the problem — instrument the code, read the logs, and let the data guide the fix.
 
+**For desktop libretro core crashes**, see `player/native/CORE_HOST.md`: the
+`spela-core-host` harness runs a core out-of-process (JVM-free, with symbols) for
+a fast `cdb`-debuggable repro. It also documents the **env command-number masking
+pitfall** (`cmd & 0xFFFF` aliasing) behind the #1237/#1243 Azahar crash, and the
+lesson that "works in RetroArch, crashes in Spela" usually means *our* libretro
+frontend behavior differs — not the hosting.
+
 ## Architecture Decisions
 - See ARCHITECTURE.md for full technical architecture
 - See `player/LAYOUT.md` for the player app's shared layout composable system (SpScreen, SpMainContentPadding, SpSectionList, etc.). All screens must use these — no custom padding or scroll code.

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -15,5 +15,10 @@ truth for current behaviour.
 | [`n64-android.md`](n64-android.md) | N64 Vulkan HW render on Android — debugging status. |
 | [`n64-macos.md`](n64-macos.md) | N64 OpenGL HW render on macOS — investigation notes. |
 
+For debugging desktop libretro **core crashes** (and the #1237/#1243 Azahar/3DS
+crash postmortem + the `cmd & 0xFFFF` env-masking pitfall), see
+[`player/native/CORE_HOST.md`](../../player/native/CORE_HOST.md) — the
+out-of-process core-host harness lives with the native code it documents.
+
 If you find one of these contradicts current code, the code wins. Update or
 delete the doc rather than backporting a bug.

--- a/player/native/CMakeLists.txt
+++ b/player/native/CMakeLists.txt
@@ -193,3 +193,62 @@ endif()
 # Note: Metal shaders are compiled from inline MSL strings at runtime
 # (see gpu_renderer_metal.m). The .metal files in shaders/ are reference
 # copies but are not pre-compiled into a .metallib.
+
+# =====================================================================
+# Out-of-process core host (desktop only) — debug/isolation harness.
+#
+# A standalone native executable that loads + runs a libretro core in its
+# own process (via the sp_host_* API in libretro_bridge.c), sharing video/
+# audio/input with a parent over a memory-mapped file. It gives a core a
+# clean native address space (like RetroArch) and full symbols (PDB), which
+# makes it a fast repro for diagnosing core/integration crashes — it's how
+# the #1243 GET_SENSOR_INTERFACE bug was pinned. See player/native/CORE_HOST.md.
+#
+# Reuses COMMON_SOURCES with SPELA_CORE_HOST defined, which compiles OUT the
+# JNI bindings — so the host links NO jvm/jawt libraries and stays JVM-free.
+# jni.h/jawt.h are needed only as headers (for the JavaVM* type, unused at
+# runtime), so we add JNI_INCLUDE_DIRS but do NOT link JNI_LIBRARIES.
+# =====================================================================
+if(NOT ANDROID)
+    add_executable(spela-core-host ${COMMON_SOURCES} src/spela_core_host.c)
+    target_compile_definitions(spela-core-host PRIVATE SPELA_CORE_HOST)
+    target_include_directories(spela-core-host PRIVATE src rcheevos/include)
+
+    find_package(JNI REQUIRED)
+    target_include_directories(spela-core-host PRIVATE ${JNI_INCLUDE_DIRS})
+
+    if(SDL2_FOUND)
+        target_include_directories(spela-core-host PRIVATE ${SDL2_INCLUDE_DIRS})
+        target_link_libraries(spela-core-host ${SDL2_LIBRARIES})
+    endif()
+
+    find_package(Vulkan REQUIRED)
+    target_include_directories(spela-core-host PRIVATE ${Vulkan_INCLUDE_DIRS})
+
+    if(APPLE)
+        find_library(MOLTENVK_LIB MoltenVK HINTS /opt/homebrew/lib /usr/local/lib)
+        find_library(METAL_FRAMEWORK Metal)
+        find_library(QUARTZCORE_FRAMEWORK QuartzCore)
+        find_library(COCOA_FRAMEWORK Cocoa)
+        find_library(OPENGL_FRAMEWORK OpenGL)
+        find_library(IOKIT_FRAMEWORK IOKit)
+        find_library(IOSURFACE_FRAMEWORK IOSurface)
+        if(MOLTENVK_LIB)
+            target_link_libraries(spela-core-host ${MOLTENVK_LIB}
+                ${METAL_FRAMEWORK} ${QUARTZCORE_FRAMEWORK} ${COCOA_FRAMEWORK}
+                ${OPENGL_FRAMEWORK} ${IOKIT_FRAMEWORK} ${IOSURFACE_FRAMEWORK})
+        else()
+            target_link_libraries(spela-core-host ${Vulkan_LIBRARIES}
+                ${METAL_FRAMEWORK} ${QUARTZCORE_FRAMEWORK} ${COCOA_FRAMEWORK}
+                ${OPENGL_FRAMEWORK})
+        endif()
+    elseif(UNIX)
+        target_link_libraries(spela-core-host ${Vulkan_LIBRARIES} dl m)
+    else()
+        target_link_libraries(spela-core-host ${Vulkan_LIBRARIES} opengl32)
+    endif()
+
+    if(TARGET compile_shaders)
+        add_dependencies(spela-core-host compile_shaders)
+    endif()
+endif()

--- a/player/native/CORE_HOST.md
+++ b/player/native/CORE_HOST.md
@@ -1,0 +1,207 @@
+# Out-of-process core host & debugging libretro core crashes (desktop)
+
+This documents `spela-core-host` — a standalone native harness for loading and
+running a libretro core **outside** the JVM — and the workflow it enables for
+diagnosing core/integration crashes on desktop. It also records the **env
+command-number masking pitfall** and the **#1237 / #1243 Azahar/3DS postmortem**,
+because that bug is the canonical example of what this tooling is for.
+
+> TL;DR for the impatient: if a libretro core crashes on desktop, build the
+> native bridge, run `spela-core-host.exe` under `cdb` against the same ROM, and
+> you get a fast, JVM-free, fully-symbolized repro. See
+> [Debugging a core crash](#debugging-a-core-crash-with-cdb).
+
+---
+
+## Why it exists
+
+The desktop player normally drives the libretro bridge **in-process via JNI**
+(`LibretroJni` → `libretro_bridge.c`). That's fine, but it makes core crashes
+hard to debug: the JVM's own exception handler turns the fault into an
+`hs_err_pid*.log` that **cannot symbolize native frames**, and the process is
+full of JVM threads, GC, and JIT noise.
+
+`spela-core-host` loads the **same bridge code** (`sp_host_*` API, see below) in
+a **plain native process** with a **PDB**, so:
+
+- a crash gives a **fully-symbolized** native stack under `cdb`/WinDbg;
+- there's no JVM to muddy signals/threads;
+- it independently answers "is this the core, our frontend, or the hosting?" —
+  if it crashes here too, the JVM is **not** the cause.
+
+It is a **debug/isolation harness**, not a shipping feature. It is desktop-only;
+Android always runs the core in-process (and doesn't have this tooling).
+
+---
+
+## Architecture
+
+```
+parent process                          spela-core-host.exe (native, no JVM)
+  (or a human + cdb)                       loads spela-libretro bridge code
+        │                                  loads the real core (azahar, …)
+        ├─ memory-mapped file ◀── BGRA framebuffer + audio + header
+        └─ (header fields)    ──▶ input state + should_stop
+```
+
+- **`sp_host_*` API** (`spela_host_api.h`, implemented at the end of
+  `libretro_bridge.c`): non-JNI entry points mirroring the JNI surface —
+  `sp_host_load_core / init / gpu_init_offscreen / load_game / run_frame /
+  render_to_bgra / get_audio / set_button / …`. They reuse the *exact* internal
+  core/video/audio/input/GPU machinery the JNI path uses.
+- **`spela_core_host.c`**: a minimal native frontend `main()` — parses args,
+  maps the shared file, runs the emulation loop, publishes frames/audio, reads
+  input, stops on request.
+- **IPC** (`spela_host_ipc.h`): a memory-mapped file — a fixed 256-byte header
+  (`SpHostHeader`) + a BGRA video buffer + an audio buffer. Chosen because both
+  a JVM (`FileChannel.map`) and native code (`CreateFileMapping`/`mmap`) can
+  share it. Sync is the `frame_counter` (host increments after each frame).
+
+**JVM-free guarantee.** The host compiles `libretro_bridge.c` with
+`-DSPELA_CORE_HOST`, which `#ifdef`s out the entire JNI bindings section. So the
+host links **no** `jvm`/`jawt` libraries. `jni.h`/`jawt.h` are still on the
+include path (for the unused `JavaVM*` type), but nothing references JVM symbols
+at link time.
+
+---
+
+## Building
+
+The host builds automatically with the native library:
+
+```
+# from player/ — the desktop env (MSVC dev shell, JAVA_HOME=JBR, Vulkan SDK,
+# SDL2, cmake on PATH) must be set up; run-desktop.ps1 shows the full setup.
+./gradlew :desktop:buildNativeLibrary
+```
+
+`cmake --build` builds every target, so `spela-core-host.exe` lands next to
+`spela-libretro.dll` in `player/desktop/build/native/`.
+
+---
+
+## Running
+
+```
+spela-core-host.exe \
+  --core   <path to *_libretro.dll> \
+  --game   <path to ROM> \
+  --system <BIOS/system dir> \
+  --save   <save dir> \
+  --shm    <path to a backing file the parent created at SP_TOTAL_SIZE bytes> \
+  [--width N --height N]        # offscreen render size (default 256x224) \
+  [--var key=value ...]         # core options, repeatable
+```
+
+The parent must create the `--shm` file at `SP_TOTAL_SIZE`
+(`256 + 16 MiB + 256 KiB ≈ 16.25 MiB`) before launching. The host writes the
+header magic when ready, then increments `frame_counter` each produced frame and
+sets `video_width/height` + the BGRA bytes; the parent reads frames when the
+counter changes and writes `input_buttons`/analog/pointer + `should_stop`.
+
+> Note on reading the header from another tool: the C struct aligns the
+> `uint64 frame_counter` to **offset 24**, not 20 (4 bytes of padding after the
+> five `uint32`s). Mirror the real C offsets, not the field order.
+
+### Phase 1 scope
+
+This is the minimum that proved out the fix. Notably **not** done yet: a JVM
+client wiring the host into the actual app (the in-process path is the shipping
+path), full software-render pixel-format conversion (Vulkan HW-render readback
+via `render_to_bgra` is the tested path), save states, shaders, fast-forward.
+
+---
+
+## Debugging a core crash with cdb
+
+`cdb` ships with WinDbg: `winget install Microsoft.WinDbg` →
+`%LOCALAPPDATA%\Microsoft\WindowsApps\cdbX64.exe`.
+
+1. Create the shm file at `SP_TOTAL_SIZE` bytes.
+2. Put the core + a ROM somewhere; run the host under cdb. A command file
+   (`-cf`) avoids shell-quoting hell. Example that breaks on the fatal
+   first-chance access violation, dumps, and quits — while passing through the
+   benign first-chance AVs a JVM-hosted process would generate (harmless here
+   since the host is JVM-free, but the pattern generalizes):
+
+   ```
+   sxe -c ".if (@rip == 0x<crashpc>) { .echo CRASH; r; kb 60; lm; qd } .else { gn }" av
+   g
+   ```
+
+   For a *data* corruption (a global written wrong), a **hardware
+   write-watchpoint** is gold:
+
+   ```
+   ba w8 0x<addr> ".echo WRITE; r; ub @rip L12; kb 20; .echo ---; g"
+   ```
+
+   That's how #1243 was cracked: the watchpoint on the garbage global showed the
+   writer; disassembling the call target revealed it was **our own
+   `environment_callback`**, called with an ordinal that decoded the bug (below).
+
+3. Symbols: the host has a PDB, so bridge frames symbolize. The core
+   (`azahar_libretro.dll` etc.) is a stripped MinGW build — frames show
+   `module+offset` and nearest-export names (often misleading); rely on the
+   bridge frames + register/memory inspection.
+
+---
+
+## ⚠️ The env command-number masking pitfall
+
+`environment_callback` does `unsigned base_cmd = cmd & 0xFFFF;` so that
+**EXPERIMENTAL** commands (`cmd | 0x10000`) match plain `case` labels — e.g.
+`GET_HW_RENDER_INTERFACE` is `41 | 0x10000` and we want it to hit `case 41`.
+
+**The trap:** our `libretro.h` is trimmed and defines some **local** constants
+with plain low numbers. If any EXPERIMENTAL command's low 16 bits collide with
+such a constant, the masked command lands on the **wrong** `case`. A `GET_*`
+command that returns an interface/struct via an out-param is then answered with
+a `case` that returns `true` **without writing the out-param** → the core uses
+uninitialized memory.
+
+When adding env handling: **handle experimental `GET_*` commands by their full
+value, before the mask** (as the `GET_SENSOR_INTERFACE` guard now does), and be
+suspicious of any low-numbered local constant that could alias `0x100xx & 0xFFFF`.
+
+---
+
+## Postmortem: #1237 / #1243 — Azahar (3DS) crash on launch
+
+**Symptom.** Launching a 3DS game crashed on desktop with
+`EXCEPTION_ACCESS_VIOLATION` deep in `retro_run` — an indirect call through a
+garbage function pointer (`call rax`, non-canonical address). Worked on Android;
+worked in standalone RetroArch with the *identical* core + ROM.
+
+**Root cause.** A command-number collision (the pitfall above). Our trimmed
+`libretro.h` defines `RETRO_ENVIRONMENT_SET_CONTROLLER_PORT_DEVICE_ENV = 25`. The
+real `RETRO_ENVIRONMENT_GET_SENSOR_INTERFACE` is `25 | EXPERIMENTAL = 0x10019`,
+which masks to `25` and matched the controller-port case — returning `true`
+**without** filling the caller's `retro_sensor_interface`. Azahar stored the
+uninitialized `{set_sensor_state, get_sensor_input}` pointers and later called
+the garbage `set_sensor_state(port, ENABLE, rate)` (the crash's `r8 = 0x3c` = 60
+= the sensor event rate confirmed it). On Android the uninitialized stack
+happened to be zero, so Azahar's null-guard hid it; on desktop the stack garbage
+was non-zero, so it crashed every launch.
+
+**Fix** (`environment_callback`, see #1246): intercept `GET_SENSOR_INTERFACE` by
+its full value before masking and decline cleanly — the core keeps null sensor
+callbacks; motion is disabled (we expose no host sensors); no crash.
+
+**Why the investigation took so long — dead ends ruled out, in order:**
+firmware/system files, graphics backend (GL ≡ Vulkan, both crashed identically),
+CPU JIT (interpreter crashed too), thread stack size (256 MB, no change), memory
+arena/address-space collision, DLL relocation + Crypto++ integrity (normal-ASLR
+false positives present in RetroArch too), JVM `-Xrs`, OBS/Wallpaper-Engine
+graphics hooks, and missing/delay-loaded dependencies.
+
+The "works in RetroArch, crashes in Spela" signal pointed (wrongly) at the
+in-process JVM hosting — until `spela-core-host` (a clean native process running
+**our** bridge) crashed **identically**, proving the hosting was not the
+variable; our frontend was. cdb on the harness then walked from the garbage
+global to the writer to the dispatcher — which turned out to be our own
+`environment_callback` — and the ordinal `0x10019` named the bug.
+
+**Lesson:** when a core works in another frontend but not ours, the difference is
+in **our libretro frontend behavior**, not necessarily the process/host. Reach
+for `spela-core-host` early.

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -13,6 +13,7 @@
 #include "libretro_bridge.h"
 #include "libretro_achievements.h"
 #include "gpu_renderer.h"
+#include "spela_host_api.h"   /* native (non-JNI) host API — implemented at end of file */
 
 #include "hw_render_gl.h"
 
@@ -885,6 +886,7 @@ static int core_load(const char *path) {
     return 0;
 }
 
+#ifndef SPELA_CORE_HOST  /* JNI bindings are excluded from the native host build */
 /* === JNI BINDINGS === */
 
 #define JNI_FUNC(ret, name) JNIEXPORT ret JNICALL Java_com_spela_player_libretro_LibretroJni_##name
@@ -2104,3 +2106,231 @@ JNI_FUNC(void, nativeCheatSet)(JNIEnv *env, jobject thiz,
     g_core.retro_cheat_set((unsigned)index, enabled == JNI_TRUE, codeStr);
     (*env)->ReleaseStringUTFChars(env, code, codeStr);
 }
+
+#endif /* !SPELA_CORE_HOST — end of JNI bindings */
+
+/* ===================================================================== */
+/* === NATIVE HOST API (non-JNI) — out-of-process core host (desktop) === */
+/*                                                                       */
+/* Mirrors the JNI entry points above but takes plain C types, so a      */
+/* native main() (spela_core_host.c) can drive a core without a JVM.     */
+/* Reuses the same static core_load / globals / subsystem functions.     */
+/* See spela_host_api.h, player/native/CORE_HOST.md, and #1243.          */
+/* ===================================================================== */
+
+#ifndef __ANDROID__  /* host process is desktop-only (Android stays in-process) */
+
+void sp_host_set_dirs(const char *system_dir, const char *save_dir) {
+    if (system_dir) {
+        strncpy(g_core.system_dir, system_dir, sizeof(g_core.system_dir) - 1);
+        g_core.system_dir[sizeof(g_core.system_dir) - 1] = '\0';
+    }
+    if (save_dir) {
+        strncpy(g_core.save_dir, save_dir, sizeof(g_core.save_dir) - 1);
+        g_core.save_dir[sizeof(g_core.save_dir) - 1] = '\0';
+    }
+}
+
+bool sp_host_load_core(const char *core_path) {
+    return core_path && core_load(core_path) == 0;
+}
+
+void sp_host_init(void) {
+    if (!g_core.handle) return;
+    video_init();
+    input_init();
+    g_core.retro_init();
+    g_core.initialized = true;
+    /* Re-bind callbacks after retro_init (some cores reset them). */
+    g_core.retro_set_video_refresh(video_refresh_callback);
+    g_core.retro_set_audio_sample(audio_sample_callback);
+    g_core.retro_set_audio_sample_batch(audio_sample_batch_callback);
+    g_core.retro_set_input_poll(input_poll_callback);
+    g_core.retro_set_input_state(input_state_callback);
+    LOGI("[host] Core initialized");
+}
+
+bool sp_host_gpu_init_offscreen(int width, int height) {
+    if (g_gpu_renderer) {
+        video_set_gpu_renderer(NULL);
+        gpu_renderer_deinit_surface(g_gpu_renderer);
+        gpu_renderer_destroy(g_gpu_renderer);
+        g_gpu_renderer = NULL;
+    }
+    g_gpu_renderer = gpu_renderer_create(GPU_BACKEND_VULKAN);
+    if (!g_gpu_renderer) {
+        LOGE("[host] Failed to create GPU renderer for offscreen");
+        return false;
+    }
+    if (g_core.hw_vk_negotiation) {
+        gpu_renderer_set_vk_negotiation(g_gpu_renderer, g_core.hw_vk_negotiation);
+    }
+    if (!gpu_renderer_init_offscreen(g_gpu_renderer, width, height)) {
+        LOGE("[host] Failed to init offscreen GPU renderer");
+        gpu_renderer_destroy(g_gpu_renderer);
+        g_gpu_renderer = NULL;
+        return false;
+    }
+    video_set_gpu_renderer(g_gpu_renderer);
+    if (g_core.hw_render_enabled &&
+        g_core.hw_render_callback.context_type == RETRO_HW_CONTEXT_VULKAN) {
+        if (gpu_renderer_hw_vulkan_init(g_gpu_renderer)) {
+            if (g_core.hw_render_callback.context_reset) {
+                g_core.hw_render_callback.context_reset();
+            }
+            LOGI("[host] Vulkan HW render context initialized (offscreen)");
+        } else {
+            LOGE("[host] Failed to init Vulkan HW render context (offscreen)");
+            g_core.hw_render_enabled = false;
+        }
+    }
+    LOGI("[host] Offscreen GPU renderer initialized");
+    return true;
+}
+
+bool sp_host_load_game(const char *game_path) {
+    if (!g_core.handle || !g_core.initialized || !game_path) return false;
+
+    struct retro_game_info game_info = {0};
+    game_info.path = game_path;
+
+    if (!g_core.system_info.need_fullpath) {
+        FILE *f = fopen(game_path, "rb");
+        if (!f) { LOGE("[host] Failed to open ROM: %s", game_path); return false; }
+        fseek(f, 0, SEEK_END);
+        game_info.size = ftell(f);
+        fseek(f, 0, SEEK_SET);
+        void *buf = malloc(game_info.size);
+        if (buf) {
+            size_t read_bytes = fread(buf, 1, game_info.size, f);
+            if (read_bytes != game_info.size) {
+                LOGE("[host] Short read from ROM: %zu of %zu", read_bytes, game_info.size);
+                free(buf); fclose(f); return false;
+            }
+            game_info.data = buf;
+        }
+        fclose(f);
+    }
+
+    bool loaded = g_core.retro_load_game(&game_info);
+    if (game_info.data) free((void *)game_info.data);
+    if (!loaded) { LOGE("[host] retro_load_game failed"); return false; }
+
+    g_core.game_loaded = true;
+    g_core.retro_get_system_av_info(&g_core.av_info);
+    audio_init(g_core.av_info.timing.sample_rate);
+    LOGI("[host] Game loaded: %ux%u @ %.2f fps, audio %.1f Hz",
+         g_core.av_info.geometry.base_width, g_core.av_info.geometry.base_height,
+         g_core.av_info.timing.fps, g_core.av_info.timing.sample_rate);
+
+    if (g_core.retro_set_controller_port_device) {
+        for (unsigned port = 0; port < 4; port++) {
+            g_core.retro_set_controller_port_device(port, RETRO_DEVICE_JOYPAD);
+        }
+    }
+
+    /* Vulkan HW render: GPU renderer was created offscreen before load_game;
+     * reinit with the core's negotiation interface so they share VkInstance. */
+    if (g_core.hw_render_enabled &&
+        g_core.hw_render_callback.context_type == RETRO_HW_CONTEXT_VULKAN &&
+        g_gpu_renderer) {
+        if (g_core.hw_vk_negotiation) {
+            gpu_renderer_set_vk_negotiation(g_gpu_renderer, g_core.hw_vk_negotiation);
+            if (!gpu_renderer_reinit_vulkan(g_gpu_renderer)) {
+                LOGE("[host] Failed to reinit Vulkan with negotiation");
+            }
+        }
+        if (gpu_renderer_hw_vulkan_init(g_gpu_renderer)) {
+            if (g_core.hw_render_callback.context_reset) {
+                g_core.hw_render_callback.context_reset();
+            }
+            LOGI("[host] Vulkan HW render context initialized after game load");
+        } else {
+            LOGE("[host] Failed to init Vulkan HW render after game load");
+        }
+    }
+    return true;
+}
+
+void sp_host_run_frame(void) {
+    if (!g_core.game_loaded) return;
+    /* Vulkan HW render: skip frames until the HW context is ready. */
+    if (g_core.hw_render_enabled &&
+        g_core.hw_render_callback.context_type == RETRO_HW_CONTEXT_VULKAN &&
+        (!g_gpu_renderer || !gpu_renderer_is_hw_render_active(g_gpu_renderer))) {
+        return;
+    }
+    if (g_core.hw_render_enabled && g_core.hw_gl_ctx) {
+        hw_gl_make_current(g_core.hw_gl_ctx);
+        hw_gl_debug_reset_frame();
+    }
+    g_core.retro_run();
+    g_first_frame_run = true;
+    if (g_core.hw_render_enabled && g_core.hw_gl_ctx) {
+        hw_gl_release_current(g_core.hw_gl_ctx);
+    }
+    achievements_do_frame();
+}
+
+unsigned    sp_host_video_width(void)       { return video_get_width(); }
+unsigned    sp_host_video_height(void)      { return video_get_height(); }
+unsigned    sp_host_pixel_format(void)      { return video_get_pixel_format(); }
+const void *sp_host_video_buffer(void)      { return video_get_frame_buffer(); }
+size_t      sp_host_video_buffer_size(void) { return video_get_frame_buffer_size(); }
+
+size_t sp_host_render_to_bgra(void *dst, size_t dst_capacity, unsigned *w, unsigned *h) {
+    if (!g_gpu_renderer || !dst) return 0;
+    return gpu_renderer_render_to_bgra(g_gpu_renderer, dst, dst_capacity, w, h);
+}
+
+size_t sp_host_get_audio(int16_t *dst, size_t dst_frames) {
+    if (!dst || dst_frames == 0) return 0;
+    audio_lock();
+    const int16_t *buf = audio_get_buffer();
+    size_t frames = audio_get_buffer_frames_unlocked();
+    if (!buf || frames == 0) { audio_unlock(); return 0; }
+    size_t copy = frames < dst_frames ? frames : dst_frames;
+    memcpy(dst, buf, copy * 2 * sizeof(int16_t));
+    audio_clear_buffer_unlocked();
+    audio_unlock();
+    return copy;
+}
+
+void sp_host_set_button(unsigned port, unsigned id, bool pressed) {
+    input_set_button(port, id, pressed);
+}
+void sp_host_set_analog(unsigned port, unsigned index, unsigned id, int16_t value) {
+    input_set_analog(port, index, id, value);
+}
+void sp_host_set_pointer(unsigned port, int16_t x, int16_t y, bool pressed) {
+    input_set_pointer(port, x, y, pressed);
+}
+void sp_host_set_core_variable(const char *key, const char *value) {
+    if (key && value) core_variables_set(key, value);
+}
+
+double sp_host_target_fps(void)     { return g_core.av_info.timing.fps; }
+double sp_host_sample_rate(void)    { return g_core.av_info.timing.sample_rate; }
+float  sp_host_aspect_ratio(void)   { return g_core.av_info.geometry.aspect_ratio; }
+bool   sp_host_is_hw_render(void)   { return g_core.hw_render_enabled; }
+bool   sp_host_is_vulkan_hw_render(void) {
+    return g_core.hw_render_enabled &&
+           g_core.hw_render_callback.context_type == RETRO_HW_CONTEXT_VULKAN;
+}
+
+void sp_host_unload(void) {
+    if (g_core.game_loaded && g_core.retro_unload_game) g_core.retro_unload_game();
+    g_core.game_loaded = false;
+}
+void sp_host_deinit(void) {
+    /* The host is a short-lived process; the OS reclaims everything on exit.
+     * Keep teardown minimal to avoid the subtle HW-render teardown hazards
+     * the in-process JNI path must handle. */
+    if (g_core.initialized && g_core.retro_deinit) {
+        video_set_shutting_down();
+        g_core.retro_deinit();
+        g_core.initialized = false;
+    }
+}
+
+#endif /* !__ANDROID__ */

--- a/player/native/src/spela_core_host.c
+++ b/player/native/src/spela_core_host.c
@@ -1,0 +1,202 @@
+/*
+ * spela_core_host — out-of-process libretro core host (desktop).
+ *
+ * A minimal native frontend that loads a libretro core via the bridge's
+ * sp_host_* API and runs it in its OWN process, sharing the framebuffer +
+ * audio + input with the Spela JVM through a memory-mapped file. This gives
+ * the core a clean native address space (like RetroArch) and avoids the
+ * in-process-JVM corruption that crashes cores such as Azahar/3DS. See #1243.
+ *
+ * Args:
+ *   --core <path> --game <path> --system <dir> --save <dir> --shm <file>
+ *   [--width N --height N] [--var key=value ...]
+ *
+ * Phase 1: focuses on Vulkan HW-render cores (Azahar). Software-rendered
+ * output is passed through raw with its pixel format in the header.
+ */
+#include "sp_platform.h"   /* windows.h on Win32; sp_sleep_ms */
+#include "spela_host_api.h"
+#include "spela_host_ipc.h"
+#include "libretro.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#ifdef _WIN32
+#  include <windows.h>
+#else
+#  include <fcntl.h>
+#  include <sys/mman.h>
+#  include <unistd.h>
+#endif
+
+#define HOSTLOG(...) do { fprintf(stderr, "[CoreHost] " __VA_ARGS__); fprintf(stderr, "\n"); fflush(stderr); } while (0)
+
+/* ---- shared-memory mapping ------------------------------------------- */
+
+static uint8_t *g_shm = NULL;
+#ifdef _WIN32
+static HANDLE g_hFile = INVALID_HANDLE_VALUE;
+static HANDLE g_hMap = NULL;
+#else
+static int g_fd = -1;
+#endif
+
+static uint8_t *map_shared(const char *path) {
+#ifdef _WIN32
+    g_hFile = CreateFileA(path, GENERIC_READ | GENERIC_WRITE,
+                          FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+                          OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (g_hFile == INVALID_HANDLE_VALUE) { HOSTLOG("CreateFile failed: %lu", GetLastError()); return NULL; }
+    g_hMap = CreateFileMappingA(g_hFile, NULL, PAGE_READWRITE, 0, SP_TOTAL_SIZE, NULL);
+    if (!g_hMap) { HOSTLOG("CreateFileMapping failed: %lu", GetLastError()); return NULL; }
+    void *base = MapViewOfFile(g_hMap, FILE_MAP_ALL_ACCESS, 0, 0, SP_TOTAL_SIZE);
+    if (!base) { HOSTLOG("MapViewOfFile failed: %lu", GetLastError()); return NULL; }
+    return (uint8_t *)base;
+#else
+    g_fd = open(path, O_RDWR);
+    if (g_fd < 0) { HOSTLOG("open shm failed"); return NULL; }
+    void *base = mmap(NULL, SP_TOTAL_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, g_fd, 0);
+    if (base == MAP_FAILED) { HOSTLOG("mmap failed"); return NULL; }
+    return (uint8_t *)base;
+#endif
+}
+
+static void mem_barrier(void) {
+#ifdef _WIN32
+    MemoryBarrier();
+#else
+    __sync_synchronize();
+#endif
+}
+
+/* ---- input ----------------------------------------------------------- */
+
+static void apply_input(SpHostHeader *h) {
+    uint32_t buttons = h->input_buttons;
+    for (unsigned id = 0; id <= RETRO_DEVICE_ID_JOYPAD_R3; id++) {
+        sp_host_set_button(0, id, (buttons >> id) & 1u);
+    }
+    sp_host_set_analog(0, RETRO_DEVICE_INDEX_ANALOG_LEFT,  RETRO_DEVICE_ID_ANALOG_X, h->analog_lx);
+    sp_host_set_analog(0, RETRO_DEVICE_INDEX_ANALOG_LEFT,  RETRO_DEVICE_ID_ANALOG_Y, h->analog_ly);
+    sp_host_set_analog(0, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X, h->analog_rx);
+    sp_host_set_analog(0, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y, h->analog_ry);
+    sp_host_set_pointer(0, (int16_t)h->pointer_x, (int16_t)h->pointer_y, h->pointer_pressed != 0);
+}
+
+/* ---- main ------------------------------------------------------------ */
+
+int main(int argc, char **argv) {
+    const char *core = NULL, *game = NULL, *system_dir = NULL, *save_dir = NULL, *shm = NULL;
+    int off_w = 256, off_h = 224;
+    const char *vars[64]; int nvars = 0;
+
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--core")   && i + 1 < argc) core = argv[++i];
+        else if (!strcmp(argv[i], "--game")   && i + 1 < argc) game = argv[++i];
+        else if (!strcmp(argv[i], "--system") && i + 1 < argc) system_dir = argv[++i];
+        else if (!strcmp(argv[i], "--save")   && i + 1 < argc) save_dir = argv[++i];
+        else if (!strcmp(argv[i], "--shm")    && i + 1 < argc) shm = argv[++i];
+        else if (!strcmp(argv[i], "--width")  && i + 1 < argc) off_w = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--height") && i + 1 < argc) off_h = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--var")    && i + 1 < argc && nvars < 64) vars[nvars++] = argv[++i];
+    }
+    if (!core || !game || !shm) {
+        HOSTLOG("usage: --core P --game P --shm FILE [--system D --save D --width N --height N --var k=v]");
+        return 2;
+    }
+
+    g_shm = map_shared(shm);
+    if (!g_shm) return 3;
+    SpHostHeader *h = (SpHostHeader *)g_shm;
+    memset(h, 0, SP_HDR_SIZE);
+    h->status = SP_STATUS_STARTING;
+    h->abi = SP_IPC_ABI;
+    uint8_t *video_buf = g_shm + SP_VIDEO_OFFSET;
+    int16_t *audio_buf = (int16_t *)(g_shm + SP_AUDIO_OFFSET);
+    const size_t audio_cap_frames = SP_AUDIO_CAP_BYTES / (2 * sizeof(int16_t));
+
+    sp_host_set_dirs(system_dir, save_dir);
+    if (!sp_host_load_core(core)) { HOSTLOG("load_core failed: %s", core); h->status = SP_STATUS_ERROR; mem_barrier(); h->magic = SP_IPC_MAGIC; return 4; }
+    sp_host_init();
+    for (int i = 0; i < nvars; i++) {
+        char tmp[256]; strncpy(tmp, vars[i], sizeof(tmp) - 1); tmp[sizeof(tmp) - 1] = 0;
+        char *eq = strchr(tmp, '=');
+        if (eq) { *eq = 0; sp_host_set_core_variable(tmp, eq + 1); }
+    }
+    /* Create the offscreen GPU renderer BEFORE load_game (matches desktop in-process
+     * order); HW Vulkan init happens inside load_game once the core declares it. */
+    sp_host_gpu_init_offscreen(off_w, off_h);
+    if (!sp_host_load_game(game)) { HOSTLOG("load_game failed: %s", game); h->status = SP_STATUS_ERROR; mem_barrier(); h->magic = SP_IPC_MAGIC; return 5; }
+
+    double fps = sp_host_target_fps(); if (fps <= 0) fps = 60.0;
+    h->target_fps = fps;
+    h->sample_rate = sp_host_sample_rate();
+    h->aspect_ratio = sp_host_aspect_ratio();
+    int vulkan = sp_host_is_vulkan_hw_render();
+    HOSTLOG("running: fps=%.2f vulkan_hw=%d offscreen=%dx%d", fps, vulkan, off_w, off_h);
+
+    h->status = SP_STATUS_RUNNING;
+    mem_barrier();
+    h->magic = SP_IPC_MAGIC;   /* signal JVM we're up */
+
+#ifdef _WIN32
+    LARGE_INTEGER freq; QueryPerformanceFrequency(&freq);
+    LARGE_INTEGER next; QueryPerformanceCounter(&next);
+    const double period = (double)freq.QuadPart / fps;
+#endif
+
+    while (!h->should_stop) {
+        apply_input(h);
+        if (!h->paused) sp_host_run_frame();
+
+        /* video */
+        unsigned w = 0, hh = 0;
+        if (vulkan) {
+            size_t bytes = sp_host_render_to_bgra(video_buf, SP_VIDEO_CAP, &w, &hh);
+            if (bytes > 0) {
+                h->video_width = w; h->video_height = hh;
+                h->video_format = 0; /* BGRA8888 */
+                h->video_bytes = (uint32_t)bytes;
+            }
+        } else {
+            /* software path (not the Phase-1 focus): pass through raw */
+            const void *fb = sp_host_video_buffer();
+            size_t sz = sp_host_video_buffer_size();
+            if (fb && sz > 0 && sz <= SP_VIDEO_CAP) {
+                memcpy(video_buf, fb, sz);
+                h->video_width = sp_host_video_width();
+                h->video_height = sp_host_video_height();
+                h->video_format = sp_host_pixel_format();
+                h->video_bytes = (uint32_t)sz;
+            }
+        }
+
+        /* audio */
+        size_t frames = sp_host_get_audio(audio_buf, audio_cap_frames);
+        h->audio_frames = (uint32_t)frames;
+
+        mem_barrier();
+        h->frame_counter++;   /* publish: JVM reads when this changes */
+
+        /* pacing */
+#ifdef _WIN32
+        next.QuadPart += (LONGLONG)period;
+        LARGE_INTEGER now; QueryPerformanceCounter(&now);
+        double remain_ms = (double)(next.QuadPart - now.QuadPart) * 1000.0 / (double)freq.QuadPart;
+        if (remain_ms > 1.0) sp_sleep_ms((int)remain_ms);
+        else if (remain_ms < -100.0) next = now; /* fell far behind; resync */
+#else
+        sp_sleep_ms((int)(1000.0 / fps));
+#endif
+    }
+
+    HOSTLOG("stopping");
+    sp_host_unload();
+    sp_host_deinit();
+    h->status = SP_STATUS_EXITED;
+    mem_barrier();
+    return 0;
+}

--- a/player/native/src/spela_host_api.h
+++ b/player/native/src/spela_host_api.h
@@ -1,0 +1,76 @@
+/*
+ * spela_host_api.h — native (non-JNI) entry points for the out-of-process
+ * core host (desktop only).
+ *
+ * The desktop player normally drives the libretro bridge in-process via JNI
+ * (LibretroJni). Some cores (e.g. Azahar/3DS) corrupt their own internal
+ * state when hosted inside the JVM process and crash; running them in a
+ * separate native process (like RetroArch does) avoids this. See #1243.
+ *
+ * These functions mirror the JNI surface but take plain C types instead of
+ * JNIEnv/jobject, so a native `main()` (spela_core_host.c) can load and run a
+ * core without a JVM. They are implemented at the end of libretro_bridge.c
+ * and reuse the same internal core/video/audio/input/GPU machinery.
+ */
+#ifndef SPELA_HOST_API_H
+#define SPELA_HOST_API_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Set system (BIOS) + save directories. Call before sp_host_load_core. */
+void sp_host_set_dirs(const char *system_dir, const char *save_dir);
+
+/* Load the core .dll/.so/.dylib. Returns true on success. */
+bool sp_host_load_core(const char *core_path);
+
+/* retro_init + video/input init (mirrors nativeInit). */
+void sp_host_init(void);
+
+/* retro_load_game. Returns true on success. */
+bool sp_host_load_game(const char *game_path);
+
+/* AV info (valid after sp_host_load_game). */
+double sp_host_target_fps(void);
+double sp_host_sample_rate(void);
+float  sp_host_aspect_ratio(void);
+
+/* HW-render queries. */
+bool sp_host_is_hw_render(void);
+bool sp_host_is_vulkan_hw_render(void);
+
+/* Offscreen Vulkan renderer for HW-render cores. Call after sp_host_load_game
+ * when sp_host_is_vulkan_hw_render() is true. */
+bool sp_host_gpu_init_offscreen(int width, int height);
+
+/* Run a single frame (retro_run with HW-render gating). */
+void sp_host_run_frame(void);
+
+/* Software-rendered frame accessors (for cores not using Vulkan HW render). */
+unsigned    sp_host_video_width(void);
+unsigned    sp_host_video_height(void);
+unsigned    sp_host_pixel_format(void);
+const void *sp_host_video_buffer(void);
+size_t      sp_host_video_buffer_size(void);
+
+/* Vulkan HW-render readback into a BGRA8888 buffer.
+ * Returns bytes written; sets *w,*h to the frame dimensions. */
+size_t sp_host_render_to_bgra(void *dst, size_t dst_capacity, unsigned *w, unsigned *h);
+
+/* Copy currently-buffered audio as interleaved stereo int16 frames into dst.
+ * dst_frames = capacity in frames (each frame = 2 int16). Returns frames copied. */
+size_t sp_host_get_audio(int16_t *dst, size_t dst_frames);
+
+/* Input (port/device per libretro). */
+void sp_host_set_button(unsigned port, unsigned id, bool pressed);
+void sp_host_set_analog(unsigned port, unsigned index, unsigned id, int16_t value);
+void sp_host_set_pointer(unsigned port, int16_t x, int16_t y, bool pressed);
+
+/* Set a core option (key/value) before sp_host_load_game. */
+void sp_host_set_core_variable(const char *key, const char *value);
+
+void sp_host_unload(void);   /* unload game */
+void sp_host_deinit(void);   /* deinit core */
+
+#endif /* SPELA_HOST_API_H */

--- a/player/native/src/spela_host_ipc.h
+++ b/player/native/src/spela_host_ipc.h
@@ -1,0 +1,61 @@
+/*
+ * spela_host_ipc.h — shared-memory layout between the Spela JVM and the
+ * out-of-process core host (spela_core_host). Backed by a memory-mapped file
+ * so the JVM (FileChannel.map) and the native host (mmap / MapViewOfFile)
+ * share the same region. See #1243.
+ *
+ * The Kotlin side (DesktopCoreHostController) mirrors these byte offsets — keep
+ * the two in sync. Layout: a fixed 256-byte header, then the BGRA video buffer,
+ * then the interleaved-stereo-int16 audio buffer.
+ */
+#ifndef SPELA_HOST_IPC_H
+#define SPELA_HOST_IPC_H
+
+#include <stdint.h>
+
+#define SP_IPC_MAGIC       0x53504831u   /* 'SPH1' */
+#define SP_IPC_ABI         1u
+
+#define SP_HDR_SIZE        256u
+#define SP_VIDEO_CAP       (16u * 1024u * 1024u)  /* up to ~2048x2048 BGRA */
+#define SP_AUDIO_CAP_BYTES (256u * 1024u)         /* >> one frame of stereo s16 */
+
+#define SP_VIDEO_OFFSET    SP_HDR_SIZE
+#define SP_AUDIO_OFFSET    (SP_VIDEO_OFFSET + SP_VIDEO_CAP)
+#define SP_TOTAL_SIZE      (SP_AUDIO_OFFSET + SP_AUDIO_CAP_BYTES)
+
+/* status values */
+#define SP_STATUS_STARTING 0u
+#define SP_STATUS_RUNNING  1u
+#define SP_STATUS_ERROR    2u
+#define SP_STATUS_EXITED   3u
+
+/* Header — must stay within SP_HDR_SIZE bytes. All fields little-endian.
+ * Producer/consumer noted per field. Synchronization is via frame_counter
+ * (host increments after writing a frame; JVM reads when it changes). */
+typedef struct {
+    uint32_t magic;          /* host writes SP_IPC_MAGIC once ready */
+    uint32_t abi;            /* SP_IPC_ABI */
+    uint32_t status;         /* SP_STATUS_* (host) */
+    uint32_t should_stop;    /* JVM -> host: set 1 to request shutdown */
+    uint32_t paused;         /* JVM -> host: set 1 to pause retro_run */
+
+    uint64_t frame_counter;  /* host: ++ after each produced frame */
+    uint32_t video_width;    /* host */
+    uint32_t video_height;   /* host */
+    uint32_t video_format;   /* host: 0 = BGRA8888 */
+    uint32_t video_bytes;    /* host: bytes valid in the video buffer */
+    uint32_t audio_frames;   /* host: stereo frames in the audio buffer this tick */
+
+    double   target_fps;     /* host */
+    double   sample_rate;    /* host */
+    float    aspect_ratio;   /* host */
+
+    /* input: JVM -> host (port 0) */
+    uint32_t input_buttons;  /* bitmask of (1 << RETRO_DEVICE_ID_JOYPAD_*) */
+    int16_t  analog_lx, analog_ly, analog_rx, analog_ry;
+    int32_t  pointer_x, pointer_y;
+    uint32_t pointer_pressed;
+} SpHostHeader;
+
+#endif /* SPELA_HOST_IPC_H */


### PR DESCRIPTION
## What

Adds **`spela-core-host`** — a standalone native harness that loads and runs a libretro core in its **own process** (JVM-free, with a PDB) — plus the documentation that came out of the #1237/#1243 investigation.

The core fix for the Azahar/3DS crash already shipped in **#1246**. This PR adds the **debug tooling that pinned it** and **documents it properly in the repo** (not just issue comments).

## Contents

- **`sp_host_*` API** (`spela_host_api.h` + impls in `libretro_bridge.c`): non-JNI entry points mirroring the JNI surface, reusing the same internal core/video/audio/input/GPU machinery.
- **`spela_core_host.c`**: native `main()` + emulation loop; shares video (BGRA), audio, and input with a parent over a **memory-mapped file** (`spela_host_ipc.h`).
- **CMake `spela-core-host` target**: built with `-DSPELA_CORE_HOST`, which compiles out the JNI bindings so the host links **no** jvm/jawt libraries (stays JVM-free — that's the whole point).
- **`player/native/CORE_HOST.md`**: documents the harness, the `cdb` debugging workflow, the **env command-number masking pitfall** (`cmd & 0xFFFF` aliasing), and the full **#1237/#1243 postmortem**.
- Discovery pointers from **CLAUDE.md** (Debugging Strategy) and **docs/notes/README.md**.

## Why keep it

It's a fast, fully-symbolized repro for desktop libretro core crashes — far better than a JVM `hs_err`. It independently answers "core vs our frontend vs hosting?" It's what cracked #1243 (cdb on the harness showed the faulting dispatch entry was our own `environment_callback`).

## Notes

- Desktop-only; Android keeps the in-process JNI path.
- Debug/isolation tool — **not** wired into the app at runtime (no JVM client yet; the in-process path remains the shipping path).
- Builds clean (`buildNativeLibrary`): both `spela-core-host.exe` and `spela-libretro.dll`.

Related: #1237, #1243, #1246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
