### PR TITLE
fix(player): recreate emulation state from scratch on game start/stop

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -785,43 +785,31 @@ class EmulationViewModel(
         // doesn't inherit a stale banner.
         val rehearsalPrompt = pendingRehearsalPrompt
         pendingRehearsalPrompt = null
-        _state.update {
-            it.copy(
-                gameId = gameId,
-                isLoading = true,
-                isPaused = false,
-                showOverlay = false,
-                showExitConfirm = false,
-                sharedSessionId = sharedSessionId,
-                turnToken = turnToken,
-                netplaySessionId = netplaySessionId,
-                sessionId = sessionId, // may be updated by ensureSession below
-                challengeId = challengeId,
-                challengeAttemptId = null,
-                challengeElapsedMs = 0,
-                challengeCompletedAttempt = null,
-                achievementEvent = null,
-                achievements = emptyList(),
-                achievementProgress = emptyList(),
-                achievementTotalPoints = 0,
-                achievementsLoading = false,
-                sessionAchievementUnlocks = emptyList(),
-                error = null,
-                statusMessage = null,
-                isFastForward = false,
-                supportsSaveStates = true,
-                isHwRenderEnabled = false,
-                secondaryToast = null,
-                touchControlPort = 0,
-                // RehearsalPrompt survives the state reset so the
-                // in-game banner is visible the moment the emulator
-                // surface composes. Closes the gap where the user
-                // would briefly see a naked emulator without knowing
-                // they're in rehearsal mode.
-                coreDecision = rehearsalPrompt,
-                showRehearsalConfirmSheet = false,
-            )
-        }
+        // Recreate the emulation state from scratch so launching a game is
+        // state-wise IDENTICAL to launching the very first game — no field
+        // from the previous game can linger (the old hand-maintained copy()
+        // reset missed gameTitle/gameId/consoleId/consoleName and others,
+        // leaving the prior game's title/frame in the overlay; see #1298).
+        // Only the launch parameters and the pre-captured rehearsal banner are
+        // seeded; everything else takes its default and is re-populated below
+        // (game detail, preferences) exactly as on a first launch.
+        _state.value = EmulationState(
+            gameId = gameId,
+            isLoading = true,
+            // Optimistic until the post-load probe; the core is assumed to
+            // support save states (matches the pre-#1298 reset behaviour).
+            supportsSaveStates = true,
+            sharedSessionId = sharedSessionId,
+            turnToken = turnToken,
+            netplaySessionId = netplaySessionId,
+            sessionId = sessionId, // may be updated by ensureSession below
+            challengeId = challengeId,
+            // RehearsalPrompt survives the reset so the in-game banner is
+            // visible the moment the emulator surface composes. Closes the gap
+            // where the user would briefly see a naked emulator without knowing
+            // they're in rehearsal mode.
+            coreDecision = rehearsalPrompt,
+        )
 
         scope.launch(dispatchers.io) {
             // Ensure any previous emulation is fully stopped before starting a new one.
@@ -1601,64 +1589,20 @@ class EmulationViewModel(
 
         libretroController.stop()
         withContext(dispatchers.main) {
+            // Clear the emulation state on exit by recreating it from scratch
+            // rather than enumerating ~50 fields to reset (which had drifted
+            // out of date and leaked gameTitle/gameId/consoleId/consoleName,
+            // leaving the prior game lingering in the overlay; see #1298).
+            // Only fields that intentionally outlive a game stop survive:
+            //  - requestExit: the navigate-away signal the UI reads AFTER the
+            //    game stops (cleared later by ClearExitRequest),
+            //  - the upload-sync counters owned by SaveManager (uploads that
+            //    outlive the session).
             _state.update {
-                it.copy(
-                    isRunning = false,
-                    isPaused = false,
-                    isLifecyclePaused = false,
-                    fps = 0f,
-                    frameTime = 0f,
-                    isHardcoreMode = false,
-                    showExitConfirm = false,
-                    showOverlay = false,
-                    secondaryDisplayActive = false,
-                    isDualScreenConsole = false,
-                    dualScreenSplitY = 0,
-                    dualScreenBottomWidth = 0,
-                    dualScreenBottomOffsetX = 0,
-                    sharedSessionId = null,
-                    turnToken = null,
-                    netplaySessionId = null,
-                    netplayPeerUsername = null,
-                    netplayPeerLatencyMs = 0,
-                    netplayPeerDisconnected = false,
-                    netplayPausedByUsername = null,
-                    netplayShowLeaveConfirm = false,
-                    netplayPauseElapsedSeconds = 0,
-                    netplaySessionExpired = false,
-                    challengeId = null,
-                    challengeAttemptId = null,
-                    challengeElapsedMs = 0,
-                    showChallengeCreation = false,
-                    isCreatingChallenge = false,
-                    challengeCreationSuccess = false,
-                    showGiveUpConfirm = false,
-                    challengeCompletedAttempt = null,
-                    sessionId = null,
-                    consoleColorTheme = null,
-                    heroUrl = null,
-                    gameDescription = null,
-                    gameDeveloper = null,
-                    gamePublisher = null,
-                    gameReleaseDate = null,
-                    gameGenre = null,
-                    gameRating = 0.0,
-                    gamePlayers = 0,
-                    showCoreMismatchDialog = false,
-                    coreMismatchSaveCoreName = "",
-                    coreMismatchCurrentCoreName = "",
-                    hasCheats = false,
-                    enabledCheatCount = 0,
-                    showCheatBrowser = false,
-                    cheats = emptyList(),
-                    achievements = emptyList(),
-                    achievementProgress = emptyList(),
-                    achievementTotalPoints = 0,
-                    achievementsLoading = false,
-                    sessionAchievementUnlocks = emptyList(),
-                    achievementEvent = null,
-                    secondaryToast = null,
-                    touchControlPort = 0,
+                EmulationState(
+                    requestExit = it.requestExit,
+                    hasPendingUploads = it.hasPendingUploads,
+                    stuckUploadCount = it.stuckUploadCount,
                 )
             }
             saveManager.currentSessionId = null

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
@@ -489,6 +489,45 @@ class EmulationViewModelGameLifecycleTest {
     }
 
     @Test
+    fun stopGameClearsGameIdentityFields() = runTest {
+        // #1298 regression: finishStopGame() must clear the game identity so a
+        // later overlay/launch can't show the previous game's title or frame.
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+        assertEquals("Test Game", vm.state.value.gameTitle)
+        assertEquals("nes", vm.state.value.consoleId)
+
+        vm.onIntent(EmulationIntent.StopGame)
+        builder.advanceTimeBy(100)
+        assertEquals("", vm.state.value.gameId)
+        assertEquals("", vm.state.value.gameTitle)
+        assertEquals("", vm.state.value.consoleId)
+        assertEquals("", vm.state.value.consoleName)
+    }
+
+    @Test
+    fun startingNewGameRecreatesStateFromScratch() = runTest {
+        // #1298 regression: launching a second game must be state-wise
+        // identical to launching the first — the prior game's title/console
+        // must not linger (the bug: overlay showed "Final Fantasy X" while
+        // Ocarina of Time was starting). The reset is synchronous, so the
+        // stale title must be gone immediately, before the new detail loads.
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+        assertEquals("Test Game", vm.state.value.gameTitle)
+
+        vm.onIntent(EmulationIntent.StartGame("game2"))
+        // No advanceTimeBy: assert the synchronous from-scratch reset.
+        assertEquals("game2", vm.state.value.gameId)
+        assertEquals("", vm.state.value.gameTitle)
+        assertEquals("", vm.state.value.consoleId)
+        assertEquals("", vm.state.value.consoleName)
+        assertTrue(vm.state.value.isLoading)
+    }
+
+    @Test
     fun startGameAutoCreatesSessionWhenNoneProvided() = runTest {
         val vm = builder.build()
         vm.onIntent(EmulationIntent.StartGame("game1"))


### PR DESCRIPTION
## Problem

The in-game `EmulationViewModel` / `EmulationState` are app-wide singletons that are never recreated. Exiting one game and starting another reused that state and reset it via two large, hand-maintained `copy()` blocks (`startGame()` and `finishStopGame()`). Those lists had drifted out of date and **omitted `gameTitle`, `gameId`, `consoleId`, `consoleName`** (among others), so the previous game leaked into the next launch: the in-game overlay showed **"Final Fantasy X" while Ocarina of Time was starting**, with FFX's last frame still on screen.

## Fix

Recreate the state from a clean baseline instead of enumerating fields to clear:

- **`startGame()`** → `_state.value = EmulationState(…launch params…)`. Launching any game is now state-wise **identical to launching the first game**, by construction. No future field addition can leak across games.
- **`finishStopGame()`** → rebuilds from a fresh `EmulationState()`.

Only the fields that *intentionally* outlive a transition are seeded/preserved (a short, legible list instead of ~50):
- start: `gameId`, `isLoading`, the session/challenge/netplay launch params, optimistic `supportsSaveStates = true`, and the pre-captured rehearsal banner;
- stop: `requestExit` (the navigate-away signal the UI reads after the game stops) and the `hasPendingUploads` / `stuckUploadCount` upload-sync counters owned by SaveManager.

## Tests

- New regression tests in `EmulationViewModelGameLifecycleTest`:
  - `stopGameClearsGameIdentityFields` — exiting clears gameId/title/console.
  - `startingNewGameRecreatesStateFromScratch` — launching a second game synchronously wipes the prior game's title (the exact bug).
- Full desktop suite green: **688 tests, 0 failures.**

## Scope

Isolated to `EmulationViewModel.kt` + its test. Surfaced while investigating the desktop N64 launch crash (#1298) but independent of it — this fixes the **UI-state lingering**; the native crash is tracked separately in #1298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
