### PR TITLE
fix(ci): pre-install pinned NDK so desktop test runs don't trigger a flaky install (#1281)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,24 @@ jobs:
           key: player-gradle-${{ hashFiles('player/**/*.gradle*', 'player/gradle/libs.versions.toml') }}
           restore-keys: |
             player-gradle-
+      # The Gradle steps below are desktop-only, but Gradle configures the
+      # :android module too, and AGP resolves the pinned NDK at configuration
+      # time. Pre-install it (and the cmake the native build pins) explicitly
+      # with retries so AGP never triggers its own un-retried, flake-prone
+      # on-the-fly install — which broke the v0.0.251 release run. ubuntu-latest
+      # ships the SDK; setup-android just ensures sdkmanager is on PATH. (#1281)
+      - uses: android-actions/setup-android@v4
+        with:
+          packages: ''
+      - name: Pre-install pinned Android NDK + cmake
+        run: |
+          for i in 1 2 3; do
+            yes | sdkmanager --install "ndk;27.0.12077973" "cmake;3.22.1" && exit 0
+            echo "::warning::sdkmanager install attempt $i failed; retrying in 15s" >&2
+            sleep 15
+          done
+          echo "::error::NDK/cmake install failed after 3 attempts" >&2
+          exit 1
       - name: Run shared desktop tests
         run: ./gradlew :shared:desktopTest
       - name: Run detekt rules unit tests

--- a/player/android/build.gradle.kts
+++ b/player/android/build.gradle.kts
@@ -33,6 +33,14 @@ android {
     namespace = "com.spela.player.android"
     compileSdk = 35
 
+    // Pin the NDK explicitly instead of inheriting AGP's default. This is the
+    // same version AGP 8.13.2 defaults to (27.0.12077973), so it's behaviour-
+    // neutral — but pinning makes the version deterministic and, crucially,
+    // lets CI pre-install this exact NDK so configuring :android (which the
+    // desktop-only :shared:desktopTest + detekt jobs do) never triggers a
+    // flaky on-the-fly NDK install. See #1281 and the CI pre-install step.
+    ndkVersion = "27.0.12077973"
+
     sourceSets["main"].manifest.srcFile("src/main/AndroidManifest.xml")
     sourceSets["main"].java.srcDirs("src/main/java")
     sourceSets["main"].res.srcDirs("src/main/res")


### PR DESCRIPTION
## Problem
The **Player unit tests** job runs desktop-only Gradle tasks (`:shared:desktopTest`, detekt), but Gradle configures the `:android` module too, and AGP resolves the NDK at **configuration time**. With no NDK pre-installed on the runner, AGP did its own **un-retried, flake-prone on-the-fly install** (download/license/network) — which failed the **v0.0.251 release run** (`InstallFailedException: Install NDK (Side by side) 27.0.12077973 failed`) and needed a manual re-run.

## Fix
- **Pin `ndkVersion = "27.0.12077973"`** in `player/android/build.gradle.kts`. This is AGP 8.13.2's default, so it's **behaviour-neutral**, but makes the NDK version explicit/deterministic and lets CI install the exact match.
- **Add `android-actions/setup-android@v4` + a retryable `sdkmanager` pre-install** of `ndk;27.0.12077973` + `cmake;3.22.1` to the job, before the Gradle steps. AGP then always finds the NDK already present instead of installing it itself. (`setup-android` ensures `sdkmanager` is on PATH; ubuntu-latest already ships the SDK location — same approach as the existing `desktop-build`/`release` jobs, #1277.)

## Verification
- `ndkVersion` pin: `./gradlew :android:help` configures `:android` cleanly locally (NDK 27.0.12077973 resolves, no install).
- YAML validated.
- The CI run on this PR exercises the new step directly (the `pull_request` event runs the workflow from this branch) — green here = the pre-install works.

Closes #1281