### PR TITLE
fix(n64): switch default N64 core to parallel_n64 (works on Windows)

### DIFF
--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -307,6 +307,36 @@ static bool environment_callback(unsigned cmd, void *data) {
                     }
                 }
 
+                /* parallel_n64 renderer selection. This core exposes its own
+                 * option keys ("parallel-n64-gfxplugin"/"parallel-n64-rspplugin"),
+                 * NOT mupen64plus_next's "rdp-plugin", so the block above never
+                 * fires for it. Same per-platform intent as mupen:
+                 * - macOS: Angrylion (software) — avoids GLideN64 GL compositing
+                 *   issues; only switched when the build advertises angrylion.
+                 * - Android: GLideN64 (GLES) — proven HW render path.
+                 * - Windows/Linux: leave default (gliden64) — confirmed working. */
+                {
+                    const struct retro_variable *v3 = (const struct retro_variable *)data;
+                    for (; v3->key; v3++) {
+                        if (v3->key && strstr(v3->key, "parallel-n64-gfxplugin")) {
+#ifdef __APPLE__
+                            if (strstr(v3->value, "angrylion")) {
+                                LOGI("parallel_n64 detected with Angrylion support, switching to software renderer on macOS");
+                                core_variables_set("parallel-n64-gfxplugin", "angrylion");
+                                core_variables_set("parallel-n64-rspplugin", "parallel");
+                            } else {
+                                LOGI("parallel_n64 detected but Angrylion NOT advertised; leaving GLideN64 default on macOS");
+                            }
+#elif defined(__ANDROID__)
+                            LOGI("parallel_n64 detected, selecting GLideN64 (GLES) renderer");
+                            core_variables_set("parallel-n64-gfxplugin", "gliden64");
+                            core_variables_set("parallel-n64-rspplugin", "hle");
+#endif
+                            break;
+                        }
+                    }
+                }
+
 #ifdef __ANDROID__
                 /* PSP (PPSSPP) backend selection on Android: force
                  * Vulkan to sidestep the Adreno EGL TLS bug

--- a/server/internal/cores/buildbot_test.go
+++ b/server/internal/cores/buildbot_test.go
@@ -32,6 +32,8 @@ func TestBuildbotURL_StandardConvention(t *testing.T) {
 			"https://buildbot.libretro.com/nightly/linux/aarch64/latest/nestopia_libretro.so.zip"},
 		{"windows x86_64", "mgba", "windows", "x86_64",
 			"https://buildbot.libretro.com/nightly/windows/x86_64/latest/mgba_libretro.dll.zip"},
+		{"windows x86_64 parallel_n64", "parallel_n64", "windows", "x86_64",
+			"https://buildbot.libretro.com/nightly/windows/x86_64/latest/parallel_n64_libretro.dll.zip"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -1053,7 +1053,7 @@ func SeedConsoles(db *gorm.DB) error {
 		{Name: "Philips CD-i", Abbreviation: "CDI", Extensions: ".chd,.cue,.iso", DefaultCore: "same_cdi", EmulatorJSCore: "same_cdi", FolderName: "cdi", ColorTheme: "#006633", Generation: 4, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		// 5th Generation
 		{Name: "PlayStation", Abbreviation: "PSX", Extensions: ".bin,.cue,.iso,.pbp,.m3u", DefaultCore: "beetle_psx_hw", EmulatorJSCore: "mednafen_psx_hw", FolderName: "psx", ColorTheme: "#003087", CoverAspect: "1:1", Generation: 5, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicyMedium, Playable: true},
-		{Name: "Nintendo 64", Abbreviation: "N64", Extensions: ".n64,.z64,.v64", DefaultCore: "mupen64plus_next", EmulatorJSCore: "mupen64plus_next", FolderName: "n64", ColorTheme: "#009e60", CoverAspect: "10:7", Generation: 5, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicyMedium, Playable: true},
+		{Name: "Nintendo 64", Abbreviation: "N64", Extensions: ".n64,.z64,.v64", DefaultCore: "parallel_n64", EmulatorJSCore: "mupen64plus_next", FolderName: "n64", ColorTheme: "#009e60", CoverAspect: "10:7", Generation: 5, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicyMedium, Playable: true},
 		{Name: "Sega Saturn", Abbreviation: "SAT", Extensions: ".iso,.bin,.cue,.chd,.m3u", DefaultCore: "yabause", EmulatorJSCore: "yabause", FolderName: "saturn", ColorTheme: "#0a4da2", Generation: 5, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicyMedium, Playable: true},
 		{Name: "Game Boy Color", Abbreviation: "GBC", Extensions: ".gbc", DefaultCore: "gambatte", EmulatorJSCore: "gambatte", FolderName: "gbc", ColorTheme: "#6638a8", CoverAspect: "7:8", Generation: 5, SaveStateSupport: true, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
 		{Name: "Atari Jaguar", Abbreviation: "JAG", Extensions: ".j64,.jag", DefaultCore: "virtualjaguar", EmulatorJSCore: "virtualjaguar", FolderName: "atarijaguar", ColorTheme: "#8b4513", Generation: 5, SaveStateSupport: false, SaveStatePolicy: SaveStatePolicySmall, Playable: true},
@@ -1236,6 +1236,7 @@ func SeedCores(db *gorm.DB) error {
 		{Name: "gambatte", DisplayName: "Gambatte", Description: "Game Boy / Game Boy Color emulator", Platforms: "windows,linux,macos,android"},
 		{Name: "mgba", DisplayName: "mGBA", Description: "Game Boy Advance emulator", Platforms: "windows,linux,macos,android"},
 		{Name: "mupen64plus_next", DisplayName: "Mupen64Plus-Next", Description: "Nintendo 64 emulator", Platforms: "windows,linux,macos,android"},
+		{Name: "parallel_n64", DisplayName: "ParaLLEl N64", Description: "Nintendo 64 emulator (default native core)", Platforms: "windows,linux,macos,android"},
 		{Name: "genesis_plus_gx", DisplayName: "Genesis Plus GX", Description: "Sega 8/16-bit emulator", Platforms: "windows,linux,macos,android"},
 		{Name: "genesis_plus_gx_wide", DisplayName: "Genesis Plus GX Wide", Description: "Sega 8/16-bit emulator (widescreen)", Platforms: "windows,linux,macos,android"},
 		{Name: "picodrive", DisplayName: "PicoDrive", Description: "Sega 8/16-bit + Sega CD/32X emulator", Platforms: "windows,linux,macos,android"},


### PR DESCRIPTION
## What

Switch the default N64 core from **mupen64plus_next** to **parallel_n64** so N64 games work on Windows.

## Why

mupen64plus_next crashes on Windows on the **first `retro_run`** (in `plugin_start_gfx`, write to null+`0x1e18`) before frame 1. A full investigation ruled out every config lever:

| Hypothesis | Result |
|---|---|
| Renderer | Crashes with GLideN64 (GL), paraLLEl-RDP (Vulkan), **and Angrylion (software)** → not the renderer |
| CPU core | Crashes with dynarec, cached, **and pure interpreter** → not the recompiler |
| GL profile/version | Confirmed core 3.2 **and** compat 4.6 contexts — both crash → not context creation |
| `get_proc_address` | Only optional GLES/OES extensions unresolved; fixing them didn't help |
| #1237-style env collision | mupen sends **zero** experimental commands → no masking collision |

It's an environment-sensitive null pointer that only manifests in our Windows frontend — fixable only with a symbolized mupen build under a watchpoint (a separate native-debugging project).

**parallel_n64 runs cleanly on Windows** (locked 60 fps, no crash) and has buildbot binaries for **all four platforms we support** (windows, linux, macos, android). Per the maintainer: "I really don't care which N64 core we use, as long as it is good with great compatibility and supports all our platforms."

## Changes

**Server** (`server/internal/db/database.go`)
- N64 console `DefaultCore`: `mupen64plus_next` → `parallel_n64` (native player only). `EmulatorJSCore` stays `mupen64plus_next` (web/EmulatorJS has no parallel_n64 build).
- Register `parallel_n64` in the core registry (`Platforms: windows,linux,macos,android`).
- `SeedConsoles` upserts `DefaultCore` and `SeedCores` create-on-missing, so **deployed DBs update on restart — no migration needed**. The buildbot poller reads cores from the DB, so parallel_n64 gets fingerprinted automatically.

**Native bridge** (`player/native/src/libretro_bridge.c`)
- parallel_n64 uses its own option keys (`parallel-n64-gfxplugin`/`-rspplugin`), **not** mupen's `rdp-plugin`, so the existing per-platform N64 block never fires for it. Added a parallel block with the same per-platform intent:
  - **macOS** → Angrylion (only when the build advertises it) — avoids the known GLideN64 GL compositing issue.
  - **Android** → GLideN64 (GLES) — proven HW path.
  - **Windows/Linux** → leave the default (gliden64) — confirmed working on Windows.

**Test** (`server/internal/cores/buildbot_test.go`)
- Regression anchor for the parallel_n64 Windows buildbot URL.

## Verification

- ✅ Native lib compiles cleanly on Windows MSVC (`spela-libretro.dll` links).
- ✅ `go test ./internal/cores/` passes (incl. new parallel_n64 URL case).
- ✅ parallel_n64 confirmed running in-app on Windows (60 fps, no crash). The bridge change is Windows-inert (override branches are macOS/Android `#ifdef`s).
- ⚠️ **macOS / Linux / Android**: use their default/override path and should get a quick verification pass on real hardware. Windows-ARM has no buildbot N64 binary (a separate, pre-existing buildbot gap affecting all cores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
