### PR TITLE
feat(player): desktop audio via SINC resampler + DRC on a decoupled output thread

### DIFF
--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopAudioPlayer.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopAudioPlayer.kt
@@ -1,122 +1,218 @@
 package com.spela.player.libretro
 
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 import java.util.logging.Logger
 import javax.sound.sampled.AudioFormat
 import javax.sound.sampled.AudioSystem
 import javax.sound.sampled.SourceDataLine
 
 /**
- * Desktop audio output using javax.sound.sampled with audio-sync frame pacing.
+ * Desktop audio output: Android-quality SINC resampling + dynamic rate
+ * control, with the device write **decoupled onto its own thread**.
  *
- * Instead of running a separate polling thread, audio samples are written
- * directly from the emulation thread via [writeSync]. The blocking
- * SourceDataLine.write() call naturally paces emulation to the audio
- * sample rate, eliminating both audio jitter and the need for sleep-based
- * frame timing. This mirrors RetroArch's "audio sync" approach.
+ *   core samples (e.g. 44100 / 32040 Hz) → native SINC resampler
+ *   → ring buffer (48000 Hz) ──[SpelaAudioOut thread]──▶ SourceDataLine
  *
- * The audio device is opened lazily on the first [writeSync] call,
- * ensuring the core's sample rate is available.
+ * Why decoupled (#1288): the Android path does a blocking `AudioTrack.write`
+ * directly on the emulation thread, and that's fine there. On desktop the
+ * equivalent blocking `SourceDataLine.write` periodically stalls the whole
+ * emulation loop for ~the device-buffer duration (~200ms) whenever the device
+ * buffer fills — verified as 18–34 fps with 200ms frameTime spikes on SNES.
+ * So here the emulation thread only ever [write]s into a ring buffer (resample
+ * + non-blocking copy); a dedicated thread drains the ring to the device with
+ * the blocking write. Emulation is never blocked by audio I/O.
+ *
+ * Dynamic rate control (±0.5%, RetroArch/Android's formula) nudges the
+ * resampling ratio based on **ring** fill to keep it ~half full — eliminating
+ * underruns/overruns and smoothing per-frame jitter. precisionSleep in the
+ * emulation loop provides the realtime pacing the blocking write used to.
+ *
+ * The device + ring + output thread open lazily on the first [write] once the
+ * core's sample rate is known.
  */
 class DesktopAudioPlayer(private val controller: DesktopLibretroController) {
 
     private val logger = Logger.getLogger("SpelaAudio")
 
-    private var sourceDataLine: SourceDataLine? = null
+    private var line: SourceDataLine? = null
     private var initAttempted = false
 
-    /** Volume level 0.0 (mute) to 1.0 (full). Applied to samples in writeSync. */
+    /** Volume level 0.0 (mute) to 1.0 (full). Applied to samples in [write]. */
     @Volatile
     var volume: Float = 1.0f
 
-    // Pre-allocated conversion buffer (resized if needed)
-    private var conversionBuffer = ByteBuffer.allocate(0).order(ByteOrder.LITTLE_ENDIAN)
+    /** Base resampling ratio: OUTPUT_RATE / coreSampleRate. Set on open. */
+    private var baseRatio = 1.0
 
-    /**
-     * Lazily open the audio device. Called automatically on the first
-     * [writeSync] when audio samples are available (sample rate is set).
-     */
+    /** Reusable resampler output (interleaved int16) — written on the emu thread. */
+    private var resampleBuf = ShortArray(16384)
+
+    // Ring buffer of resampled interleaved-stereo int16 at OUTPUT_RATE. The DRC
+    // target buffer (mirrors the role of Android's AudioTrack buffer). Guarded
+    // by `lock`; drained by the output thread, filled by [write].
+    private var ring = ShortArray(0)
+    private var head = 0
+    private var tail = 0
+    private var count = 0 // shorts currently buffered
+    private val lock = Any()
+
+    @Volatile
+    private var running = false
+    private var outputThread: Thread? = null
+
+    companion object {
+        const val OUTPUT_RATE = 48000
+        private const val FRAME_BYTES = 4 // stereo * 16-bit
+
+        /** Ring capacity in milliseconds — the DRC keeps it ~half full, so it
+         *  contributes ~half this to latency. Kept small for low latency; the
+         *  per-frame audio burst (~17ms at 60fps) plus normal jitter fits
+         *  comfortably in half of this. */
+        private const val RING_MS = 60
+
+        /** Device line buffer — the output thread keeps it fed; it's the last
+         *  line of defence against an underrun (audible crackle), so don't
+         *  shrink it as aggressively as the ring. */
+        private const val DEVICE_MS = 30
+
+        /** Rate control delta (matches RetroArch / Android). ±0.5% at buffer
+         *  extremes — ~8.6 cents, well below audibility. */
+        private const val RATE_CONTROL_DELTA = 0.005
+    }
+
+    /** Lazily open the device + ring + output thread. Returns false until the
+     *  core's sample rate is available (try again next frame). */
     private fun ensureStarted(): Boolean {
-        if (sourceDataLine != null) return true
+        if (line != null) return true
         if (initAttempted) return false
 
-        val sampleRate = controller.getSampleRate()
-        if (sampleRate <= 0) return false // Not ready yet, try next frame
+        val coreSampleRate = controller.getSampleRate()
+        if (coreSampleRate <= 0.0) return false // not ready yet
 
         initAttempted = true
-        logger.info("Audio starting: sampleRate=$sampleRate")
+        baseRatio = OUTPUT_RATE.toDouble() / coreSampleRate
+        ring = ShortArray(OUTPUT_RATE * 2 * RING_MS / 1000)
 
-        val format = AudioFormat(
-            sampleRate.toFloat(),
-            16,     // 16-bit samples
-            2,      // stereo
-            true,   // signed
-            false,  // little-endian
-        )
+        val format = AudioFormat(OUTPUT_RATE.toFloat(), 16, 2, true, false) // signed, little-endian
+        val deviceBytes = OUTPUT_RATE * FRAME_BYTES * DEVICE_MS / 1000
 
-        // ~46ms buffer — small for low latency. Audio-sync pacing keeps the
-        // buffer steadily filled, so underruns don't occur in normal operation.
-        val bufferSize = (sampleRate * 2 * 2 * 0.046).toInt()
-
-        try {
-            sourceDataLine = AudioSystem.getSourceDataLine(format).also {
-                it.open(format, bufferSize)
+        return try {
+            line = AudioSystem.getSourceDataLine(format).also {
+                it.open(format, deviceBytes)
                 it.start()
             }
-            logger.info("Audio device opened successfully (buffer=${bufferSize} bytes, ~46ms)")
-            return true
+            running = true
+            outputThread = Thread({ outputLoop() }, "SpelaAudioOut").apply {
+                isDaemon = true
+                priority = Thread.MAX_PRIORITY
+                start()
+            }
+            logger.info(
+                "Audio started: core=$coreSampleRate out=$OUTPUT_RATE " +
+                    "baseRatio=${"%.4f".format(baseRatio)} ring=${RING_MS}ms device=${DEVICE_MS}ms",
+            )
+            true
         } catch (e: Exception) {
             logger.severe("Failed to open audio device: ${e.message}")
-            return false
+            false
         }
+    }
+
+    /**
+     * Dynamic resampling ratio from the **ring** fill (RetroArch's
+     * audio_driver_flush formula): emptier than half → ratio up (more output);
+     * fuller than half → ratio down (drain). Keeps the ring ~half full.
+     */
+    fun calculateRatio(): Double {
+        if (ring.isEmpty()) return baseRatio
+        val avail = synchronized(lock) { ring.size - count } // free shorts
+        val half = (ring.size / 2).coerceAtLeast(1)
+        val direction = (avail - half).toDouble() / half
+        return baseRatio * (1.0 + RATE_CONTROL_DELTA * direction)
+    }
+
+    /**
+     * Resample the core's buffered audio at [ratio] and enqueue it into the
+     * ring — **non-blocking**, called from the emulation thread. The output
+     * thread does the blocking device write, so emulation never stalls on audio.
+     */
+    fun write(ratio: Double) {
+        if (!ensureStarted()) return
+        val n = controller.resampleAudio(resampleBuf, ratio) // interleaved shorts
+        if (n <= 0) return
+
+        val vol = volume * volume * volume // perceptual curve, matches old writeSync
+        if (vol < 0.999f) {
+            for (i in 0 until n) {
+                resampleBuf[i] = (resampleBuf[i] * vol).toInt()
+                    .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+            }
+        }
+        synchronized(lock) {
+            val cap = ring.size
+            for (i in 0 until n) {
+                if (count >= cap) { // ring full (output thread fell behind) — drop oldest
+                    head = (head + 1) % cap
+                    count--
+                }
+                ring[tail] = resampleBuf[i]
+                tail = (tail + 1) % cap
+                count++
+            }
+        }
+    }
+
+    private val scratch = ShortArray(4096)
+    private val scratchBytes = ByteArray(8192)
+
+    private fun outputLoop() {
+        val l = line ?: return
+        while (running) {
+            var n: Int
+            synchronized(lock) {
+                n = minOf(scratch.size, count)
+                for (i in 0 until n) {
+                    scratch[i] = ring[head]
+                    head = (head + 1) % ring.size
+                }
+                count -= n
+            }
+            if (n == 0) {
+                Thread.sleep(2) // ring empty — device buffer covers the gap
+                continue
+            }
+            var bi = 0
+            for (i in 0 until n) {
+                val s = scratch[i].toInt()
+                scratchBytes[bi++] = (s and 0xFF).toByte()
+                scratchBytes[bi++] = ((s shr 8) and 0xFF).toByte()
+            }
+            try {
+                l.write(scratchBytes, 0, n * 2) // blocking — on THIS thread, not emulation
+            } catch (_: Exception) {
+                break
+            }
+        }
+    }
+
+    fun pause() {
+        line?.stop()
+    }
+
+    fun resume() {
+        line?.start()
     }
 
     fun stop() {
-        sourceDataLine?.let {
-            it.drain()
+        running = false
+        outputThread?.join(500)
+        outputThread = null
+        line?.let {
+            it.flush()
             it.stop()
             it.close()
         }
-        sourceDataLine = null
+        line = null
         initAttempted = false
-    }
-
-    /**
-     * Write audio samples to the output device. Blocks until the device
-     * accepts the data, which naturally paces the caller (emulation thread)
-     * to the audio sample rate. This is the core of audio-sync frame pacing.
-     *
-     * On the first call, lazily opens the audio device (sample rate must be
-     * available from the core by this point).
-     *
-     * Called from the emulation thread after each retro_run().
-     *
-     * @return true if audio was written (and blocking occurred), false if
-     *         the device isn't ready yet (caller should fall back to sleep-based pacing).
-     */
-    fun writeSync(samples: ShortArray): Boolean {
-        if (!ensureStarted()) return false
-        val line = sourceDataLine ?: return false
-        val needed = samples.size * 2
-        if (conversionBuffer.capacity() < needed) {
-            conversionBuffer = ByteBuffer.allocate(needed).order(ByteOrder.LITTLE_ENDIAN)
-        }
-        conversionBuffer.clear()
-        // Apply logarithmic volume curve: human hearing is logarithmic, so
-        // a linear slider position needs exponential scaling to feel natural.
-        // vol^3 gives a good perceptual curve (50% slider ≈ 12.5% amplitude).
-        val linear = volume
-        val vol = linear * linear * linear
-        val shortBuf = conversionBuffer.asShortBuffer()
-        if (vol >= 0.999f) {
-            shortBuf.put(samples)
-        } else {
-            for (s in samples) {
-                shortBuf.put((s * vol).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort())
-            }
-        }
-        line.write(conversionBuffer.array(), 0, needed)
-        return true
+        synchronized(lock) { head = 0; tail = 0; count = 0 }
     }
 }

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
@@ -262,6 +262,11 @@ class DesktopLibretroController(
     fun getAudioBuffer(): ShortArray? = jni.nativeGetAudioBuffer()
     fun getSampleRate(): Double = jni.nativeGetSampleRate()
 
+    /** Resample the core's buffered audio (SINC) by [ratio] into [out];
+     *  returns the interleaved-stereo short count. Drains the core buffer.
+     *  Used by [DesktopAudioPlayer] for dynamic-rate-control output (#1288). */
+    fun resampleAudio(out: ShortArray, ratio: Double): Int = jni.nativeResampleAudio(out, ratio)
+
     fun setButton(port: Int, buttonId: Int, pressed: Boolean) {
         jni.nativeSetInputButton(port, buttonId, pressed)
         // Also update netplay-side button state (avoids JNI feedback loop)
@@ -403,18 +408,18 @@ class DesktopLibretroController(
                 renderGpuFrameToBgra()
             }
 
-            // Audio-sync frame pacing: write audio to device (blocking write
-            // paces emulation to the audio sample rate). Falls back to
-            // precisionSleep if no audio player or no samples available.
-            // Audio-sync frame pacing: write audio to device (blocking write
-            // paces emulation to the audio sample rate). Falls back to
-            // precisionSleep if no audio player, no samples, or device not ready.
+            // Audio output via SINC resampler + dynamic rate control, then
+            // pace the loop to the core's target FPS. This mirrors the Android
+            // path (and RetroArch): the DRC'd blocking write keeps the device
+            // buffer ~half-full and provides realtime back-pressure, while
+            // precisionSleep caps the rate at targetFps. The old raw per-frame
+            // writeSync caused choppy audio / wrong speed on bursty,
+            // frontend-paced cores like Play! (PS2). (#1288)
             val ap = audioPlayer
-            val audioSamples = jni.nativeGetAudioBuffer()
-            val synced = if (ap != null && !fastForward && audioSamples != null && audioSamples.isNotEmpty()) {
-                ap.writeSync(audioSamples)
-            } else false
-            if (!synced && !fastForward) {
+            if (ap != null && !fastForward) {
+                ap.write(ap.calculateRatio())
+            }
+            if (!fastForward) {
                 precisionSleep(frameStart + frameTimeNs)
             }
 


### PR DESCRIPTION
## What

Replaces desktop audio (raw per-frame blocking `writeSync` at the core rate) with the **Android/RetroArch audio model**: native **SINC resampler → 48000 Hz** with **±0.5% dynamic rate control** keeping the buffer ~half full.

## Why

The old per-frame blocking `writeSync` produced choppy audio / wrong speed on bursty, frontend-paced cores. Mirroring Android's proven SINC+DRC path fixes that and gives consistent, RetroArch-quality resampling across platforms.

## Desktop-specific twist

Android blocks `AudioTrack.write` directly on the emulation thread — fine there. On desktop, a blocking `SourceDataLine.write` on the emu thread periodically **stalls the whole emulation loop** for ~the device-buffer duration when the device buffer fills (measured: **18–34 fps with 200ms frameTime spikes on SNES**). So here the device write runs on a **dedicated max-priority output thread** fed by a ring buffer; the emulation thread only resamples + enqueues (non-blocking). DRC is driven by ring fill; `precisionSleep` provides realtime pacing. Result: emulation stays locked to target FPS.

## Latency

Tuned to **~60ms** (ring 60ms + device 30ms — two one-line constants, easy to retune). ~5ms isn't achievable with software emulator audio: the core delivers audio in per-frame bursts (~17–20ms), so the buffer must hold a frame or two to avoid gaps; the device buffer adds its own floor.

## Validation

Locked FPS + clean audio on:
- **NES** (Super Mario Bros, 48000 passthrough — `baseRatio=1.0`)
- **SNES** (A Link to the Past, 32040→48000 resampling)
- **PSP** (PPSSPP, HW-render core)

Full `:shared:desktopTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
