### PR TITLE
fix(web): cap Modal height at the viewport and scroll the body (#1290)

### DIFF
--- a/web/src/components/ui/modal.test.tsx
+++ b/web/src/components/ui/modal.test.tsx
@@ -53,4 +53,37 @@ describe("Modal", () => {
     await userEvent.click(closeButton);
     expect(onClose).toHaveBeenCalledOnce();
   });
+
+  it("caps height at the viewport and scrolls the body, keeping the header pinned (#1290)", () => {
+    render(
+      <Modal open onClose={vi.fn()} title="Devices">
+        <div>device row</div>
+      </Modal>,
+    );
+    const dialog = screen.getByRole("dialog");
+    // Dialog is bounded to the viewport and laid out as a column.
+    expect(dialog.className).toContain("max-h-[calc(100vh-2rem)]");
+    expect(dialog.className).toContain("flex-col");
+
+    // Header doesn't shrink, so the title + close button stay reachable.
+    const header = dialog.querySelector("div.shrink-0");
+    expect(header).not.toBeNull();
+    expect(header).toHaveTextContent("Devices");
+
+    // The body scrolls internally instead of overflowing the viewport.
+    const body = screen.getByText("device row").parentElement;
+    expect(body?.className).toContain("overflow-y-auto");
+    expect(body?.className).toContain("min-h-0");
+  });
+
+  it("preserves the bodyClassName escape hatch alongside scroll handling", () => {
+    render(
+      <Modal open onClose={vi.fn()} title="Edge to edge" bodyClassName="p-0">
+        <div>flush content</div>
+      </Modal>,
+    );
+    const body = screen.getByText("flush content").parentElement;
+    expect(body?.className).toContain("p-0");
+    expect(body?.className).toContain("overflow-y-auto");
+  });
 });

--- a/web/src/components/ui/modal.tsx
+++ b/web/src/components/ui/modal.tsx
@@ -74,14 +74,17 @@ export function Modal({
         aria-modal="true"
         aria-label={title}
         className={cn(
-          "relative w-full rounded-2xl bg-surface-900 border border-surface-800 shadow-2xl",
+          // Cap the dialog at the viewport (the overlay's p-4 leaves 1rem of
+          // breathing room top/bottom) and lay it out as a column so the header
+          // stays pinned and only the body scrolls when content is tall. (#1290)
+          "relative flex w-full max-h-[calc(100vh-2rem)] flex-col rounded-2xl bg-surface-900 border border-surface-800 shadow-2xl",
           "animate-in fade-in zoom-in-95 duration-200",
           sizeStyles[size],
           className,
         )}
       >
         {title && (
-          <div className="flex items-center justify-between px-6 py-4 border-b border-surface-800">
+          <div className="flex shrink-0 items-center justify-between px-6 py-4 border-b border-surface-800">
             <h2 className="text-lg font-semibold text-surface-100">{title}</h2>
             <button
               onClick={onClose}
@@ -92,7 +95,10 @@ export function Modal({
             </button>
           </div>
         )}
-        <div className={bodyClassName}>{children}</div>
+        {/* min-h-0 lets this flex child shrink below its content height so
+            overflow-y-auto actually scrolls instead of pushing the dialog past
+            the viewport. (#1290) */}
+        <div className={cn("min-h-0 overflow-y-auto", bodyClassName)}>{children}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Problem
The shared `Modal` (`web/src/components/ui/modal.tsx`) had no max-height or overflow handling. A tall body — e.g. **Admin → Users → Devices** with a long device list — grew past the viewport with no scrollbar, so the header/close button and the top/bottom rows became unreachable.

## Fix
Lay the dialog out as a flex column capped at `max-h-[calc(100vh-2rem)]` (the overlay's `p-4` leaves 1rem top/bottom), keep the header `shrink-0` so it stays pinned, and give the body `overflow-y-auto min-h-0` so it scrolls internally. This fixes **every** modal, not just Devices. The `bodyClassName` escape hatch (`p-0`) is preserved for edge-to-edge content — no negative margins.

Short modals are unaffected (`max-h` is a ceiling they never hit; no `flex-1` forces growth), and the dialog stays vertically centered.

## Tests
Extended `modal.test.tsx` (+2 tests): locks in the height cap / column layout / pinned header / scrollable body, and verifies the `bodyClassName` override still merges with the scroll utilities. Full web suite green (1628 tests); `tsc` + `vite build` clean.

## Review
Combined code-reviewer + ui-agent pass (AGENTS.md gate): verdict **ship**, no blocking findings, all 25 `Modal` consumers surveyed — no regression risk. jsdom can't assert real scroll, so a Playwright E2E on the Devices modal is a noted optional follow-up.

Closes #1290