### PR TITLE
feat(server): HTTP Range support for resumable downloads + fix FFX write-deadline on real game path

### DIFF
--- a/server/internal/api/download_range_test.go
+++ b/server/internal/api/download_range_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseByteRange(t *testing.T) {
+	const size = int64(1000)
+	tests := []struct {
+		header             string
+		wantStart, wantEnd int64
+		wantOK             bool
+	}{
+		{"", 0, 0, false},
+		{"bytes=0-", 0, 999, true},
+		{"bytes=500-", 500, 999, true}, // the resume case
+		{"bytes=100-199", 100, 199, true},
+		{"bytes=900-99999", 900, 999, true}, // end clamped to size-1
+		{"bytes=-100", 900, 999, true},      // suffix: last 100 bytes
+		{"bytes=-2000", 0, 999, true},       // suffix larger than file → whole file
+		{"bytes=abc-", 0, 0, false},
+		{"bytes=100-50", 0, 0, false},        // end < start
+		{"bytes=0-100,200-300", 0, 0, false}, // multi-range unsupported → serve full
+		{"items=0-", 0, 0, false},            // wrong unit
+		{"bytes=-", 0, 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.header, func(t *testing.T) {
+			start, end, ok := parseByteRange(tc.header, size)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantStart, start, "start")
+				assert.Equal(t, tc.wantEnd, end, "end")
+			}
+		})
+	}
+}
+
+// TestDownloadGame_RangeRequests verifies the game-download endpoint supports
+// HTTP Range so an interrupted download can resume (#1296): a Range request
+// returns 206 with just the tail, a stale If-Range validator falls back to a
+// full 200 (so the client restarts cleanly), and an offset past EOF is 416.
+func TestDownloadGame_RangeRequests(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	psxDir := filepath.Join(cfg.GameDirs[0], "psx")
+	require.NoError(t, os.MkdirAll(psxDir, 0755))
+	content := []byte("0123456789abcdefghijklmnopqrstuvwxyz-RESUME-ME-FROM-THE-MIDDLE!!")
+	size := len(content)
+	require.NoError(t, os.WriteFile(filepath.Join(psxDir, "game.chd"), content, 0644))
+
+	var psxConsole db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "PSX").First(&psxConsole).Error)
+	game := db.Game{
+		ConsoleID: psxConsole.ID,
+		Title:     "Range Test",
+		FileName:  "game.chd",
+		FilePath:  filepath.Join("psx", "game.chd"),
+		FileSize:  int64(size),
+	}
+	require.NoError(t, database.Create(&game).Error)
+	url := fmt.Sprintf("/api/games/%d/download", game.ID)
+
+	get := func(headers map[string]string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", url, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	// Full download advertises range support + a strong validator.
+	full := get(nil)
+	require.Equal(t, http.StatusOK, full.Code)
+	assert.Equal(t, "bytes", full.Header().Get("Accept-Ranges"))
+	etag := full.Header().Get("ETag")
+	assert.NotEmpty(t, etag, "a validator (ETag) is required for safe resume")
+	assert.Equal(t, content, full.Body.Bytes())
+
+	// Resume: Range from an offset → 206 with only the tail.
+	const offset = 36
+	part := get(map[string]string{"Range": fmt.Sprintf("bytes=%d-", offset)})
+	assert.Equal(t, http.StatusPartialContent, part.Code)
+	assert.Equal(t, fmt.Sprintf("bytes %d-%d/%d", offset, size-1, size), part.Header().Get("Content-Range"))
+	assert.Equal(t, strconv.Itoa(size-offset), part.Header().Get("Content-Length"))
+	assert.Equal(t, content[offset:], part.Body.Bytes())
+
+	// Resume with the matching validator still serves the partial.
+	ok := get(map[string]string{"Range": fmt.Sprintf("bytes=%d-", offset), "If-Range": etag})
+	assert.Equal(t, http.StatusPartialContent, ok.Code)
+	assert.Equal(t, content[offset:], ok.Body.Bytes())
+
+	// File changed under the client (stale validator) → ignore the range and
+	// serve the full file (200) so the client restarts rather than splices.
+	stale := get(map[string]string{"Range": fmt.Sprintf("bytes=%d-", offset), "If-Range": `"stale-0-0"`})
+	assert.Equal(t, http.StatusOK, stale.Code)
+	assert.Equal(t, content, stale.Body.Bytes())
+
+	// Offset at/past EOF → 416 Range Not Satisfiable.
+	past := get(map[string]string{"Range": fmt.Sprintf("bytes=%d-", size)})
+	assert.Equal(t, http.StatusRequestedRangeNotSatisfiable, past.Code)
+}

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -32,22 +32,6 @@ import (
 func streamFileFromDisk(absPath, downloadName, contentType string) *huma.StreamResponse {
 	return &huma.StreamResponse{
 		Body: func(hctx huma.Context) {
-			// Large game/disc downloads (multi-GB ISOs) routinely exceed the
-			// server's global http.Server WriteTimeout: the connection is
-			// closed mid-stream after WriteTimeout seconds regardless of
-			// progress, so e.g. a 4.5GB ISO dies at ~120s / ~3.5GB every time
-			// (the cut point varies with bandwidth). Clear the write deadline
-			// for this streaming response so the transfer can take as long as
-			// it needs; the global timeout still guards normal API responses.
-			// Covers disc + save downloads too — both stream through here.
-			//
-			// BodyWriter() is the underlying http.ResponseWriter under the
-			// humago adapter; under huma's test adapter it's a buffer, so the
-			// type check keeps this a no-op there (humago.Unwrap would panic on
-			// a non-humago context).
-			if rw, ok := hctx.BodyWriter().(http.ResponseWriter); ok {
-				_ = http.NewResponseController(rw).SetWriteDeadline(time.Time{})
-			}
 			f, err := os.Open(absPath)
 			if err != nil {
 				hctx.SetStatus(http.StatusInternalServerError)
@@ -58,18 +42,126 @@ func streamFileFromDisk(absPath, downloadName, contentType string) *huma.StreamR
 				hctx.SetHeader("Content-Type", contentType)
 			}
 			hctx.SetHeader("Content-Disposition", fmt.Sprintf("attachment; filename=%q", downloadName))
-			// Advertise the exact byte count so clients can show accurate
-			// download progress. Without this the body is chunked (no
-			// Content-Length), the player can't learn the transfer size, and
-			// it falls back to the DB file size — which for compressed
-			// single-file formats (e.g. .rvz) is the logical/uncompressed
-			// size, leaving the progress bar stuck well under 100%. (#1235)
-			if info, serr := f.Stat(); serr == nil {
-				hctx.SetHeader("Content-Length", strconv.FormatInt(info.Size(), 10))
+			info, serr := f.Stat()
+			if serr != nil {
+				// Can't size it — stream the whole file, no ranges/deadline reset.
+				_, _ = io.Copy(hctx.BodyWriter(), f)
+				return
+			}
+			// Clear the write deadline (so multi-GB transfers aren't cut off by
+			// the global WriteTimeout) and serve a Range/resume request when
+			// present; otherwise fall through to a full stream. (#1294/#1296)
+			if serveFileRangeOrFull(hctx, f, info.Size(), info.ModTime(), true) {
+				return
 			}
 			_, _ = io.Copy(hctx.BodyWriter(), f)
 		},
 	}
+}
+
+// serveFileRangeOrFull clears the per-connection write deadline (so multi-GB
+// downloads aren't cut off by the server's global http.Server WriteTimeout —
+// #1294) and, when rangeable, serves an HTTP Range request so an interrupted
+// download can resume (#1296): a satisfiable "bytes=N-" with a matching (or
+// absent) If-Range validator gets a 206 with just that slice; an offset past
+// EOF gets 416; a stale If-Range validator (the file changed under the client)
+// falls back to a full 200 so the client restarts cleanly rather than splicing.
+//
+// Returns true when it fully wrote the response (the caller must not write
+// more); false when the caller should stream the whole file — Content-Length
+// is already set for that case. Pass rangeable=false when the body is
+// transformed (e.g. iNES header normalization) so a byte range can't be
+// reproduced; the file is then always served whole (but the deadline is still
+// cleared).
+//
+// BodyWriter() is the underlying http.ResponseWriter under the humago adapter;
+// under huma's test adapter it's a buffer, so the type check keeps the deadline
+// reset a no-op there (humago.Unwrap would panic on a non-humago context).
+func serveFileRangeOrFull(hctx huma.Context, f *os.File, size int64, modTime time.Time, rangeable bool) (handled bool) {
+	if rw, ok := hctx.BodyWriter().(http.ResponseWriter); ok {
+		_ = http.NewResponseController(rw).SetWriteDeadline(time.Time{})
+	}
+	if !rangeable {
+		hctx.SetHeader("Content-Length", strconv.FormatInt(size, 10))
+		return false
+	}
+	etag := fmt.Sprintf("%q", fmt.Sprintf("%d-%d", size, modTime.UnixNano()))
+	hctx.SetHeader("Accept-Ranges", "bytes")
+	hctx.SetHeader("ETag", etag)
+
+	start, end, isRange := parseByteRange(hctx.Header("Range"), size)
+	if isRange {
+		if ir := hctx.Header("If-Range"); ir != "" && ir != etag {
+			isRange = false // file changed under the client — serve full, client restarts
+		}
+	}
+	if !isRange {
+		hctx.SetHeader("Content-Length", strconv.FormatInt(size, 10))
+		return false
+	}
+	if start >= size {
+		hctx.SetHeader("Content-Range", fmt.Sprintf("bytes */%d", size))
+		hctx.SetStatus(http.StatusRequestedRangeNotSatisfiable)
+		return true
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		hctx.SetStatus(http.StatusInternalServerError)
+		return true
+	}
+	hctx.SetHeader("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, size))
+	hctx.SetHeader("Content-Length", strconv.FormatInt(end-start+1, 10))
+	hctx.SetStatus(http.StatusPartialContent)
+	_, _ = io.CopyN(hctx.BodyWriter(), f, end-start+1)
+	return true
+}
+
+// parseByteRange parses a single HTTP Range header ("bytes=start-end",
+// "bytes=start-", or suffix "bytes=-N") against a known content size.
+// It returns ok=false for an absent, malformed, or multi-range header, in
+// which case the caller should serve the full file. end is inclusive and
+// clamped to size-1. Only a single range is supported — sufficient for
+// download resume, which always asks for "bytes=<offset>-".
+func parseByteRange(header string, size int64) (start, end int64, ok bool) {
+	const prefix = "bytes="
+	if !strings.HasPrefix(header, prefix) {
+		return 0, 0, false
+	}
+	spec := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+	if spec == "" || strings.Contains(spec, ",") {
+		return 0, 0, false // multi-range not supported — serve full
+	}
+	dash := strings.IndexByte(spec, '-')
+	if dash < 0 {
+		return 0, 0, false
+	}
+	startStr := strings.TrimSpace(spec[:dash])
+	endStr := strings.TrimSpace(spec[dash+1:])
+	if startStr == "" {
+		// suffix range: bytes=-N → last N bytes
+		n, err := strconv.ParseInt(endStr, 10, 64)
+		if err != nil || n <= 0 {
+			return 0, 0, false
+		}
+		if n > size {
+			n = size
+		}
+		return size - n, size - 1, true
+	}
+	s, err := strconv.ParseInt(startStr, 10, 64)
+	if err != nil || s < 0 {
+		return 0, 0, false
+	}
+	if endStr == "" {
+		return s, size - 1, true // bytes=N-
+	}
+	e, err := strconv.ParseInt(endStr, 10, 64)
+	if err != nil || e < s {
+		return 0, 0, false
+	}
+	if e > size-1 {
+		e = size - 1
+	}
+	return s, e, true
 }
 
 // streamSaveFromDisk wraps [streamFileFromDisk] with an X-Compression
@@ -1020,16 +1112,24 @@ func (h *GameHandler) HumaDownloadGame(_ context.Context, in *GameDownloadInput)
 			defer f.Close()
 			hctx.SetHeader("Content-Type", "application/octet-stream")
 			hctx.SetHeader("Content-Disposition", fmt.Sprintf("inline; filename=%q", game.FileName))
-			// Advertise the exact transfer size so the player shows accurate
-			// download progress. Without it the body is chunked (no
-			// Content-Length) and the client falls back to the DB file size,
-			// which for compressed formats (PSP, .rvz, .chd) is the
-			// logical/uncompressed size — leaving the bar stuck well under
-			// 100%. The streamed byte count equals the on-disk size; the
-			// iNES normalization below rewrites the first 16 bytes in place,
-			// so the length is unchanged. (#1261, follow-up to #1235/#1248)
-			if info, serr := f.Stat(); serr == nil {
-				hctx.SetHeader("Content-Length", strconv.FormatInt(info.Size(), 10))
+			info, serr := f.Stat()
+			if serr != nil {
+				// Can't size it — stream the whole file, no ranges/deadline reset.
+				_, _ = io.Copy(hctx.BodyWriter(), f)
+				return
+			}
+			// Clear the write deadline so multi-GB game downloads (e.g. a 4.5GB
+			// PS2 ISO) aren't cut off mid-stream by the global WriteTimeout —
+			// this is the path game downloads actually take, which #1294 missed.
+			// Also serve a Range/resume request when present (#1296). Range is
+			// disabled for .nes files because the iNES normalization below
+			// rewrites the first 16 bytes in memory, so a byte range would
+			// splice the unmodified on-disk header onto the resumed tail; .nes
+			// ROMs are tiny, so resume isn't needed there. serveFileRangeOrFull
+			// sets Content-Length for the full-stream case, preserving the
+			// accurate progress fix (#1261, follow-up to #1235/#1248).
+			if serveFileRangeOrFull(hctx, f, info.Size(), info.ModTime(), !normalizeINES) {
+				return
 			}
 			w := hctx.BodyWriter()
 			if normalizeINES {


### PR DESCRIPTION
Step 1 (load-bearing) of #1296 (resumable downloads). Also completes the #1294 write-deadline fix, which was applied to the wrong handler.

## Two things in one path

### 1. The FFX write-deadline fix never reached game downloads
#1294/#1295 cleared the per-connection write deadline in `streamFileFromDisk` so multi-GB transfers aren't cut off by the global `http.Server` `WriteTimeout`. But **game ROM/ISO downloads don't go through `streamFileFromDisk`** — they go through `HumaDownloadGame`'s own inline single-file streaming. So v0.0.252 shipped, but the 4.5 GB FFX ISO would **still die at the 120 s `WriteTimeout`**. This PR clears the deadline on the path game downloads actually take.

> ⚠️ A new release is required to deploy the real FFX fix — v0.0.252 does not contain it.

### 2. HTTP Range support (resumable downloads, step 1)
`GET /api/games/{id}/download` now serves `206 Partial Content` for `Range: bytes=N-`, advertising `Accept-Ranges: bytes` and a strong `size+mtime` ETag validator so the client can detect a changed file and resume safely.

## Implementation
Both concerns share the same byte-streaming code, so they're unified into one helper:

- **`serveFileRangeOrFull(hctx, f, size, modTime, rangeable)`** — clears the write deadline, then:
  - `rangeable=true`: sets `Accept-Ranges`/`ETag`; on a satisfiable `Range` with a matching (or absent) `If-Range` → `206` with just that slice; stale `If-Range` (file changed) → falls back to full `200` so the client restarts cleanly instead of splicing; offset past EOF → `416`.
  - `rangeable=false` or no range header: sets `Content-Length`, returns `false` so the caller streams the whole file.
- Used by **both** `streamFileFromDisk` (disc/save downloads) and `HumaDownloadGame`'s inline path (game/ISO downloads).
- Range is **disabled for `.nes`** (`rangeable=false`): the iNES header is normalized in memory, so a byte-range can't reproduce the transformed bytes — and `.nes` ROMs are tiny, so resume isn't needed there. The deadline is still cleared.

## Tests
- `TestParseByteRange` — table-driven range-header parsing (offsets, suffix ranges, clamping, malformed/multi-range rejection).
- `TestDownloadGame_RangeRequests` — full integration via the real router: `200` advertises `Accept-Ranges`+`ETag`; `Range` → `206` with the correct tail + `Content-Range`/`Content-Length`; matching `If-Range` → `206`; stale `If-Range` → full `200`; offset past EOF → `416`.
- `TestStreamFileFromDiskClearsWriteDeadline` (from #1294) still passes.
- Full `internal/api` package green (`ok ... 409s`).

## Follow-ups (in #1296)
Client partial persistence + resume, shared `DownloadState.PAUSED`/`failureReason`, toast Resume action + game-detail CTA state machine, Downloads view rows, and desktop E2E + Android smoke tests.