### PR TITLE
feat(player): "Show in folder" action to reveal a download in the OS file manager

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailActionsMenuTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailActionsMenuTest.kt
@@ -149,6 +149,36 @@ class GameDetailActionsMenuTest {
     }
 
     @Test
+    fun cachedGameActionsMenuShowsOpenDownloadFolder() = runComposeUiTest {
+        // #1259: downloaded games on desktop expose "Show in folder" in the
+        // actions menu (currentPlatform() is non-Android in the desktop test).
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        onNodeWithContentDescription("More actions").performClick()
+        advanceQuick(harness)
+
+        onNodeWithText("Show in folder").assertIsDisplayed()
+    }
+
+    @Test
+    fun uncachedGameActionsMenuHidesOpenDownloadFolder() = runComposeUiTest {
+        // Not downloaded → nothing to reveal → item hidden.
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        onNodeWithContentDescription("More actions").performClick()
+        advanceQuick(harness)
+
+        onNodeWithText("Show in folder").assertDoesNotExist()
+    }
+
+    @Test
     fun actionsMenuDismissesOnItemClick() = runComposeUiTest {
         val harness = createLoggedInHarness()
 

--- a/player/shared/src/androidMain/kotlin/com/spela/player/util/FileManager.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/util/FileManager.kt
@@ -1,0 +1,9 @@
+package com.spela.player.util
+
+/**
+ * No-op on Android: downloads live in app-private internal storage
+ * (context.filesDir), which the system file manager can't browse, so there
+ * is nothing to reveal. The UI hides the "Show in folder" action on Android.
+ * (#1259)
+ */
+actual fun revealInFileManager(path: String): Boolean = false

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
@@ -18,6 +18,7 @@ sealed interface GameDetailIntent {
     data object ConsumeAutoLaunch : GameDetailIntent
     data object PlayGame : GameDetailIntent
     data object DeleteLocalGame : GameDetailIntent
+    data object OpenDownloadFolder : GameDetailIntent
     data object ShowDeleteDownloadDialog : GameDetailIntent
     data object DismissDeleteDownloadDialog : GameDetailIntent
     data object ToggleFavorite : GameDetailIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameActionsMenu.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameActionsMenu.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.WatchLater
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material.icons.outlined.LibraryAdd
 import androidx.compose.material.icons.outlined.WatchLater
 import androidx.compose.material3.CircularProgressIndicator
@@ -50,6 +51,13 @@ internal fun GameActionsMenu(
      * pointless when the console itself never opted out.
      */
     onSaveStateSettings: (() -> Unit)? = null,
+    /**
+     * Optional "Show in folder" menu item — opens the downloaded game's
+     * folder in the OS file manager. Provided only for downloaded games on
+     * platforms that can reveal it (desktop); null on Android, where
+     * downloads live in app-private storage. (#1259)
+     */
+    onOpenDownloadFolder: (() -> Unit)? = null,
     onAdminScrape: (() -> Unit)? = null,
     onAdminRefreshAchievements: (() -> Unit)? = null,
     isAdminActionLoading: Boolean = false,
@@ -140,6 +148,29 @@ internal fun GameActionsMenu(
                     )
                 },
             )
+
+            if (onOpenDownloadFolder != null) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = "Show in folder",
+                            style = SpTypography.BodyMedium,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onOpenDownloadFolder()
+                    },
+                    modifier = Modifier.testTag("game_detail_menu_open_download_folder"),
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Outlined.FolderOpen,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    },
+                )
+            }
 
             if (onSaveStateSettings != null) {
                 DropdownMenuItem(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -54,6 +54,7 @@ import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.util.currentPlatform
 import com.spela.player.util.formatBytes
 import com.spela.player.util.formatPlayTime
 
@@ -95,6 +96,7 @@ fun GameHeroContent(
     onAddToCollection: () -> Unit,
     onCreateNetplay: ((String) -> Unit)?,
     onDeleteLocalGame: () -> Unit,
+    onOpenDownloadFolder: () -> Unit = {},
     syncState: GameSyncState?,
     onNavigateToAchievements: () -> Unit = {},
     onAdminScrape: (() -> Unit)? = null,
@@ -341,6 +343,12 @@ fun GameHeroContent(
                 onGradient = true,
                 onSaveStateSettings = if (showSaveStateSettings) {
                     { showGameSettingsSheet = true }
+                } else null,
+                // Only for downloaded games, and only where the OS file
+                // manager can browse the download location — i.e. desktop,
+                // not Android (app-private storage). (#1259)
+                onOpenDownloadFolder = if (state.isGameCached && currentPlatform() != "android") {
+                    onOpenDownloadFolder
                 } else null,
                 onAdminScrape = onAdminScrape,
                 onAdminRefreshAchievements = onAdminRefreshAchievements,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -164,6 +164,7 @@ fun GameDetailScreen(
                     onAddToCollection = { viewModel.onIntent(GameDetailIntent.ShowAddToCollectionDialog) },
                     onCreateNetplay = onCreateNetplay,
                     onDeleteLocalGame = { viewModel.onIntent(GameDetailIntent.ShowDeleteDownloadDialog) },
+                    onOpenDownloadFolder = { viewModel.onIntent(GameDetailIntent.OpenDownloadFolder) },
                     syncState = syncState,
                     onNavigateToAchievements = { onNavigateToAchievements?.invoke(gameId) },
                     onAdminScrape = if (state.isAdmin) {{ viewModel.onIntent(GameDetailIntent.AdminScrapeGame) }} else null,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -24,6 +24,7 @@ import com.spela.player.domain.repository.GameStatsRepository
 import com.spela.player.presentation.intent.GameDetailIntent
 import com.spela.player.presentation.state.GameDetailState
 import com.spela.player.util.DispatcherProvider
+import com.spela.player.util.revealInFileManager
 import com.spela.player.domain.model.GameDetail
 import com.spela.player.domain.model.INSTANT_DOWNLOAD_FALLBACK_DELAY_MS
 import com.spela.player.domain.model.INSTANT_DOWNLOAD_THRESHOLD_BYTES
@@ -117,6 +118,7 @@ class GameDetailViewModel(
             GameDetailIntent.ConsumeAutoLaunch -> _state.update { it.copy(pendingAutoLaunch = false) }
             GameDetailIntent.PlayGame -> { /* Handled by UI navigation to emulation screen */ }
             GameDetailIntent.DeleteLocalGame -> deleteLocalGame()
+            GameDetailIntent.OpenDownloadFolder -> openDownloadFolder()
             GameDetailIntent.ShowDeleteDownloadDialog -> _state.update {
                 it.copy(showDeleteDownloadDialog = true)
             }
@@ -591,6 +593,14 @@ class GameDetailViewModel(
         scope.launch(dispatchers.io) {
             downloadRepository.deleteLocalGame(gameId)
             _state.update { it.copy(isGameCached = false, showDeleteDownloadDialog = false) }
+        }
+    }
+
+    private fun openDownloadFolder() {
+        val gameId = currentGameId ?: return
+        scope.launch(dispatchers.io) {
+            val path = downloadRepository.getLocalGamePath(gameId) ?: return@launch
+            revealInFileManager(path)
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/FileManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/FileManager.kt
@@ -1,0 +1,11 @@
+package com.spela.player.util
+
+/**
+ * Opens the containing folder of [path] in the OS-native file manager
+ * (Explorer / Finder / the default file manager).
+ *
+ * Returns true if a file manager was launched, false if unsupported or on
+ * error. Unsupported on Android, where downloads live in app-private
+ * storage that no file manager can browse (#1259).
+ */
+expect fun revealInFileManager(path: String): Boolean

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/util/FileManager.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/util/FileManager.kt
@@ -1,0 +1,24 @@
+package com.spela.player.util
+
+import java.io.File
+
+actual fun revealInFileManager(path: String): Boolean {
+    val file = File(path)
+    // getLocalGamePath returns the game file; open its containing folder.
+    val folder = (if (file.isDirectory) file else file.parentFile) ?: return false
+    if (!folder.exists()) return false
+
+    val os = System.getProperty("os.name").lowercase()
+    val cmd = when {
+        os.contains("win") -> listOf("explorer.exe", folder.absolutePath)
+        os.contains("mac") -> listOf("open", folder.absolutePath)
+        else -> listOf("xdg-open", folder.absolutePath)
+    }
+    return try {
+        ProcessBuilder(cmd).start()
+        true
+    } catch (e: Exception) {
+        println("[FileManager] failed to open $folder: ${e.message}")
+        false
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **"Show in folder"** item to the game detail actions ("...") menu that opens the downloaded game's folder in the OS-native file manager (#1259).

## How it works

- **`revealInFileManager(path)`** — new `expect`/`actual` util:
  - **Desktop** (Windows / macOS / Linux): opens the containing folder via `explorer` / `open` / `xdg-open`.
  - **Android**: no-op — downloads live in app-private `context.filesDir`, which no file manager can browse, so the action is hidden there. (This is a hard platform constraint, not a choice; revealing app-private storage isn't possible without relocating downloads to shared storage, which is out of scope.)
- `GameDetailViewModel.openDownloadFolder()` resolves the path via `DownloadRepository.getLocalGamePath` and reveals it.
- The item lives in `GameActionsMenu` (the always-present "..." menu), shown only for downloaded games (`state.isGameCached`) on platforms that can reveal (`currentPlatform() != "android"`). So it covers **both playable and non-playable** games — the non-playable (unsupported-console) case being exactly where the on-disk file is most useful.

## Cross-platform status

✅ Windows, macOS, Linux desktop · ⚪ Android (hidden — app-private storage).

## Test

`GameDetailActionsMenuTest`: the item shows for a cached game and is hidden for an uncached one. Assertions only — clicking would spawn the real OS file manager. Verified locally: `:desktop:desktopTest --tests GameDetailActionsMenuTest` → BUILD SUCCESSFUL.

The Android `actual` is pure Kotlin and is compiled on CI via `:android:detektDebugAndroid`.

Closes #1259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
