### PR TITLE
fix(server): make download write-deadline clear panic-safe (fix master)

### DIFF
--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
-	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"github.com/spela/server/internal/bios"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/scanner"
@@ -41,8 +40,13 @@ func streamFileFromDisk(absPath, downloadName, contentType string) *huma.StreamR
 			// for this streaming response so the transfer can take as long as
 			// it needs; the global timeout still guards normal API responses.
 			// Covers disc + save downloads too — both stream through here.
-			if _, w := humago.Unwrap(hctx); w != nil {
-				_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+			//
+			// BodyWriter() is the underlying http.ResponseWriter under the
+			// humago adapter; under huma's test adapter it's a buffer, so the
+			// type check keeps this a no-op there (humago.Unwrap would panic on
+			// a non-humago context).
+			if rw, ok := hctx.BodyWriter().(http.ResponseWriter); ok {
+				_ = http.NewResponseController(rw).SetWriteDeadline(time.Time{})
 			}
 			f, err := os.Open(absPath)
 			if err != nil {


### PR DESCRIPTION
## Why
#1294 cleared the download write deadline via `humago.Unwrap(hctx)`, which **panics** (`"not a humago context"`) under huma's test adapter. Several existing tests (`TestDownloadSharedSave`, `TestGetBiosFile_Success`, `TestDownloadChallengeSave`, `TestGetBiosFile_SpecialCharNameServesWhenPresent`, …) stream through `streamFileFromDisk` with a test context and panicked → **Go tests went red on master** (the #1294 `--admin` merge bypassed the failed check, which it shouldn't have).

## Fix
`hctx.BodyWriter()` **is** the underlying `http.ResponseWriter` under the humago adapter (and a buffer under the test adapter), so a type assertion gets the writer in production and is a safe no-op in tests — no panic, and no `humago` import needed.

```go
if rw, ok := hctx.BodyWriter().(http.ResponseWriter); ok {
    _ = http.NewResponseController(rw).SetWriteDeadline(time.Time{})
}
```

The actual fix (clearing the deadline so 4.5 GB downloads finish) is unchanged and still covered by `TestStreamFileFromDiskClearsWriteDeadline`.

## Verified
Full `internal/api` suite passes locally (`ok … 428s`), including all four tests that failed on master and the deadline test.

Refs #1294, #1293.