### PR TITLE
fix(player): gate retro_run on context_reset for Vulkan HW render (PSP crash)

### DIFF
--- a/player/native/src/gpu_renderer.h
+++ b/player/native/src/gpu_renderer.h
@@ -82,6 +82,11 @@ void *gpu_renderer_hw_vulkan_get_interface(gpu_renderer_t *r);
 void gpu_renderer_hw_render_frame(gpu_renderer_t *r, unsigned width, unsigned height);
 void gpu_renderer_hw_vulkan_deinit(gpu_renderer_t *r);
 bool gpu_renderer_is_hw_render_active(gpu_renderer_t *r);
+/* Context-reset gating: the renderer goes hw_render_active before the core's
+ * context_reset() runs; mark/query whether context_reset has completed so
+ * retro_run can wait for the core's GPU backend to exist. See #925/#1270. */
+void gpu_renderer_mark_hw_context_reset_done(gpu_renderer_t *r);
+bool gpu_renderer_is_hw_context_reset_done(gpu_renderer_t *r);
 void gpu_renderer_set_hw_bottom_left_origin(gpu_renderer_t *r, bool bottom_left);
 /* Wait for GPU to finish all pending work (call before context_destroy) */
 void gpu_renderer_wait_idle(gpu_renderer_t *r);

--- a/player/native/src/gpu_renderer_vulkan.c
+++ b/player/native/src/gpu_renderer_vulkan.c
@@ -221,6 +221,12 @@ struct gpu_renderer {
 
     /* Vulkan HW render state (Phase 4) */
     bool hw_render_active;
+    /* Set true only after the core's context_reset() has run (which builds the
+     * core's GPU backend). The emulation thread gates retro_run on this so it
+     * can't run a frame in the window between hw_render_active flipping true
+     * (end of gpu_renderer_hw_vulkan_init) and context_reset completing — that
+     * window crashed PSP/PPSSPP on its first GE list. See #925/#1270. */
+    bool hw_context_reset_done;
     bool hw_offscreen_frame_ready; /* offscreen HW frame readback is valid */
     bool hw_bottom_left_origin; /* core renders with OpenGL-style Y-up */
     struct retro_hw_render_interface_vulkan hw_vk_interface;
@@ -1050,6 +1056,10 @@ bool gpu_renderer_hw_vulkan_init(gpu_renderer_t *r) {
     }
 
     r->hw_render_active = true;
+    /* Re-arm the context-reset gate: this init made the renderer active, but
+     * the core's context_reset() hasn't run yet — the bridge calls
+     * gpu_renderer_mark_hw_context_reset_done() once it has. */
+    r->hw_context_reset_done = false;
     r->hw_offscreen_frame_ready = false;
     VK_LOGI("Vulkan HW render initialized (queue_family=%u, sync_mask=0x%x, bottom_left=%d, offscreen=%d)",
             r->queue_family_index, (1u << MAX_FRAMES_IN_FLIGHT) - 1,
@@ -1611,6 +1621,14 @@ void gpu_renderer_hw_vulkan_deinit(gpu_renderer_t *r) {
 
 bool gpu_renderer_is_hw_render_active(gpu_renderer_t *r) {
     return r && r->hw_render_active;
+}
+
+void gpu_renderer_mark_hw_context_reset_done(gpu_renderer_t *r) {
+    if (r) r->hw_context_reset_done = true;
+}
+
+bool gpu_renderer_is_hw_context_reset_done(gpu_renderer_t *r) {
+    return r && r->hw_context_reset_done;
 }
 
 void gpu_renderer_wait_idle(gpu_renderer_t *r) {

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -668,6 +668,7 @@ static bool environment_callback(unsigned cmd, void *data) {
                         if (g_core.hw_render_callback.context_reset) {
                             g_core.hw_render_callback.context_reset();
                         }
+                        gpu_renderer_mark_hw_context_reset_done(g_gpu_renderer);
                         LOGI("Vulkan HW render context initialized lazily "
                              "(on GET_HW_RENDER_INTERFACE)");
                     } else {
@@ -1037,6 +1038,7 @@ JNI_FUNC(jboolean, nativeLoadGame)(JNIEnv *env, jobject thiz, jstring gamePath) 
                 if (g_core.hw_render_callback.context_reset) {
                     g_core.hw_render_callback.context_reset();
                 }
+                gpu_renderer_mark_hw_context_reset_done(g_gpu_renderer);
                 LOGI("Vulkan HW render context initialized after game load");
             } else {
                 LOGE("Failed to init Vulkan HW render context after game load");
@@ -1113,15 +1115,22 @@ JNI_FUNC(jboolean, nativeLoadGame)(JNIEnv *env, jobject thiz, jstring gamePath) 
 
 JNI_FUNC(void, nativeRun)(JNIEnv *env, jobject thiz) {
     if (!g_core.game_loaded) return;
-    /* Vulkan HW render: skip frames until Vulkan HW context is ready */
+    /* Vulkan HW render: skip frames until the Vulkan HW context is active AND
+     * the core's context_reset() has completed. hw_render_active flips true at
+     * the end of gpu_renderer_hw_vulkan_init(), which runs BEFORE the caller
+     * invokes context_reset() — gating on active alone let the emulation thread
+     * run a frame in that gap, before the core built its GPU backend, crashing
+     * PSP/PPSSPP on its first GE display list (#925/#1270). */
     if (g_core.hw_render_enabled &&
         g_core.hw_render_callback.context_type == RETRO_HW_CONTEXT_VULKAN &&
-        (!g_gpu_renderer || !gpu_renderer_is_hw_render_active(g_gpu_renderer))) {
+        (!g_gpu_renderer || !gpu_renderer_is_hw_render_active(g_gpu_renderer) ||
+         !gpu_renderer_is_hw_context_reset_done(g_gpu_renderer))) {
         static int vk_skip_count = 0;
         if (++vk_skip_count <= 5 || vk_skip_count % 300 == 0) {
-            LOGI("VK HW: skipping frame %d (renderer=%p active=%d)",
+            LOGI("VK HW: skipping frame %d (renderer=%p active=%d ctxReset=%d)",
                  vk_skip_count, (void*)g_gpu_renderer,
-                 g_gpu_renderer ? gpu_renderer_is_hw_render_active(g_gpu_renderer) : -1);
+                 g_gpu_renderer ? gpu_renderer_is_hw_render_active(g_gpu_renderer) : -1,
+                 g_gpu_renderer ? gpu_renderer_is_hw_context_reset_done(g_gpu_renderer) : -1);
         }
         return;
     }
@@ -1911,6 +1920,7 @@ JNI_FUNC(jboolean, nativeGpuInit)(JNIEnv *env, jobject thiz, jobject surface) {
             if (g_core.hw_render_callback.context_reset) {
                 g_core.hw_render_callback.context_reset();
             }
+            gpu_renderer_mark_hw_context_reset_done(g_gpu_renderer);
             LOGI("Vulkan HW render context initialized for core");
         } else {
             LOGE("Failed to init Vulkan HW render context");
@@ -2028,6 +2038,7 @@ JNI_FUNC(jboolean, nativeGpuInitOffscreen)(JNIEnv *env, jobject thiz, jint width
             if (g_core.hw_render_callback.context_reset) {
                 g_core.hw_render_callback.context_reset();
             }
+            gpu_renderer_mark_hw_context_reset_done(g_gpu_renderer);
             LOGI("Vulkan HW render context initialized for core (offscreen)");
         } else {
             LOGE("Failed to init Vulkan HW render context (offscreen)");


### PR DESCRIPTION
## Summary

After #1270 dropped the 2s PSP+Vulkan pre-run sleep, PSP games crashed deterministically on the AYN Thor — native `SIGSEGV` in `GPUCommon::EnqueueList ← sceGeListEnQueue`, on the game's first GE display list.

**Root cause (ours, not PPSSPP):** `nativeRun()` skips frames until the Vulkan HW context is ready, but gated on `gpu_renderer_is_hw_render_active()`. That flag flips true at the **end of `gpu_renderer_hw_vulkan_init()`** — which runs **before** the caller invokes `context_reset()`, where PPSSPP builds its `GPUCommon` backend. The emulation thread could slip a `retro_run` into that window and execute the game's first GE call before the GPU existed. PSP issues a GE list immediately → crashed every time; Dolphin renders later → survived (GameCube/Vulkan worked in the same session). The old 2s sleep had masked this gap too, not just the deadlock the upstream fix addressed.

## Fix

A `hw_context_reset_done` flag on the renderer, re-armed (false) on each `gpu_renderer_hw_vulkan_init()` and set true only after the core's `context_reset()` returns (all four Vulkan paths). `nativeRun()`'s Vulkan gate now waits for **both** `hw_render_active` **and** `hw_context_reset_done`.

## Verified on the AYN Thor (Burnout Legends, PSP)

```
VK HW: skipping frame 3 (active=1 ctxReset=0)   ← old code ran retro_run + crashed here
VK HW: skipping frame 4 (active=1 ctxReset=0)
VK HW: skipping frame 5 (active=1 ctxReset=0)
Vulkan HW render context initialized for core   ← context_reset done → gate opens
→ game runs, no SIGSEGV
```

Refs #925, #1270.