### PR TITLE
feat(player): resumable game downloads — recover from interrupted transfers

### DIFF
--- a/player/shared/src/androidMain/kotlin/com/spela/player/platform/AndroidFileStorage.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/platform/AndroidFileStorage.kt
@@ -81,6 +81,20 @@ class AndroidFileStorage(private val context: Context) : FileStorage {
         }
     }
 
+    override suspend fun appendFileStreaming(
+        path: String,
+        writer: suspend (append: suspend (ByteArray, Int, Int) -> Unit) -> Unit,
+    ) = withContext(Dispatchers.IO) {
+        val file = File(path)
+        file.parentFile?.mkdirs()
+        // append = true: continue after the existing bytes on disk (resume), #1296.
+        java.io.FileOutputStream(file, true).use { fos ->
+            writer { bytes, offset, length ->
+                fos.write(bytes, offset, length)
+            }
+        }
+    }
+
     override suspend fun getFileSize(path: String): Long = File(path).length()
 
     override suspend fun listFiles(path: String): List<String> = withContext(Dispatchers.IO) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/local/ExpectedSchema.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/local/ExpectedSchema.kt
@@ -36,5 +36,9 @@ object ExpectedSchema {
             "retry_count", "last_error",
         ),
         "OnboardingHintEntity" to setOf("hint_key", "dismissed_at"),
+        "PartialDownloadEntity" to setOf(
+            "game_id", "game_title", "file_name", "local_path",
+            "expected_size", "validator", "failure_reason", "updated_at",
+        ),
     )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -49,6 +49,21 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
+/**
+ * Outcome of a [SpelaApiClient.downloadGameToFile] transfer, used to drive
+ * resume bookkeeping (#1296).
+ *
+ * @property validator the server's current ETag for the file, to send as
+ *   If-Range on a future resume (null if the server sent none).
+ * @property resumed true when the server honored a Range request (206) and the
+ *   bytes were appended to an existing partial; false for a full transfer (200),
+ *   which means any prior partial was overwritten from scratch.
+ */
+data class DownloadResult(
+    val validator: String?,
+    val resumed: Boolean,
+)
+
 class SpelaApiClient(
     private val engineFactory: io.ktor.client.engine.HttpClientEngineFactory<*>,
     private val tokenManager: TokenManager,
@@ -1501,17 +1516,55 @@ class SpelaApiClient(
         gameId: String,
         fileStorage: FileStorage,
         destPath: String,
+        resumeFrom: Long = 0,
+        validator: String? = null,
+        onResponseInfo: (validator: String?, fullSize: Long?) -> Unit = { _, _ -> },
         onProgress: (Long, Long?) -> Unit = { _, _ -> },
-    ) {
-        client.prepareGet("$baseUrl/api/games/$gameId/download") {
+    ): DownloadResult {
+        return client.prepareGet("$baseUrl/api/games/$gameId/download") {
             timeout {
                 requestTimeoutMillis = Long.MAX_VALUE
+            }
+            // Resume: request only the bytes after the partial, guarded by the
+            // server's validator. A changed file makes the server ignore the
+            // range and send a full 200, which we then write from scratch
+            // rather than splice mismatched bytes onto a stale partial. (#1296)
+            if (resumeFrom > 0) {
+                header(HttpHeaders.Range, "bytes=$resumeFrom-")
+                if (validator != null) {
+                    header(HttpHeaders.IfRange, validator)
+                }
             }
         }.execute { response ->
             if (!response.status.isSuccess()) {
                 throw RuntimeException("Game download failed: HTTP ${response.status.value}")
             }
-            streamResponseToFile(response, fileStorage, destPath, onProgress)
+            // Capture the server's current validator so a later resume can send
+            // If-Range and detect a file that changed underneath us.
+            val serverValidator = response.headers[HttpHeaders.ETag]
+            // 206 means the server honored our range — append to the partial.
+            // Anything else (200) is a full transfer: range ignored, no range
+            // support, or a stale validator → write from scratch.
+            val resumed = resumeFrom > 0 && response.status == HttpStatusCode.PartialContent
+            // Authoritative full size of the file the server is serving NOW.
+            // For a 206 the Content-Length is the REMAINING bytes, so add the
+            // resume offset; for a 200 it already is the full size.
+            val contentLen = response.contentLength()
+            val fullSize: Long? = if (resumed && contentLen != null) resumeFrom + contentLen else contentLen
+            // Surface validator + true size before streaming so they're
+            // persisted even if the transfer dies mid-stream (the very state a
+            // later resume needs). (#1296)
+            onResponseInfo(serverValidator, fullSize)
+            if (resumed) {
+                streamResponseToFile(
+                    response, fileStorage, destPath,
+                    startOffset = resumeFrom, append = true, totalOverride = fullSize,
+                    onProgress = onProgress,
+                )
+            } else {
+                streamResponseToFile(response, fileStorage, destPath, onProgress = onProgress)
+            }
+            DownloadResult(validator = serverValidator, resumed = resumed)
         }
     }
 
@@ -1655,7 +1708,7 @@ class SpelaApiClient(
             if (!response.status.isSuccess()) {
                 throw RuntimeException("Disc download failed: HTTP ${response.status.value}")
             }
-            streamResponseToFile(response, fileStorage, destPath, onProgress)
+            streamResponseToFile(response, fileStorage, destPath, onProgress = onProgress)
         }
     }
 
@@ -1663,28 +1716,37 @@ class SpelaApiClient(
         response: HttpResponse,
         fileStorage: FileStorage,
         destPath: String,
+        startOffset: Long = 0,
+        append: Boolean = false,
+        totalOverride: Long? = null,
         onProgress: (Long, Long?) -> Unit,
     ) {
-        val totalBytes = response.contentLength()
+        // For a 206 resume, totalOverride is the full size (offset + remaining);
+        // for a 200 it's null and the response Content-Length is the full size.
+        val totalBytes = totalOverride ?: response.contentLength()
         val channel = response.bodyAsChannel()
-        var downloaded = 0L
-        println("[Download] Starting stream to $destPath, Content-Length=$totalBytes")
+        // downloaded tracks bytes-on-disk, so it starts at the partial offset
+        // when resuming — progress then continues from where it stopped.
+        var downloaded = startOffset
+        println("[Download] Streaming to $destPath startOffset=$startOffset append=$append total=$totalBytes")
 
-        fileStorage.writeFileStreaming(destPath) { append ->
+        val pump: suspend (suspend (ByteArray, Int, Int) -> Unit) -> Unit = { write ->
             val buffer = ByteArray(65536)
             var chunkCount = 0
             while (true) {
                 val bytesRead = channel.readAvailable(buffer)
                 if (bytesRead == -1) break
-                append(buffer, 0, bytesRead)
+                write(buffer, 0, bytesRead)
                 downloaded += bytesRead
                 chunkCount++
-                if (chunkCount % 100 == 0) {
-                    println("[Download] chunk=$chunkCount downloaded=$downloaded total=$totalBytes")
-                }
                 onProgress(downloaded, totalBytes)
             }
-            println("[Download] Finished: $chunkCount chunks, $downloaded bytes written")
+            println("[Download] Finished: $chunkCount chunks, $downloaded bytes on disk")
+        }
+        if (append) {
+            fileStorage.appendFileStreaming(destPath, pump)
+        } else {
+            fileStorage.writeFileStreaming(destPath, pump)
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1518,7 +1518,7 @@ class SpelaApiClient(
         destPath: String,
         resumeFrom: Long = 0,
         validator: String? = null,
-        onResponseInfo: (validator: String?, fullSize: Long?) -> Unit = { _, _ -> },
+        onResponseInfo: (validator: String?, fullSize: Long?, resumed: Boolean) -> Unit = { _, _, _ -> },
         onProgress: (Long, Long?) -> Unit = { _, _ -> },
     ): DownloadResult {
         return client.prepareGet("$baseUrl/api/games/$gameId/download") {
@@ -1551,10 +1551,10 @@ class SpelaApiClient(
             // resume offset; for a 200 it already is the full size.
             val contentLen = response.contentLength()
             val fullSize: Long? = if (resumed && contentLen != null) resumeFrom + contentLen else contentLen
-            // Surface validator + true size before streaming so they're
-            // persisted even if the transfer dies mid-stream (the very state a
-            // later resume needs). (#1296)
-            onResponseInfo(serverValidator, fullSize)
+            // Surface validator + true size + whether the range was honored,
+            // before streaming, so they're persisted even if the transfer dies
+            // mid-stream (the very state a later resume needs). (#1296)
+            onResponseInfo(serverValidator, fullSize, resumed)
             if (resumed) {
                 streamResponseToFile(
                     response, fileStorage, destPath,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package com.spela.player.data.repository
 
 import com.spela.player.data.local.SpelaDatabase
+import com.spela.player.data.remote.api.DownloadResult
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.GameDto
+import com.spela.player.domain.model.DownloadFailureReason
 import com.spela.player.domain.model.DownloadProgress
 import com.spela.player.domain.model.DownloadState
 import com.spela.player.domain.model.DownloadedGame
@@ -10,10 +12,12 @@ import com.spela.player.domain.repository.DownloadRepository
 import com.spela.player.util.FileStorage
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.coroutineContext
 
 class DownloadRepositoryImpl(
@@ -99,22 +103,48 @@ class DownloadRepositoryImpl(
     }
 
     /**
-     * Walks `getGamesDir()` and deletes any per-game directory that has
-     * no row in the `downloads` table. These are orphans from process
-     * death, force-stop, or crashes that aborted [downloadGame] before
-     * the [DownloadEntity] insert ran — without this scan they'd sit on
-     * disk forever (no UI surface lists them, and the user has no
-     * "phantom partial" to discover).
+     * Launch-time download reconciliation (call exactly once from the DI graph):
      *
-     * Idempotent: running this twice in a row produces the same result.
-     * Should be called exactly once at app launch from the DI graph.
-     * See #845.
+     * 1. **Restores resumable partials** ([PartialDownloadEntity]) into the
+     *    in-memory state as PAUSED so the UI offers Resume after an app restart,
+     *    with progress reflecting the bytes already on disk. (#1296)
+     * 2. **Deletes orphan directories** under `getGamesDir()` that have neither a
+     *    completed-download row nor a resumable-partial row — leftovers from
+     *    process death/force-stop that aborted [downloadGame] before either row
+     *    was written. Without this they'd sit on disk forever (no UI lists them).
+     *
+     * Idempotent: running twice produces the same result. See #845, #1296.
      */
     override suspend fun scanForOrphanedDownloads() {
+        // (1) Restore resumable partials into the in-memory state. Their dirs are
+        // also protected from the orphan sweep below.
+        val partials = database.spelaDatabaseQueries.getAllPartialDownloads().executeAsList()
+        for (p in partials) {
+            val onDisk = if (fileStorage.fileExists(p.local_path)) fileStorage.getFileSize(p.local_path) else 0L
+            val reason = p.failure_reason?.let { runCatching { DownloadFailureReason.valueOf(it) }.getOrNull() }
+            // Seed the monotonic high-water so a subsequent resume doesn't snap
+            // the bar back to 0 before its first chunk lands.
+            monotonicBytes(p.game_id, onDisk)
+            downloads.update {
+                it + (p.game_id to DownloadProgress(
+                    gameId = p.game_id,
+                    gameTitle = p.game_title,
+                    state = DownloadState.PAUSED,
+                    bytesDownloaded = onDisk,
+                    totalBytes = if (p.expected_size > 0) p.expected_size else -1L,
+                    failureReason = reason,
+                ))
+            }
+        }
+
+        // (2) Sweep orphan dirs. A dir is tracked if it's a completed download
+        // OR has a resumable partial — neither should be deleted.
         val gamesDir = fileStorage.getGamesDir()
         if (!fileStorage.fileExists(gamesDir)) return
-        val tracked = database.spelaDatabaseQueries.getAllDownloads()
-            .executeAsList().map { it.game_id }.toSet()
+        val tracked = (
+            database.spelaDatabaseQueries.getAllDownloads().executeAsList().map { it.game_id } +
+                partials.map { it.game_id }
+            ).toSet()
         val onDisk = try {
             fileStorage.listFiles(gamesDir)
         } catch (e: Exception) {
@@ -198,25 +228,133 @@ class DownloadRepositoryImpl(
             }
         }.onSuccess { path ->
             val fileSize = try { fileStorage.getDirectorySize(fileStorage.getGamesDir() + "/$gameId") } catch (_: Exception) { 0L }
-            val now = kotlin.time.Clock.System.now().toEpochMilliseconds()
-            database.spelaDatabaseQueries.insertDownload(gameId, path, fileSize, now)
+            database.spelaDatabaseQueries.insertDownload(gameId, path, fileSize, nowMillis())
+            // The download finished — drop any resumable-partial record so the
+            // game reads as fully cached, not paused. (#1296)
+            database.spelaDatabaseQueries.deletePartialDownload(gameId)
             refreshDownloadedGames()
             takeActiveJob(gameId)
         }.onFailure { error ->
+            handleDownloadFailure(gameId, gameTitle, error)
+        }
+    }
+
+    override suspend fun resumeDownload(gameId: String): Result<String> {
+        val partial = database.spelaDatabaseQueries.getPartialDownload(gameId).executeAsOneOrNull()
+            ?: return Result.failure(IllegalStateException("No resumable partial for game $gameId"))
+        val gameTitle = partial.game_title
+        val path = partial.local_path
+        // Capture the caller's Job so cancelDownload can interrupt the resume.
+        setActiveJob(gameId, coroutineContext[Job]!!)
+        return runCatching {
+            // The partial file's current size IS the resume offset. If the file
+            // vanished (manual cleanup), start over from zero.
+            val resumeFrom = if (fileStorage.fileExists(path)) fileStorage.getFileSize(path) else 0L
+            // Seed the monotonic high-water so the bar continues from the offset
+            // rather than snapping back to 0 before the first 206 chunk lands.
+            monotonicBytes(gameId, resumeFrom)
+            downloads.update {
+                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, resumeFrom, partial.expected_size))
+            }
+            transferSingleFile(gameId, gameTitle, path, partial.expected_size, resumeFrom, partial.validator)
+        }.onSuccess { resolvedPath ->
+            val fileSize = try { fileStorage.getDirectorySize(fileStorage.getGamesDir() + "/$gameId") } catch (_: Exception) { 0L }
+            database.spelaDatabaseQueries.insertDownload(gameId, resolvedPath, fileSize, nowMillis())
+            database.spelaDatabaseQueries.deletePartialDownload(gameId)
+            refreshDownloadedGames()
             takeActiveJob(gameId)
-            cleanupPartialDownload(gameId)
-            resetSpeed(gameId)
-            // User-initiated cancel surfaces as CancellationException via runCatching.
-            // Treat it as IDLE rather than FAILED so the UI doesn't show an error
-            // toast for an action the user just took intentionally.
-            if (error is CancellationException) {
-                downloads.update { it - gameId }
-                throw error
+        }.onFailure { error ->
+            handleDownloadFailure(gameId, gameTitle, error)
+        }
+    }
+
+    /**
+     * Resolves the in-memory + persisted state when a download stops without
+     * completing. Shared by [downloadGame] and [resumeDownload].
+     *
+     * - **Cancellation** (user pause, app backgrounded/killed): keep the
+     *   partial and surface PAUSED. The partial row was persisted at download
+     *   start, so nothing else is needed — and the coroutine is cancelled, so
+     *   suspend/DB work here would throw. Re-throws so structured concurrency
+     *   still unwinds.
+     * - **Resumable failure** (network drop, server cut, unknown error): keep
+     *   the partial, stamp the reason, surface PAUSED with a [DownloadFailureReason].
+     * - **Terminal failure** (corrupt bytes, disk full): discard the partial so
+     *   a restart is clean, surface FAILED. (#1296)
+     */
+    private suspend fun handleDownloadFailure(gameId: String, gameTitle: String, error: Throwable) {
+        takeActiveJob(gameId)
+        // Read display bytes/total from the last in-memory progress (non-suspend,
+        // safe even when the coroutine is cancelled). The exact resume offset is
+        // re-derived by statting the file at resume time.
+        val last = downloads.value[gameId]
+        val onDisk = last?.bytesDownloaded ?: 0L
+        val total = last?.totalBytes ?: -1L
+        resetSpeed(gameId)
+
+        if (error is CancellationException) {
+            downloads.update {
+                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.PAUSED, onDisk, total))
+            }
+            throw error
+        }
+
+        val reason = classifyFailure(error)
+        if (reason.resumable) {
+            // Keep the partial; record why so the UI shows the right copy. Guard
+            // the DB write with NonCancellable so a racing cancel can't abort the
+            // bookkeeping half-done.
+            withContext(NonCancellable) {
+                database.spelaDatabaseQueries.updatePartialDownloadFailure(reason.name, nowMillis(), gameId)
             }
             downloads.update {
-                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.FAILED))
+                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.PAUSED, onDisk, total, failureReason = reason))
+            }
+        } else {
+            // Terminal — discard the partial (file + record) so any restart is clean.
+            withContext(NonCancellable) {
+                cleanupPartialDownload(gameId)
+                database.spelaDatabaseQueries.deletePartialDownload(gameId)
+            }
+            downloads.update {
+                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.FAILED, failureReason = reason))
             }
         }
+    }
+
+    /**
+     * Maps a download error to a [DownloadFailureReason]. Defaults to NETWORK
+     * (resumable) for unrecognised errors — better to offer Resume than
+     * dead-end the user on an opaque failure. Terminal causes are matched
+     * explicitly. (#1296)
+     */
+    private fun classifyFailure(error: Throwable): DownloadFailureReason {
+        val msg = (error.message ?: "").lowercase()
+        return when {
+            "size mismatch" in msg || "empty file" in msg -> DownloadFailureReason.CORRUPT
+            "enospc" in msg || "no space" in msg || "not enough space" in msg -> DownloadFailureReason.DISK_FULL
+            Regex("http 5\\d\\d").containsMatchIn(msg) -> DownloadFailureReason.SERVER
+            else -> DownloadFailureReason.NETWORK
+        }
+    }
+
+    private fun nowMillis(): Long = kotlin.time.Clock.System.now().toEpochMilliseconds()
+
+    private fun persistPartialRow(
+        gameId: String,
+        gameTitle: String,
+        fileName: String,
+        path: String,
+        expectedSize: Long,
+        validator: String?,
+    ) {
+        database.spelaDatabaseQueries.insertPartialDownload(
+            gameId, gameTitle, fileName, path, expectedSize, validator, null, nowMillis(),
+        )
+    }
+
+    private fun updatePartialHeaders(gameId: String, validator: String?, expectedSize: Long) {
+        database.spelaDatabaseQueries.updatePartialDownloadHeaders(validator, expectedSize, nowMillis(), gameId)
     }
 
     override suspend fun downloadGameToDirectory(
@@ -297,7 +435,48 @@ class DownloadRepositoryImpl(
         val actualFileName = fileName.ifEmpty { gameId }
         val path = "$gameDir/$actualFileName"
 
-        apiClient.downloadGameToFile(gameId, fileStorage, path) { downloaded, total ->
+        // Record a resumable partial BEFORE streaming so an interrupted transfer
+        // — including a hard process kill that never reaches a failure handler —
+        // leaves a row to resume from (and shields the dir from the orphan
+        // sweep). The validator is filled in once response headers arrive. (#1296)
+        persistPartialRow(gameId, gameTitle, actualFileName, path, expectedSize, validator = null)
+
+        return transferSingleFile(gameId, gameTitle, path, expectedSize, resumeFrom = 0, validator = null)
+    }
+
+    /**
+     * Streams a single-file game to [path] — fresh ([resumeFrom] = 0) or
+     * resumed (the on-disk offset, with a [validator] for If-Range) — updating
+     * progress and the partial record, then validates the result against the
+     * size the server reported for THIS transfer. Shared by the fresh and
+     * resume paths. (#1296)
+     */
+    private suspend fun transferSingleFile(
+        gameId: String,
+        gameTitle: String,
+        path: String,
+        expectedSize: Long,
+        resumeFrom: Long,
+        validator: String?,
+    ): String {
+        // Authoritative full size of the file the server is serving, learned
+        // from response headers; the DB size is only a fallback until then.
+        var serverTotal: Long = if (expectedSize > 0) expectedSize else -1L
+
+        val result = apiClient.downloadGameToFile(
+            gameId,
+            fileStorage,
+            path,
+            resumeFrom = resumeFrom,
+            validator = validator,
+            onResponseInfo = { serverValidator, fullSize ->
+                if (fullSize != null && fullSize > 0) serverTotal = fullSize
+                // Persist validator + true size immediately so a later resume is
+                // safe and shows correct progress even if this attempt dies
+                // mid-stream — the very state resume needs. (#1296)
+                updatePartialHeaders(gameId, serverValidator, fullSize ?: expectedSize)
+            },
+        ) { downloaded, total ->
             // Prefer the server's Content-Length (`total`) — it's the exact
             // number of bytes we'll receive, so `downloaded` reaches it and the
             // bar hits 100%. The DB file size can disagree with the transfer:
@@ -315,13 +494,16 @@ class DownloadRepositoryImpl(
         }
 
         val actualSize = fileStorage.getFileSize(path)
-        println("[Download] File written: path=$path actualSize=$actualSize expectedSize=$expectedSize")
+        println("[Download] File written: path=$path actualSize=$actualSize serverTotal=$serverTotal resumed=${result.resumed}")
         if (actualSize == 0L) {
             throw RuntimeException("Download produced empty file: $path")
         }
-        if (expectedSize > 0 && actualSize != expectedSize) {
+        // Validate against the size the server reported for THIS transfer, not
+        // the possibly-stale DB size — otherwise a legitimately changed file
+        // (served fresh via a 200 on resume) looks like a size mismatch. (#1296)
+        if (serverTotal > 0 && actualSize != serverTotal) {
             throw RuntimeException(
-                "Download size mismatch: expected $expectedSize bytes, got $actualSize bytes"
+                "Download size mismatch: expected $serverTotal bytes, got $actualSize bytes"
             )
         }
         resetSpeed(gameId)
@@ -538,22 +720,23 @@ class DownloadRepositoryImpl(
     }
 
     override suspend fun cancelDownload(gameId: String) {
-        // Cancel the in-flight job (if any). This propagates CancellationException
-        // through the runCatching block in downloadGame, which then runs
-        // cleanupPartialDownload via the onFailure branch — so disk space is
-        // reclaimed automatically. cancelDownload itself doesn't need to call
-        // cleanup directly.
-        takeActiveJob(gameId)?.cancel(CancellationException("download cancelled by user"))
-        // Defensive: if the job already completed (or never started), drop the
-        // in-memory progress entry and tracker manually.
-        downloads.update { it - gameId }
-        // Drop the tracker too so a cancel-then-restart starts with a fresh
-        // window. Without this the old samples briefly inflate the reported
-        // speed of the new download until they age out.
-        resetSpeed(gameId)
+        // Stop the in-flight transfer but KEEP the partial — an interrupted
+        // download is resumable now (#1296). Cancelling the job propagates
+        // CancellationException into the runCatching block of
+        // downloadGame/resumeDownload, whose failure handler records PAUSED and
+        // leaves the partial file + its row in place. If there's no active job
+        // (already paused/done), this is a no-op. Use deleteLocalGame to remove
+        // a partial entirely.
+        takeActiveJob(gameId)?.cancel(CancellationException("download paused by user"))
     }
 
     override suspend fun getLocalGamePath(gameId: String): String? {
+        // An in-progress / paused / failed partial is on disk under the final
+        // name but isn't a complete, playable file — never resolve it as cached
+        // until the download finishes and its partial row is cleared. (#1296)
+        if (database.spelaDatabaseQueries.getPartialDownload(gameId).executeAsOneOrNull() != null) {
+            return null
+        }
         val gameDir = fileStorage.getGamesDir() + "/$gameId"
         // Check multi-disc first: M3U must exist AND disc images must be present.
         // Without this check, a partial download (M3U written but discs not yet
@@ -606,6 +789,10 @@ class DownloadRepositoryImpl(
         }
         downloads.update { it - gameId }
         database.spelaDatabaseQueries.deleteDownload(gameId)
+        // Also clear any resumable partial — this is the removal path for both
+        // a completed game and a paused/failed partial ("Start over"/"Cancel"). (#1296)
+        database.spelaDatabaseQueries.deletePartialDownload(gameId)
+        resetSpeed(gameId)
         refreshDownloadedGames()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
@@ -291,16 +291,25 @@ class DownloadRepositoryImpl(
         val onDisk = last?.bytesDownloaded ?: 0L
         val total = last?.totalBytes ?: -1L
         resetSpeed(gameId)
+        // Resume needs a persisted partial record. Paths that never write one
+        // (multi-disc, tar bundles) can't be resumed, so they must NOT surface a
+        // PAUSED/Resume affordance that would dead-end on resumeDownload. This is
+        // a synchronous query — safe to read even on a cancelled coroutine. (#1296)
+        val hasPartial = database.spelaDatabaseQueries.getPartialDownload(gameId).executeAsOneOrNull() != null
 
         if (error is CancellationException) {
             downloads.update {
-                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.PAUSED, onDisk, total))
+                if (hasPartial) {
+                    it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.PAUSED, onDisk, total))
+                } else {
+                    it - gameId // nothing to resume — a plain cancel, drop the entry
+                }
             }
             throw error
         }
 
         val reason = classifyFailure(error)
-        if (reason.resumable) {
+        if (reason.resumable && hasPartial) {
             // Keep the partial; record why so the UI shows the right copy. Guard
             // the DB write with NonCancellable so a racing cancel can't abort the
             // bookkeeping half-done.
@@ -311,7 +320,8 @@ class DownloadRepositoryImpl(
                 it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.PAUSED, onDisk, total, failureReason = reason))
             }
         } else {
-            // Terminal — discard the partial (file + record) so any restart is clean.
+            // Terminal, OR resumable but with no partial to resume from → discard
+            // and surface FAILED so the UI offers Start over, not a broken Resume.
             withContext(NonCancellable) {
                 cleanupPartialDownload(gameId)
                 database.spelaDatabaseQueries.deletePartialDownload(gameId)
@@ -333,6 +343,9 @@ class DownloadRepositoryImpl(
         return when {
             "size mismatch" in msg || "empty file" in msg -> DownloadFailureReason.CORRUPT
             "enospc" in msg || "no space" in msg || "not enough space" in msg -> DownloadFailureReason.DISK_FULL
+            // 416: our partial is past the server file's end (e.g. it shrank
+            // under a same validator). Resuming again just re-416s — restart.
+            "http 416" in msg -> DownloadFailureReason.CORRUPT
             Regex("http 5\\d\\d").containsMatchIn(msg) -> DownloadFailureReason.SERVER
             else -> DownloadFailureReason.NETWORK
         }
@@ -469,8 +482,13 @@ class DownloadRepositoryImpl(
             path,
             resumeFrom = resumeFrom,
             validator = validator,
-            onResponseInfo = { serverValidator, fullSize ->
+            onResponseInfo = { serverValidator, fullSize, resumed ->
                 if (fullSize != null && fullSize > 0) serverTotal = fullSize
+                // If we asked to resume but the server restarted from scratch
+                // (200 — the file changed), the byte counter is going back to 0;
+                // clear the high-water seeded at the old offset so the bar tracks
+                // the fresh transfer instead of sticking at the stale offset. (#1296)
+                if (resumeFrom > 0 && !resumed) resetSpeed(gameId)
                 // Persist validator + true size immediately so a later resume is
                 // safe and shows correct progress even if this attempt dies
                 // mid-stream — the very state resume needs. (#1296)
@@ -781,6 +799,9 @@ class DownloadRepositoryImpl(
     }
 
     override suspend fun deleteLocalGame(gameId: String) {
+        // Stop any in-flight transfer first so it can't keep writing to a dir
+        // we're about to delete (e.g. "Start over" while a job is somehow live).
+        takeActiveJob(gameId)?.cancel(CancellationException("download removed"))
         val gameDir = fileStorage.getGamesDir() + "/$gameId"
         if (fileStorage.isDirectory(gameDir)) {
             fileStorage.deleteDirectory(gameDir)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package com.spela.player.data.repository
 
 import com.spela.player.data.local.SpelaDatabase
-import com.spela.player.data.remote.api.DownloadResult
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.GameDto
 import com.spela.player.domain.model.DownloadFailureReason

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -307,8 +307,50 @@ enum class DownloadState {
     IDLE,
     QUEUED,
     DOWNLOADING,
+
+    /**
+     * A resumable partial exists on disk but no transfer is active — the
+     * download stopped and can continue from its current byte offset. Set
+     * either by a user-initiated pause/cancel-keeping-partial or by a
+     * *resumable* failure (network drop, server cut the connection). The UI
+     * offers **Resume**. See [DownloadProgress.failureReason] for the cause
+     * (null = user-initiated). (#1296)
+     */
+    PAUSED,
     COMPLETED,
+
+    /**
+     * The download stopped and cannot be safely resumed — the partial (if any)
+     * was discarded. The only recovery is a clean restart ("Start over"). See
+     * [DownloadProgress.failureReason] for which terminal condition applied.
+     */
     FAILED,
+}
+
+/**
+ * Why a download stopped, used to drive recovery UI copy and decide whether a
+ * partial is resumable. Resumable causes leave the partial on disk and surface
+ * as [DownloadState.PAUSED]; terminal causes discard the partial and surface as
+ * [DownloadState.FAILED]. (#1296)
+ */
+enum class DownloadFailureReason(val resumable: Boolean) {
+    /** Transient connectivity loss (wifi drop, timeout, reset). Resume. */
+    NETWORK(resumable = true),
+
+    /** Server cut the connection mid-stream (e.g. write timeout, 5xx). Resume. */
+    SERVER(resumable = true),
+
+    /** Server file changed since the partial (size/ETag mismatch). The stale
+     *  partial is discarded; the only safe path is a clean restart. */
+    FILE_CHANGED(resumable = false),
+
+    /** The partial is corrupt or its offset no longer matches the server.
+     *  Restart cleanly rather than splice a bad file. */
+    CORRUPT(resumable = false),
+
+    /** Not enough free disk space to finish. Restarting won't help until the
+     *  user frees space, so this is terminal with specific copy. */
+    DISK_FULL(resumable = false),
 }
 
 data class DownloadProgress(
@@ -322,6 +364,13 @@ data class DownloadProgress(
     /** Rolling-window average bytes per second over the most recent
      *  ~2 s of progress samples. 0 when stalled or not yet computable. */
     val bytesPerSecond: Long = 0,
+    /**
+     * Why the download stopped, for PAUSED/FAILED states. null when the
+     * download is healthy or was paused by the user (no error). For PAUSED
+     * this is a resumable cause (or null for a user pause); for FAILED it's a
+     * terminal cause. (#1296)
+     */
+    val failureReason: DownloadFailureReason? = null,
 ) {
     val progress: Float
         get() = when {
@@ -332,6 +381,10 @@ data class DownloadProgress(
 
     val isIndeterminate: Boolean
         get() = totalBytes < 0
+
+    /** True when a partial exists that can be resumed (PAUSED state). */
+    val isResumable: Boolean
+        get() = state == DownloadState.PAUSED
 }
 
 // RetroAchievements

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -340,12 +340,13 @@ enum class DownloadFailureReason(val resumable: Boolean) {
     /** Server cut the connection mid-stream (e.g. write timeout, 5xx). Resume. */
     SERVER(resumable = true),
 
-    /** Server file changed since the partial (size/ETag mismatch). The stale
-     *  partial is discarded; the only safe path is a clean restart. */
-    FILE_CHANGED(resumable = false),
+    // Note: a file that changed on the server is NOT a failure reason — the
+    // resume request's stale If-Range makes the server send a full 200, which
+    // the client writes from scratch and completes successfully. It never
+    // surfaces as a FAILED state, so there is no FILE_CHANGED value here.
 
-    /** The partial is corrupt or its offset no longer matches the server.
-     *  Restart cleanly rather than splice a bad file. */
+    /** The partial is corrupt or its offset no longer matches the server
+     *  (e.g. a 416). Restart cleanly rather than splice a bad file. */
     CORRUPT(resumable = false),
 
     /** Not enough free disk space to finish. Restarting won't help until the

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/DownloadRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/DownloadRepository.kt
@@ -23,6 +23,28 @@ interface DownloadRepository {
         destDir: String,
     ): Result<String> = Result.failure(UnsupportedOperationException("downloadGameToDirectory not supported"))
 
+    /**
+     * Resumes a paused or resumably-failed download from the bytes already on
+     * disk. Requires a partial-download record (created when the download first
+     * started, so it survives process death). Sends an HTTP Range request from
+     * the current on-disk offset, guarded by the stored validator; if the
+     * server reports the file changed it transparently restarts from scratch.
+     * Returns the local path on success. On a resumable failure the partial is
+     * kept and the state returns to PAUSED; on a terminal failure the partial
+     * is discarded and the state is FAILED. (#1296)
+     *
+     * Default is a no-op failure for fakes that don't exercise resume; the
+     * production [com.spela.player.data.repository.DownloadRepositoryImpl]
+     * overrides it.
+     */
+    suspend fun resumeDownload(gameId: String): Result<String> =
+        Result.failure(UnsupportedOperationException("resumeDownload not supported"))
+
+    /**
+     * Stops the in-flight transfer but KEEPS the partial so it can be resumed
+     * later — an interrupted download is recoverable, not discarded. The state
+     * becomes PAUSED. Use [deleteLocalGame] to remove a partial entirely. (#1296)
+     */
     suspend fun cancelDownload(gameId: String)
     suspend fun getLocalGamePath(gameId: String): String?
     suspend fun isGameCached(gameId: String): Boolean

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
@@ -11,6 +11,12 @@ sealed interface GameDetailIntent {
      * the screen invokes its onPlay handler. See #932.
      */
     data object DownloadGameAndPlay : GameDetailIntent
+
+    /** Resume a paused/failed download from its on-disk offset (#1296). */
+    data object ResumeDownload : GameDetailIntent
+
+    /** Discard the partial and download the game over from scratch (#1296). */
+    data object RestartDownload : GameDetailIntent
     /**
      * Screen-side acknowledgement that the auto-launch signal was
      * consumed. Clears [GameDetailState.pendingAutoLaunch] so the

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
@@ -114,6 +114,9 @@ fun SpDownloadProgressBar(
     /** Smoothed bytes-per-second. 0 hides the speed label so a stalled
      *  download doesn't show a stale value (#801). */
     bytesPerSecond: Long = 0,
+    /** Paused/interrupted-but-resumable: tints the bar amber and labels it
+     *  "Paused" instead of showing a (stale) speed. (#1296) */
+    paused: Boolean = false,
 ) {
     val byteLabelColor = if (onGradient) SpColor.OnGradientSecondary else SpColor.OnBackgroundTertiary
     val indeterminateTrackColor = if (onGradient) SpColor.OnGradientTrack else SpColor.SurfaceBright
@@ -150,7 +153,11 @@ fun SpDownloadProgressBar(
             Column(modifier = Modifier.testTag("sp_download_progress_bar_determinate")) {
                 SpProgressBar(
                     progress = progress.coerceAtLeast(0f),
-                    progressColors = listOf(SpColor.Accent, SpColor.AccentLight),
+                    progressColors = if (paused) {
+                        listOf(SpColor.DownloadPaused, SpColor.DownloadPaused)
+                    } else {
+                        listOf(SpColor.Accent, SpColor.AccentLight)
+                    },
                     onGradient = onGradient,
                 )
             }
@@ -162,7 +169,13 @@ fun SpDownloadProgressBar(
                 style = SpTypography.LabelSmall,
                 color = byteLabelColor,
             )
-            if (bytesPerSecond > 0) {
+            if (paused) {
+                Text(
+                    text = " · Paused",
+                    style = SpTypography.LabelSmall,
+                    color = byteLabelColor,
+                )
+            } else if (bytesPerSecond > 0) {
                 Text(
                     text = " · ${formatBytes(bytesPerSecond)}/s",
                     style = SpTypography.LabelSmall,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -98,6 +98,10 @@ fun GameHeroContent(
     onDeleteLocalGame: () -> Unit,
     onOpenDownloadFolder: () -> Unit = {},
     onDownloadToFolder: () -> Unit = {},
+    /** Resume a paused/resumably-failed partial from its offset (#1296). */
+    onResumeDownload: () -> Unit = {},
+    /** Discard the partial and download from scratch (terminal failure) (#1296). */
+    onRestartDownload: () -> Unit = {},
     syncState: GameSyncState?,
     onNavigateToAchievements: () -> Unit = {},
     onAdminScrape: (() -> Unit)? = null,
@@ -306,9 +310,24 @@ fun GameHeroContent(
                     )
                 }
             } else {
+                // A paused/resumably-failed partial → Resume; a terminally
+                // failed one → Start over. Otherwise a fresh Download. (#1296)
+                val dpState = state.downloadProgress?.state
+                val isPaused = dpState == DownloadState.PAUSED
+                val isTerminalFailed = dpState == DownloadState.FAILED
+                val pausedPct = state.downloadProgress
+                    ?.takeIf { it.totalBytes > 0 }
+                    ?.let { (it.progress * 100).toInt().coerceIn(0, 100) }
                 val menuItems = buildList {
                     if (onCreateNetplay != null && supportsNetplay) {
                         add(SpSplitButtonMenuItem("Netplay") { onCreateNetplay(gameId) })
+                    }
+                    // Recovery options for a stopped partial.
+                    if (isPaused) {
+                        add(SpSplitButtonMenuItem("Start over") { onRestartDownload() })
+                    }
+                    if (isPaused || isTerminalFailed) {
+                        add(SpSplitButtonMenuItem("Remove download") { onDeleteLocalGame() })
                     }
                 }
                 // For a game Spela can't emulate, downloading to the managed
@@ -318,10 +337,17 @@ fun GameHeroContent(
                 SpSplitButton(
                     text = when {
                         isBusy -> "Downloading..."
+                        isPaused -> pausedPct?.let { "Resume $it%" } ?: "Resume"
+                        isTerminalFailed -> "Start over"
                         downloadToFolder -> "Download to folder…"
                         else -> "Download"
                     },
-                    onClick = if (downloadToFolder) onDownloadToFolder else onDownloadGame,
+                    onClick = when {
+                        isPaused -> onResumeDownload
+                        isTerminalFailed -> onRestartDownload
+                        downloadToFolder -> onDownloadToFolder
+                        else -> onDownloadGame
+                    },
                     modifier = Modifier
                         .focusRestoreItem(
                             key = "game_detail_play",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.BiosMissingFile
+import com.spela.player.domain.model.DownloadFailureReason
 import com.spela.player.domain.model.DownloadState
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.INSTANT_DOWNLOAD_THRESHOLD_BYTES
@@ -455,6 +456,12 @@ fun GameHeroContent(
         // state.isInstantDownload flips false and the regular UI
         // takes over.
         val showDownloadStatus = state.isDownloading && !state.isInstantDownload
+        // A paused (resumable) download shows its progress on the hero too, so
+        // the "Resume N%" CTA has a visual anchor — mirroring the Downloads
+        // screen. Paused is a stable state (no per-frame progress), so showing
+        // the bar here doesn't reintroduce the #797/#894 reflow. (#1296)
+        val pausedDp = state.downloadProgress?.takeIf { it.state == DownloadState.PAUSED }
+        val showPausedStatus = pausedDp != null && !isBusy
         val statusText = when {
             state.isScraping -> "Scraping…"
             state.isScrapeQueued -> "Scrape queued"
@@ -463,6 +470,11 @@ fun GameHeroContent(
                 val p = state.downloadProgress
                 if (p != null && p.totalDiscs > 1) "Downloading disc ${p.currentDisc}/${p.totalDiscs}…"
                 else "Downloading…"
+            }
+            showPausedStatus -> when (pausedDp?.failureReason) {
+                DownloadFailureReason.NETWORK -> "Connection lost — Resume to continue"
+                DownloadFailureReason.SERVER -> "Server interrupted — Resume to continue"
+                else -> "Paused — Resume to continue"
             }
             else -> null
         }
@@ -486,8 +498,9 @@ fun GameHeroContent(
                     horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
                 ) {
                     // Show spinner for non-download statuses (scraping, sync).
-                    // Downloads already have a spinner in the button.
-                    if (!showDownloadStatus) {
+                    // Downloads already have a spinner in the button; a paused
+                    // download is stopped, so no spinner there either.
+                    if (!showDownloadStatus && !showPausedStatus) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(14.dp),
                             strokeWidth = 2.dp,
@@ -503,14 +516,17 @@ fun GameHeroContent(
 
                 // Latched on isDownloading. The dp object's individual
                 // values (progress, bytes) still update continuously —
-                // only the show/hide decision is held stable.
-                if (showDownloadStatus) {
+                // only the show/hide decision is held stable. The paused
+                // variant renders the same bar in amber so the Resume CTA has
+                // a visual anchor. (#1296)
+                if (showDownloadStatus || showPausedStatus) {
                     val dp = state.downloadProgress
                     SpDownloadProgressBar(
                         progress = dp?.progress ?: -1f,
                         bytesDownloaded = dp?.bytesDownloaded ?: 0L,
                         totalBytes = dp?.totalBytes ?: -1L,
-                        bytesPerSecond = dp?.bytesPerSecond ?: 0L,
+                        bytesPerSecond = if (showPausedStatus) 0L else dp?.bytesPerSecond ?: 0L,
+                        paused = showPausedStatus,
                         onGradient = true,
                         modifier = Modifier.fillMaxWidth(),
                     )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DownloadsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DownloadsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.DownloadFailureReason
 import com.spela.player.domain.model.DownloadProgress
 import com.spela.player.domain.model.DownloadState
 import com.spela.player.domain.model.DownloadedGame
@@ -151,6 +152,9 @@ fun DownloadsScreen(
                         download = download,
                         isCancelling = download.gameId in state.cancellingGameIds,
                         onCancel = { viewModel.onIntent(DownloadsIntent.CancelDownload(download.gameId)) },
+                        onResume = { viewModel.onIntent(DownloadsIntent.ResumeDownload(download.gameId)) },
+                        onRestart = { viewModel.onIntent(DownloadsIntent.RestartDownload(download.gameId, download.gameTitle)) },
+                        onRemove = { viewModel.onIntent(DownloadsIntent.RemoveDownload(download.gameId)) },
                         modifier = Modifier.focusRestoreItem(key ="download_${download.gameId}"),
                     )
                 }
@@ -189,14 +193,42 @@ fun DownloadsScreen(
     }
 }
 
+/** Status label + optional helper line for a download row, by state + cause (#1296). */
+private data class DownloadStatusCopy(val label: String, val helper: String?)
+
+private fun downloadStatusCopy(d: DownloadProgress): DownloadStatusCopy {
+    val pct = if (d.totalBytes > 0) (d.progress * 100).toInt().coerceIn(0, 100) else null
+    val resumeFrom = pct?.let { "Resume from $it%" } ?: "Resume where it left off"
+    return when (d.state) {
+        DownloadState.DOWNLOADING -> DownloadStatusCopy("Downloading", null)
+        DownloadState.QUEUED -> DownloadStatusCopy("Queued", null)
+        DownloadState.COMPLETED -> DownloadStatusCopy("Completed", null)
+        DownloadState.IDLE -> DownloadStatusCopy("Idle", null)
+        DownloadState.PAUSED -> when (d.failureReason) {
+            DownloadFailureReason.NETWORK -> DownloadStatusCopy("Connection lost", resumeFrom)
+            DownloadFailureReason.SERVER -> DownloadStatusCopy("Server interrupted", resumeFrom)
+            else -> DownloadStatusCopy("Paused", resumeFrom)
+        }
+        DownloadState.FAILED -> when (d.failureReason) {
+            DownloadFailureReason.DISK_FULL -> DownloadStatusCopy("Not enough space", "Free up space, then start over")
+            DownloadFailureReason.CORRUPT -> DownloadStatusCopy("Download corrupted", "Start over to fix it")
+            DownloadFailureReason.FILE_CHANGED -> DownloadStatusCopy("File changed on server", "Start over")
+            else -> DownloadStatusCopy("Download failed", "Start over")
+        }
+    }
+}
+
 @Composable
 private fun DownloadItem(
     download: DownloadProgress,
     isCancelling: Boolean = false,
     onCancel: () -> Unit,
+    onResume: () -> Unit = {},
+    onRestart: () -> Unit = {},
+    onRemove: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    val statusText = download.state.name.lowercase().replaceFirstChar { it.uppercase() }
+    val copy = downloadStatusCopy(download)
     val displayTitle = download.gameTitle.ifEmpty { "Game ${download.gameId}" }
 
     SpCard(modifier = modifier) {
@@ -205,10 +237,13 @@ private fun DownloadItem(
                 .fillMaxWidth()
                 .padding(SpSpacing.Default)
                 .semantics {
-                    contentDescription = "$displayTitle, $statusText" +
-                            if (download.state == DownloadState.DOWNLOADING)
-                                if (download.isIndeterminate) ", downloading" else ", ${(download.progress * 100).toInt()} percent"
-                            else ""
+                    contentDescription = "$displayTitle, ${copy.label}" +
+                            when {
+                                download.state == DownloadState.DOWNLOADING && download.isIndeterminate -> ", downloading"
+                                download.state == DownloadState.DOWNLOADING || download.state == DownloadState.PAUSED ->
+                                    if (download.totalBytes > 0) ", ${(download.progress * 100).toInt()} percent" else ""
+                                else -> ""
+                            }
                 },
         ) {
             Row(
@@ -225,6 +260,7 @@ private fun DownloadItem(
                             when (download.state) {
                                 DownloadState.DOWNLOADING -> SpColor.DownloadActive
                                 DownloadState.QUEUED -> SpColor.DownloadQueued
+                                DownloadState.PAUSED -> SpColor.DownloadPaused
                                 DownloadState.COMPLETED -> SpColor.DownloadComplete
                                 DownloadState.FAILED -> SpColor.DownloadFailed
                                 DownloadState.IDLE -> SpColor.DownloadIdle
@@ -241,31 +277,64 @@ private fun DownloadItem(
                         color = SpColor.OnCard,
                     )
                     Text(
-                        text = statusText,
+                        text = copy.helper ?: copy.label,
                         style = SpTypography.BodySmall,
                         color = SpColor.OnBackgroundTertiary,
                     )
                 }
 
-                if (download.state == DownloadState.DOWNLOADING || download.state == DownloadState.QUEUED) {
-                    SpButton(
-                        text = if (isCancelling) "Cancelling..." else "Cancel",
-                        onClick = onCancel,
-                        style = SpButtonStyle.Ghost,
-                        isLoading = isCancelling,
-                        enabled = !isCancelling,
+                // Primary action by state. Cancel pauses (keeps the partial);
+                // Resume continues a paused partial; Start over re-downloads a
+                // terminally-failed game from scratch. (#1296)
+                when (download.state) {
+                    DownloadState.DOWNLOADING, DownloadState.QUEUED -> {
+                        val label = if (download.state == DownloadState.QUEUED) "Cancel" else "Pause"
+                        SpButton(
+                            text = if (isCancelling) "…" else label,
+                            onClick = onCancel,
+                            style = SpButtonStyle.Ghost,
+                            isLoading = isCancelling,
+                            enabled = !isCancelling,
+                        )
+                    }
+                    DownloadState.PAUSED -> SpButton(
+                        text = "Resume",
+                        onClick = onResume,
+                        style = SpButtonStyle.Primary,
                     )
+                    DownloadState.FAILED -> SpButton(
+                        text = "Start over",
+                        onClick = onRestart,
+                        style = SpButtonStyle.Primary,
+                    )
+                    else -> {}
                 }
             }
 
-            if (download.state == DownloadState.DOWNLOADING) {
+            // Progress bar for an in-flight download AND for a paused one, so
+            // the user sees how far the resume will continue from. (#1296)
+            if (download.state == DownloadState.DOWNLOADING || download.state == DownloadState.PAUSED) {
                 Spacer(Modifier.height(SpSpacing.Medium))
                 SpDownloadProgressBar(
                     progress = download.progress,
                     bytesDownloaded = download.bytesDownloaded,
                     totalBytes = download.totalBytes,
-                    bytesPerSecond = download.bytesPerSecond,
+                    bytesPerSecond = if (download.state == DownloadState.PAUSED) 0 else download.bytesPerSecond,
+                    paused = download.state == DownloadState.PAUSED,
                 )
+            }
+
+            // Secondary "Remove" for paused/failed partials — reclaim disk space
+            // without resuming. (#1296)
+            if (download.state == DownloadState.PAUSED || download.state == DownloadState.FAILED) {
+                Spacer(Modifier.height(SpSpacing.Small))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    SpButton(
+                        text = "Remove",
+                        onClick = onRemove,
+                        style = SpButtonStyle.Ghost,
+                    )
+                }
             }
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DownloadsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DownloadsScreen.kt
@@ -212,7 +212,6 @@ private fun downloadStatusCopy(d: DownloadProgress): DownloadStatusCopy {
         DownloadState.FAILED -> when (d.failureReason) {
             DownloadFailureReason.DISK_FULL -> DownloadStatusCopy("Not enough space", "Free up space, then start over")
             DownloadFailureReason.CORRUPT -> DownloadStatusCopy("Download corrupted", "Start over to fix it")
-            DownloadFailureReason.FILE_CHANGED -> DownloadStatusCopy("File changed on server", "Start over")
             else -> DownloadStatusCopy("Download failed", "Start over")
         }
     }
@@ -288,9 +287,13 @@ private fun DownloadItem(
                 // terminally-failed game from scratch. (#1296)
                 when (download.state) {
                     DownloadState.DOWNLOADING, DownloadState.QUEUED -> {
-                        val label = if (download.state == DownloadState.QUEUED) "Cancel" else "Pause"
+                        val queued = download.state == DownloadState.QUEUED
                         SpButton(
-                            text = if (isCancelling) "…" else label,
+                            text = when {
+                                isCancelling -> if (queued) "Cancelling…" else "Pausing…"
+                                queued -> "Cancel"
+                                else -> "Pause"
+                            },
                             onClick = onCancel,
                             style = SpButtonStyle.Ghost,
                             isLoading = isCancelling,
@@ -330,7 +333,7 @@ private fun DownloadItem(
                 Spacer(Modifier.height(SpSpacing.Small))
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                     SpButton(
-                        text = "Remove",
+                        text = "Remove download",
                         onClick = onRemove,
                         style = SpButtonStyle.Ghost,
                     )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -166,6 +166,8 @@ fun GameDetailScreen(
                     onDeleteLocalGame = { viewModel.onIntent(GameDetailIntent.ShowDeleteDownloadDialog) },
                     onOpenDownloadFolder = { viewModel.onIntent(GameDetailIntent.OpenDownloadFolder) },
                     onDownloadToFolder = { viewModel.onIntent(GameDetailIntent.DownloadToFolder) },
+                    onResumeDownload = { viewModel.onIntent(GameDetailIntent.ResumeDownload) },
+                    onRestartDownload = { viewModel.onIntent(GameDetailIntent.RestartDownload) },
                     syncState = syncState,
                     onNavigateToAchievements = { onNavigateToAchievements?.invoke(gameId) },
                     onAdminScrape = if (state.isAdmin) {{ viewModel.onIntent(GameDetailIntent.AdminScrapeGame) }} else null,
@@ -577,14 +579,21 @@ fun GameDetailScreen(
             modifier = Modifier.align(Alignment.BottomCenter),
         )
 
-        // Error snackbar
+        // Error snackbar. On a resumable failure (network drop / server cut),
+        // the partial is kept and the toast offers Resume as the recovery
+        // action rather than a dead-end Dismiss. (#1296)
         SpSnackbar(
             data = state.error?.let {
+                val resumable = state.downloadProgress?.isResumable == true
                 SpSnackbarData(
                     message = it,
                     type = SpSnackbarType.Error,
-                    actionLabel = "Dismiss",
-                    onAction = { viewModel.onIntent(GameDetailIntent.DismissError) },
+                    actionLabel = if (resumable) "Resume" else "Dismiss",
+                    onAction = {
+                        viewModel.onIntent(
+                            if (resumable) GameDetailIntent.ResumeDownload else GameDetailIntent.DismissError,
+                        )
+                    },
                 )
             },
             onDismiss = { viewModel.onIntent(GameDetailIntent.DismissError) },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
@@ -84,9 +84,12 @@ object SpColor {
     val DownloadComplete = Success
     val DownloadFailed = Error
 
-    // A paused/interrupted-but-resumable download — amber "action available",
-    // distinct from the red of a terminal failure. (#1296)
-    val DownloadPaused = Warning
+    // A paused/interrupted-but-resumable download — its own warm amber-orange:
+    // "stopped, action available", deliberately distinct from the bright-yellow
+    // Warning that QUEUED uses (the 4dp status stripe is the only colour cue in
+    // a Downloads row, so paused and queued must not share it) and from the red
+    // of a terminal failure. (#1296)
+    val DownloadPaused = Color(0xFFFF9800)
 
     // On-gradient surface tokens — for badges, buttons, and other
     // controls that sit on top of the colorful console banner gradient.

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
@@ -84,6 +84,10 @@ object SpColor {
     val DownloadComplete = Success
     val DownloadFailed = Error
 
+    // A paused/interrupted-but-resumable download — amber "action available",
+    // distinct from the red of a terminal failure. (#1296)
+    val DownloadPaused = Warning
+
     // On-gradient surface tokens — for badges, buttons, and other
     // controls that sit on top of the colorful console banner gradient.
     // Centralised so the badges in ConsoleComponents.kt, the Tinted

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/DownloadsViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/DownloadsViewModel.kt
@@ -22,7 +22,19 @@ data class DownloadsState(
 
 sealed interface DownloadsIntent {
     data object LoadDownloads : DownloadsIntent
+
+    /** Pause an in-flight download (keeps the partial; #1296). */
     data class CancelDownload(val gameId: String) : DownloadsIntent
+
+    /** Resume a paused/failed download from its on-disk offset (#1296). */
+    data class ResumeDownload(val gameId: String) : DownloadsIntent
+
+    /** Discard a partial and start the download over from scratch (#1296). */
+    data class RestartDownload(val gameId: String, val gameTitle: String) : DownloadsIntent
+
+    /** Remove a partial entirely (no resume), reclaiming its disk space (#1296). */
+    data class RemoveDownload(val gameId: String) : DownloadsIntent
+
     data class DeleteLocalGame(val gameId: String) : DownloadsIntent
     data object ClearCache : DownloadsIntent
 }
@@ -52,6 +64,9 @@ class DownloadsViewModel(
         when (intent) {
             DownloadsIntent.LoadDownloads -> loadDownloads()
             is DownloadsIntent.CancelDownload -> cancelDownload(intent.gameId)
+            is DownloadsIntent.ResumeDownload -> resumeDownload(intent.gameId)
+            is DownloadsIntent.RestartDownload -> restartDownload(intent.gameId, intent.gameTitle)
+            is DownloadsIntent.RemoveDownload -> deleteLocalGame(intent.gameId)
             is DownloadsIntent.DeleteLocalGame -> deleteLocalGame(intent.gameId)
             DownloadsIntent.ClearCache -> clearCache()
         }
@@ -70,6 +85,22 @@ class DownloadsViewModel(
         scope.launch(dispatchers.io) {
             downloadRepository.cancelDownload(gameId)
             _state.update { it.copy(cancellingGameIds = it.cancellingGameIds - gameId) }
+        }
+    }
+
+    private fun resumeDownload(gameId: String) {
+        scope.launch(dispatchers.io) {
+            downloadRepository.resumeDownload(gameId)
+        }
+    }
+
+    private fun restartDownload(gameId: String, gameTitle: String) {
+        scope.launch(dispatchers.io) {
+            // Discard the partial, then start a fresh download.
+            downloadRepository.deleteLocalGame(gameId)
+            downloadRepository.downloadGame(gameId, gameTitle)
+            val cacheSize = downloadRepository.getCacheSize()
+            _state.update { it.copy(cacheSize = cacheSize) }
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -117,6 +117,8 @@ class GameDetailViewModel(
             GameDetailIntent.DownloadGame -> downloadGame()
             GameDetailIntent.DownloadToFolder -> downloadToFolder()
             GameDetailIntent.DownloadGameAndPlay -> downloadGameAndPlay()
+            GameDetailIntent.ResumeDownload -> resumeDownload()
+            GameDetailIntent.RestartDownload -> restartDownload()
             GameDetailIntent.ConsumeAutoLaunch -> _state.update { it.copy(pendingAutoLaunch = false) }
             GameDetailIntent.PlayGame -> { /* Handled by UI navigation to emulation screen */ }
             GameDetailIntent.DeleteLocalGame -> deleteLocalGame()
@@ -607,6 +609,39 @@ class GameDetailViewModel(
                     }
                 },
             )
+        }
+    }
+
+    /**
+     * Resume a paused/resumably-failed download from its on-disk offset (#1296).
+     * Clears any error toast (the resume is the recovery) and reuses the same
+     * success/failure handling as a fresh download.
+     */
+    private fun resumeDownload() {
+        val gameId = currentGameId ?: return
+        _state.update { it.copy(isDownloading = true, error = null) }
+        scope.launch(dispatchers.io) {
+            downloadRepository.resumeDownload(gameId).fold(
+                onSuccess = {
+                    _state.update { it.copy(isGameCached = true, isDownloading = false) }
+                    currentGameId?.let { loadCheats(it) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message, isDownloading = false) }
+                },
+            )
+        }
+    }
+
+    /**
+     * Discard the partial and download the game over from scratch — the
+     * recovery for a terminal failure (corrupt/disk-full/changed file). (#1296)
+     */
+    private fun restartDownload() {
+        val gameId = currentGameId ?: return
+        scope.launch(dispatchers.io) {
+            downloadRepository.deleteLocalGame(gameId)
+            downloadGame()
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -26,6 +26,7 @@ import com.spela.player.presentation.state.GameDetailState
 import com.spela.player.util.DispatcherProvider
 import com.spela.player.util.pickDirectory
 import com.spela.player.util.revealInFileManager
+import com.spela.player.domain.model.DownloadState
 import com.spela.player.domain.model.GameDetail
 import com.spela.player.domain.model.INSTANT_DOWNLOAD_FALLBACK_DELAY_MS
 import com.spela.player.domain.model.INSTANT_DOWNLOAD_THRESHOLD_BYTES
@@ -398,7 +399,21 @@ class GameDetailViewModel(
 
         downloadObserveJob = scope.launch(dispatchers.io) {
             downloadRepository.observeDownload(gameId).collect { progress ->
-                _state.update { it.copy(downloadProgress = progress) }
+                // Reconcile the isDownloading latch from the observed state. A
+                // download paused/failed from another surface (e.g. the Downloads
+                // screen) cancels this VM's downloadGame coroutine, so its
+                // .fold(onFailure) — the usual place isDownloading clears — never
+                // runs; without this the CTA stays stuck on "Downloading…" and
+                // never flips to Resume / Start over. (#1296)
+                val settled = progress.state == DownloadState.PAUSED ||
+                    progress.state == DownloadState.FAILED ||
+                    progress.state == DownloadState.COMPLETED
+                _state.update {
+                    it.copy(
+                        downloadProgress = progress,
+                        isDownloading = if (settled) false else it.isDownloading,
+                    )
+                }
             }
         }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/FileStorage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/FileStorage.kt
@@ -35,6 +35,23 @@ interface FileStorage {
         path: String,
         writer: suspend (append: suspend (ByteArray, Int, Int) -> Unit) -> Unit,
     )
+
+    /**
+     * Like [writeFileStreaming] but APPENDS to the file at [path] instead of
+     * truncating it — the writer's bytes are written after the current end of
+     * file. Used to resume an interrupted download by continuing its `.part`
+     * file from the byte offset already on disk (#1296). Creates the file (and
+     * parent dirs) if absent, behaving like [writeFileStreaming] in that case.
+     *
+     * Default throws; only the production platform implementations
+     * (Desktop/Android) support real append. Test stubs that don't exercise
+     * resume can keep the default.
+     */
+    suspend fun appendFileStreaming(
+        path: String,
+        writer: suspend (append: suspend (ByteArray, Int, Int) -> Unit) -> Unit,
+    ): Unit = throw UnsupportedOperationException("appendFileStreaming not supported")
+
     suspend fun getFileSize(path: String): Long
     suspend fun listFiles(path: String): List<String>
     suspend fun isDirectory(path: String): Boolean

--- a/player/shared/src/commonMain/sqldelight/com/spela/player/SpelaDatabase.sq
+++ b/player/shared/src/commonMain/sqldelight/com/spela/player/SpelaDatabase.sq
@@ -46,6 +46,51 @@ DELETE FROM DownloadEntity WHERE game_id = ?;
 deleteAllDownloads:
 DELETE FROM DownloadEntity;
 
+-- Resumable partial downloads (#1296). One row per game whose download is
+-- interrupted/paused and can be resumed from its on-disk byte offset. The
+-- partial file lives at local_path; its current size IS the resume offset
+-- (no need to store byte counts — stat the file). validator is the server's
+-- ETag for If-Range so a changed file forces a clean restart. failure_reason
+-- is a DownloadFailureReason name (null = user-initiated pause). A completed
+-- download deletes its row here and inserts into DownloadEntity instead.
+CREATE TABLE PartialDownloadEntity (
+    game_id TEXT NOT NULL PRIMARY KEY,
+    game_title TEXT NOT NULL DEFAULT '',
+    file_name TEXT NOT NULL,
+    local_path TEXT NOT NULL,
+    expected_size INTEGER NOT NULL DEFAULT 0,
+    validator TEXT,
+    failure_reason TEXT,
+    updated_at INTEGER NOT NULL
+);
+
+insertPartialDownload:
+INSERT OR REPLACE INTO PartialDownloadEntity(game_id, game_title, file_name, local_path, expected_size, validator, failure_reason, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+
+getPartialDownload:
+SELECT * FROM PartialDownloadEntity WHERE game_id = ?;
+
+getAllPartialDownloads:
+SELECT * FROM PartialDownloadEntity;
+
+-- Record the server validator (ETag) + authoritative total once response
+-- headers arrive, so a later resume can send If-Range and show correct
+-- progress even if the very first attempt fails mid-stream.
+updatePartialDownloadHeaders:
+UPDATE PartialDownloadEntity SET validator = ?, expected_size = ?, updated_at = ? WHERE game_id = ?;
+
+-- Stamp why a kept partial stopped (resumable cause), without needing the
+-- rest of the row in scope at the failure site.
+updatePartialDownloadFailure:
+UPDATE PartialDownloadEntity SET failure_reason = ?, updated_at = ? WHERE game_id = ?;
+
+deletePartialDownload:
+DELETE FROM PartialDownloadEntity WHERE game_id = ?;
+
+deleteAllPartialDownloads:
+DELETE FROM PartialDownloadEntity;
+
 -- Auth tokens
 CREATE TABLE AuthTokenEntity (
     id INTEGER NOT NULL PRIMARY KEY DEFAULT 1,

--- a/player/shared/src/commonMain/sqldelight/com/spela/player/migrations/4.sqm
+++ b/player/shared/src/commonMain/sqldelight/com/spela/player/migrations/4.sqm
@@ -1,0 +1,13 @@
+-- Migration from schema version 4 to 5: add PartialDownloadEntity table so
+-- interrupted/paused game downloads survive process death and can be resumed
+-- from their on-disk byte offset instead of restarting from zero. See #1296.
+CREATE TABLE PartialDownloadEntity (
+    game_id TEXT NOT NULL PRIMARY KEY,
+    game_title TEXT NOT NULL DEFAULT '',
+    file_name TEXT NOT NULL,
+    local_path TEXT NOT NULL,
+    expected_size INTEGER NOT NULL DEFAULT 0,
+    validator TEXT,
+    failure_reason TEXT,
+    updated_at INTEGER NOT NULL
+);

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/platform/DesktopFileStorage.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/platform/DesktopFileStorage.kt
@@ -84,6 +84,20 @@ class DesktopFileStorage : FileStorage {
         }
     }
 
+    override suspend fun appendFileStreaming(
+        path: String,
+        writer: suspend (append: suspend (ByteArray, Int, Int) -> Unit) -> Unit,
+    ) = withContext(Dispatchers.IO) {
+        val file = File(path)
+        file.parentFile?.mkdirs()
+        // append = true: continue after the existing bytes on disk (resume), #1296.
+        java.io.FileOutputStream(file, true).use { fos ->
+            writer { bytes, offset, length ->
+                fos.write(bytes, offset, length)
+            }
+        }
+    }
+
     override suspend fun getFileSize(path: String): Long = File(path).length()
 
     override suspend fun listFiles(path: String): List<String> = withContext(Dispatchers.IO) {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/DownloadRepositoryResumeTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/DownloadRepositoryResumeTest.kt
@@ -1,0 +1,321 @@
+package com.spela.player.data.repository
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.spela.player.data.local.SpelaDatabase
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.interceptor.TokenManager
+import com.spela.player.domain.model.DownloadFailureReason
+import com.spela.player.domain.model.DownloadState
+import com.spela.player.util.FileStorage
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Resume-path tests for [DownloadRepositoryImpl] (#1296). Drives the real
+ * SpelaApiClient against a [FakeDownloadServer] (a MockEngine honouring
+ * Range/If-Range like the Go server) plus an in-memory [FileStorage] and
+ * SQLite, so the full client resume round-trip — Range request, 206 append,
+ * stale-validator restart, partial persistence/restore — is exercised
+ * without a device or backend. Server-side 206 correctness is covered
+ * separately by the Go TestDownloadGame_RangeRequests.
+ */
+class DownloadRepositoryResumeTest {
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var database: SpelaDatabase
+    private lateinit var fileStorage: ResumeInMemoryFileStorage
+    private lateinit var server: FakeDownloadServer
+    private lateinit var repo: DownloadRepositoryImpl
+
+    private val gameId = "4242"
+    private val fileName = "game.iso"
+    private fun pathFor(id: String) = "${fileStorage.getGamesDir()}/$id/$fileName"
+
+    @BeforeTest
+    fun setup() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        SpelaDatabase.Schema.create(driver)
+        database = SpelaDatabase(driver)
+        fileStorage = ResumeInMemoryFileStorage()
+        server = FakeDownloadServer(content = bytes(0, 60), etag = "\"v1\"")
+        val apiClient = SpelaApiClient(server.factory(), TokenManager())
+        apiClient.setBaseUrl("http://localhost")
+        repo = DownloadRepositoryImpl(apiClient, fileStorage, database)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    /** Seed a partial: the first [prefixLen] bytes on disk + a tracking row. */
+    private suspend fun seedPartial(id: String, prefixLen: Int, validator: String?, expectedSize: Long) {
+        val path = pathFor(id)
+        // Real getGamesDir() mkdirs(); the fake must register it too so the
+        // launch-time orphan sweep doesn't early-return on a "missing" dir.
+        fileStorage.createDirectory(fileStorage.getGamesDir())
+        fileStorage.createDirectory("${fileStorage.getGamesDir()}/$id")
+        fileStorage.writeFile(path, server.content.copyOfRange(0, prefixLen))
+        database.spelaDatabaseQueries.insertPartialDownload(
+            id, "Game $id", fileName, path, expectedSize, validator, null, 1_000L,
+        )
+    }
+
+    @Test
+    fun resumeAppendsFromOffsetAndProducesByteIdenticalFile() = runTest {
+        seedPartial(gameId, prefixLen = 20, validator = "\"v1\"", expectedSize = 60)
+
+        val result = repo.resumeDownload(gameId)
+
+        assertTrue(result.isSuccess, "resume should succeed: ${result.exceptionOrNull()}")
+        // Only the tail was requested — fewer bytes than a fresh download.
+        assertEquals("bytes=20-", server.lastRange, "resume must Range-request from the on-disk offset")
+        assertEquals("\"v1\"", server.lastIfRange, "resume must guard with the stored validator")
+        // The on-disk file is byte-identical to a full download.
+        assertEquals(server.content.toList(), fileStorage.readFile(pathFor(gameId)).toList())
+        // Completion bookkeeping: partial row cleared, completed row written.
+        assertNull(database.spelaDatabaseQueries.getPartialDownload(gameId).executeAsOneOrNull())
+        assertTrue(database.spelaDatabaseQueries.getDownload(gameId).executeAsOneOrNull() != null)
+        assertEquals(DownloadState.COMPLETED, repo.observeDownload(gameId).first().state)
+    }
+
+    @Test
+    fun resumeWithStaleValidatorRestartsCleanlyInsteadOfSplicing() = runTest {
+        // Partial holds 20 bytes of the OLD file; the server now has different
+        // content under a new validator.
+        seedPartial(gameId, prefixLen = 20, validator = "\"old\"", expectedSize = 60)
+        server.content = bytes(100, 50) // different bytes AND a different length
+        server.etag = "\"v2\""
+
+        val result = repo.resumeDownload(gameId)
+
+        assertTrue(result.isSuccess, "stale-validator resume should still complete via a full restart")
+        // The file is the NEW content in full — never the stale prefix spliced
+        // onto fresh bytes.
+        assertEquals(server.content.toList(), fileStorage.readFile(pathFor(gameId)).toList())
+        assertEquals(50, fileStorage.getFileSize(pathFor(gameId)))
+        assertEquals(DownloadState.COMPLETED, repo.observeDownload(gameId).first().state)
+    }
+
+    @Test
+    fun pausedPartialIsRestoredOnLaunchAndProtectedFromOrphanSweep() = runTest {
+        seedPartial(gameId, prefixLen = 25, validator = "\"v1\"", expectedSize = 60)
+        // An unrelated orphan (no rows) should still be swept.
+        val orphan = "${fileStorage.getGamesDir()}/9999"
+        fileStorage.createDirectory(orphan)
+        fileStorage.writeFile("$orphan/junk.bin", byteArrayOf(1))
+
+        // Fresh repo instance = an app restart; nothing in memory yet.
+        val freshRepo = DownloadRepositoryImpl(
+            SpelaApiClient(server.factory(), TokenManager()).also { it.setBaseUrl("http://localhost") },
+            fileStorage,
+            database,
+        )
+        freshRepo.scanForOrphanedDownloads()
+
+        val restored = freshRepo.observeDownload(gameId).first()
+        assertEquals(DownloadState.PAUSED, restored.state, "partial must come back as resumable after restart")
+        assertEquals(25L, restored.bytesDownloaded, "restored progress reflects bytes on disk")
+        assertEquals(60L, restored.totalBytes)
+        // Partial dir survived; the true orphan was removed.
+        assertTrue(fileStorage.fileExists(pathFor(gameId)), "partial file must survive the orphan sweep")
+        assertTrue("9999" !in fileStorage.listFiles(fileStorage.getGamesDir()), "real orphan still swept")
+    }
+
+    @Test
+    fun partialDownloadIsNotResolvedAsPlayableUntilComplete() = runTest {
+        seedPartial(gameId, prefixLen = 20, validator = "\"v1\"", expectedSize = 60)
+        // Incomplete: never report it as a cached/playable game.
+        assertNull(repo.getLocalGamePath(gameId))
+        assertTrue(!repo.isGameCached(gameId))
+
+        repo.resumeDownload(gameId)
+
+        // After completion the partial row is gone, so it resolves normally.
+        assertEquals(pathFor(gameId), repo.getLocalGamePath(gameId))
+        assertTrue(repo.isGameCached(gameId))
+    }
+
+    @Test
+    fun multiplePartialsResumeIndependently() = runTest {
+        val other = "777"
+        seedPartial(gameId, prefixLen = 10, validator = "\"v1\"", expectedSize = 60)
+        seedPartial(other, prefixLen = 40, validator = "\"v1\"", expectedSize = 60)
+
+        val result = repo.resumeDownload(gameId)
+
+        assertTrue(result.isSuccess)
+        assertEquals(server.content.toList(), fileStorage.readFile(pathFor(gameId)).toList())
+        // The untouched partial is still pending and still on disk.
+        assertTrue(database.spelaDatabaseQueries.getPartialDownload(other).executeAsOneOrNull() != null)
+        assertEquals(40, fileStorage.getFileSize(pathFor(other)))
+    }
+
+    @Test
+    fun resumeWithoutAPartialRecordFailsCleanly() = runTest {
+        val result = repo.resumeDownload("does-not-exist")
+        assertTrue(result.isFailure, "resume with no partial record must fail, not crash")
+    }
+
+    @Test
+    fun terminalDiskFullFailureDiscardsPartialAndSurfacesReason() = runTest {
+        seedPartial(gameId, prefixLen = 20, validator = "\"v1\"", expectedSize = 60)
+        fileStorage.failAppendWith = RuntimeException("write failed: ENOSPC no space left on device")
+
+        val result = repo.resumeDownload(gameId)
+
+        assertTrue(result.isFailure)
+        val progress = repo.observeDownload(gameId).first()
+        assertEquals(DownloadState.FAILED, progress.state)
+        assertEquals(DownloadFailureReason.DISK_FULL, progress.failureReason)
+        // Terminal failure discards the partial so a restart is clean.
+        assertNull(database.spelaDatabaseQueries.getPartialDownload(gameId).executeAsOneOrNull())
+    }
+
+    private fun bytes(start: Int, count: Int): ByteArray = ByteArray(count) { (start + it).toByte() }
+}
+
+/**
+ * A MockEngine standing in for the Go download endpoint: serves the full file
+ * (200) or a 206 tail for a `Range: bytes=N-` request, and falls back to a
+ * full 200 when an `If-Range` validator is stale — matching the server.
+ */
+private class FakeDownloadServer(var content: ByteArray, var etag: String) {
+    var lastRange: String? = null
+    var lastIfRange: String? = null
+
+    fun factory(): HttpClientEngineFactory<MockEngineConfig> =
+        object : HttpClientEngineFactory<MockEngineConfig> {
+            override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine =
+                MockEngine(MockEngineConfig().apply {
+                    addHandler { request ->
+                        val range = request.headers[HttpHeaders.Range]
+                        val ifRange = request.headers[HttpHeaders.IfRange]
+                        lastRange = range
+                        lastIfRange = ifRange
+                        val size = content.size
+                        val start = range
+                            ?.removePrefix("bytes=")?.substringBefore('-')?.toIntOrNull()
+                        val stale = ifRange != null && ifRange != etag
+                        when {
+                            start == null || stale -> respond(
+                                content,
+                                HttpStatusCode.OK,
+                                headersOf(
+                                    HttpHeaders.ETag to listOf(etag),
+                                    HttpHeaders.AcceptRanges to listOf("bytes"),
+                                    // The real server always sets Content-Length;
+                                    // MockEngine won't for a ByteArray, so be explicit.
+                                    HttpHeaders.ContentLength to listOf(size.toString()),
+                                ),
+                            )
+                            start in 0..size -> respond(
+                                content.copyOfRange(start, size),
+                                HttpStatusCode.PartialContent,
+                                headersOf(
+                                    HttpHeaders.ETag to listOf(etag),
+                                    HttpHeaders.AcceptRanges to listOf("bytes"),
+                                    HttpHeaders.ContentRange to listOf("bytes $start-${size - 1}/$size"),
+                                    HttpHeaders.ContentLength to listOf((size - start).toString()),
+                                ),
+                            )
+                            else -> respond(ByteArray(0), HttpStatusCode.RequestedRangeNotSatisfiable)
+                        }
+                    }
+                    block()
+                })
+        }
+}
+
+/** In-memory [FileStorage] with real append semantics for the resume tests. */
+private class ResumeInMemoryFileStorage : FileStorage {
+    private val files = mutableMapOf<String, ByteArray>()
+    private val dirs = mutableSetOf<String>()
+
+    /** When set, the next append throws this — simulates a disk/IO failure. */
+    var failAppendWith: Throwable? = null
+
+    override fun getGamesDir(): String = "/test/games"
+    override fun getCoresDir(): String = "/test/cores"
+    override fun getSavesDir(): String = "/test/saves"
+    override fun getBiosDir(): String = "/test/bios"
+
+    override suspend fun createDirectory(path: String) { dirs.add(path) }
+
+    override suspend fun writeFile(path: String, data: ByteArray) {
+        files[path] = data
+        val parent = path.substringBeforeLast('/', "")
+        if (parent.isNotEmpty()) dirs.add(parent)
+    }
+
+    override suspend fun readFile(path: String): ByteArray = files[path] ?: byteArrayOf()
+    override suspend fun fileExists(path: String): Boolean = path in dirs || path in files
+
+    override suspend fun deleteFile(path: String) { files.remove(path) }
+
+    override suspend fun deleteDirectory(path: String) {
+        dirs.remove(path)
+        val prefix = "$path/"
+        files.keys.filter { it.startsWith(prefix) }.forEach { files.remove(it) }
+        dirs.removeAll { it.startsWith(prefix) }
+    }
+
+    override suspend fun getDirectorySize(path: String): Long =
+        files.entries.filter { it.key.startsWith("$path/") }.sumOf { it.value.size.toLong() }
+
+    override suspend fun writeFileStreaming(
+        path: String,
+        writer: suspend (append: suspend (ByteArray, Int, Int) -> Unit) -> Unit,
+    ) {
+        val buf = ArrayList<Byte>()
+        writer { data, offset, length -> for (i in 0 until length) buf.add(data[offset + i]) }
+        files[path] = buf.toByteArray()
+        val parent = path.substringBeforeLast('/', "")
+        if (parent.isNotEmpty()) dirs.add(parent)
+    }
+
+    override suspend fun appendFileStreaming(
+        path: String,
+        writer: suspend (append: suspend (ByteArray, Int, Int) -> Unit) -> Unit,
+    ) {
+        val buf = ArrayList<Byte>().apply { files[path]?.forEach { add(it) } }
+        writer { data, offset, length ->
+            failAppendWith?.let { throw it }
+            for (i in 0 until length) buf.add(data[offset + i])
+        }
+        files[path] = buf.toByteArray()
+    }
+
+    override suspend fun getFileSize(path: String): Long = files[path]?.size?.toLong() ?: 0L
+
+    override suspend fun listFiles(path: String): List<String> {
+        val prefix = "$path/"
+        val direct = mutableSetOf<String>()
+        for (f in files.keys) if (f.startsWith(prefix)) direct.add(f.removePrefix(prefix).substringBefore('/'))
+        for (d in dirs) if (d.startsWith(prefix)) direct.add(d.removePrefix(prefix).substringBefore('/'))
+        return direct.toList()
+    }
+
+    override suspend fun isDirectory(path: String): Boolean = path in dirs
+
+    override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
+    override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+    override suspend fun extractFirstZipEntryFromFile(zipPath: String, destPath: String) {}
+    override suspend fun tarDirectoryToFile(dirPath: String, destPath: String): Long = 0L
+    override suspend fun extractTarFile(tarPath: String, destDir: String) {}
+    override suspend fun sha256File(path: String): String? = null
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/DownloadRepositoryResumeTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/DownloadRepositoryResumeTest.kt
@@ -172,6 +172,24 @@ class DownloadRepositoryResumeTest {
     }
 
     @Test
+    fun resumableNetworkFailureKeepsPartialAndMarksPaused() = runTest {
+        seedPartial(gameId, prefixLen = 20, validator = "\"v1\"", expectedSize = 60)
+        fileStorage.failAppendWith = RuntimeException("connection reset by peer")
+
+        val result = repo.resumeDownload(gameId)
+
+        assertTrue(result.isFailure)
+        val progress = repo.observeDownload(gameId).first()
+        assertEquals(DownloadState.PAUSED, progress.state, "a transient network failure stays resumable")
+        assertEquals(DownloadFailureReason.NETWORK, progress.failureReason)
+        // Partial KEPT so the user can resume again.
+        assertTrue(
+            database.spelaDatabaseQueries.getPartialDownload(gameId).executeAsOneOrNull() != null,
+            "a resumable failure must keep the partial record",
+        )
+    }
+
+    @Test
     fun terminalDiskFullFailureDiscardsPartialAndSurfacesReason() = runTest {
         seedPartial(gameId, prefixLen = 20, validator = "\"v1\"", expectedSize = 60)
         fileStorage.failAppendWith = RuntimeException("write failed: ENOSPC no space left on device")


### PR DESCRIPTION
Client half of #1296. The server half (HTTP Range + 206/If-Range + the real write-deadline fix) merged in #1300 and shipped in v0.0.253.

A download interrupted by a wifi drop, a server cut, a user pause, or process death now leaves a **resumable partial** instead of a dead-end error toast. Resume continues from the bytes already on disk — a 4 GB download that dies at 95% continues from 95%, not 0%.

## Engine
- **Stream resume** (`SpelaApiClient.downloadGameToFile`): sends `Range: bytes=N-` + `If-Range`, **appends on 206**, **restarts from scratch on 200** (server says the file changed) so a stale partial is never spliced. Captures the `ETag` the moment headers arrive, so a mid-stream failure still leaves a usable validator. New `FileStorage.appendFileStreaming` (Desktop + Android).
- **Partial persistence** (`PartialDownloadEntity`, SQLDelight migration `4.sqm`): one row per interrupted download — path, validator, expected size, failure reason — written at download **start** so a hard process kill is still resumable. Cleared on completion/removal.
- **`DownloadRepositoryImpl`**: `resumeDownload()`; a shared failure handler that **keeps** the partial + marks `PAUSED` for resumable causes (network/server) and **discards** it + marks `FAILED` for terminal ones (corrupt/disk-full). Gated so paths that never write a partial (multi-disc/tar) surface "Start over", not a broken Resume. `cancelDownload` now **pauses** (keeps the partial); `getLocalGamePath` treats a partial as not-yet-playable; `scanForOrphanedDownloads` restores `PAUSED` on launch and protects partial dirs from the orphan sweep (#845).

## Model
- `DownloadState.PAUSED` + `DownloadFailureReason` (resumable vs terminal) + `DownloadProgress.failureReason`/`isResumable`.

## UI
- **Game-detail CTA state machine**: Download → **Resume N%** (overflow: Start over / Remove download) → Start over (terminal). The hero shows the amber paused progress bar so the Resume CTA has a visual anchor.
- **Error toast** carries a **Resume** action on a resumable failure instead of a dead-end Dismiss.
- **Downloads view**: Paused/Failed rows with state-aware copy and Resume / Start over / Remove; `SpDownloadProgressBar` gains a paused (amber) variant; new `DownloadPaused` color token.

## Tests
`DownloadRepositoryResumeTest` (8): byte-identical resume from offset, stale-validator clean restart (no splicing), launch-time `PAUSED` restore + orphan-sweep protection, partial-not-playable gating, multi-game independence, no-record failure, resumable-NETWORK keeps partial, terminal disk-full discards. Full shared + desktop E2E suites green. Server-side 206 correctness is covered by the Go `TestDownloadGame_RangeRequests`.

## Review
code-reviewer + ui-agent reviewed (AGENTS.md gate); all HIGH + MEDIUM findings addressed in the second commit (dead-end-Resume gating, stuck `isDownloading`, paused-bar on hero, distinct paused color, file-changed progress reset, job-cancel-before-delete, 416-terminal, copy cleanups).

## Remaining (on-device follow-up)
Manual Android smoke on the AYN Thor — a real wifi-drop → Resume round-trip — when redeployed. The resume *logic* is covered by the desktop suite + the server Go Range test; this is the integration/network confirmation per the desktop-primary / Android-smoke strategy in CLAUDE.md.

Closes #1296