### PR TITLE
fix(player): drop region flag emoji where they don't render (Windows/Linux)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpRegionChip.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpRegionChip.kt
@@ -2,6 +2,7 @@ package com.spela.player.presentation.ui.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.spela.player.util.currentPlatform
 
 /**
  * ROLE component — a chip that displays a game region with its flag emoji.
@@ -16,9 +17,8 @@ fun SpRegionChip(
     modifier: Modifier = Modifier,
     onGradient: Boolean = false,
 ) {
-    val flag = getRegionFlag(region)
     SpChip(
-        text = if (flag != null) "$flag $region" else region,
+        text = regionChipText(region, currentPlatform()),
         isSelected = true,
         modifier = modifier,
         onGradient = onGradient,
@@ -26,26 +26,56 @@ fun SpRegionChip(
 }
 
 private val regionFlags = mapOf(
-    "USA" to "\uD83C\uDDFA\uD83C\uDDF8",
-    "Japan" to "\uD83C\uDDEF\uD83C\uDDF5",
-    "Europe" to "\uD83C\uDDEA\uD83C\uDDFA",
-    "World" to "\uD83C\uDF0D",
-    "Korea" to "\uD83C\uDDF0\uD83C\uDDF7",
-    "Brazil" to "\uD83C\uDDE7\uD83C\uDDF7",
-    "France" to "\uD83C\uDDEB\uD83C\uDDF7",
-    "Germany" to "\uD83C\uDDE9\uD83C\uDDEA",
-    "Spain" to "\uD83C\uDDEA\uD83C\uDDF8",
-    "Italy" to "\uD83C\uDDEE\uD83C\uDDF9",
-    "Australia" to "\uD83C\uDDE6\uD83C\uDDFA",
-    "China" to "\uD83C\uDDE8\uD83C\uDDF3",
-    "Canada" to "\uD83C\uDDE8\uD83C\uDDE6",
-    "UK" to "\uD83C\uDDEC\uD83C\uDDE7",
-    "Sweden" to "\uD83C\uDDF8\uD83C\uDDEA",
-    "Netherlands" to "\uD83C\uDDF3\uD83C\uDDF1",
-    "Russia" to "\uD83C\uDDF7\uD83C\uDDFA",
-    "Taiwan" to "\uD83C\uDDF9\uD83C\uDDFC",
-    "Asia" to "\uD83C\uDF0F",
+    "USA" to "🇺🇸",
+    "Japan" to "🇯🇵",
+    "Europe" to "🇪🇺",
+    "World" to "🌍",
+    "Korea" to "🇰🇷",
+    "Brazil" to "🇧🇷",
+    "France" to "🇫🇷",
+    "Germany" to "🇩🇪",
+    "Spain" to "🇪🇸",
+    "Italy" to "🇮🇹",
+    "Australia" to "🇦🇺",
+    "China" to "🇨🇳",
+    "Canada" to "🇨🇦",
+    "UK" to "🇬🇧",
+    "Sweden" to "🇸🇪",
+    "Netherlands" to "🇳🇱",
+    "Russia" to "🇷🇺",
+    "Taiwan" to "🇹🇼",
+    "Asia" to "🌏",
 )
 
 private fun getRegionFlag(region: String): String? =
     regionFlags.entries.firstOrNull { region.contains(it.key, ignoreCase = true) }?.value
+
+/**
+ * Builds the chip label, prefixing the flag emoji only when it will
+ * actually render on [platform].
+ *
+ * Country flags are regional-indicator pairs (e.g. 🇺🇸 = U+1F1FA U+1F1F8).
+ * The default Windows/Linux desktop fonts ship no flag glyphs, so those
+ * render as the bare indicator letters ("US"). Drop the flag there and
+ * show the region name alone. Globe emoji (🌍/🌏 for World/Asia) are a
+ * single codepoint that *does* render everywhere, so they're kept. macOS
+ * and Android render flag emoji natively. (#1253)
+ */
+internal fun regionChipText(region: String, platform: String): String {
+    val flag = getRegionFlag(region)
+    return if (flag != null && flagRendersOn(flag, platform)) "$flag $region" else region
+}
+
+internal fun flagRendersOn(flag: String, platform: String): Boolean {
+    if (!isRegionalIndicatorFlag(flag)) return true // globes etc. render everywhere
+    return platform != "windows" && platform != "linux"
+}
+
+/**
+ * True when [flag] is a regional-indicator flag emoji (a surrogate pair
+ * whose low surrogate is in the regional-indicator block U+1F1E6..U+1F1FF).
+ * Globe emoji like 🌍 share the same high surrogate (0xD83C) but a
+ * different low surrogate, so the low surrogate is what distinguishes them.
+ */
+private fun isRegionalIndicatorFlag(flag: String): Boolean =
+    flag.length >= 2 && flag[0].code == 0xD83C && flag[1].code in 0xDDE6..0xDDFF

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/ui/components/SpRegionChipTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/ui/components/SpRegionChipTest.kt
@@ -1,0 +1,57 @@
+package com.spela.player.presentation.ui.components
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * #1253: country flag emoji render as bare indicator letters ("US") on
+ * Windows/Linux desktop. regionChipText drops the flag there but keeps it
+ * where it renders (macOS, Android) and keeps globe emoji everywhere.
+ */
+class SpRegionChipTest {
+
+    @Test
+    fun countryFlagShownOnMacAndAndroid() {
+        assertEquals("🇺🇸 USA", regionChipText("USA", "macos"))
+        assertEquals("🇺🇸 USA", regionChipText("USA", "android"))
+        assertEquals("🇯🇵 Japan", regionChipText("Japan", "macos"))
+    }
+
+    @Test
+    fun countryFlagDroppedOnWindowsAndLinux() {
+        assertEquals("USA", regionChipText("USA", "windows"))
+        assertEquals("USA", regionChipText("USA", "linux"))
+        assertEquals("Japan", regionChipText("Japan", "windows"))
+    }
+
+    @Test
+    fun globeEmojiKeptEverywhere() {
+        // World/Asia use single-codepoint globe emoji that render in the
+        // default Windows/Linux fonts — they must not be dropped.
+        assertEquals("🌍 World", regionChipText("World", "windows"))
+        assertEquals("🌏 Asia", regionChipText("Asia", "linux"))
+        assertEquals("🌍 World", regionChipText("World", "macos"))
+    }
+
+    @Test
+    fun unknownRegionHasNoFlag() {
+        assertEquals("Atlantis", regionChipText("Atlantis", "windows"))
+        assertEquals("Atlantis", regionChipText("Atlantis", "macos"))
+    }
+
+    @Test
+    fun regionMatchingIsCaseInsensitiveSubstring() {
+        // "USA, Europe" contains "USA" → matched.
+        assertEquals("🇺🇸 USA, Europe", regionChipText("USA, Europe", "macos"))
+    }
+
+    @Test
+    fun flagRendersOnClassifiesRegionalIndicatorVsGlobe() {
+        assertFalse(flagRendersOn("🇺🇸", "windows"))
+        assertTrue(flagRendersOn("🇺🇸", "macos"))
+        assertTrue(flagRendersOn("🌍", "windows")) // globe renders everywhere
+        assertTrue(flagRendersOn("🌏", "linux"))
+    }
+}


### PR DESCRIPTION
## Summary

Region chips rendered the country code letters instead of the flag on Windows desktop — e.g. `US USA` instead of `🇺🇸 USA` (#1253).

## Root cause

`SpRegionChip` prefixes a flag emoji built from regional-indicator pairs (`🇺🇸` = U+1F1FA U+1F1F8). The default Windows/Linux desktop fonts (Segoe UI Emoji on Windows) ship **no** flag glyphs, so the pair falls back to rendering each regional indicator as its bare letter → `US`, `JP`, …

## Fix

`regionChipText(region, platform)` prefixes the flag only when it will render on the current platform (`currentPlatform()`):
- **macOS / Android** — flags kept (native flag rendering).
- **Windows / Linux** — flag dropped; region name shown alone (`USA`).
- **Globe emoji** (`🌍`/`🌏` for World/Asia) are single codepoints that render everywhere, so they're always kept. The classifier inspects the low surrogate to distinguish a regional-indicator flag from a globe.

Pure logic (`regionChipText` / `flagRendersOn`), covered by `SpRegionChipTest`.

## Tradeoff

Linux desktops with a flag-capable font (e.g. Noto Color Emoji) also lose the flag. A fully consistent alternative is bundling flag image assets for all platforms — a larger design change worth tracking separately. This PR fixes the broken-looking letters with a minimal, well-tested change.

Closes #1253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
