### PR TITLE
fix(player): make non-playable game's Delete Download button visible

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -281,7 +281,12 @@ fun GameHeroContent(
                     SpButton(
                         text = "Delete Download",
                         onClick = onDeleteLocalGame,
-                        style = SpButtonStyle.Ghost,
+                        // Tinted, not Ghost: this is the sole action for a
+                        // non-playable game, sitting on the gradient hero.
+                        // Ghost on a gradient is just white text with no
+                        // fill/border and reads as transparent (#1256). Tinted
+                        // is the established gradient-hero button treatment.
+                        style = SpButtonStyle.Tinted,
                         onGradient = true,
                         modifier = Modifier.focusRestoreItem(
                             key = "game_detail_play",


### PR DESCRIPTION
## Summary

For a non-playable game (unsupported console) the only action on the detail hero is **Delete Download**, and it rendered as a transparent ghost button (#1256).

## Root cause

`GameHeroContent` used `SpButtonStyle.Ghost` with `onGradient = true`. On the gradient hero, Ghost is just white text with no fill or border, so the sole action looks transparent/empty.

## Fix

Switch to `SpButtonStyle.Tinted` — the design-system treatment purpose-built for buttons sitting on the colorful console banner gradient (white-tint fill + thin white border, #930). The button is now clearly visible.

Visual-only change (swap to an existing button style); no logic change.

Closes #1256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
