### PR TITLE
fix(server): make Go test suite pass on Windows + fix cross-platform path/URL bugs

### DIFF
--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -86,7 +86,9 @@ func (h *ConsoleHandler) resolvePreviewScreenshotPath(_ context.Context, console
 	cachedPath := filepath.Join("previews", console.Abbreviation, "preview.png")
 	fullCachedPath := h.Storage.ImagePath(cachedPath)
 	if _, err := os.Stat(fullCachedPath); err == nil {
-		return "/api/images/" + cachedPath, nil
+		// filepath.ToSlash keeps the URL path-separated even when the
+		// cache path was built with the OS separator (backslash on Windows).
+		return "/api/images/" + filepath.ToSlash(cachedPath), nil
 	}
 
 	libRetroSystem, ok := scraper.AbbreviationToLibRetro[console.Abbreviation]
@@ -123,7 +125,7 @@ func (h *ConsoleHandler) resolvePreviewScreenshotPath(_ context.Context, console
 		slog.Warn("failed to cache preview screenshot", "console", console.Abbreviation, "error", err)
 		return "", huma.Error500InternalServerError("failed to cache preview")
 	}
-	return "/api/images/" + savedPath, nil
+	return "/api/images/" + filepath.ToSlash(savedPath), nil
 }
 
 

--- a/server/internal/api/huma_misc.go
+++ b/server/internal/api/huma_misc.go
@@ -392,7 +392,7 @@ func (h *SavedSearchHandler) HumaListSavedSearches(ctx context.Context, _ *ListS
 	}
 
 	var searches []db.SavedSearch
-	if err := h.DB.Where("user_id = ?", uid).Order("created_at DESC").Find(&searches).Error; err != nil {
+	if err := h.DB.Where("user_id = ?", uid).Order("created_at DESC, id DESC").Find(&searches).Error; err != nil {
 		return nil, huma.Error500InternalServerError("failed to fetch saved searches")
 	}
 

--- a/server/internal/api/upload_handler_test.go
+++ b/server/internal/api/upload_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/spela/server/internal/auth"
@@ -1648,6 +1649,13 @@ func TestCheckWritable_WritableDir(t *testing.T) {
 }
 
 func TestCheckWritable_ReadonlyDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// os.Chmod(0555) cannot make a directory read-only on Windows —
+		// it only toggles the read-only file attribute, which does not
+		// stop the owner from creating files. checkWritable's probe
+		// therefore succeeds. The behaviour is POSIX-only (#1225).
+		t.Skip("read-only directory semantics are not reproducible on Windows")
+	}
 	env := setupUploadTestEnv(t)
 
 	// Make the game directory read-only

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -539,7 +539,10 @@ func extractRelativeByConsoleFolders(absPath string, folderNames map[string]bool
 	parts := strings.Split(filepath.ToSlash(absPath), "/")
 	for i, part := range parts {
 		if folderNames[part] && i < len(parts)-1 {
-			return filepath.Join(parts[i:]...)
+			// Join with "/" (not filepath.Join) so the stored relative
+			// path is canonical across host OSes — filepath.Join would
+			// emit backslashes on Windows, breaking dedup idempotency.
+			return strings.Join(parts[i:], "/")
 		}
 	}
 	return absPath

--- a/server/internal/scraper/scrape_result_test.go
+++ b/server/internal/scraper/scrape_result_test.go
@@ -21,6 +21,13 @@ func setupScrapeResultDB(t *testing.T) *gorm.DB {
 	})
 	require.NoError(t, err)
 	require.NoError(t, database.AutoMigrate(&db.GameScrapeResult{}))
+	// Close the SQLite handle before t.TempDir cleanup removes the file.
+	// Windows cannot delete a file that is still open (#1225).
+	t.Cleanup(func() {
+		if sqlDB, err := database.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
 	return database
 }
 

--- a/server/internal/scraper/scraper_igdb_test.go
+++ b/server/internal/scraper/scraper_igdb_test.go
@@ -37,6 +37,13 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		&db.GameArtworkImage{}, &db.GameReleaseDate{},
 		&db.GameVideo{}, &db.GameLanguageSupport{}, &db.GameAgeRating{},
 	))
+	// Close the SQLite handle before t.TempDir cleanup removes the file.
+	// Windows cannot delete a file that is still open (#1225).
+	t.Cleanup(func() {
+		if sqlDB, err := database.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
 	return database
 }
 

--- a/server/internal/storage/storage_test.go
+++ b/server/internal/storage/storage_test.go
@@ -26,7 +26,9 @@ func TestNewStorage(t *testing.T) {
 func TestSaveStatePath(t *testing.T) {
 	store := &Storage{SaveDir: "/data/saves"}
 	path := store.SaveStatePath(1, 42, "save.sav")
-	assert.Equal(t, "/data/saves/user_1/game_42/save.sav", path)
+	// SaveStatePath builds a real on-disk path, so it uses the OS separator
+	// (backslash on Windows). ToSlash normalises for a stable assertion.
+	assert.Equal(t, "/data/saves/user_1/game_42/save.sav", filepath.ToSlash(path))
 }
 
 func TestWriteAndReadSave(t *testing.T) {


### PR DESCRIPTION
## Summary

The Go test suite failed when run on Windows (#1225). Triage found **three classes** of failure — two of which were genuine cross-platform production bugs masked by the Linux/macOS-only dev environment, not just test issues.

## Production fixes (real bugs, only surfaced on Windows)

- **`db.extractRelativeByConsoleFolders`** rejoined path segments with `filepath.Join`, emitting backslashes on Windows. The result is a canonical DB-stored relative path that gets deduped, so a Windows host produced a different canonical form and broke migration idempotency (rule #7). Now joins with `/` so the stored path is OS-independent.
- **`resolvePreviewScreenshotPath`** built an HTTP URL with `filepath.Join`, yielding `/api/images/previews\NES\preview.png` on Windows. URLs must use `/` — wrapped in `filepath.ToSlash`.
- **Saved-search list** ordered only by `created_at DESC`; two rows created sub-millisecond apart tie under Windows' coarser clock and return in undefined order. Added `id DESC` as a deterministic tiebreaker.

## Test-only fixes

- `storage.TestSaveStatePath`: `SaveStatePath` builds a real on-disk path (OS separator is correct), so normalise with `filepath.ToSlash` before asserting.
- scraper `setupTestDB` / `setupScrapeResultDB` leaked the SQLite handle; Windows can't delete an open file, so `t.TempDir` cleanup failed the test. Close the DB in a `t.Cleanup` registered after `t.TempDir`.
- `TestCheckWritable_ReadonlyDir` relies on POSIX `chmod(0555)` semantics that don't make a directory read-only on Windows — skipped there.

## Verification

Full `go test ./...` is green on Windows with `CGO_ENABLED=1` (all packages, including the 269s `internal/api` suite). Production behaviour on Linux is unchanged (`ToSlash`/`strings.Join("/")` are no-ops where the separator is already `/`).

Closes #1225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
