### PR TITLE
feat(player): transparent title bar on Linux (undecorated window + Compose chrome)

### DIFF
--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/LinuxTitleBar.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/LinuxTitleBar.kt
@@ -1,0 +1,204 @@
+package com.spela.player.desktop
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+/**
+ * Linux window chrome for the undecorated-window path.
+ *
+ * JBR's WindowDecorations/CustomTitleBar API is not implemented on Linux
+ * (JBR-6413; verified: JBR.getWindowDecorations() == null on JBR 21 X11), so
+ * the transparent-title-bar look used on macOS/Windows is achieved here with
+ * an undecorated window plus this Compose-drawn strip: the app's content and
+ * background extend behind it (the strip itself is transparent), with
+ * caption buttons drawn as plain glyphs on the right.
+ *
+ * Dragging uses JBR's WindowMove service when available — a native WM move
+ * (_NET_WM_MOVERESIZE), so KWin/GNOME snapping and tiling work — and the
+ * caller provides a fallback for non-JBR runtimes. Edge resizing is handled
+ * by Compose's built-in UndecoratedWindowResizer (active for undecorated +
+ * resizable windows); this strip only owns move/min/max/close.
+ *
+ * Pure presentation: window operations are injected as callbacks so the
+ * desktop test suite can drive it without a real window.
+ */
+@Composable
+fun LinuxTitleBarChrome(
+    isMaximized: Boolean,
+    onMinimize: () -> Unit,
+    onToggleMaximize: () -> Unit,
+    onClose: () -> Unit,
+    /** Begin a window move; return true when a native move was engaged. */
+    onDragStart: () -> Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier.testTag("linux-titlebar")) {
+        // Drag region: everything left of the caption buttons. Double-click
+        // toggles maximize (standard CSD affordance); a drag hands the window
+        // to the WM via onDragStart.
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .testTag("linux-titlebar-drag")
+                .pointerInput(Unit) {
+                    detectTapGestures(onDoubleTap = { onToggleMaximize() })
+                }
+                .pointerInput(Unit) {
+                    detectDragGestures(
+                        onDragStart = { onDragStart() },
+                        onDrag = { change, _ -> change.consume() },
+                    )
+                },
+        )
+        CaptionButton(
+            tag = "linux-titlebar-minimize",
+            onClick = onMinimize,
+        ) { color ->
+            val y = size.height * 0.55f
+            drawLine(color, Offset(size.width * 0.32f, y), Offset(size.width * 0.68f, y), strokeWidth = density)
+        }
+        CaptionButton(
+            tag = "linux-titlebar-maximize",
+            onClick = onToggleMaximize,
+        ) { color ->
+            val s = size.minDimension
+            if (isMaximized) {
+                // Restore: two offset squares
+                drawRect(
+                    color,
+                    topLeft = Offset(s * 0.38f, s * 0.30f),
+                    size = androidx.compose.ui.geometry.Size(s * 0.30f, s * 0.30f),
+                    style = androidx.compose.ui.graphics.drawscope.Stroke(width = density),
+                )
+                drawRect(
+                    color,
+                    topLeft = Offset(s * 0.30f, s * 0.38f),
+                    size = androidx.compose.ui.geometry.Size(s * 0.30f, s * 0.30f),
+                    style = androidx.compose.ui.graphics.drawscope.Stroke(width = density),
+                )
+            } else {
+                drawRect(
+                    color,
+                    topLeft = Offset(s * 0.32f, s * 0.32f),
+                    size = androidx.compose.ui.geometry.Size(s * 0.36f, s * 0.36f),
+                    style = androidx.compose.ui.graphics.drawscope.Stroke(width = density),
+                )
+            }
+        }
+        CaptionButton(
+            tag = "linux-titlebar-close",
+            onClick = onClose,
+            hoverColor = Color(0xFFE81123),
+        ) { color ->
+            val s = size.minDimension
+            drawLine(color, Offset(s * 0.34f, s * 0.34f), Offset(s * 0.66f, s * 0.66f), strokeWidth = density)
+            drawLine(color, Offset(s * 0.66f, s * 0.34f), Offset(s * 0.34f, s * 0.66f), strokeWidth = density)
+        }
+    }
+}
+
+/**
+ * A single caption button: fixed-width hover-highlighted hit area with a
+ * Canvas-drawn glyph. Glyphs are drawn (not icon assets) so the chrome has
+ * no icon-set dependency and matches the thin-line CSD style. Excluded from
+ * the gamepad focus system — window chrome is pointer-only.
+ */
+@Composable
+private fun CaptionButton(
+    tag: String,
+    onClick: () -> Unit,
+    hoverColor: Color = Color.White.copy(alpha = 0.12f),
+    glyph: androidx.compose.ui.graphics.drawscope.DrawScope.(color: Color) -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    Box(
+        modifier = Modifier
+            .width(46.dp)
+            .fillMaxHeight()
+            .testTag(tag)
+            .focusProperties { canFocus = false }
+            .hoverable(interaction)
+            .background(if (hovered) hoverColor else Color.Transparent)
+            .pointerInput(onClick) {
+                detectTapGestures(onTap = { onClick() })
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        // Chrome palette is fixed (the app is dark-themed and the strip sits
+        // outside the app's MaterialTheme): white glyphs, slightly dimmed
+        // until hovered. Matches the #0A0A10 fallback background in Main.kt.
+        val glyphColor = if (hovered) Color.White else Color.White.copy(alpha = 0.75f)
+        Canvas(modifier = Modifier.fillMaxSize()) { glyph(glyphColor) }
+    }
+}
+
+/* ===== JBR WindowMove (native WM drag) ===== */
+
+private val jbrWindowMove: Any? by lazy {
+    runCatching {
+        Class.forName("com.jetbrains.JBR").getMethod("getWindowMove").invoke(null)
+    }.getOrNull()
+}
+
+private val jbrStartMovingMethod: java.lang.reflect.Method? by lazy {
+    runCatching {
+        Class.forName("com.jetbrains.WindowMove")
+            .getMethod("startMovingTogetherWithMouse", java.awt.Window::class.java, Integer.TYPE)
+    }.getOrNull()
+}
+
+/**
+ * Hand the in-progress mouse drag to the window manager as a native window
+ * move (JBR WindowMove, X11 _NET_WM_MOVERESIZE). Returns false off-JBR or
+ * when the service is unavailable; callers fall back to manual moving.
+ */
+fun startNativeWindowMove(window: java.awt.Window): Boolean {
+    val service = jbrWindowMove ?: return false
+    val method = jbrStartMovingMethod ?: return false
+    return runCatching {
+        method.invoke(service, window, java.awt.event.MouseEvent.BUTTON1)
+        true
+    }.getOrDefault(false)
+}
+
+/**
+ * True when JBR offers the WindowDecorations (CustomTitleBar) service —
+ * i.e. the existing applyJbrTransparentTitleBar path can work. On Linux JBR
+ * this is currently always false (JBR-6413); checked up front so the window
+ * can be created undecorated before AWT realizes it.
+ */
+fun isJbrWindowDecorationsAvailable(): Boolean =
+    runCatching {
+        Class.forName("com.jetbrains.JBR").getMethod("getWindowDecorations").invoke(null) != null
+    }.getOrDefault(false)
+
+/**
+ * True when JBR offers the WindowMove service (native WM drag). The custom
+ * Linux chrome is only enabled when this holds — without it an undecorated
+ * window couldn't be dragged at all, which is a worse degradation than the
+ * standard title bar (non-JBR dev runs keep the decorated window).
+ */
+fun isJbrWindowMoveAvailable(): Boolean = jbrWindowMove != null && jbrStartMovingMethod != null

--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.useResource
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import com.spela.player.di.commonModule
@@ -83,6 +84,17 @@ fun main(args: Array<String>) {
 
     val windowState = rememberWindowState(width = 1280.dp, height = 720.dp)
 
+    // Linux: JBR's CustomTitleBar API is not implemented on X11 (JBR-6413),
+    // so the transparent-title-bar look is achieved with an undecorated
+    // window plus Compose-drawn chrome (LinuxTitleBar.kt). Only enabled when
+    // JBR's WindowMove service exists — without native WM drag an
+    // undecorated window would be unmovable, so non-JBR dev runs keep the
+    // standard decorated window. Decided before Window() because
+    // undecorated must be set when the AWT frame is created.
+    val useLinuxCustomChrome = remember {
+        isLinux && !isJbrWindowDecorationsAvailable() && isJbrWindowMoveAvailable()
+    }
+
     Window(
         onCloseRequest = {
             gamepadPoller.stop()
@@ -91,6 +103,7 @@ fun main(args: Array<String>) {
         title = windowTitle,
         state = windowState,
         icon = icon,
+        undecorated = useLinuxCustomChrome,
     ) {
         // Pause the game (and play-time accrual) when the window is minimized
         // or loses focus, and resume when it comes back — mirroring Android's
@@ -133,11 +146,24 @@ fun main(args: Array<String>) {
 
         // Windows / Linux: transparent title bar matching the macOS appearance.
         // Uses JetBrains Runtime (JBR) custom title bar API when available
-        // (always present in packaged distributions). Gracefully degrades
-        // to standard title bar on other JDKs (dev mode).
-        if (isWindows || isLinux) {
+        // (always present in packaged distributions on Windows; never on
+        // Linux X11 — see useLinuxCustomChrome). Gracefully degrades to the
+        // standard title bar on other JDKs (dev mode).
+        if (isWindows || (isLinux && !useLinuxCustomChrome)) {
             LaunchedEffect(Unit) {
                 applyJbrTransparentTitleBar(window)
+            }
+        }
+
+        // Undecorated Linux window: set the AWT background to the app's dark
+        // base immediately so the frame doesn't flash white before Compose
+        // renders (same fallback color as the macOS/Windows paths).
+        if (useLinuxCustomChrome) {
+            LaunchedEffect(Unit) {
+                val bg = java.awt.Color(10, 10, 16) // #0A0A10
+                window.background = bg
+                window.rootPane.background = bg
+                window.contentPane.background = bg
             }
         }
 
@@ -147,6 +173,7 @@ fun main(args: Array<String>) {
         // through the transparent title bar.
         val titleBarInset = when {
             isMacOS -> 28.dp
+            useLinuxCustomChrome -> 32.dp
             (isWindows || isLinux) && isJbrTitleBarActive -> 32.dp
             else -> 0.dp
         }
@@ -188,6 +215,35 @@ fun main(args: Array<String>) {
                         .onPointerEvent(PointerEventType.Move) { jbrMarkTitleBarDraggable() }
                         .onPointerEvent(PointerEventType.Enter) { jbrMarkTitleBarDraggable() }
                         .onPointerEvent(PointerEventType.Press) { jbrMarkTitleBarDraggable() },
+                )
+            }
+
+            // Linux undecorated path: Compose-drawn window chrome (drag strip
+            // + caption buttons) over the transparent top inset. Window
+            // operations go through windowState so Compose stays the source
+            // of truth (the maximize glyph follows placement). Edge resizing
+            // is Compose's built-in UndecoratedWindowResizer.
+            if (useLinuxCustomChrome) {
+                LinuxTitleBarChrome(
+                    isMaximized = windowState.placement == WindowPlacement.Maximized,
+                    onMinimize = { windowState.isMinimized = true },
+                    onToggleMaximize = {
+                        windowState.placement =
+                            if (windowState.placement == WindowPlacement.Maximized) {
+                                WindowPlacement.Floating
+                            } else {
+                                WindowPlacement.Maximized
+                            }
+                    },
+                    onClose = {
+                        gamepadPoller.stop()
+                        exitApplication()
+                    },
+                    onDragStart = { startNativeWindowMove(window) },
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .fillMaxWidth()
+                        .height(titleBarInset),
                 )
             }
         }

--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
@@ -82,25 +82,6 @@ fun main(args: Array<String>) {
     val icon = useResource("spela-icon.svg") { loadSvgPainter(it, Density(1f)) }
 
     val windowState = rememberWindowState(width = 1280.dp, height = 720.dp)
-    val windowInfo = LocalWindowInfo.current
-
-    // Pause the game (and play-time accrual) when the window is minimized
-    // or loses focus, and resume when it comes back — mirroring Android's
-    // onPause/onResume. Without this, a game left in the background keeps
-    // running and counting play time (#1282).
-    LaunchedEffect(Unit) {
-        snapshotFlow { windowInfo.isWindowFocused && !windowState.isMinimized }
-            .collect { active ->
-                val st = emulationViewModel.state.value
-                if (!active && st.isRunning && !st.isPaused) {
-                    println("[PlayTime] window background → pause (game=${st.gameId})")
-                    emulationViewModel.onIntent(EmulationIntent.LifecyclePause)
-                } else if (active && st.isLifecyclePaused) {
-                    println("[PlayTime] window foreground → resume (game=${st.gameId})")
-                    emulationViewModel.onIntent(EmulationIntent.LifecycleResume)
-                }
-            }
-    }
 
     Window(
         onCloseRequest = {
@@ -111,6 +92,28 @@ fun main(args: Array<String>) {
         state = windowState,
         icon = icon,
     ) {
+        // Pause the game (and play-time accrual) when the window is minimized
+        // or loses focus, and resume when it comes back — mirroring Android's
+        // onPause/onResume. Without this, a game left in the background keeps
+        // running and counting play time (#1282).
+        //
+        // Must live INSIDE the Window content: LocalWindowInfo is provided
+        // per-window — reading it at application{} scope throws
+        // "CompositionLocal LocalWindowInfo not present" on startup.
+        val windowInfo = LocalWindowInfo.current
+        LaunchedEffect(Unit) {
+            snapshotFlow { windowInfo.isWindowFocused && !windowState.isMinimized }
+                .collect { active ->
+                    val st = emulationViewModel.state.value
+                    if (!active && st.isRunning && !st.isPaused) {
+                        println("[PlayTime] window background → pause (game=${st.gameId})")
+                        emulationViewModel.onIntent(EmulationIntent.LifecyclePause)
+                    } else if (active && st.isLifecyclePaused) {
+                        println("[PlayTime] window foreground → resume (game=${st.gameId})")
+                        emulationViewModel.onIntent(EmulationIntent.LifecycleResume)
+                    }
+                }
+        }
         // macOS: transparent title bar that lets Compose content show through.
         // Uses official OpenJDK client properties (JDK 12+/17+).
         // fullWindowContent extends Compose rendering behind the title bar.

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/LinuxTitleBarTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/LinuxTitleBarTest.kt
@@ -1,0 +1,113 @@
+package com.spela.player.desktop
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.doubleClick
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for the Linux undecorated-window chrome (LinuxTitleBar.kt).
+ * Window operations are injected as callbacks, so the chrome is exercised
+ * without a real undecorated window; Main.kt wires the callbacks to
+ * WindowState / exitApplication.
+ */
+@OptIn(ExperimentalTestApi::class)
+class LinuxTitleBarTest {
+
+    @Test
+    fun rendersDragRegionAndAllCaptionButtons() = runComposeUiTest {
+        setContent {
+            LinuxTitleBarChrome(
+                isMaximized = false,
+                onMinimize = {},
+                onToggleMaximize = {},
+                onClose = {},
+                onDragStart = { false },
+                modifier = Modifier.fillMaxWidth().height(32.dp),
+            )
+        }
+
+        onNodeWithTag("linux-titlebar").assertIsDisplayed()
+        onNodeWithTag("linux-titlebar-drag").assertIsDisplayed()
+        onNodeWithTag("linux-titlebar-minimize").assertIsDisplayed()
+        onNodeWithTag("linux-titlebar-maximize").assertIsDisplayed()
+        onNodeWithTag("linux-titlebar-close").assertIsDisplayed()
+    }
+
+    @Test
+    fun captionButtonsInvokeTheirCallbacks() = runComposeUiTest {
+        var minimized = 0
+        var toggled = 0
+        var closed = 0
+        setContent {
+            LinuxTitleBarChrome(
+                isMaximized = false,
+                onMinimize = { minimized++ },
+                onToggleMaximize = { toggled++ },
+                onClose = { closed++ },
+                onDragStart = { false },
+                modifier = Modifier.fillMaxWidth().height(32.dp),
+            )
+        }
+
+        onNodeWithTag("linux-titlebar-minimize").performClick()
+        onNodeWithTag("linux-titlebar-maximize").performClick()
+        onNodeWithTag("linux-titlebar-close").performClick()
+
+        assertEquals(1, minimized)
+        assertEquals(1, toggled)
+        assertEquals(1, closed)
+    }
+
+    @Test
+    fun doubleClickOnDragRegionTogglesMaximize() = runComposeUiTest {
+        var toggled = 0
+        setContent {
+            LinuxTitleBarChrome(
+                isMaximized = false,
+                onMinimize = {},
+                onToggleMaximize = { toggled++ },
+                onClose = {},
+                onDragStart = { false },
+                modifier = Modifier.fillMaxWidth().height(32.dp),
+            )
+        }
+
+        onNodeWithTag("linux-titlebar-drag").performTouchInput { doubleClick() }
+
+        assertEquals(1, toggled)
+    }
+
+    @Test
+    fun dragOnDragRegionStartsWindowMove() = runComposeUiTest {
+        var dragStarts = 0
+        setContent {
+            LinuxTitleBarChrome(
+                isMaximized = false,
+                onMinimize = {},
+                onToggleMaximize = {},
+                onClose = {},
+                onDragStart = { dragStarts++; true },
+                modifier = Modifier.fillMaxWidth().height(32.dp),
+            )
+        }
+
+        onNodeWithTag("linux-titlebar-drag").performTouchInput {
+            down(center)
+            moveBy(androidx.compose.ui.geometry.Offset(40f, 0f))
+            up()
+        }
+
+        assertTrue(dragStarts >= 1, "drag should engage the window move")
+    }
+}


### PR DESCRIPTION
## Summary
Brings the transparent title bar to **Linux**, completing cross-platform parity (macOS via `apple.awt` client properties, Windows via JBR `CustomTitleBar`, and now Linux).

JBR's `WindowDecorations`/`CustomTitleBar` API isn't implemented on Linux X11 (JBR-6413 — `JBR.getWindowDecorations() == null` on JBR 21.0.11), so `applyJbrTransparentTitleBar` always degraded to the standard opaque bar there. This achieves the same look with an **undecorated window + Compose-drawn chrome** (`LinuxTitleBar.kt`):

- **Transparent 32dp strip** — the app's content/gradient extends behind it, matching macOS/Windows (reuses `LocalTitleBarInset`).
- **Native dragging** via JBR's `WindowMove` service (X11 `_NET_WM_MOVERESIZE`), so KWin/GNOME **snapping and tiling work**; double-click toggles maximize.
- **Caption buttons** (minimize / maximize-restore / close) drawn as thin-line CSD-style `Canvas` glyphs, hover-highlighted (close hovers red); excluded from the gamepad focus system (pointer-only).
- **Edge/corner resize** handled by Compose's built-in `UndecoratedWindowResizer`.
- **Gated on `WindowMove` availability** — non-JBR dev runs keep the standard decorated window (rather than an unmovable undecorated one); if a future JBR ships `WindowDecorations` on Linux, the existing JBR path takes precedence automatically.

The chrome is a pure composable with injected window operations, unit-tested in the desktop suite (render, button callbacks, double-click maximize, drag-engages-move).

## Also fixes a launch-crash regression from #1283
#1283's window focus/minimize observer (for play-time pause) read `LocalWindowInfo.current` at `application {}` scope. That CompositionLocal is provided **per-window**, so on current master **every desktop launch throws `CompositionLocal LocalWindowInfo not present`** during first composition and the app never comes up. CI didn't catch it because the desktop test suite drives composables via the harness, not `main()`. This PR moves the read (and its `snapshotFlow` collector) inside the `Window` content lambda. **Desktop launch on master is broken until this lands** — worth prioritizing.

## Verification
On-device KDE Plasma 6 (Wayland/XWayland): transparency, native drag + snapping, edge resize, double-click maximize, all caption buttons. Desktop unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
