### PR TITLE
fix(player): accrue play time from frames, not wall-clock (#1282)

### DIFF
--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
@@ -11,6 +11,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerEventType
@@ -29,6 +31,7 @@ import com.spela.player.libretro.DesktopGamepadSynth
 import com.spela.player.presentation.ui.gamepad.InputModeClassifier
 import com.spela.player.presentation.App
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
+import com.spela.player.presentation.intent.EmulationIntent
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.NavigationViewModel
 import com.spela.player.presentation.viewmodel.EmulationViewModel
@@ -76,13 +79,32 @@ fun main(args: Array<String>) {
 
     val icon = useResource("spela-icon.svg") { loadSvgPainter(it, Density(1f)) }
 
+    val windowState = rememberWindowState(width = 1280.dp, height = 720.dp)
+    val windowInfo = LocalWindowInfo.current
+
+    // Pause the game (and play-time accrual) when the window is minimized
+    // or loses focus, and resume when it comes back — mirroring Android's
+    // onPause/onResume. Without this, a game left in the background keeps
+    // running and counting play time (#1282).
+    LaunchedEffect(Unit) {
+        snapshotFlow { windowInfo.isWindowFocused && !windowState.isMinimized }
+            .collect { active ->
+                val st = emulationViewModel.state.value
+                if (!active && st.isRunning && !st.isPaused) {
+                    emulationViewModel.onIntent(EmulationIntent.LifecyclePause)
+                } else if (active && st.isLifecyclePaused) {
+                    emulationViewModel.onIntent(EmulationIntent.LifecycleResume)
+                }
+            }
+    }
+
     Window(
         onCloseRequest = {
             gamepadPoller.stop()
             exitApplication()
         },
         title = windowTitle,
-        state = rememberWindowState(width = 1280.dp, height = 720.dp),
+        state = windowState,
         icon = icon,
     ) {
         // macOS: transparent title bar that lets Compose content show through.

--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
@@ -91,8 +91,10 @@ fun main(args: Array<String>) {
             .collect { active ->
                 val st = emulationViewModel.state.value
                 if (!active && st.isRunning && !st.isPaused) {
+                    println("[PlayTime] window background → pause (game=${st.gameId})")
                     emulationViewModel.onIntent(EmulationIntent.LifecyclePause)
                 } else if (active && st.isLifecyclePaused) {
+                    println("[PlayTime] window foreground → resume (game=${st.gameId})")
                     emulationViewModel.onIntent(EmulationIntent.LifecycleResume)
                 }
             }

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
@@ -84,6 +84,14 @@ class AndroidLibretroController(
     @Volatile
     private var currentFrameTime = 0f
 
+    /* Active play-time accrual (#1282). The emulation thread adds the
+     * clamped wall-clock gap between presented frames; the reporter
+     * drains via consumeActivePlayMillis(). lastFrameNanos is reset to 0
+     * on pause so the gap across a pause isn't counted on resume. */
+    private val activePlayMillis = java.util.concurrent.atomic.AtomicLong(0L)
+    @Volatile
+    private var lastFrameNanos = 0L
+
     /* Video: emulation thread writes to back buffer, then swaps to front for Compose */
     private val _frameBitmap = MutableStateFlow<Bitmap?>(null)
     val frameBitmap: StateFlow<Bitmap?> = _frameBitmap.asStateFlow()
@@ -236,12 +244,27 @@ class AndroidLibretroController(
 
     override fun pause() {
         paused = true
+        // Reset the frame-gap baseline so the paused stretch isn't
+        // credited as play time when the loop resumes (#1282).
+        lastFrameNanos = 0L
         audioPlayer?.pause()
     }
 
     override fun resume() {
         paused = false
         audioPlayer?.resume()
+    }
+
+    override fun consumeActivePlayMillis(): Long = activePlayMillis.getAndSet(0L)
+
+    /** Credit the wall-clock gap since the previous presented frame to
+     *  the active-play accumulator, clamped so an idle/suspended stretch
+     *  isn't counted (#1282). Called once per frame from the emulation
+     *  loop(s) — the only writer of [lastFrameNanos]. */
+    private fun accrueActivePlayTime(nowNanos: Long) {
+        val delta = frameDeltaMillis(lastFrameNanos, nowNanos)
+        if (delta > 0L) activePlayMillis.addAndGet(delta)
+        lastFrameNanos = nowNanos
     }
 
     override fun stop() {
@@ -462,6 +485,7 @@ class AndroidLibretroController(
             }
 
             val frameStart = System.nanoTime()
+            accrueActivePlayTime(frameStart)
 
             jni.nativeRun()
 
@@ -561,6 +585,7 @@ class AndroidLibretroController(
             }
 
             val frameStart = System.nanoTime()
+            accrueActivePlayTime(frameStart)
             val currentFrame = frameCounter
 
             // 1. Capture local input state from the JNI input table

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
@@ -114,6 +114,7 @@ class PresenceService(
         paused = false
         currentGameId = gameId
         drainPlayMillis = drainMillis
+        println("[PlayTime] start game=$gameId")
 
         // Initial 0-second ping marks the user as playing this game
         // immediately (server sets current-game presence on any report).
@@ -133,10 +134,16 @@ class PresenceService(
                 // Always drain to keep the accumulator from growing while
                 // paused; only the reporting is gated on `paused`.
                 pendingMillis += drainPlayMillis?.invoke() ?: 0L
-                if (paused) continue
+                if (paused) {
+                    if (pendingMillis > 0L) {
+                        println("[PlayTime] paused — holding ${pendingMillis}ms (game=$gid)")
+                    }
+                    continue
+                }
                 val (seconds, remainder) = splitForFlush(pendingMillis)
                 pendingMillis = remainder
                 if (seconds > 0L) {
+                    println("[PlayTime] report game=$gid +${seconds}s (carry ${remainder}ms)")
                     try {
                         apiClient.updatePlayTime(gid, seconds)
                     } catch (_: Exception) {
@@ -165,6 +172,7 @@ class PresenceService(
             scope.launch(dispatchers.io) {
                 try {
                     val (seconds, _) = splitForFlush(drain?.invoke() ?: 0L)
+                    println("[PlayTime] stop game=$gameId final +${seconds}s")
                     if (seconds > 0L) apiClient.updatePlayTime(gameId, seconds)
                 } catch (_: Exception) {
                     // Best effort

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
@@ -1,6 +1,7 @@
 package com.spela.player.data.remote
 
 import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.libretro.splitForFlush
 import com.spela.player.util.DispatcherProvider
 import io.ktor.client.*
 import io.ktor.client.plugins.websocket.*
@@ -37,6 +38,13 @@ class PresenceService(
     private var heartbeatJob: Job? = null
     @Volatile
     private var currentGameId: String? = null
+
+    // Drains the milliseconds of *active* play (frames advanced) since the
+    // last call from the emulation controller. Play time is reported from
+    // this — not wall-clock — so paused/backgrounded/stalled time is never
+    // counted (#1282). Null when no game is running.
+    @Volatile
+    private var drainPlayMillis: (() -> Long)? = null
 
     @Volatile
     var paused: Boolean = false
@@ -94,15 +102,21 @@ class PresenceService(
     }
 
     /**
-     * Start sending play-time heartbeats for the given game.
-     * Each heartbeat reports the interval seconds and marks the user as playing.
+     * Start reporting play time for the given game. [drainMillis] is polled
+     * each interval for the milliseconds of *active* play (frames advanced)
+     * since the previous poll; the reporter sends the real accrued seconds
+     * — not a flat interval — carrying any sub-second remainder forward so
+     * nothing is lost or invented. Time while paused/backgrounded/stalled
+     * drains as ~0, so it isn't counted (#1282).
      */
-    fun startHeartbeat(gameId: String) {
+    fun startHeartbeat(gameId: String, drainMillis: () -> Long) {
         stopHeartbeat()
         paused = false
         currentGameId = gameId
+        drainPlayMillis = drainMillis
 
-        // Send initial heartbeat immediately
+        // Initial 0-second ping marks the user as playing this game
+        // immediately (server sets current-game presence on any report).
         scope.launch(dispatchers.io) {
             try {
                 apiClient.updatePlayTime(gameId, 0)
@@ -112,33 +126,50 @@ class PresenceService(
         }
 
         heartbeatJob = scope.launch(dispatchers.io) {
+            var pendingMillis = 0L
             while (isActive) {
                 delay(HEARTBEAT_INTERVAL_MS)
-                if (paused) continue // Don't report play time while paused/backgrounded
                 val gid = currentGameId ?: break
-                try {
-                    val seconds = HEARTBEAT_INTERVAL_MS / 1000
-                    apiClient.updatePlayTime(gid, seconds)
-                } catch (_: Exception) {
-                    // Best effort, will retry on next interval
+                // Always drain to keep the accumulator from growing while
+                // paused; only the reporting is gated on `paused`.
+                pendingMillis += drainPlayMillis?.invoke() ?: 0L
+                if (paused) continue
+                val (seconds, remainder) = splitForFlush(pendingMillis)
+                pendingMillis = remainder
+                if (seconds > 0L) {
+                    try {
+                        apiClient.updatePlayTime(gid, seconds)
+                    } catch (_: Exception) {
+                        // Best effort; the un-drained remainder is already
+                        // carried in pendingMillis, so nothing is lost.
+                    }
                 }
             }
         }
     }
 
     /**
-     * Stop sending play-time heartbeats.
-     * Sends a final API call to clear the game status on the server (best-effort).
+     * Stop reporting play time. Flushes any active play accrued since the
+     * last interval, then clears the game status on the server (both
+     * best-effort).
      */
     fun stopHeartbeat() {
         val gameId = currentGameId
+        val drain = drainPlayMillis
         heartbeatJob?.cancel()
         heartbeatJob = null
         currentGameId = null
+        drainPlayMillis = null
 
-        // Fire-and-forget: tell the server we stopped playing
         if (gameId != null) {
             scope.launch(dispatchers.io) {
+                try {
+                    val (seconds, _) = splitForFlush(drain?.invoke() ?: 0L)
+                    if (seconds > 0L) apiClient.updatePlayTime(gameId, seconds)
+                } catch (_: Exception) {
+                    // Best effort
+                }
+                // Tell the server we stopped playing
                 try {
                     apiClient.clearCurrentGame(gameId)
                 } catch (_: Exception) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/PlayTimeAccrual.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/PlayTimeAccrual.kt
@@ -1,0 +1,52 @@
+package com.spela.player.libretro
+
+/**
+ * Largest wall-clock gap between two consecutive presented frames that
+ * still counts as active play time, in milliseconds.
+ *
+ * When the emulator is actually running, frames arrive every ~16 ms
+ * (60 fps) up to ~66 ms on a struggling 15 fps core — always well under
+ * this cap. A gap larger than the cap means the emulator was *not*
+ * advancing frames (in-app pause, app backgrounded, OS suspend, lid
+ * closed, a long stall), so the gap is clamped to one cap's worth: the
+ * idle stretch is not credited as play time. This is the mechanism that
+ * keeps "game loaded but not running" time out of the total (#1282).
+ */
+const val MAX_FRAME_GAP_MILLIS: Long = 250L
+
+/**
+ * Clamped wall-clock delta (ms) to credit for a frame presented at
+ * [nowNanos], given the previous presented frame at [prevNanos].
+ *
+ * Returns 0 when there is no previous frame ([prevNanos] == 0, the
+ * baseline-reset sentinel used after a pause) or the delta is
+ * non-positive (clock skew). Otherwise the delta is clamped to
+ * [maxGapMillis] so a no-frame stretch credits at most one frame.
+ */
+fun frameDeltaMillis(
+    prevNanos: Long,
+    nowNanos: Long,
+    maxGapMillis: Long = MAX_FRAME_GAP_MILLIS,
+): Long {
+    if (prevNanos == 0L) return 0L
+    val deltaMs = (nowNanos - prevNanos) / 1_000_000L
+    if (deltaMs <= 0L) return 0L
+    return if (deltaMs > maxGapMillis) maxGapMillis else deltaMs
+}
+
+/** Result of folding newly-drained active-play millis into a reporter's
+ *  pending bucket: the whole seconds to report now, and the sub-second
+ *  remainder to carry forward so nothing is lost across flushes. */
+data class PlayTimeFlush(val secondsToSend: Long, val remainderMillis: Long)
+
+/**
+ * Splits [pendingMillis] into whole seconds to report and the leftover
+ * milliseconds to carry to the next flush. Keeping the remainder means a
+ * series of sub-second/odd flushes still sums to the right total instead
+ * of truncating a little every time.
+ */
+fun splitForFlush(pendingMillis: Long): PlayTimeFlush {
+    if (pendingMillis <= 0L) return PlayTimeFlush(0L, pendingMillis.coerceAtLeast(0L))
+    val seconds = pendingMillis / 1000L
+    return PlayTimeFlush(seconds, pendingMillis - seconds * 1000L)
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -1333,8 +1333,13 @@ class EmulationViewModel(
                             initAchievements(gameId)
                         }
 
-                        // Start play-time heartbeat for online presence
-                        presenceService.startHeartbeat(gameId)
+                        // Start play-time reporting. Time is accrued from
+                        // frames actually advanced (drained from the
+                        // controller), not wall-clock, so paused/background
+                        // time isn't counted (#1282).
+                        presenceService.startHeartbeat(gameId) {
+                            libretroController.consumeActivePlayMillis()
+                        }
 
                         // Start shared session heartbeat if in shared session mode
                         if (sharedSessionId != null) {
@@ -2066,6 +2071,14 @@ interface LibretroController {
     fun unserializeFromFile(path: String): Boolean = false
     fun setFastForward(enabled: Boolean)
     fun performanceStats(): kotlinx.coroutines.flow.Flow<Pair<Float, Float>>
+
+    /** Drains and returns the wall-clock milliseconds the emulator has
+     *  actively advanced frames since the last call (resetting the
+     *  internal counter to 0). Play time is accrued from this so that
+     *  time while paused / backgrounded / suspended / stalled — when no
+     *  frames are produced — is not counted. Default 0 for fakes and
+     *  platforms that don't track it. See #1282. */
+    fun consumeActivePlayMillis(): Long = 0L
 
     /** True once retro_run() has returned at least one frame for the
      *  currently loaded game. Replaces a fixed Dolphin-tuned wait

--- a/player/shared/src/commonTest/kotlin/com/spela/player/libretro/PlayTimeAccrualTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/libretro/PlayTimeAccrualTest.kt
@@ -1,0 +1,91 @@
+package com.spela.player.libretro
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlayTimeAccrualTest {
+
+    private val ms = 1_000_000L // nanos per millisecond
+
+    @Test
+    fun noPreviousFrame_creditsZero() {
+        // prevNanos == 0 is the baseline-reset sentinel (set on pause / first frame).
+        assertEquals(0L, frameDeltaMillis(prevNanos = 0L, nowNanos = 5_000 * ms))
+    }
+
+    @Test
+    fun normalFrameGap_creditsActualDelta() {
+        // 16 ms between frames (~60 fps) is credited in full.
+        assertEquals(16L, frameDeltaMillis(prevNanos = 1_000 * ms, nowNanos = 1_016 * ms))
+    }
+
+    @Test
+    fun strugglingFrameRate_underCap_creditsActualDelta() {
+        // 66 ms (~15 fps) is still below the cap and credited in full.
+        assertEquals(66L, frameDeltaMillis(prevNanos = 0L + 100 * ms, nowNanos = 166 * ms))
+    }
+
+    @Test
+    fun longGap_isClampedToCap() {
+        // A 3-hour stretch with no frames (backgrounded / suspended) credits
+        // at most one cap's worth, not 3 hours.
+        val threeHoursNanos = 3L * 3600 * 1000 * ms
+        assertEquals(
+            MAX_FRAME_GAP_MILLIS,
+            frameDeltaMillis(prevNanos = 1 * ms, nowNanos = 1 * ms + threeHoursNanos),
+        )
+    }
+
+    @Test
+    fun gapExactlyAtCap_isNotClamped() {
+        assertEquals(
+            MAX_FRAME_GAP_MILLIS,
+            frameDeltaMillis(prevNanos = ms, nowNanos = ms + MAX_FRAME_GAP_MILLIS * ms),
+        )
+    }
+
+    @Test
+    fun nonPositiveDelta_creditsZero() {
+        // Clock skew / equal timestamps must never credit (or go negative).
+        assertEquals(0L, frameDeltaMillis(prevNanos = 5_000 * ms, nowNanos = 5_000 * ms))
+        assertEquals(0L, frameDeltaMillis(prevNanos = 5_000 * ms, nowNanos = 4_000 * ms))
+    }
+
+    @Test
+    fun subMillisDelta_creditsZero() {
+        // Less than 1 ms rounds down to 0 (carried implicitly by the next frame's larger delta).
+        assertEquals(0L, frameDeltaMillis(prevNanos = ms, nowNanos = ms + 500_000L))
+    }
+
+    @Test
+    fun splitForFlush_wholeSeconds() {
+        assertEquals(PlayTimeFlush(secondsToSend = 30L, remainderMillis = 0L), splitForFlush(30_000L))
+    }
+
+    @Test
+    fun splitForFlush_carriesRemainder() {
+        // 1500 ms -> send 1s, carry 500 ms.
+        assertEquals(PlayTimeFlush(secondsToSend = 1L, remainderMillis = 500L), splitForFlush(1_500L))
+    }
+
+    @Test
+    fun splitForFlush_belowOneSecond_sendsNothing_carriesAll() {
+        assertEquals(PlayTimeFlush(secondsToSend = 0L, remainderMillis = 800L), splitForFlush(800L))
+    }
+
+    @Test
+    fun splitForFlush_zeroOrNegative_sendsNothing() {
+        assertEquals(PlayTimeFlush(0L, 0L), splitForFlush(0L))
+        assertEquals(PlayTimeFlush(0L, 0L), splitForFlush(-50L))
+    }
+
+    @Test
+    fun splitForFlush_remainderAccumulatesToWholeSecond() {
+        // Two 1500 ms flushes: 1s+carry500, then (500+1500)=2000 -> 2s.
+        val first = splitForFlush(1_500L)
+        assertEquals(1L, first.secondsToSend)
+        val second = splitForFlush(first.remainderMillis + 1_500L)
+        assertEquals(2L, second.secondsToSend)
+        assertEquals(0L, second.remainderMillis)
+    }
+}

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
@@ -113,6 +113,14 @@ class DesktopLibretroController(
     @Volatile
     private var currentFrameTime = 0f
 
+    /* Active play-time accrual (#1282). The emulation thread adds the
+     * clamped wall-clock gap between presented frames; the reporter
+     * drains via consumeActivePlayMillis(). lastFrameNanos is reset to 0
+     * on pause so the gap across a pause isn't counted on resume. */
+    private val activePlayMillis = java.util.concurrent.atomic.AtomicLong(0L)
+    @Volatile
+    private var lastFrameNanos = 0L
+
     /**
      * Double-buffered rendered frame output for offscreen Metal rendering.
      * The emulation thread renders into one buffer while the Compose thread
@@ -165,10 +173,25 @@ class DesktopLibretroController(
 
     override fun pause() {
         paused = true
+        // Reset the frame-gap baseline so the paused stretch isn't
+        // credited as play time when the loop resumes (#1282).
+        lastFrameNanos = 0L
     }
 
     override fun resume() {
         paused = false
+    }
+
+    override fun consumeActivePlayMillis(): Long = activePlayMillis.getAndSet(0L)
+
+    /** Credit the wall-clock gap since the previous presented frame to
+     *  the active-play accumulator, clamped so an idle/suspended stretch
+     *  isn't counted (#1282). Called once per frame from the emulation
+     *  loop(s) — the only writer of [lastFrameNanos]. */
+    private fun accrueActivePlayTime(nowNanos: Long) {
+        val delta = frameDeltaMillis(lastFrameNanos, nowNanos)
+        if (delta > 0L) activePlayMillis.addAndGet(delta)
+        lastFrameNanos = nowNanos
     }
 
     /** Set by emulation thread; signals that unload+deinit should happen on the emu thread. */
@@ -364,6 +387,7 @@ class DesktopLibretroController(
             }
 
             val frameStart = System.nanoTime()
+            accrueActivePlayTime(frameStart)
 
             jni.nativeRun()
 
@@ -454,6 +478,7 @@ class DesktopLibretroController(
             }
 
             val frameStart = System.nanoTime()
+            accrueActivePlayTime(frameStart)
             val currentFrame = frameCounter
 
             // 1. Capture local input from netplayLocalButtons (set by setButton),

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/PresenceServiceHeartbeatTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/PresenceServiceHeartbeatTest.kt
@@ -1,0 +1,121 @@
+package com.spela.player.data.remote
+
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.interceptor.TokenManager
+import com.spela.player.util.DispatcherProvider
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Locks the frame-driven contract of the play-time reporter (#1282): the
+ * reporter sources play time by *polling the controller's active-frame
+ * drain*, once per interval and once on stop — rather than crediting a
+ * flat wall-clock interval. The drain lambda is invoked synchronously in
+ * the reporter loop, so these assertions are deterministic.
+ *
+ * The value arithmetic the reporter applies to the drained millis (whole
+ * seconds + sub-second carry) is covered exhaustively by
+ * [com.spela.player.libretro.splitForFlush] unit tests; the network POST
+ * itself is not asserted here because MockEngine completes on a real
+ * dispatcher, which is non-deterministic under virtual time.
+ *
+ * Runs on a separate-Job scope sharing runTest's scheduler so the
+ * never-ending loop isn't tracked by runTest cleanup (cancelled in
+ * `finally`); Unconfined so launched work runs eagerly to its next
+ * suspension.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PresenceServiceHeartbeatTest {
+
+    private val intervalMs = 30_000L // PresenceService.HEARTBEAT_INTERVAL_MS
+
+    private class TestDispatchers(d: CoroutineDispatcher) : DispatcherProvider {
+        override val main = d
+        override val io = d
+        override val default = d
+    }
+
+    /** Always-OK engine; we don't assert on requests here. */
+    private object OkEngineFactory : HttpClientEngineFactory<MockEngineConfig> {
+        override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine =
+            MockEngine(MockEngineConfig().apply {
+                addHandler {
+                    respond("{}", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+                }
+                block()
+            })
+    }
+
+    private fun withService(
+        block: suspend TestScope.(service: PresenceService) -> Unit,
+    ) = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val serviceScope = CoroutineScope(dispatcher + Job())
+        val tokenManager = TokenManager().also { it.setTokens("test-access", "test-refresh") }
+        val apiClient = SpelaApiClient(OkEngineFactory, tokenManager).also { it.setBaseUrl("http://localhost:8080") }
+        val service = PresenceService(apiClient, OkEngineFactory, TestDispatchers(dispatcher), serviceScope)
+        try {
+            block(service)
+        } finally {
+            service.stopHeartbeat()
+            serviceScope.cancel()
+        }
+    }
+
+    @Test
+    fun pollsActivePlayDrainOncePerInterval() = withService { service ->
+        var drainCalls = 0
+        service.startHeartbeat("5") { drainCalls++; 0L }
+
+        advanceTimeBy(intervalMs * 3 + 1)
+
+        // One poll per heartbeat interval — play time tracks frames, not a
+        // flat clock tick.
+        assertEquals(3, drainCalls)
+    }
+
+    @Test
+    fun keepsPollingWhilePaused_soAccumulatorDoesNotGrowUnbounded() = withService { service ->
+        var drainCalls = 0
+        service.startHeartbeat("5") { drainCalls++; 0L }
+        service.paused = true
+
+        advanceTimeBy(intervalMs * 2 + 1)
+
+        // Paused gates *reporting*, not draining — the accumulator is still
+        // emptied each interval (so it can't balloon while paused).
+        assertEquals(2, drainCalls)
+    }
+
+    @Test
+    fun stopDrainsAnyRemainingActivePlay() = withService { service ->
+        var drainCalls = 0
+        service.startHeartbeat("5") { drainCalls++; 0L }
+        val afterStart = drainCalls
+
+        service.stopHeartbeat()
+        advanceTimeBy(1)
+
+        // Stop performs a final drain so partial play since the last
+        // interval isn't lost.
+        assertTrue(drainCalls > afterStart, "stop should drain once more (was $afterStart, now $drainCalls)")
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -155,6 +155,18 @@ open class StubLibretroController : LibretroController {
     override fun getSRAM(): ByteArray? { getSRAMCallCount++; return getSRAMResult }
     override fun setSRAM(data: ByteArray): Boolean { setSRAMCallCount++; lastSetSRAMData = data; return setSRAMResult }
     override fun clearNetplayMode() { clearNetplayModeCallCount++ }
+
+    /** Drives [consumeActivePlayMillis] — set the active-play millis the
+     *  next drain should return. Reset to 0 on each drain, mirroring the
+     *  real controller's getAndSet semantics (#1282). */
+    var activePlayMillisToReturn = 0L
+    var consumeActivePlayMillisCallCount = 0; private set
+    override fun consumeActivePlayMillis(): Long {
+        consumeActivePlayMillisCallCount++
+        val v = activePlayMillisToReturn
+        activePlayMillisToReturn = 0L
+        return v
+    }
 }
 
 class StubLibretroControllerWithVariableTracking : LibretroController {


### PR DESCRIPTION
## Problem
A user's profile showed **~180 hours played** without having actually played — only launching games to test. The play-time model counted far more than real play.

There is one counting mechanism, entirely client-driven: a heartbeat reporting **a flat 30 s every 30 s** while a game is loaded and not `paused`; the server just sums it (`SUM(play_time)`). Three things inflated it:
1. **No desktop background pause** — `lifecyclePause()` (which sets `paused`) was wired only on Android. A game loaded while the desktop window is minimized/unfocused/idle kept counting.
2. **Wall-clock, not frame-driven** — 30 s was credited even with zero frames advanced (OS-suspended, stalled).
3. **Orphan-loop risk** — overlapping `startHeartbeat()` calls could leak a reporting loop that keeps adding time in parallel.

## Fix (frame-driven, per #1282 design)
- **Controller** (`Android`/`Desktop`LibretroController): accrue clamped wall-clock between presented frames — `min(frameGap, 250 ms)`. A no-frame stretch credits nothing, so pause/background/OS-suspend/stall time is excluded. Drained via `consumeActivePlayMillis()`. Hooked at the libretro **frontend** frame pump (one `retro_run` per displayed frame) so a core's internal multithreading is irrelevant; using wall-clock rather than frame count keeps fast-forward honest. Baseline reset on `pause()`.
- **PresenceService**: a single owned reporter drains the controller each interval and reports the **actual** accrued seconds (sub-second remainder carried forward), replacing the flat-30 loop. Drain semantics make any stray loop harmless (it can't multiply the total).
- **Desktop `Main.kt`**: pause the game + reporting on window focus-loss / minimize and resume on return, mirroring Android `onPause`/`onResume`.

## Tests
- `PlayTimeAccrualTest` (commonTest): `frameDeltaMillis` clamp/zero/skew + `splitForFlush` seconds + remainder-carry math.
- `PresenceServiceHeartbeatTest` (desktopTest): the reporter polls the controller drain once per interval and once on stop (deterministic — the network POST isn't asserted since MockEngine completes on a real dispatcher, which would be flaky under virtual time).

Verified locally: full `:shared:desktopTest` green, `:shared:compileDebugKotlinAndroid` + `:desktop:compileKotlinDesktop` compile.

## Note for review
The controller change affects **Android** (frame loop + `pause()`), so it's worth a quick on-device check (e.g. AYN Thor: confirm closing the lid pauses accrual) before/after merge — desktop tests can't cover that path.

Closes #1282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)