### PR TITLE
chore(player): de-duplicate BIOS-sync comment left by #1227 (#1207)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/BiosRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/BiosRepository.kt
@@ -24,10 +24,6 @@ open class BiosRepository(
             // lists optional BIOS the server may not hold (PS2, X68000, …);
             // attempting to download a "missing" entry just 404s and spams
             // the log on every startup (#1207).
-            // Skip files the server itself reports as absent. The registry
-            // lists optional BIOS the server may not hold (PS2, X68000, …);
-            // attempting to download a "missing" entry just 404s and spams
-            // the log on every startup (#1207).
             if (file.status == "missing") continue
             val localDir = if (!file.subDir.isNullOrEmpty()) "$biosDir/${file.subDir}" else biosDir
             val localPath = "$localDir/${file.name}"


### PR DESCRIPTION
#1207's functional fix (skip server-missing optional BIOS so startup doesn't 404-spam) already shipped in **#1227**. That change accidentally pasted its explanatory comment twice — this removes the duplicate. No behavior change.

The reported 404s (PS2 `SCPH-70004/70000`, NDS `firmware.bin`, X68000 `IPLROM30.DAT`/`CGROM.DAT`) are all `Required:false` BIOS the operator hasn't uploaded; the client skips them and surfaces only *required* missing files via `preLaunchBiosCheck`.

Closes #1207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)