### PR TITLE
feat(player): "Download to folder…" for non-emulated games

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailNotPlayableTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailNotPlayableTest.kt
@@ -64,4 +64,25 @@ class GameDetailNotPlayableTest {
         onNodeWithText("Castlevania").assertIsDisplayed()
         onNodeWithTag("game_detail_not_playable_notice").assertDoesNotExist()
     }
+
+    @Test
+    fun nonPlayableGameOffersDownloadToFolder() = runComposeUiTest {
+        // #1257: a non-playable game uses "Download to folder…" instead of the
+        // managed "Download". Use a large file (> instant-download threshold)
+        // so the regular download-button path is taken. Desktop test platform
+        // is non-Android, so the folder variant is enabled. Assertion only —
+        // clicking would open a real OS folder picker.
+        val harness = createHarness()
+        val bigGame = vitaGame.copy(
+            id = "vita-2",
+            title = "Big Unsupported Title",
+            fileSize = 64L * 1024 * 1024,
+        )
+        harness.gameRepo.games = harness.gameRepo.games + bigGame
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "vita-2")
+
+        onNodeWithText("Big Unsupported Title").assertIsDisplayed()
+        onNodeWithText("Download to folder", substring = true).assertIsDisplayed()
+    }
 }

--- a/player/shared/src/androidMain/kotlin/com/spela/player/util/FolderPicker.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/util/FolderPicker.kt
@@ -1,0 +1,8 @@
+package com.spela.player.util
+
+/**
+ * No folder picker on Android: choosing an arbitrary download destination
+ * needs the Storage Access Framework (a per-Activity result flow), which is
+ * out of scope. Returns null so the caller keeps the default behavior. (#1257)
+ */
+actual fun pickDirectory(title: String): String? = null

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
@@ -219,6 +219,55 @@ class DownloadRepositoryImpl(
         }
     }
 
+    override suspend fun downloadGameToDirectory(
+        gameId: String,
+        gameTitle: String,
+        destDir: String,
+    ): Result<String> {
+        setActiveJob(gameId, coroutineContext[Job]!!)
+        return runCatching {
+            downloads.update { it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.QUEUED)) }
+            downloads.update { it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING)) }
+
+            val gameDetail = apiClient.getGameDetail(gameId)
+            val fileName = gameDetail.fileName.ifEmpty { gameId }
+            val expectedSize = gameDetail.fileSize
+            // destDir is a user-chosen absolute path; write the file directly
+            // into it. Unlike downloadGame this records no DB row, so the game
+            // is never treated as "cached" — the file lives outside the games
+            // dir purely for the user. (#1257)
+            val destPath = "$destDir/$fileName"
+
+            apiClient.downloadGameToFile(gameId, fileStorage, destPath) { downloaded, total ->
+                val reportedTotal = total ?: if (expectedSize > 0) expectedSize else -1L
+                val monotonic = monotonicBytes(gameId, downloaded)
+                val speed = recordSpeed(gameId, monotonic)
+                downloads.update {
+                    it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, monotonic, reportedTotal, bytesPerSecond = speed))
+                }
+            }
+
+            resetSpeed(gameId)
+            val actualSize = fileStorage.getFileSize(destPath)
+            downloads.update {
+                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.COMPLETED, actualSize, actualSize))
+            }
+            destPath
+        }.also {
+            takeActiveJob(gameId)
+        }.onFailure { error ->
+            takeActiveJob(gameId)
+            resetSpeed(gameId)
+            if (error is CancellationException) {
+                downloads.update { it - gameId }
+                throw error
+            }
+            downloads.update {
+                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.FAILED))
+            }
+        }
+    }
+
     /**
      * Mirrors the server's packaging decision in
      * `huma_downloads.go::HumaDownloadGame`: extensions that the server

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/DownloadRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/DownloadRepository.kt
@@ -9,6 +9,20 @@ interface DownloadRepository {
     fun observeDownload(gameId: String): Flow<DownloadProgress>
     fun observeDownloadedGames(): Flow<List<DownloadedGame>>
     suspend fun downloadGame(gameId: String, gameTitle: String = ""): Result<String>
+
+    /**
+     * Downloads a game's file directly into [destDir] (an absolute path the
+     * user chose), bypassing the managed cache and DB tracking. For games
+     * Spela can't emulate, where the file is only useful outside the app
+     * (#1257). Progress is emitted via [observeDownload] keyed by gameId.
+     * Default is a no-op failure for fakes that don't support it.
+     */
+    suspend fun downloadGameToDirectory(
+        gameId: String,
+        gameTitle: String,
+        destDir: String,
+    ): Result<String> = Result.failure(UnsupportedOperationException("downloadGameToDirectory not supported"))
+
     suspend fun cancelDownload(gameId: String)
     suspend fun getLocalGamePath(gameId: String): String?
     suspend fun isGameCached(gameId: String): Boolean

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
@@ -3,6 +3,7 @@ package com.spela.player.presentation.intent
 sealed interface GameDetailIntent {
     data class LoadGame(val gameId: String) : GameDetailIntent
     data object DownloadGame : GameDetailIntent
+    data object DownloadToFolder : GameDetailIntent
     /**
      * Silent download-then-launch path for sub-threshold games. The
      * ViewModel kicks off the download, suppresses progress UI for

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -97,6 +97,7 @@ fun GameHeroContent(
     onCreateNetplay: ((String) -> Unit)?,
     onDeleteLocalGame: () -> Unit,
     onOpenDownloadFolder: () -> Unit = {},
+    onDownloadToFolder: () -> Unit = {},
     syncState: GameSyncState?,
     onNavigateToAchievements: () -> Unit = {},
     onAdminScrape: (() -> Unit)? = null,
@@ -310,9 +311,17 @@ fun GameHeroContent(
                         add(SpSplitButtonMenuItem("Netplay") { onCreateNetplay(gameId) })
                     }
                 }
+                // For a game Spela can't emulate, downloading to the managed
+                // cache is pointless — let the user pick a folder instead
+                // (desktop only; Android keeps the default). (#1257)
+                val downloadToFolder = !game.playable && currentPlatform() != "android"
                 SpSplitButton(
-                    text = if (isBusy) "Downloading..." else "Download",
-                    onClick = onDownloadGame,
+                    text = when {
+                        isBusy -> "Downloading..."
+                        downloadToFolder -> "Download to folder…"
+                        else -> "Download"
+                    },
+                    onClick = if (downloadToFolder) onDownloadToFolder else onDownloadGame,
                     modifier = Modifier
                         .focusRestoreItem(
                             key = "game_detail_play",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -165,6 +165,7 @@ fun GameDetailScreen(
                     onCreateNetplay = onCreateNetplay,
                     onDeleteLocalGame = { viewModel.onIntent(GameDetailIntent.ShowDeleteDownloadDialog) },
                     onOpenDownloadFolder = { viewModel.onIntent(GameDetailIntent.OpenDownloadFolder) },
+                    onDownloadToFolder = { viewModel.onIntent(GameDetailIntent.DownloadToFolder) },
                     syncState = syncState,
                     onNavigateToAchievements = { onNavigateToAchievements?.invoke(gameId) },
                     onAdminScrape = if (state.isAdmin) {{ viewModel.onIntent(GameDetailIntent.AdminScrapeGame) }} else null,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -24,6 +24,7 @@ import com.spela.player.domain.repository.GameStatsRepository
 import com.spela.player.presentation.intent.GameDetailIntent
 import com.spela.player.presentation.state.GameDetailState
 import com.spela.player.util.DispatcherProvider
+import com.spela.player.util.pickDirectory
 import com.spela.player.util.revealInFileManager
 import com.spela.player.domain.model.GameDetail
 import com.spela.player.domain.model.INSTANT_DOWNLOAD_FALLBACK_DELAY_MS
@@ -114,6 +115,7 @@ class GameDetailViewModel(
         when (intent) {
             is GameDetailIntent.LoadGame -> loadGame(intent.gameId)
             GameDetailIntent.DownloadGame -> downloadGame()
+            GameDetailIntent.DownloadToFolder -> downloadToFolder()
             GameDetailIntent.DownloadGameAndPlay -> downloadGameAndPlay()
             GameDetailIntent.ConsumeAutoLaunch -> _state.update { it.copy(pendingAutoLaunch = false) }
             GameDetailIntent.PlayGame -> { /* Handled by UI navigation to emulation screen */ }
@@ -496,6 +498,26 @@ class GameDetailViewModel(
             } catch (e: Exception) {
                 println("GameDetailViewModel: scrape request failed for game $gameId: ${e.message}")
             }
+        }
+    }
+
+    /**
+     * Download a game Spela can't emulate to a user-chosen folder (#1257).
+     * Prompts for the destination, then streams the file there (no managed
+     * cache entry). Progress flows through the same observeDownload path as
+     * a normal download. On platforms without a folder picker (Android) the
+     * picker returns null and this is a no-op.
+     */
+    private fun downloadToFolder() {
+        val gameId = currentGameId ?: return
+        val gameTitle = _state.value.gameDetail?.game?.title ?: ""
+        scope.launch(dispatchers.io) {
+            val dir = pickDirectory("Choose a folder to download to") ?: return@launch
+            _state.update { it.copy(isDownloading = true) }
+            downloadRepository.downloadGameToDirectory(gameId, gameTitle, dir).fold(
+                onSuccess = { _state.update { it.copy(isDownloading = false) } },
+                onFailure = { error -> _state.update { it.copy(error = error.message, isDownloading = false) } },
+            )
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/FolderPicker.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/FolderPicker.kt
@@ -1,0 +1,11 @@
+package com.spela.player.util
+
+/**
+ * Shows a native folder picker and returns the chosen directory's absolute
+ * path, or null if the user cancelled or the platform has no picker.
+ *
+ * Blocking — call from a background dispatcher. Unsupported on Android
+ * (returns null); used on desktop to choose where to download a game Spela
+ * can't emulate (#1257).
+ */
+expect fun pickDirectory(title: String): String?

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/util/FolderPicker.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/util/FolderPicker.kt
@@ -1,0 +1,25 @@
+package com.spela.player.util
+
+import javax.swing.JFileChooser
+import javax.swing.SwingUtilities
+
+actual fun pickDirectory(title: String): String? {
+    var result: String? = null
+    val task = Runnable {
+        val chooser = JFileChooser().apply {
+            dialogTitle = title
+            fileSelectionMode = JFileChooser.DIRECTORIES_ONLY
+        }
+        if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
+            result = chooser.selectedFile?.absolutePath
+        }
+    }
+    // The picker is modal and must run on the AWT event thread; callers are
+    // on a background dispatcher, so marshal across.
+    if (SwingUtilities.isEventDispatchThread()) {
+        task.run()
+    } else {
+        SwingUtilities.invokeAndWait(task)
+    }
+    return result
+}


### PR DESCRIPTION
## Summary

A game Spela can't emulate is only useful as a file *outside* the app, so downloading it into the managed cache (app-private on Android, an unbrowsable app-data dir on desktop) is pointless. For non-playable games on desktop, the **Download** button becomes **"Download to folder…"** — it prompts for a destination and streams the file straight there. (#1257)

## Implementation

- **`pickDirectory(title)`** — new `expect`/`actual`:
  - **Desktop**: `JFileChooser` (DIRECTORIES_ONLY), marshalled to the AWT event thread.
  - **Android**: returns null (a Storage Access Framework picker is a per-Activity result flow, out of scope), so the UI keeps the default Download.
- **`DownloadRepository.downloadGameToDirectory(gameId, title, destDir)`** — streams the game file into `destDir` with **no DB/cache row** (the game never becomes "cached"), reusing the existing progress flow (`observeDownload`). The interface has a default returning an unsupported failure, so the test fakes need no changes.
- **UI**: `GameHeroContent` shows "Download to folder…" only for `!game.playable` on non-Android; `GameDetailViewModel.downloadToFolder()` picks the directory (on the IO dispatcher) then downloads. Playable games and Android are unchanged.

## Cross-platform status

✅ Windows, macOS, Linux desktop · ⚪ Android (keeps the default managed download — no SAF picker).

## Test

`GameDetailNotPlayableTest`: a large (> instant-download threshold) non-playable game shows the "Download to folder…" label. Assertion only — clicking would open a real OS folder picker. Verified locally: `:desktop:desktopTest` → BUILD SUCCESSFUL. The Android `actual` is pure Kotlin, compiled on CI via `:android:detektDebugAndroid`.

Closes #1257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
