### PR TITLE
feat(player): show a not-playable notice for unsupported-console games

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailNotPlayableTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailNotPlayableTest.kt
@@ -1,0 +1,67 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.Console
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+
+/**
+ * #1255: a game for a console Spela can't emulate (playable = false) must
+ * surface a "not playable" notice on the detail hero, instead of leaving
+ * the absent Play button as the only signal. Playable games show no notice.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class GameDetailNotPlayableTest {
+
+    private val vitaConsole = Console(
+        id = "psvita",
+        name = "PlayStation Vita",
+        abbreviation = "VITA",
+        gameCount = 1,
+        colorTheme = "#1e3a8a",
+        saveStateSupport = false,
+    )
+
+    private val vitaGame = Game(
+        id = "vita-1",
+        title = "Unsupported Vita Title",
+        consoleId = "psvita",
+        consoleName = "PlayStation Vita",
+        playable = false,
+        fileSize = 524288,
+        fileName = "game.vpk",
+    )
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        harness.gameRepo.consoles = harness.gameRepo.consoles + vitaConsole
+        harness.gameRepo.games = harness.gameRepo.games + vitaGame
+        return harness
+    }
+
+    @Test
+    fun nonPlayableGameShowsNotice() = runComposeUiTest {
+        val harness = createHarness()
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "vita-1")
+
+        onNodeWithText("Unsupported Vita Title").assertIsDisplayed()
+        onNodeWithTag("game_detail_not_playable_notice").assertIsDisplayed()
+    }
+
+    @Test
+    fun playableGameShowsNoNotice() = runComposeUiTest {
+        val harness = createHarness()
+        setContent { harness.App() }
+        // Castlevania (id = 1) is a regular, playable seed game.
+        navigateToGameDetail(harness, "1")
+
+        onNodeWithText("Castlevania").assertIsDisplayed()
+        onNodeWithTag("game_detail_not_playable_notice").assertDoesNotExist()
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
@@ -185,6 +186,13 @@ fun GameHeroContent(
                     onClick = onNavigateToAchievements,
                 )
             }
+        }
+
+        // Not-playable notice: surface clearly that an unsupported-console
+        // game can't be played in Spela, before/at download time — otherwise
+        // the only signal is the absent Play button. (#1255)
+        if (!game.playable) {
+            NotPlayableNotice(consoleName = game.consoleName)
         }
 
         // Action buttons + size hint. Wrapping inner Column keeps the
@@ -537,6 +545,36 @@ private fun CommunityRatingBadge(averageRating: Double, ratingCount: Long) {
             text = "($ratingCount)",
             style = SpTypography.LabelMedium,
             color = SpColor.OnBackgroundTertiary,
+        )
+    }
+}
+
+/**
+ * Notice shown on the hero for a game whose console Spela can't emulate.
+ * Makes the "not playable" state explicit instead of leaving the absent
+ * Play button as the only signal. (#1255)
+ */
+@Composable
+private fun NotPlayableNotice(consoleName: String) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.testTag("game_detail_not_playable_notice"),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Info,
+            contentDescription = null,
+            tint = SpColor.OnGradientSecondary,
+            modifier = Modifier.size(18.dp),
+        )
+        Text(
+            text = if (consoleName.isNotBlank()) {
+                "Not playable in Spela — $consoleName isn't supported yet. You can still download the files."
+            } else {
+                "Not playable in Spela — this console isn't supported yet. You can still download the files."
+            },
+            style = SpTypography.BodySmall,
+            color = SpColor.OnGradientSecondary,
         )
     }
 }


### PR DESCRIPTION
## Summary

A game for a console Spela can't emulate (e.g. PS Vita) gave **no indication** it wasn't playable — the only signal was the absent Play button, which the user discovered only after downloading (#1255).

## Fix

Add a `NotPlayableNotice` on the detail hero, shown whenever `!game.playable`: an info icon plus *"Not playable in Spela — &lt;console&gt; isn't supported yet. You can still download the files."* It renders before/at download time (independent of cached state), so the user knows up front.

## Test

`GameDetailNotPlayableTest` (desktop E2E via `SpelaTestHarness`):
- non-playable game → notice displayed
- playable game (Castlevania seed) → notice absent

Verified locally: `:desktop:desktopTest --tests GameDetailNotPlayableTest` → BUILD SUCCESSFUL.

Closes #1255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
