### PR TITLE
fix(search): match multi-word queries with non-adjacent title words (#1310)

### DIFF
--- a/server/internal/api/huma_search_social.go
+++ b/server/internal/api/huma_search_social.go
@@ -137,9 +137,7 @@ func (h *SearchHandler) HumaSearch(ctx context.Context, in *SearchInput) (*Searc
 	escapedQuery := escapeLikePattern(query)
 	likePattern := "%" + escapedQuery + "%"
 
-	gamesLikePattern := "%" + escapeLikePattern(gameQuery) + "%"
-
-	games := h.searchGames(gamesLikePattern, limit, priorityAbbr)
+	games := h.searchGames(gameQuery, limit, priorityAbbr)
 	consoles := h.searchConsoles(likePattern, limit)
 	developers := h.searchDevelopers(likePattern, limit)
 	publishers := h.searchPublishers(likePattern, limit)

--- a/server/internal/api/search_handler.go
+++ b/server/internal/api/search_handler.go
@@ -163,11 +163,36 @@ func (h *SearchHandler) extractConsoleHint(query string) (cleanedQuery string, p
 	return cleaned, matched
 }
 
+// titleLikeClauses tokenizes a query on whitespace and returns an AND-ed
+// set of "<column> LIKE ?" fragments — one per token — alongside the
+// matching %...%-wrapped, escaped arguments. Requiring every token to
+// appear (rather than matching the whole query as one substring) lets a
+// multi-word query match titles where the words are non-adjacent, e.g.
+// "symphony night" → "Castlevania: Symphony of the Night". A single
+// token reduces to one fragment, preserving the original behavior.
+func titleLikeClauses(column, query string) (clause string, args []any) {
+	tokens := strings.Fields(query)
+	if len(tokens) == 0 {
+		tokens = []string{query}
+	}
+	fragments := make([]string, len(tokens))
+	args = make([]any, len(tokens))
+	for i, t := range tokens {
+		fragments[i] = column + " LIKE ?" + likeEscape
+		args[i] = "%" + escapeLikePattern(t) + "%"
+	}
+	return strings.Join(fragments, " AND "), args
+}
+
 // searchGames searches for games matching the query, excluding soft-deleted entries.
+//
+// The query is tokenized on whitespace and every token must appear in
+// the title (see [titleLikeClauses]), so multi-word queries match titles
+// whose words are non-adjacent.
 //
 // When priorityAbbr is non-empty, games on that console float to the top
 // of the result list without filtering out other consoles' results.
-func (h *SearchHandler) searchGames(likePattern string, limit int, priorityAbbr string) SearchCategoryResult[SearchGameResult] {
+func (h *SearchHandler) searchGames(gameQuery string, limit int, priorityAbbr string) SearchCategoryResult[SearchGameResult] {
 	type gameRow struct {
 		ID          uint
 		Title       string
@@ -179,12 +204,13 @@ func (h *SearchHandler) searchGames(likePattern string, limit int, priorityAbbr 
 		CoverAspect string
 	}
 
-	likeClause := "games.title LIKE ?" + likeEscape + " AND games.deleted_at IS NULL"
+	titleClause, titleArgs := titleLikeClauses("games.title", gameQuery)
+	likeClause := "(" + titleClause + ") AND games.deleted_at IS NULL"
 
 	var total int64
 	h.DB.Model(&db.Game{}).
 		Joins("JOIN consoles ON consoles.id = games.console_id").
-		Where(likeClause, likePattern).
+		Where(likeClause, titleArgs...).
 		Count(&total)
 
 	var rows []gameRow
@@ -192,7 +218,7 @@ func (h *SearchHandler) searchGames(likePattern string, limit int, priorityAbbr 
 		Table("games").
 		Select("games.id, games.title, games.cover_url, consoles.name as console_name, consoles.abbreviation as console_abbr, games.developer, games.genre, consoles.cover_aspect").
 		Joins("JOIN consoles ON consoles.id = games.console_id").
-		Where(likeClause, likePattern)
+		Where(likeClause, titleArgs...)
 
 	// Priority-console hint: matching console first, then alphabetical
 	// within each bucket. Implemented via a CASE expression on the

--- a/server/internal/api/search_handler_test.go
+++ b/server/internal/api/search_handler_test.go
@@ -501,6 +501,48 @@ func TestSearch_PlatformCodeHintDoesNotFilterOtherConsoles(t *testing.T) {
 		"NES hint must not filter out SNES + GBA results when no NES title matches")
 }
 
+// TestSearch_MultiWordNonAdjacent covers #1310: a multi-word query must
+// match a title where the query words appear with other words between
+// them. "symphony night" must match "Castlevania: Symphony of the
+// Night" — the old single-substring LIKE '%symphony night%' pattern
+// required the words to be adjacent and missed it.
+func TestSearch_MultiWordNonAdjacent(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+
+	var snes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snes).Error)
+
+	game := db.Game{ConsoleID: snes.ID, Title: "Castlevania: Symphony of the Night", FileName: "sotn.smc", FilePath: "/roms/snes/sotn.smc"}
+	require.NoError(t, database.Create(&game).Error)
+
+	code, resp := searchGet(t, router, token, "/api/search?q="+url.QueryEscape("symphony night"))
+	require.Equal(t, http.StatusOK, code)
+
+	require.Equal(t, 1, resp.Games.Total)
+	require.Len(t, resp.Games.Results, 1)
+	assert.Equal(t, "Castlevania: Symphony of the Night", resp.Games.Results[0].Title)
+}
+
+// TestSearch_MultiWordRequiresAllTokens asserts the AND semantics: every
+// query token must appear in the title. A query mixing a matching and a
+// non-matching token must not return the game.
+func TestSearch_MultiWordRequiresAllTokens(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+
+	var snes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snes).Error)
+
+	game := db.Game{ConsoleID: snes.ID, Title: "Castlevania: Symphony of the Night", FileName: "sotn.smc", FilePath: "/roms/snes/sotn.smc"}
+	require.NoError(t, database.Create(&game).Error)
+
+	// "symphony" matches but "zelda" does not — AND of tokens means no result.
+	code, resp := searchGet(t, router, token, "/api/search?q="+url.QueryEscape("symphony zelda"))
+	require.Equal(t, http.StatusOK, code)
+
+	assert.Equal(t, 0, resp.Games.Total)
+	assert.Empty(t, resp.Games.Results)
+}
+
 func TestSearch_LimitDefaultsAndBounds(t *testing.T) {
 	database, router, token := setupSearchEnv(t)
 


### PR DESCRIPTION
Fixes #1310.

## Problem
The global search (cmd+K palette) matched the whole query as a single `LIKE '%query%'` substring, so a multi-word query only matched titles where the words appeared **adjacent**. Typing `symphony night` missed **Castlevania: Symphony of the Night** because `of the` sits between the words.

## Fix
Tokenize the game-title query on whitespace and require **every token** to appear in the title — an AND of one `LIKE '%token%'` clause per token (`server/internal/api/search_handler.go`, new `titleLikeClauses` helper).

- Single-token queries reduce to one fragment → identical to the old behavior.
- Adjacent multi-word queries (`super mario`) are unaffected — both tokens still match.
- Only non-adjacent matches are newly included.
- Tokens are escaped (`escapeLikePattern`) and parameter-bound, same as before — no injection surface.

Backend-only change. The web palette (`search-palette.tsx` / `use-search.ts`) just calls `GET /api/search`, so this covers cmd+K with no frontend change.

## Tests (failing-first, then green)
- `TestSearch_MultiWordNonAdjacent` — `symphony night` → matches `Castlevania: Symphony of the Night` (this is the issue's requested regression test).
- `TestSearch_MultiWordRequiresAllTokens` — a matching + non-matching token returns nothing (AND semantics).

Full `internal/api` package passes (incl. the existing platform-code-hint tests); `go vet` and `go build ./...` clean.