### PR TITLE
fix(server): set Content-Length on single-file game downloads

### DIFF
--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -2656,6 +2656,48 @@ func TestDownloadGame_CueBinServeTar(t *testing.T) {
 	assert.Len(t, fileNames, 2, "tar should contain exactly 2 files")
 }
 
+// TestDownloadGame_SingleFileSetsContentLength verifies the fallback
+// single-file path advertises Content-Length = the on-disk byte count, so
+// the player can show accurate download progress instead of falling back to
+// the (possibly logical/uncompressed) DB file size. Regression for #1261.
+func TestDownloadGame_SingleFileSetsContentLength(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	psxDir := filepath.Join(cfg.GameDirs[0], "psx")
+	require.NoError(t, os.MkdirAll(psxDir, 0755))
+
+	// A compressed single-file format whose on-disk (transfer) size differs
+	// from the DB FileSize (which for such formats is the logical size).
+	isoContent := []byte("compressed disc image bytes — smaller than logical size")
+	require.NoError(t, os.WriteFile(filepath.Join(psxDir, "game.chd"), isoContent, 0644))
+
+	var psxConsole db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "PSX").First(&psxConsole).Error)
+
+	game := db.Game{
+		ConsoleID: psxConsole.ID,
+		Title:     "Test Single File",
+		FileName:  "game.chd",
+		FilePath:  filepath.Join("psx", "game.chd"),
+		FileSize:  9_999_999, // logical size, deliberately != on-disk size
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/games/%d/download", game.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	// Content-Length must equal the actual transferred bytes, not the DB size.
+	assert.Equal(t, strconv.Itoa(len(isoContent)), w.Header().Get("Content-Length"),
+		"Content-Length should be the on-disk transfer size")
+	assert.Equal(t, len(isoContent), w.Body.Len())
+}
+
 // TestDownloadGame_CueBinServeZip verifies the zip format option for .cue downloads.
 func TestDownloadGame_CueBinServeZip(t *testing.T) {
 	database, cfg := setupTestEnv(t)

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -1003,6 +1003,17 @@ func (h *GameHandler) HumaDownloadGame(_ context.Context, in *GameDownloadInput)
 			defer f.Close()
 			hctx.SetHeader("Content-Type", "application/octet-stream")
 			hctx.SetHeader("Content-Disposition", fmt.Sprintf("inline; filename=%q", game.FileName))
+			// Advertise the exact transfer size so the player shows accurate
+			// download progress. Without it the body is chunked (no
+			// Content-Length) and the client falls back to the DB file size,
+			// which for compressed formats (PSP, .rvz, .chd) is the
+			// logical/uncompressed size — leaving the bar stuck well under
+			// 100%. The streamed byte count equals the on-disk size; the
+			// iNES normalization below rewrites the first 16 bytes in place,
+			// so the length is unchanged. (#1261, follow-up to #1235/#1248)
+			if info, serr := f.Stat(); serr == nil {
+				hctx.SetHeader("Content-Length", strconv.FormatInt(info.Size(), 10))
+			}
 			w := hctx.BodyWriter()
 			if normalizeINES {
 				var head [16]byte


### PR DESCRIPTION
## Summary

The desktop download progress bar stalled well under 100% for compressed single-file games (e.g. Burnout Legends PSP ~400 MB finished at ~30%), while the downloaded-bytes counter was correct (#1261).

## Root cause

`HumaDownloadGame`'s fallback single-file path was a hand-rolled `huma.StreamResponse` that set Content-Type and Content-Disposition but **not Content-Length**, so the response body was chunked. The desktop player's `streamResponseToFile` reads `response.contentLength()`, gets `null`, and `DownloadRepositoryImpl` falls back to the DB `game.fileSize`. For compressed formats (PSP, `.rvz`, `.chd`) that DB size is the **logical/uncompressed** size (~1.3 GB) while the real transfer is the compressed file (~400 MB) → `progress = 400MB / 1.3GB ≈ 30%`.

(FFX `.iso` and MGS `.zip` happened to work only because their DB `fileSize` equals the on-disk transfer size, so the wrong fallback was coincidentally correct.)

This path did **not** use the `streamFileFromDisk` helper that #1235/#1248 fixed.

## Fix

Set `Content-Length` = the on-disk file size on the fallback path. The streamed byte count equals the file size (the iNES header normalization rewrites the first 16 bytes in place, unchanged length), so the client uses the exact transfer size and the bar reaches 100% regardless of compression.

## Test

`TestDownloadGame_SingleFileSetsContentLength` creates a `.chd` whose DB `FileSize` deliberately differs from the on-disk size and asserts the response `Content-Length` equals the actual transferred bytes (fails before the fix).

Follow-up to #1235 / #1248. Closes #1261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
