### PR TITLE
fix(player): stop the game cleanly on desktop window close (#1286)

### DIFF
--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.Alignment
@@ -42,6 +43,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.context.startKoin
 import org.koin.java.KoinJavaComponent.getKoin
 
@@ -82,6 +86,7 @@ fun main(args: Array<String>) {
 
     val icon = useResource("spela-icon.svg") { loadSvgPainter(it, Density(1f)) }
 
+    val appScope = rememberCoroutineScope()
     val windowState = rememberWindowState(width = 1280.dp, height = 720.dp)
 
     // Linux: JBR's CustomTitleBar API is not implemented on X11 (JBR-6413),
@@ -98,7 +103,25 @@ fun main(args: Array<String>) {
     Window(
         onCloseRequest = {
             gamepadPoller.stop()
-            exitApplication()
+            if (emulationViewModel.state.value.isRunning) {
+                // Stop the running game cleanly before exiting: StopGame runs
+                // auto-save + core teardown, then flips isRunning=false. Closing
+                // without this skips the save AND leaves the (non-daemon)
+                // emulation thread running headless — audio keeps playing and
+                // the process lingers. Defer the exit until the stop completes
+                // (bounded, so a stuck save can't block shutdown forever). (#1286)
+                println("[Shutdown] game running — stopping (auto-save + teardown) before exit…")
+                emulationViewModel.onIntent(EmulationIntent.StopGame)
+                appScope.launch {
+                    withTimeoutOrNull(12_000) {
+                        emulationViewModel.state.first { !it.isRunning }
+                    }
+                    println("[Shutdown] stop complete — exiting")
+                    exitApplication()
+                }
+            } else {
+                exitApplication()
+            }
         },
         title = windowTitle,
         state = windowState,

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
@@ -167,6 +167,11 @@ class DesktopLibretroController(
             }
         }, "SpelaEmulation").apply {
             priority = Thread.MAX_PRIORITY
+            // Daemon so the emulation loop (and its audio) can never outlive
+            // the JVM if the app exits without a clean stop() — otherwise a
+            // window-close that skips teardown leaves the process running
+            // headless with audio still playing. (#1286)
+            isDaemon = true
             start()
         }
     }


### PR DESCRIPTION
## Problem
Closing the desktop window mid-game didn't stop emulation. `onCloseRequest` only stopped the gamepad poller and called `exitApplication()`:
- **Data loss**: `stopGame()`'s auto-save (`saveSramOnStop`) never ran → unsaved progress lost on close.
- **Orphaned audio / lingering process**: the `SpelaEmulation` thread is non-daemon, so after the UI tore down it kept calling `retro_run()` + writing audio — the game ran headless with music playing until the JVM eventually died.

Found while testing FFX (PS2) on Windows: closed the app, music kept playing; confirmed no Spela process was alive once the JVM finally exited.

## Fix
- `onCloseRequest`: when a game is running, dispatch `EmulationIntent.StopGame` (pause → auto-save → core `unloadGame`/`deinit` on the emulation thread) and **defer `exitApplication()` until `isRunning` flips false**, bounded by a 12s timeout so a stuck save can't hang shutdown.
- Mark the `SpelaEmulation` thread `isDaemon = true` as a backstop — the loop + its audio can never outlive the JVM on any exit path.

## Testing note
This is entrypoint (`main()`) code — the desktop test harness drives composables, not `main()`, so it isn't unit-coverable here (same gap that let the `LocalWindowInfo` regression through in #1283). Verified **manually**: closing mid-game runs the save, audio stops immediately, process exits.

Closes #1286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)