### PR TITLE
fix(activity): stop play-time heartbeat from flooding the activity feed (683 pages of dupes)

### DIFF
--- a/server/internal/api/game_handler_test.go
+++ b/server/internal/api/game_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spela/server/internal/db"
 	"github.com/stretchr/testify/assert"
@@ -210,6 +211,98 @@ func TestUpdatePlayTime_CreatesPlayHistory(t *testing.T) {
 	require.NoError(t, err, "PlayHistory should be created after UpdatePlayTime")
 	assert.Equal(t, int64(60), ph.PlayTime)
 	assert.False(t, ph.LastPlayed.IsZero(), "LastPlayed should be set")
+}
+
+// postPlayTime is a small helper that POSTs a play-time heartbeat for the
+// given game and asserts it succeeds.
+func postPlayTime(t *testing.T, router http.Handler, token, gameID string, seconds int64) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]interface{}{"seconds": seconds})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/games/"+gameID+"/play-time", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestUpdatePlayTime_HeartbeatsCreateSingleStartedPlayingEvent reproduces the
+// activity-feed flood: the player's PresenceService calls POST /play-time as a
+// 30s heartbeat for the whole session (initial 0s ping + one per interval +
+// final flush). Each call must NOT spawn its own "started_playing" event —
+// otherwise a multi-hour session produces hundreds of identical feed rows.
+// A single continuous session must yield exactly ONE "started_playing" event.
+func TestUpdatePlayTime_HeartbeatsCreateSingleStartedPlayingEvent(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	var user db.User
+	require.NoError(t, database.Order("id DESC").First(&user).Error)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Heartbeat Game", FileName: "hb.nes", FilePath: "/tmp/hb.nes", FileSize: 100}
+	require.NoError(t, database.Create(&game).Error)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	// Simulate one session: an initial 0s ping plus several 30s heartbeats,
+	// all arriving back-to-back (well within the same session).
+	postPlayTime(t, router, token, gameID, 0)
+	for i := 0; i < 5; i++ {
+		postPlayTime(t, router, token, gameID, 30)
+	}
+
+	// Play time still accumulates across every heartbeat.
+	var ph db.PlayHistory
+	require.NoError(t, database.Where("user_id = ? AND game_id = ?", user.ID, game.ID).First(&ph).Error)
+	assert.Equal(t, int64(150), ph.PlayTime, "play time accumulates across heartbeats (5 x 30s)")
+
+	// But only ONE started_playing activity event for the whole session.
+	var count int64
+	database.Model(&db.ActivityEvent{}).
+		Where("user_id = ? AND game_id = ? AND event_type = ?", user.ID, game.ID, "started_playing").
+		Count(&count)
+	assert.Equal(t, int64(1), count, "a single play session must create exactly one started_playing event")
+}
+
+// TestUpdatePlayTime_NewSessionAfterGapEmitsNewEvent guards against the fix
+// being too aggressive: a genuinely new session — one that starts long after
+// the previous heartbeat — should still produce its own "started_playing"
+// event, so the feed reflects each distinct play session.
+func TestUpdatePlayTime_NewSessionAfterGapEmitsNewEvent(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	var user db.User
+	require.NoError(t, database.Order("id DESC").First(&user).Error)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Two Session Game", FileName: "ts.nes", FilePath: "/tmp/ts.nes", FileSize: 100}
+	require.NoError(t, database.Create(&game).Error)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	// Session 1.
+	postPlayTime(t, router, token, gameID, 30)
+
+	// Simulate the session ending: back-date the last heartbeat far enough
+	// that the next report is unambiguously a new session.
+	require.NoError(t, database.Model(&db.PlayHistory{}).
+		Where("user_id = ? AND game_id = ?", user.ID, game.ID).
+		Update("last_played", time.Now().Add(-2*time.Hour)).Error)
+
+	// Session 2.
+	postPlayTime(t, router, token, gameID, 30)
+
+	var count int64
+	database.Model(&db.ActivityEvent{}).
+		Where("user_id = ? AND game_id = ? AND event_type = ?", user.ID, game.ID, "started_playing").
+		Count(&count)
+	assert.Equal(t, int64(2), count, "two distinct sessions must create two started_playing events")
 }
 
 // TestDownloadGame_NormalizesINESHeader verifies that .nes ROMs with a

--- a/server/internal/api/huma_game.go
+++ b/server/internal/api/huma_game.go
@@ -770,7 +770,12 @@ func (h *GameHandler) HumaUpdatePlayTime(ctx context.Context, in *UpdateGamePlay
 
 	var ph db.PlayHistory
 	result := h.DB.Where("user_id = ? AND game_id = ?", uid, gid).First(&ph)
+	// Whether this report begins a new play session. A brand-new PlayHistory
+	// row is always a new session; an existing one only when the previous
+	// report was long enough ago (gap measured before LastPlayed is bumped).
+	newSession := false
 	if result.Error == gorm.ErrRecordNotFound {
+		newSession = true
 		ph = db.PlayHistory{
 			UserID:     uid,
 			GameID:     uint(gid),
@@ -781,6 +786,7 @@ func (h *GameHandler) HumaUpdatePlayTime(ctx context.Context, in *UpdateGamePlay
 			return nil, huma.Error500InternalServerError("failed to create play history")
 		}
 	} else {
+		newSession = time.Since(ph.LastPlayed) > db.StartedPlayingSessionGap
 		newTotal := ph.PlayTime + seconds
 		if newTotal > maxPlayTimeSeconds {
 			newTotal = maxPlayTimeSeconds
@@ -798,9 +804,13 @@ func (h *GameHandler) HumaUpdatePlayTime(ctx context.Context, in *UpdateGamePlay
 		h.Hub.SetUserGame(uid, uint(gid))
 	}
 
-	CreateActivityEvent(h.DB, h.Hub, uid, "started_playing", uint(gid), StartedPlayingMetadata{
-		Seconds: seconds,
-	})
+	// Only emit a feed event when a session actually starts — not on every
+	// heartbeat, which would flood the activity feed.
+	if newSession {
+		CreateActivityEvent(h.DB, h.Hub, uid, "started_playing", uint(gid), StartedPlayingMetadata{
+			Seconds: seconds,
+		})
+	}
 
 	return &UpdateGamePlayTimeOutput{
 		Body: UpdateGamePlayTimeResponse{

--- a/server/internal/db/activity_event_dedup_test.go
+++ b/server/internal/db/activity_event_dedup_test.go
@@ -1,0 +1,85 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDedupeStartedPlayingEvents verifies the one-time cleanup that collapses
+// the historical "started_playing" flood (one event per 30s heartbeat) down to
+// one event per play session, while leaving other event types and other games
+// untouched — and that it is idempotent (re-running changes nothing).
+func TestDedupeStartedPlayingEvents(t *testing.T) {
+	database := setupTestDB(t)
+
+	user := User{Username: "player", Email: "p@example.com", PasswordHash: "x", Role: RoleUser}
+	require.NoError(t, database.Create(&user).Error)
+	console := seedNESConsole(t, database)
+	gameA := Game{ConsoleID: console.ID, Title: "Game A", FileName: "a.nes", FilePath: "/tmp/a.nes", FileSize: 1}
+	gameB := Game{ConsoleID: console.ID, Title: "Game B", FileName: "b.nes", FilePath: "/tmp/b.nes", FileSize: 1}
+	require.NoError(t, database.Create(&gameA).Error)
+	require.NoError(t, database.Create(&gameB).Error)
+
+	mk := func(eventType string, gameID *uint, at time.Time) {
+		require.NoError(t, database.Create(&ActivityEvent{
+			UserID:    user.ID,
+			EventType: eventType,
+			GameID:    gameID,
+			CreatedAt: at,
+		}).Error)
+	}
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Game A, session 1: 6 dense heartbeats 30s apart (the flood).
+	for i := 0; i < 6; i++ {
+		mk("started_playing", &gameA.ID, base.Add(time.Duration(i)*30*time.Second))
+	}
+	// Game A, session 2: a new session two hours later, 3 more heartbeats.
+	s2 := base.Add(2 * time.Hour)
+	for i := 0; i < 3; i++ {
+		mk("started_playing", &gameA.ID, s2.Add(time.Duration(i)*30*time.Second))
+	}
+
+	// A different game's session — must be collapsed independently, not merged.
+	mk("started_playing", &gameB.ID, base.Add(10*time.Second))
+	mk("started_playing", &gameB.ID, base.Add(40*time.Second))
+
+	// A non-started_playing event — must never be touched.
+	mk("favorited_game", &gameA.ID, base.Add(45*time.Second))
+
+	countSP := func(gameID uint) int64 {
+		var c int64
+		database.Model(&ActivityEvent{}).
+			Where("event_type = ? AND game_id = ?", "started_playing", gameID).Count(&c)
+		return c
+	}
+	countType := func(eventType string) int64 {
+		var c int64
+		database.Model(&ActivityEvent{}).Where("event_type = ?", eventType).Count(&c)
+		return c
+	}
+
+	require.NoError(t, dedupeStartedPlayingEvents(database))
+
+	// Game A collapses to one event per session (2), Game B to one (1).
+	assert.Equal(t, int64(2), countSP(gameA.ID), "game A: one started_playing per session")
+	assert.Equal(t, int64(1), countSP(gameB.ID), "game B: one started_playing for its single session")
+	assert.Equal(t, int64(1), countType("favorited_game"), "non-play events untouched")
+
+	// The survivors are the earliest event of each session.
+	var survivors []ActivityEvent
+	require.NoError(t, database.Where("event_type = ? AND game_id = ?", "started_playing", gameA.ID).
+		Order("created_at").Find(&survivors).Error)
+	require.Len(t, survivors, 2)
+	assert.True(t, survivors[0].CreatedAt.Equal(base), "session 1 keeps its first event")
+	assert.True(t, survivors[1].CreatedAt.Equal(s2), "session 2 keeps its first event")
+
+	// Idempotent: a second pass deletes nothing more.
+	require.NoError(t, dedupeStartedPlayingEvents(database))
+	assert.Equal(t, int64(2), countSP(gameA.ID), "idempotent for game A")
+	assert.Equal(t, int64(1), countSP(gameB.ID), "idempotent for game B")
+}

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -346,7 +347,79 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		}
 	}
 
+	// One-time cleanup: collapse the historical "started_playing" activity
+	// flood (the play-time handler used to emit one event per 30s heartbeat)
+	// down to one event per session. Idempotent — safe on every startup.
+	if err := dedupeStartedPlayingEvents(db); err != nil {
+		slog.Warn("started_playing activity dedupe failed", "error", err)
+	}
+
 	return db, nil
+}
+
+// StartedPlayingSessionGap is how long after the previous play-time report a
+// new report must arrive to count as a new play session. Shared by the
+// play-time handler (which emits a "started_playing" feed event only when a
+// session starts) and dedupeStartedPlayingEvents. The player heartbeats play
+// time every 30s, so this sits well above the heartbeat cadence and brief
+// pauses, but low enough that resuming after a real break reads as new.
+const StartedPlayingSessionGap = 10 * time.Minute
+
+// dedupeStartedPlayingEvents collapses historical "started_playing" activity
+// events down to one per play session. Before the heartbeat fix, every 30s
+// play-time report created its own event, flooding the activity feed with
+// hundreds of identical rows per session. Two events for the same
+// (user, game) within StartedPlayingSessionGap of each other belong to the
+// same session; only the first is kept. Idempotent: once collapsed, the
+// survivors are more than a gap apart, so a second run deletes nothing.
+func dedupeStartedPlayingEvents(database *gorm.DB) error {
+	type evRow struct {
+		ID        uint
+		UserID    uint
+		GameID    *uint
+		CreatedAt time.Time
+	}
+	var rows []evRow
+	if err := database.Model(&ActivityEvent{}).
+		Where("event_type = ? AND game_id IS NOT NULL", "started_playing").
+		Order("user_id, game_id, created_at").
+		Find(&rows).Error; err != nil {
+		return err
+	}
+
+	type sessionKey struct {
+		userID uint
+		gameID uint
+	}
+	lastSeen := make(map[sessionKey]time.Time)
+	var toDelete []uint
+	for _, r := range rows {
+		k := sessionKey{r.UserID, *r.GameID}
+		// A report within the gap of the previous one for the same game is a
+		// continuation heartbeat, not a new session — drop it.
+		if prev, ok := lastSeen[k]; ok && r.CreatedAt.Sub(prev) <= StartedPlayingSessionGap {
+			toDelete = append(toDelete, r.ID)
+		}
+		lastSeen[k] = r.CreatedAt
+	}
+	if len(toDelete) == 0 {
+		return nil
+	}
+
+	// Hard-delete (Unscoped) in batches to stay under SQLite's bound-parameter
+	// limit on deployments with a large backlog.
+	const batchSize = 500
+	for i := 0; i < len(toDelete); i += batchSize {
+		end := i + batchSize
+		if end > len(toDelete) {
+			end = len(toDelete)
+		}
+		if err := database.Unscoped().Where("id IN ?", toDelete[i:end]).
+			Delete(&ActivityEvent{}).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // MigrateToRelativePaths converts absolute game file paths to relative paths.


### PR DESCRIPTION
## Problem

The activity feed is flooded with duplicate **"started playing"** events — the deployed server had **683 pages**. One play session produced dozens-to-hundreds of identical `started_playing` rows (same user, same game, ~same timestamp).

## Root cause

`POST /api/games/{id}/play-time` (`GameHandler.HumaUpdatePlayTime`) created a `started_playing` `ActivityEvent` on **every** call. But that endpoint isn't a one-shot — it's the player's **presence heartbeat** (`PresenceService`): an initial 0s ping, one report per `HEARTBEAT_INTERVAL_MS = 30s` of active play, and a final flush. So each session emitted `1 + N + 1` events.

## Fix

1. **Gate the event on session start.** `HumaUpdatePlayTime` now emits `started_playing` only when the report begins a *new* session — detected by the gap since the previous heartbeat (`> StartedPlayingSessionGap = 10m`), measured before `LastPlayed` is bumped. Play time still accumulates on every heartbeat.
2. **One-time idempotent cleanup.** `dedupeStartedPlayingEvents` (runs at startup, alongside the existing backfills) collapses the historical flood down to one event per session — leaving other event types and other games untouched. Survivors end up more than a gap apart, so a second run deletes nothing (`f(f(x)) = f(x)`).
3. Shared `StartedPlayingSessionGap` constant lives in the `db` package (lower layer); the api handler reuses it.

## Tests (failing-first, then green)

- `TestUpdatePlayTime_HeartbeatsCreateSingleStartedPlayingEvent` — one session of 6 heartbeats: **6 events before the fix, 1 after**.
- `TestUpdatePlayTime_NewSessionAfterGapEmitsNewEvent` — two genuinely separate sessions still produce 2 events.
- `TestDedupeStartedPlayingEvents` — flood collapses to one-per-session, `favorited_game` and a second game untouched, idempotent on re-run.

Full server suite (`go test ./...`) green locally (CGO/SQLite, 15 packages).

Closes #1305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
