### PR TITLE
fix(player): pace desktop emulation on the video clock, not audio back-pressure (#1288)

### DIFF
--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
@@ -403,18 +403,28 @@ class DesktopLibretroController(
                 renderGpuFrameToBgra()
             }
 
-            // Audio-sync frame pacing: write audio to device (blocking write
-            // paces emulation to the audio sample rate). Falls back to
-            // precisionSleep if no audio player or no samples available.
-            // Audio-sync frame pacing: write audio to device (blocking write
-            // paces emulation to the audio sample rate). Falls back to
-            // precisionSleep if no audio player, no samples, or device not ready.
+            // Output audio. A blocking write naturally absorbs part of the
+            // frame budget for cores that emit a full ~(sampleRate/fps) chunk
+            // every retro_run(); that's fine — the precisionSleep below then
+            // just no-ops.
             val ap = audioPlayer
             val audioSamples = jni.nativeGetAudioBuffer()
-            val synced = if (ap != null && !fastForward && audioSamples != null && audioSamples.isNotEmpty()) {
+            if (ap != null && !fastForward && audioSamples != null && audioSamples.isNotEmpty()) {
                 ap.writeSync(audioSamples)
-            } else false
-            if (!synced && !fastForward) {
+            }
+
+            // Always cap the loop to the core's target FPS (video-clock
+            // pacing) — the primary throttle, matching the Android loop and
+            // RetroArch's frame limiter. Audio back-pressure alone cannot pace
+            // every core: free-running cores like Play! (PS2) run their VM on
+            // a separate thread and retro_run() only *harvests* the latest
+            // frame plus a small, non-cumulative audio chunk. The device then
+            // under-feeds, write() never blocks, and without this cap the loop
+            // runs unthrottled — video too fast and audio choppy (#1288).
+            // precisionSleep returns immediately when a blocking audio write
+            // already consumed the budget, so audio-synced cores are
+            // unaffected.
+            if (!fastForward) {
                 precisionSleep(frameStart + frameTimeNs)
             }
 


### PR DESCRIPTION
## Problem
PS2 (Play! core) runs **too fast with choppy audio** on desktop (reproduced on Windows *and* Linux — not platform-specific).

## Root cause (investigated against Play! source — jpd002/Play-)
The desktop loop throttled emulation **only** via audio back-pressure (`SourceDataLine.write()` blocking when the ~46ms device buffer fills), which assumes the core emits ~`sampleRate/fps` samples every `retro_run()`.

Play! violates that:
- It runs the PS2 VM on its **own thread** (free-running); `retro_run()` just **harvests** the current video frame + flushes the latest audio chunk.
- `CSH_LibreAudio::Write()` **overwrites** its buffer (resize+memcpy, not append); `ProcessBuffer()` flushes only that latest chunk.

So the device under-feeds → `write()` never blocks → the loop runs unthrottled (**video too fast**) and harvested chunks get dropped (**choppy audio**). RetroArch works because it caps `retro_run()` to `av_info.timing.fps` (60) with its frame limiter.

## Fix
Always `precisionSleep(frameStart + frameTimeNs)` to cap the loop at the core's target FPS — the **primary** throttle, matching our **Android** loop and RetroArch. The audio write stays (it may still block for well-behaved cores); `precisionSleep` no-ops when the write already consumed the frame budget, so cores that audio-sync correctly today are unaffected. Netplay loop unchanged (lockstep-paced).

## Verification
Pending on-device check (relaunching to confirm FFX runs at ~correct speed with clean audio). Entrypoint/loop timing isn't covered by the test harness; verifying manually. Will confirm before merge.

Closes #1288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)