### PR TITLE
fix(server): clear write deadline for file downloads so large ISOs finish

### DIFF
--- a/server/internal/api/download_write_deadline_test.go
+++ b/server/internal/api/download_write_deadline_test.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deadlineRecorder is an http.ResponseWriter that records SetWriteDeadline
+// calls and captures the response body. Used to assert that file-download
+// streaming clears the per-connection write deadline — without that, the
+// server's global http.Server WriteTimeout cuts multi-GB game/disc downloads
+// mid-stream (a 4.5GB ISO died at ~120s / ~3.5GB every time).
+type deadlineRecorder struct {
+	header        http.Header
+	body          []byte
+	writeDeadline time.Time
+	deadlineSet   bool
+}
+
+func (d *deadlineRecorder) Header() http.Header {
+	if d.header == nil {
+		d.header = http.Header{}
+	}
+	return d.header
+}
+
+func (d *deadlineRecorder) Write(p []byte) (int, error) {
+	d.body = append(d.body, p...)
+	return len(p), nil
+}
+
+func (d *deadlineRecorder) WriteHeader(int) {}
+
+func (d *deadlineRecorder) SetWriteDeadline(t time.Time) error {
+	d.writeDeadline = t
+	d.deadlineSet = true
+	return nil
+}
+
+func TestStreamFileFromDiskClearsWriteDeadline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "game.iso")
+	content := []byte("pretend this is a multi-GB ISO")
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+
+	rec := &deadlineRecorder{}
+	req := httptest.NewRequest(http.MethodGet, "/api/games/1/download", nil)
+	ctx := humago.NewContext(
+		&huma.Operation{Method: http.MethodGet, Path: "/api/games/{id}/download"},
+		req, rec,
+	)
+
+	streamFileFromDisk(path, "game.iso", "application/octet-stream").Body(ctx)
+
+	assert.True(t, rec.deadlineSet,
+		"download streaming must clear the write deadline so large transfers aren't cut off by the global WriteTimeout")
+	assert.True(t, rec.writeDeadline.IsZero(),
+		"write deadline should be cleared (zero time), got %v", rec.writeDeadline)
+	assert.Equal(t, content, rec.body, "the full file should stream through")
+}

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -12,8 +12,10 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"github.com/spela/server/internal/bios"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/scanner"
@@ -31,6 +33,17 @@ import (
 func streamFileFromDisk(absPath, downloadName, contentType string) *huma.StreamResponse {
 	return &huma.StreamResponse{
 		Body: func(hctx huma.Context) {
+			// Large game/disc downloads (multi-GB ISOs) routinely exceed the
+			// server's global http.Server WriteTimeout: the connection is
+			// closed mid-stream after WriteTimeout seconds regardless of
+			// progress, so e.g. a 4.5GB ISO dies at ~120s / ~3.5GB every time
+			// (the cut point varies with bandwidth). Clear the write deadline
+			// for this streaming response so the transfer can take as long as
+			// it needs; the global timeout still guards normal API responses.
+			// Covers disc + save downloads too — both stream through here.
+			if _, w := humago.Unwrap(hctx); w != nil {
+				_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+			}
 			f, err := os.Open(absPath)
 			if err != nil {
 				hctx.SetStatus(http.StatusInternalServerError)


### PR DESCRIPTION
## Summary
Large game/disc downloads (multi-GB ISOs) were cut off mid-stream **every time** — e.g. Final Fantasy X (4.5 GB PS2 ISO) died at ~3.5 GB on every attempt.

**Root cause (server):** `http.Server{WriteTimeout: 120s}` (`main.go:501`) closes the connection 120 s into *any* response, regardless of progress. A 4.5 GB transfer can't complete in 120 s at typical bandwidth, so the server severs it.

**Confirmed on the AYN Thor:** the download died at exactly **120 s** (start 17:58:45 → last byte 18:00:45). Two attempts cut at **3.557 GB** and **3.716 GB** — same ~120 s wall-clock, different byte counts (time-based, so the cut point tracks bandwidth). The Kotlin client is correct (`requestTimeoutMillis = Long.MAX_VALUE`, `Long` counters) — it just receives a hung-up connection.

## Fix
Clear the per-connection write deadline in `streamFileFromDisk` via `http.NewResponseController(w).SetWriteDeadline(time.Time{})` (huma's raw writer via `humago.Unwrap`). The transfer can now take as long as it needs; the global `WriteTimeout` still guards normal API responses. `streamFileFromDisk` is the single choke point for **game, disc, and save** downloads (disc + save stream through it), so one change covers all large-file paths.

## Test
`TestStreamFileFromDiskClearsWriteDeadline` — drives the handler with a recording `ResponseWriter` and asserts the write deadline is cleared (zero time) and the full file streams through. Passes; `go build ./...` clean.

Closes #1293