### PR TITLE
fix(player): retry + diagnose Collections cold-load deserialization failures

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -43,6 +43,10 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.utils.io.*
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import kotlinx.coroutines.delay
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
 class SpelaApiClient(
@@ -57,6 +61,64 @@ class SpelaApiClient(
         ignoreUnknownKeys = true
         isLenient = true
         encodeDefaults = true
+    }
+
+    // ── Cold-load resilience + diagnostics (#1231) ──
+    // A truncated/garbled 2xx body — connection contention while cores prefetch,
+    // a proxy/CDN hiccup, etc. — surfaces as a hard SerializationException and a
+    // user-visible error, even though a retry would succeed. For read-only GETs
+    // we (a) capture the exact exception + raw body so the failure is
+    // diagnosable, and (b) retry the transient failure modes so one bad response
+    // self-heals. GETs only — never wrap a mutating call (would double-submit).
+
+    private fun isTransient(e: Throwable): Boolean {
+        if (e is SerializationException) return true
+        if (e is HttpRequestTimeoutException) return true
+        // Match by class name to stay multiplatform-import-safe across Ktor's
+        // socket/IO exception hierarchy and expectSuccess's 5xx wrapper.
+        val n = e::class.simpleName ?: ""
+        return n.contains("Timeout") || n.contains("IOException") ||
+            n.contains("Socket") || n.contains("Connect") ||
+            n.contains("ServerResponse") // 5xx via expectSuccess — safe to retry on idempotent GETs
+    }
+
+    private suspend fun <T> retryTransient(
+        label: String,
+        attempts: Int = 3,
+        block: suspend () -> T,
+    ): T {
+        var last: Throwable? = null
+        repeat(attempts) { i ->
+            try {
+                return block()
+            } catch (e: Throwable) {
+                last = e
+                if (!isTransient(e) || i == attempts - 1) throw e
+                println("[ApiDiag] $label transient ${e::class.simpleName} (attempt ${i + 1}/$attempts) — retrying")
+                delay(250L * (i + 1))
+            }
+        }
+        throw last ?: IllegalStateException(label)
+    }
+
+    // Read the body as text and decode it ourselves so the raw payload is in
+    // hand if decoding fails — ContentNegotiation's .body() consumes the stream,
+    // leaving nothing to log. Uses the same Json instance as ContentNegotiation.
+    private suspend fun <T : Any> com.spela.client.infrastructure.HttpResponse<T>.bodyDiagnostic(
+        label: String,
+        deserializer: DeserializationStrategy<T>,
+    ): T {
+        val raw = response.bodyAsText()
+        return try {
+            json.decodeFromString(deserializer, raw)
+        } catch (e: SerializationException) {
+            println(
+                "[ApiDiag] $label deserialization failed: ${e::class.simpleName}: " +
+                    "${e.message?.take(300)} | httpStatus=$status bodyLen=${raw.length} " +
+                    "bodyHead=${raw.take(400)}",
+            )
+            throw e
+        }
     }
 
     private val client = HttpClient(engineFactory) {
@@ -1201,20 +1263,30 @@ class SpelaApiClient(
     suspend fun getMyCollections(
         page: Int = 1,
         pageSize: Int = 20,
-    ): com.spela.client.models.PaginatedResponseCollectionResponse {
-        return collectionsApi.listMyCollections(page = page.toLong(), pageSize = pageSize.toLong()).body()
+    ): com.spela.client.models.PaginatedResponseCollectionResponse = retryTransient("getMyCollections") {
+        collectionsApi.listMyCollections(page = page.toLong(), pageSize = pageSize.toLong())
+            .bodyDiagnostic(
+                "getMyCollections",
+                com.spela.client.models.PaginatedResponseCollectionResponse.serializer(),
+            )
     }
 
     suspend fun getPublicCollections(
         page: Int = 1,
         pageSize: Int = 20,
-    ): com.spela.client.models.PaginatedResponseCollectionResponse {
-        return collectionsApi.listPublicCollections(page = page.toLong(), pageSize = pageSize.toLong()).body()
+    ): com.spela.client.models.PaginatedResponseCollectionResponse = retryTransient("getPublicCollections") {
+        collectionsApi.listPublicCollections(page = page.toLong(), pageSize = pageSize.toLong())
+            .bodyDiagnostic(
+                "getPublicCollections",
+                com.spela.client.models.PaginatedResponseCollectionResponse.serializer(),
+            )
     }
 
-    suspend fun getCollection(id: String): com.spela.client.models.CollectionDetailResponse {
-        return collectionsApi.getCollection(id).body()
-    }
+    suspend fun getCollection(id: String): com.spela.client.models.CollectionDetailResponse =
+        retryTransient("getCollection") {
+            collectionsApi.getCollection(id)
+                .bodyDiagnostic("getCollection", com.spela.client.models.CollectionDetailResponse.serializer())
+        }
 
     suspend fun createCollection(
         request: com.spela.client.models.CreateCollectionRequest,

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SpelaApiClientCollectionResilienceTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SpelaApiClientCollectionResilienceTest.kt
@@ -1,0 +1,103 @@
+package com.spela.player.data.remote
+
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.interceptor.TokenManager
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Cold-load resilience for the Collections screen (#1231).
+ *
+ * A truncated / garbled 2xx body — connection contention while cores prefetch,
+ * a proxy hiccup — used to surface as a hard JSON error even though a retry
+ * would succeed. `SpelaApiClient.getMyCollections/getPublicCollections/
+ * getCollection` now retry the transient failure modes (and log the raw body).
+ * These tests pin that behaviour.
+ */
+class SpelaApiClientCollectionResilienceTest {
+
+    // Minimal PaginatedResponseCollectionResponse with one CollectionResponse —
+    // every @Required field present, else strict deserialization rejects it.
+    private val validJson = """
+        {
+          "data": [
+            {
+              "id": "1", "userId": "u1", "username": "alice", "avatarUrl": "",
+              "name": "My Collection", "description": "", "isPublic": true,
+              "coverUrl": "", "gameCount": 0,
+              "createdAt": "2026-04-21T00:00:00Z", "updatedAt": "2026-04-21T00:00:00Z"
+            }
+          ],
+          "total": 1, "page": 1, "pageSize": 20
+        }
+    """.trimIndent()
+
+    // A 2xx body that is cut off mid-object → SerializationException on decode.
+    private val truncatedJson = """{"data":[{"id":"1","userId":"u1","""
+
+    private fun sequencedEngine(
+        callCounter: IntArray,
+        bodyFor: (Int) -> Pair<String, HttpStatusCode>,
+    ) = object : HttpClientEngineFactory<MockEngineConfig> {
+        override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine =
+            MockEngine(MockEngineConfig().apply {
+                addHandler { _ ->
+                    callCounter[0]++
+                    val (body, status) = bodyFor(callCounter[0])
+                    respond(body, status, headersOf(HttpHeaders.ContentType, "application/json"))
+                }
+                block()
+            })
+    }
+
+    private suspend fun client(engineFactory: HttpClientEngineFactory<MockEngineConfig>): SpelaApiClient {
+        val tokenManager = TokenManager().also { it.setTokens("a", "r") }
+        return SpelaApiClient(engineFactory, tokenManager).also { it.setBaseUrl("http://localhost:8080") }
+    }
+
+    @Test
+    fun getMyCollectionsRetriesAndRecoversAfterTruncatedBody() = runTest {
+        val calls = intArrayOf(0)
+        val apiClient = client(
+            sequencedEngine(calls) { n ->
+                (if (n == 1) truncatedJson else validJson) to HttpStatusCode.OK
+            },
+        )
+
+        val result = apiClient.getMyCollections()
+
+        assertEquals(2, calls[0], "expected exactly one retry after the first truncated body")
+        assertEquals(1, result.data.size)
+        assertEquals("My Collection", result.data[0].name)
+    }
+
+    @Test
+    fun getMyCollectionsGivesUpAfterRepeatedTruncation() = runTest {
+        val calls = intArrayOf(0)
+        val apiClient = client(sequencedEngine(calls) { truncatedJson to HttpStatusCode.OK })
+
+        assertFailsWith<SerializationException> { apiClient.getMyCollections() }
+        assertEquals(3, calls[0], "should retry up to the attempt cap, then surface the error")
+    }
+
+    @Test
+    fun getMyCollectionsDoesNotRetryNonTransientError() = runTest {
+        val calls = intArrayOf(0)
+        // 404 is a hard client error (not transient) — must not be retried.
+        val apiClient = client(sequencedEngine(calls) { """{"title":"not found"}""" to HttpStatusCode.NotFound })
+
+        assertFailsWith<Throwable> { apiClient.getMyCollections() }
+        assertEquals(1, calls[0], "non-transient 4xx must not be retried")
+    }
+}


### PR DESCRIPTION
## Summary

Resolves the user-visible half of #1231 (Collections screen JSON/deserialization error on cold load, intermittent) and instruments the rest.

**Investigation** (full writeup on the issue) ruled out a schema mismatch:
- The cold-load DTOs (`getCurrentUser` + `getMyCollections` + `getPublicCollections`) are all `@Required` and always emitted by the server; both the list `Data` and detail `Games` use `make(...)` → `[]`, never `null`.
- `expectSuccess = true` means a non-2xx (401 token race, 5xx) throws an **HTTP** exception, not a `SerializationException`.

So a JSON/deser error can only come from a **truncated/garbled 2xx body** — connection contention while cores prefetch, or a proxy/CDN hiccup at the server — which a retry clears. (Platform-agnostic, matching "probably not Windows-exclusive".)

## Change (test-only paths, read-only GETs)

`getMyCollections` / `getPublicCollections` / `getCollection` now:
- **`retryTransient`** — retry transient failures (`SerializationException`, timeouts, IO/socket, 5xx) with backoff, so one bad response self-heals instead of a hard error. GETs only — never wraps a mutating call (would double-submit).
- **`bodyDiagnostic`** — read the body as text and decode it ourselves, logging the exact exception + raw body head on failure (`ContentNegotiation`'s `.body()` consumes the stream, so there's nothing to log otherwise). This pins the root cause if it recurs:
  - `Unexpected EOF` → truncation
  - `Expected '{'` → non-JSON body (proxy/HTML)
  - `Field 'X' is required` → a real schema gap

## Tests

`SpelaApiClientCollectionResilienceTest` (MockEngine): recovers after a truncated body (1 retry), gives up after the attempt cap (`SerializationException`), and does **not** retry a non-transient 4xx.

## Why "Refs" not "Closes"

This auto-recovers the transient case and makes the next occurrence self-identifying. Keeping #1231 open until an `[ApiDiag]` log from a real occurrence confirms it was truly transient (vs a hidden data-dependent schema gap to reconcile).