### PR TITLE
chore(ci): fix desktop-build setup failure (setup-vulkan-sdk cache@v2)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install Vulkan SDK (Windows)
         if: runner.os == 'Windows'
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.290.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader


### PR DESCRIPTION
## Summary

The manual `Desktop Build (macOS, Linux, Windows)` workflow failed at **"Set up job"** for every matrix Build job — before any checkout/compile — with:

```
##[error]This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`.
```

## Root cause

`humbletim/setup-vulkan-sdk@v1.2.0` transitively depends on `actions/cache@v2`, which GitHub now hard-fails. At "Set up job" GitHub downloads **every** referenced action regardless of `if:`, so even though the Vulkan step is Windows-only, all matrix jobs (macОС/Windows/Ubuntu/ARM64) died at setup. (Flatpak + AppImage jobs don't reference the action, which is why they passed and compiled the native lib.)

## Fix

Bump `setup-vulkan-sdk` v1.2.0 → **v1.2.1**, which uses `actions/cache@v4`. Same inputs (`vulkan-query-version` / `vulkan-components` / `vulkan-use-cache`), so the Windows Vulkan SDK step behaves identically.

`release.yml` is unaffected (it sets up Vulkan manually per-OS, no `setup-vulkan-sdk`), so real releases were never at risk — this only repairs the ad-hoc manual desktop-build workflow.

## Verification

Dispatched `desktop-build.yml` on this branch to confirm the matrix jobs now get past "Set up job".

Closes #1274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
