### PR TITLE
fix(web): move console "Browse all games" CTA to the top, aligning with the player app (#1312)

### DIFF
--- a/AGENT_TEAM.md
+++ b/AGENT_TEAM.md
@@ -618,6 +618,15 @@ Sections within a screen must be ordered by relevance to the user:
 3. **Browse / Discovery** (Browse All Games button, genre filters)
 4. **Metadata** (developer info, stats) — least urgent
 
+**Carve-out — console detail screen "Browse all" CTA (#1312):** On the
+console detail screen, the "Browse all N games" CTA leads the content
+(directly under the hero banner, above Continue Playing) on **both** the
+player app and the web app, intentionally. The player app requires it
+first so it owns d-pad/default focus (`ConsoleScreen.kt`); the web app
+matches that placement for cross-client consistency
+(`console-detail-page.tsx`). This is a deliberate exception to the
+"Continue Playing first" rule for this one screen — do not "fix" it back.
+
 ### Design System Review Checklist (for UI Agent)
 
 Before approving any UI PR, verify:

--- a/web/src/pages/__tests__/console-detail-page.test.tsx
+++ b/web/src/pages/__tests__/console-detail-page.test.tsx
@@ -115,17 +115,36 @@ describe("ConsoleDetailPage", () => {
       expect(screen.getByText("100 games")).toBeInTheDocument();
     });
 
-    it("renders the terminal Browse-all CTA below the curated shelves (#1095)", () => {
-      // Pre-#1095 the Browse link lived in the banner's bottom-right
-      // corner with test ID `banner-browse-games`. The hero banner is
-      // now pure identity; the Browse-all CTA moves to a terminal
-      // "Library" section below the showcase shelves with the new
-      // test ID `browse-all-games-cta`.
+    it("renders the Browse-all CTA above the curated shelves, aligned with the player app (#1312)", () => {
+      // #1095 moved the Browse link out of the hero banner into a
+      // "Library" section. It originally lived at the *bottom*, below
+      // the showcase shelves. #1312 moves it to the *top* — directly
+      // under the hero banner, above the shelves — to match the player
+      // app's console screen (ConsoleScreen.kt), where "Browse all" is
+      // the first section under the banner.
+      mockUseConsoleShowcase.mockReturnValue({
+        data: {
+          console: makeConsole({ id: "snes", name: "Super Nintendo" }),
+          essentials: [],
+          launchGames: [],
+          hiddenGems: [],
+          recentlyPlayed: [makeGame({ id: "rp1", title: "Half-Played Game" })],
+          recentlyAdded: [],
+          topDevelopers: [],
+        },
+      });
       renderPage();
+
       const cta = screen.getByTestId("browse-all-games-cta");
       expect(cta).toBeInTheDocument();
       expect(cta).toHaveTextContent("Browse all 100 Super Nintendo games");
       expect(cta).toHaveAttribute("href", "/consoles/snes/games");
+
+      // The CTA must render before the first curated shelf in DOM order.
+      const shelf = screen.getByTestId("recently-played-section");
+      expect(
+        cta.compareDocumentPosition(shelf) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
     });
 
     it("does not render inline search input", () => {

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -187,14 +187,12 @@ export function ConsoleDetailPage() {
           )}
         </>
       ) : (
-        /* Large library: showcase sections + terminal browse CTA */
+        /* Large library: Browse-all CTA first (directly under the
+           banner), then the curated showcase shelves. The CTA leads so
+           the console screen matches the player app, where "Browse all"
+           is the first section under the hero banner (ConsoleScreen.kt).
+           See #1312. */
         <>
-          <ConsoleRecentlyPlayed consoleId={id!} />
-          <ConsoleEssentials consoleId={id!} />
-          <ConsoleLaunchGames consoleId={id!} />
-          <ConsoleHiddenGems consoleId={id!} />
-          <ConsoleTopDevelopers consoleId={id!} />
-          <ConsoleRecentlyAdded consoleId={id!} />
           {gameCount > BROWSE_CTA_THRESHOLD && (
             <TitledSection title="Library" icon={Library}>
               <Link
@@ -209,6 +207,12 @@ export function ConsoleDetailPage() {
               </Link>
             </TitledSection>
           )}
+          <ConsoleRecentlyPlayed consoleId={id!} />
+          <ConsoleEssentials consoleId={id!} />
+          <ConsoleLaunchGames consoleId={id!} />
+          <ConsoleHiddenGems consoleId={id!} />
+          <ConsoleTopDevelopers consoleId={id!} />
+          <ConsoleRecentlyAdded consoleId={id!} />
         </>
       )}
     </SectionList>


### PR DESCRIPTION
Closes #1312.

## Problem
On the **console detail screen**, the "Browse all N <console> games" CTA sits in different places across clients:
- **Player app** (`ConsoleScreen.kt`): first section, directly under the hero banner.
- **Web** (`console-detail-page.tsx`): last — a terminal "Library" section *after* every curated showcase shelf.

## Change
Move the web CTA to the **top** of the large-library content (directly under the hero banner), so it leads the screen exactly like the player app. Only the large-library branch (`gameCount > BROWSE_CTA_THRESHOLD`) renders the CTA; small/empty libraries are unchanged. `data-testid="browse-all-games-cta"` is unchanged.

## Placement decision
This intentionally places the Browse/Discovery CTA ahead of "Continue Playing" on this one screen, which is a deliberate exception to **AGENT_TEAM rule 8** ("Continue Playing first"). The player app does the same (there it's required so the CTA owns d-pad/default focus); web matches it for cross-client consistency. The exception is now documented as an explicit carve-out in `AGENT_TEAM.md` so it isn't "fixed" back later.

## Review gate
- **UI agent**: APPROVE-WITH-NOTES — flagged the rule-8 tension; resolved by the explicit product decision + the documented carve-out.
- **Code reviewer**: APPROVE — surgical JSX reorder, no orphaned imports, `tsc`/`eslint` clean.

## Tests
- The `#1095` "terminal CTA below the shelves" test becomes a `#1312` test that also asserts DOM ordering (CTA before the first curated shelf) via `compareDocumentPosition`.
- Small-library and empty-library "CTA absent" tests still pass.
- Full `console-detail-page` suite (14 tests) green; full web unit suite + `npm run build` green locally.