### PR TITLE
fix(player): correct upside-down PS2 (and other desktop GL HW-render) games

### DIFF
--- a/player/native/src/hw_render_gl_desktop.c
+++ b/player/native/src/hw_render_gl_desktop.c
@@ -775,20 +775,12 @@ unsigned hw_gl_read_pixels(hw_gl_context_t *ctx, void *out_data, size_t out_capa
     /* Read BGRA pixels (XRGB8888 compatible) */
     ctx->pfn_glReadPixels(0, 0, w, h, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, out_data);
 
-    /* Flip vertically (GL origin is bottom-left, we need top-left) */
-    uint8_t *pixels = (uint8_t *)out_data;
-    size_t row_bytes = (size_t)w * 4;
-    uint8_t *temp = (uint8_t *)malloc(row_bytes);
-    if (temp) {
-        for (unsigned y = 0; y < h / 2; y++) {
-            uint8_t *top = pixels + y * row_bytes;
-            uint8_t *bot = pixels + (h - 1 - y) * row_bytes;
-            memcpy(temp, top, row_bytes);
-            memcpy(top, bot, row_bytes);
-            memcpy(bot, temp, row_bytes);
-        }
-        free(temp);
-    }
+    /* Do NOT flip vertically here. The frame is presented through
+     * gpu_renderer_render_to_bgra, whose vertex shader applies
+     * flip_y = hw_bottom_left_origin to convert the GL bottom-left origin
+     * to the screen top-left origin. Flipping here as well double-flips,
+     * producing an upside-down image (#1254). This matches the Android
+     * readback path (hw_render_gl_android.c). */
 
     if (out_width) *out_width = w;
     if (out_height) *out_height = h;


### PR DESCRIPTION
## Summary

PS2 games rendered **upside down** on the Windows desktop build (#1254).

PS2 runs on the **Play!** core via **OpenGL HW render** with `bottom_left_origin=1`, routed through the desktop GL pbuffer readback path. The frame was being flipped **twice**:

1. `hw_gl_read_pixels` (`player/native/src/hw_render_gl_desktop.c`) manually flipped the readback rows — *"GL origin is bottom-left, we need top-left"*.
2. `gpu_renderer_render_to_bgra` (`player/native/src/gpu_renderer_vulkan.c`) then presents with `flip_y = hw_bottom_left_origin` (= 1), so the vertex shader flips **again**.

Two flips = upside down. This is why it was desktop-only.

## Fix

Remove the manual flip in `hw_gl_read_pixels`, leaving the GL→screen origin conversion to the present shader's `flip_y` (which keys off `bottom_left_origin`). This matches the **Android** readback path, which already deliberately does **not** flip in readback (`hw_render_gl_android.c`: *"Flipping here would double-flip, producing an upside-down image"*). Also fixes any other GL HW-render core that takes the desktop readback path.

## Verification

Native bridge rebuilt and the desktop app relaunched with the fix; PS2 (Play!) confirmed rendering right-side-up. No automated coverage is feasible for native GL readback orientation; the fix aligns desktop with the documented present-path contract and the Android implementation.

Closes #1254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
