### PR TITLE
fix(player): download progress bar stuck under 100% on completion (#1235)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
@@ -249,11 +249,15 @@ class DownloadRepositoryImpl(
         val path = "$gameDir/$actualFileName"
 
         apiClient.downloadGameToFile(gameId, fileStorage, path) { downloaded, total ->
-            // Prefer the DB file size over Content-Length. OkHttp transparently
-            // decompresses gzip responses, so Content-Length may report the
-            // compressed size while downloaded bytes count decompressed data,
-            // causing the progress bar to jump past 100%.
-            val reportedTotal = if (expectedSize > 0) expectedSize else (total ?: -1)
+            // Prefer the server's Content-Length (`total`) — it's the exact
+            // number of bytes we'll receive, so `downloaded` reaches it and the
+            // bar hits 100%. The DB file size can disagree with the transfer:
+            // for compressed single-file formats (.rvz, .chd) it's the
+            // logical/uncompressed size, which left the bar stuck well under
+            // 100%. Game downloads aren't Content-Encoding: gzip'd, so
+            // Content-Length is the true received-byte count on every engine.
+            // Fall back to the DB size only if the server omits it. (#1235)
+            val reportedTotal = total ?: if (expectedSize > 0) expectedSize else -1L
             val monotonic = monotonicBytes(gameId, downloaded)
             val speed = recordSpeed(gameId, monotonic)
             downloads.update {
@@ -314,7 +318,12 @@ class DownloadRepositoryImpl(
             // Single file — stream to disk
             val discPath = "$gameDir/${disc.fileName}"
             apiClient.downloadDiscToFile(gameId, disc.discNumber.toInt(), fileStorage, discPath) { downloaded, total ->
-                val reportedTotal = if (disc.fileSize > 0) disc.fileSize else (total ?: -1)
+                // Prefer the server's Content-Length over the DB disc.fileSize:
+                // it's the exact transfer size, so the bar reaches 100%. For
+                // compressed single-file discs (.rvz, .chd) the DB size is the
+                // logical/uncompressed size and left the bar stuck ~50%. This
+                // matches the .cue/.gdi branch above. (#1235)
+                val reportedTotal = total ?: if (disc.fileSize > 0) disc.fileSize else -1L
                 val monotonic = monotonicBytes(gameId, downloaded)
                 val speed = recordSpeed(gameId, monotonic)
                 downloads.update {

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -41,6 +41,15 @@ func streamFileFromDisk(absPath, downloadName, contentType string) *huma.StreamR
 				hctx.SetHeader("Content-Type", contentType)
 			}
 			hctx.SetHeader("Content-Disposition", fmt.Sprintf("attachment; filename=%q", downloadName))
+			// Advertise the exact byte count so clients can show accurate
+			// download progress. Without this the body is chunked (no
+			// Content-Length), the player can't learn the transfer size, and
+			// it falls back to the DB file size — which for compressed
+			// single-file formats (e.g. .rvz) is the logical/uncompressed
+			// size, leaving the progress bar stuck well under 100%. (#1235)
+			if info, serr := f.Stat(); serr == nil {
+				hctx.SetHeader("Content-Length", strconv.FormatInt(info.Size(), 10))
+			}
 			_, _ = io.Copy(hctx.BodyWriter(), f)
 		},
 	}


### PR DESCRIPTION
Game-details download bar filled only partway (e.g. ~50% for GameCube `.rvz`) even when the download completed.

**Root cause (both ends):**
- Server `streamFileFromDisk` sent **no `Content-Length`** (chunked body) for single-file downloads, so the client couldn't learn the transfer size.
- Client used the DB `fileSize` as the bar denominator. For compressed single-file formats (`.rvz`, `.chd`) that's the **logical/uncompressed** size, while the bytes actually transferred are the smaller compressed container → `downloaded/total` topped out below 1.0.

**Fix:**
- Server sets `Content-Length` = the file's byte size on single-file downloads (games, discs, cores, BIOS). Game downloads aren't `Content-Encoding: gzip`'d, so it equals the received byte count on every client engine.
- Client prefers the server's `Content-Length` over the DB size for the plain + single-file-disc paths, matching the `.cue/.gdi` archive path. The denominator is now the real transfer size → bar reaches 100% at completion for any format.

Verified: server pkg type-checks (`go build ./internal/api`), shared Kotlin `compileKotlinDesktop` BUILD SUCCESSFUL. End-to-end (bar→100%) needs a server rebuild + re-download.

Closes #1235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)