### PR TITLE
fix(player): clamp GL HW-render readback to the core-reported frame size

### DIFF
--- a/player/native/src/hw_render_gl.h
+++ b/player/native/src/hw_render_gl.h
@@ -42,9 +42,19 @@ uintptr_t hw_gl_get_framebuffer(hw_gl_context_t *ctx);
 /* Resolve GL function addresses (macOS links GL statically via dlsym) */
 void *hw_gl_get_proc_address(const char *sym);
 
-/* Read FBO to CPU buffer as XRGB8888, flipping vertically (GL origin is bottom-left).
- * Returns number of pixels read, or 0 on failure. */
+/* Read the HW framebuffer to a CPU buffer as XRGB8888.
+ *
+ * Reads the core-reported frame region (req_width x req_height) from the
+ * bottom-left of the FBO, clamped to the FBO's actual size. The FBO can be
+ * larger than the current frame (e.g. left over from a prior larger frame
+ * before hw_gl_resize_fbo shrinks it), so reading the whole FBO would both
+ * overflow a buffer sized for the reported frame and capture empty padding
+ * (#1268). Pass req_width/req_height = 0 to read the full FBO.
+ *
+ * The actual region read is written to out_width/out_height. Returns the
+ * number of pixels read, or 0 on failure. */
 unsigned hw_gl_read_pixels(hw_gl_context_t *ctx, void *out_data, size_t out_capacity,
+                           unsigned req_width, unsigned req_height,
                            unsigned *out_width, unsigned *out_height);
 
 /* Debug: reset per-frame counters (call before retro_run) */

--- a/player/native/src/hw_render_gl_android.c
+++ b/player/native/src/hw_render_gl_android.c
@@ -256,12 +256,18 @@ void *hw_gl_get_proc_address(const char *sym) {
 }
 
 unsigned hw_gl_read_pixels(hw_gl_context_t *ctx, void *out_data, size_t out_capacity,
+                           unsigned req_width, unsigned req_height,
                            unsigned *out_width, unsigned *out_height) {
     if (!ctx || !ctx->initialized || !out_data) return 0;
 
     unsigned w = ctx->surface_width;
     unsigned h = ctx->surface_height;
     if (w == 0 || h == 0) return 0;
+    /* Clamp to the core-reported frame size; the surface can be larger than
+     * the current frame, which the core renders into the bottom-left
+     * region. No-op when they match (the steady-state case). (#1268) */
+    if (req_width != 0 && req_width < w) w = req_width;
+    if (req_height != 0 && req_height < h) h = req_height;
 
     size_t needed = (size_t)w * h * 4; /* XRGB8888 output */
 

--- a/player/native/src/hw_render_gl_desktop.c
+++ b/player/native/src/hw_render_gl_desktop.c
@@ -756,11 +756,20 @@ void *hw_gl_get_proc_address(const char *sym) {
 }
 
 unsigned hw_gl_read_pixels(hw_gl_context_t *ctx, void *out_data, size_t out_capacity,
+                           unsigned req_width, unsigned req_height,
                            unsigned *out_width, unsigned *out_height) {
     if (!ctx || !ctx->initialized || !out_data) return 0;
 
     unsigned w = ctx->fbo_width;
     unsigned h = ctx->fbo_height;
+    // Clamp to the core-reported frame size. The FBO can be larger than the
+    // current frame (left over from a prior larger frame before
+    // hw_gl_resize_fbo shrinks it); the core renders into the bottom-left
+    // req_width x req_height region. Reading the full FBO would overflow the
+    // caller's buffer (sized for the reported frame) and capture padding. (#1268)
+    if (req_width != 0 && req_width < w) w = req_width;
+    if (req_height != 0 && req_height < h) h = req_height;
+    if (w == 0 || h == 0) return 0;
     size_t needed = (size_t)w * h * 4;
 
     if (out_capacity < needed) {

--- a/player/native/src/hw_render_gl_macos.m
+++ b/player/native/src/hw_render_gl_macos.m
@@ -1168,6 +1168,7 @@ static bool fbo_has_content(GLuint fbo_id, unsigned fw, unsigned fh) {
 }
 
 unsigned hw_gl_read_pixels(hw_gl_context_t *ctx, void *out_data, size_t out_capacity,
+                           unsigned req_width, unsigned req_height,
                            unsigned *out_width, unsigned *out_height) {
     if (!ctx || !ctx->cgl_ctx) return 0;
 
@@ -1175,6 +1176,12 @@ unsigned hw_gl_read_pixels(hw_gl_context_t *ctx, void *out_data, size_t out_capa
     unsigned h = ctx->fbo_height;
 
     if (!out_data || w == 0 || h == 0) return 0;
+
+    /* Clamp to the core-reported frame size; the FBO can be larger than the
+     * current frame, which the core renders into the bottom-left region.
+     * No-op when they match (the steady-state case). (#1268) */
+    if (req_width != 0 && req_width < w) w = req_width;
+    if (req_height != 0 && req_height < h) h = req_height;
 
     CGLSetCurrentContext(ctx->cgl_ctx);
 

--- a/player/native/src/libretro_video.c
+++ b/player/native/src/libretro_video.c
@@ -237,8 +237,14 @@ void video_refresh_callback(const void *data, unsigned width, unsigned height, s
             }
 
             unsigned rb_w = 0, rb_h = 0;
+            // Pass the core-reported frame size so the readback is clamped to
+            // it: the FBO can be larger than the current frame (the resize to
+            // the new dims happens below, after this read), which previously
+            // overflowed the buffer and dropped the frame with a "Buffer too
+            // small" error. (#1268)
             unsigned pixels = hw_gl_read_pixels(g_core.hw_gl_ctx, video_state.frame_buffer,
-                                                video_state.frame_buffer_size, &rb_w, &rb_h);
+                                                video_state.frame_buffer_size, width, height,
+                                                &rb_w, &rb_h);
 
             if (pixels > 0) {
                 video_state.width = rb_w;


### PR DESCRIPTION
## Summary

Fixes dropped frames + `[HW_GL ERROR] Buffer too small` spam on the desktop GL HW-render readback path (Play!/PS2), found while fixing #1254.

## Root cause

`hw_gl_read_pixels` read the **full FBO** (`ctx->fbo_width × fbo_height`), but the caller (`libretro_video.c`) sized the readback buffer from the **core-reported callback dims**, and `hw_gl_resize_fbo` runs *after* the read. So when the FBO was larger than the current frame (left over from a prior larger frame), the read needed more than the buffer held and bailed:

```
[HW_GL ERROR] Buffer too small: need 73400320, have 1146880   (Play!/PS2 boot)
```

Reading the whole FBO is also wrong — the core renders the frame into the bottom-left (frame-sized) region of an over-allocated FBO, so padding would be captured.

## Fix

`hw_gl_read_pixels` now takes the requested (core-reported) `width/height` and clamps the read region to `min(request, FBO)`. The caller passes the `video_refresh` dims. The buffer is therefore always large enough, the correct frame region is read, and the drop/error is gone.

The clamp is a **no-op when the FBO/surface already matches the frame** (the steady-state case), so the Android (`surface_width/height`) and macOS (`.m`, `fbo_width/height`) impls are behavior-preserving — `req=0` also means "read full FBO".

## Verification

PR CI does **not** compile native code (`android-build.yml` / `desktop-build.yml` are `workflow_dispatch`-only; `desktopTest` doesn't build the native lib). So:
- **Desktop (Windows)** native lib built locally → `spela-libretro.dll` + `spela-core-host.exe` link clean.
- **Android + macOS/Linux/Windows** verified by dispatching the manual build workflows on this branch (see checks/links in comments).

Closes #1268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
