### PR TITLE
chore(ci): bump docker actions off deprecated Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,12 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,12 +96,12 @@ jobs:
       - name: Extract version from tag
         id: meta
         run: echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

`docker/login-action@v3` and `docker/build-push-action@v6` declare the Node 20 runtime, which GitHub is removing. Release/CI runs already logged the deprecation warning and were being force-shimmed onto Node 24 (seen on the v0.0.249 release).

## Fix

Bump to the current majors, which target Node 24 (`using: 'node24'` in their `action.yml`):
- `docker/login-action` v3 → **v4** (v4.2.0 latest)
- `docker/build-push-action` v6 → **v7** (v7.2.0 latest)

Our usage — `registry`/`username`/`password` and `context`/`push`/`tags`/`build-args` — is unchanged across these majors, so no config changes are needed. Applied to both Docker image jobs: `ci.yml` (push to master) and `release.yml` (tag push).

## Note

The Docker jobs only run on push-to-master / tag, not on PRs, so this PR's Go/Web/Player checks won't exercise the bump directly — it's validated on the next master push after merge.

Closes #1269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
