### PR TITLE
security: implement backend audit fixes (#1331)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,7 @@ frontend behavior differs — not the hosting.
 - See ARCHITECTURE.md for full technical architecture
 - See `player/LAYOUT.md` for the player app's shared layout composable system (SpScreen, SpMainContentPadding, SpSectionList, etc.). All screens must use these — no custom padding or scroll code.
 - See `player/GAMEPAD_NAVIGATION.md` for the player app's focus system. **Required reading before touching any focus / autoFocus / focusRestoreItem / rememberFocus / LocalFocusMemory / ComposeFocusBridge call, MainActivity.onKeyDown, or SpScreen's tap handler** — it documents non-obvious invariants (capture-once-on-mount, FocusRequester sharing, the AnimatedContent re-fire bug, default-focus / restore semantics, and the hybrid touch+gamepad input-mode recovery flow from #1194) that break in subtle ways if you "simplify" them.
+- See `server/internal/cores/CORE_INTEGRITY.md` for the core-download trust model. **Required reading before changing the buildbot poller's fetch/verify path** — cores are native executables the player runs, so the doc spells out why fetches are HTTPS-strict, why buildbot nightlies are trust-on-fetch (no upstream signatures/stable hashes to pin), and the operator off-switches (#1315).
 - SQLite as default database (self-hosted friendly)
 - JWT authentication with refresh token rotation
 - REST API + WebSocket for real-time events

--- a/server/cmd/seed/main.go
+++ b/server/cmd/seed/main.go
@@ -24,6 +24,22 @@ func main() {
 		slog.Error("failed to initialize database", "error", err)
 		os.Exit(1)
 	}
+
+	// Refuse to seed a database that already has users. This tool creates demo
+	// accounts with well-known passwords (admin/admin123, player/player123), so
+	// running it against a real/populated database would inject weak
+	// credentials. Override with SPELA_SEED_FORCE=true for an intentional dev
+	// re-seed. (#1330)
+	var userCount int64
+	if err := database.Model(&db.User{}).Count(&userCount).Error; err != nil {
+		slog.Error("failed to count existing users", "error", err)
+		os.Exit(1)
+	}
+	if userCount > 0 && os.Getenv("SPELA_SEED_FORCE") != "true" {
+		slog.Error("refusing to seed: database already has users; set SPELA_SEED_FORCE=true to override", "users", userCount)
+		os.Exit(1)
+	}
+
 	if err := db.SeedConsoles(database); err != nil {
 		slog.Error("failed to seed consoles", "error", err)
 		os.Exit(1)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -519,11 +519,14 @@ func main() {
 
 	slog.Info("server listening", "port", port)
 	srv := &http.Server{
-		Addr:         ":" + port,
-		Handler:      router,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 120 * time.Second, // generous for large file downloads
-		IdleTimeout:  120 * time.Second,
+		Addr:    ":" + port,
+		Handler: router,
+		// ReadHeaderTimeout bounds slow-header (Slowloris) clients with a
+		// dedicated deadline rather than relying on ReadTimeout alone (#1326).
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      120 * time.Second, // generous for large file downloads
+		IdleTimeout:       120 * time.Second,
 	}
 
 	// Graceful shutdown: listen for SIGINT/SIGTERM and drain in-flight requests

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -203,6 +203,12 @@ func main() {
 		slog.Warn("failed to migrate shared sessions", "error", err)
 	}
 
+	// Preserve open registration for installs that predate the
+	// secure-by-default change (#1319). Fresh installs stay closed.
+	if err := db.MigratePreserveOpenRegistration(database); err != nil {
+		slog.Warn("failed to preserve registration default", "error", err)
+	}
+
 	// Create ES-DE console subdirectories in game dirs
 	if err := scanner.CreateConsoleFolders(database, gameDirs); err != nil {
 		slog.Warn("failed to create console folders", "error", err)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -98,6 +98,14 @@ func main() {
 		}
 	}
 
+	// Test mode registers the destructive /api/test/reset endpoint and relaxes
+	// the JWT-secret strength check — never safe in production. Refuse to start
+	// if an operator enabled it alongside a release build (#1330).
+	if testMode && os.Getenv("GIN_MODE") == "release" {
+		slog.Error("FATAL: SPELA_TEST_MODE must not be enabled with GIN_MODE=release (it exposes /api/test/reset)")
+		os.Exit(1)
+	}
+
 	// Derive or use explicit encryption key.
 	// A separate key is strongly recommended so that JWT secret rotation
 	// does not require re-encrypting stored data.

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/http"
 	_ "net/http/pprof" // profiling endpoint at /debug/pprof/
 	"os"
@@ -11,6 +12,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"golang.org/x/net/netutil"
 
 	"github.com/spela/server/internal/api"
 	"github.com/spela/server/internal/auth"
@@ -546,7 +549,25 @@ func main() {
 		}
 	}()
 
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	// Cap total concurrent connections so a single source can't exhaust file
+	// descriptors / goroutines by holding many open connections to anonymous
+	// endpoints (#1329). Generous default; tune via SPELA_MAX_CONNECTIONS.
+	// Operators behind a reverse proxy may also bound this at the proxy.
+	maxConns := 4096
+	if v := os.Getenv("SPELA_MAX_CONNECTIONS"); v != "" {
+		if parsed, perr := strconv.Atoi(v); perr == nil && parsed > 0 {
+			maxConns = parsed
+		}
+	}
+	ln, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		slog.Error("failed to bind listener", "addr", srv.Addr, "error", err)
+		os.Exit(1)
+	}
+	ln = netutil.LimitListener(ln, maxConns)
+	slog.Info("connection cap configured", "maxConnections", maxConns)
+
+	if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
 		slog.Error("server failed", "error", err)
 		os.Exit(1)
 	}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -117,6 +117,24 @@ func main() {
 		slog.Info("CORS: same-origin only (set SPELA_CORS_ORIGINS to allow cross-origin requests)")
 	}
 
+	// Effective key for decrypting secret server settings at startup, matching
+	// the router's resolution (#1318). auth.Decrypt returns legacy plaintext
+	// (no "enc:" prefix) unchanged, so this is safe before any value has been
+	// re-saved through the encrypting admin path.
+	settingsKey := encryptionKey
+	if len(settingsKey) == 0 {
+		settingsKey = auth.DeriveEncryptionKey(jwtSecret)
+	}
+	decryptSetting := func(v string) string {
+		if v == "" {
+			return v
+		}
+		if plain, err := auth.Decrypt(v, settingsKey); err == nil {
+			return plain
+		}
+		return v
+	}
+
 	slog.Info("starting Spela server", "port", port, "gameDirs", gameDirs)
 
 	// Initialize database
@@ -217,7 +235,7 @@ func main() {
 				case "igdb_client_id":
 					clientID = s.Value
 				case "igdb_client_secret":
-					clientSecret = s.Value
+					clientSecret = decryptSetting(s.Value)
 				}
 			}
 		}
@@ -229,7 +247,7 @@ func main() {
 		if raAPIKey == "" {
 			var setting db.ServerSetting
 			database.Where("key = ?", "ra_api_key").First(&setting)
-			raAPIKey = setting.Value
+			raAPIKey = decryptSetting(setting.Value)
 		}
 		if raAPIKey != "" {
 			metaScraper.RAClient = retroachievements.NewRAClient()
@@ -242,7 +260,7 @@ func main() {
 		} else {
 			var setting db.ServerSetting
 			if err := database.Where("key = ?", "steamgriddb_api_key").First(&setting).Error; err == nil && setting.Value != "" {
-				metaScraper.ConfigureSteamGridDB(setting.Value)
+				metaScraper.ConfigureSteamGridDB(decryptSetting(setting.Value))
 			}
 		}
 	}
@@ -312,17 +330,17 @@ func main() {
 
 	// Create router
 	router, _ := api.NewRouter(api.Config{
-		DB:            database,
-		JWTSecret:     jwtSecret,
-		EncryptionKey: encryptionKey,
-		GameDirs:      gameDirs,
-		Storage:       store,
-		Scanner:       gameScanner,
-		Scraper:       metaScraper,
-		Hub:           hub,
-		NetplayHub:    netplayHub,
-		CoreDir:       coreDir,
-		FrontendDir:   frontendDir,
+		DB:                           database,
+		JWTSecret:                    jwtSecret,
+		EncryptionKey:                encryptionKey,
+		GameDirs:                     gameDirs,
+		Storage:                      store,
+		Scanner:                      gameScanner,
+		Scraper:                      metaScraper,
+		Hub:                          hub,
+		NetplayHub:                   netplayHub,
+		CoreDir:                      coreDir,
+		FrontendDir:                  frontendDir,
 		CORSOrigins:                  corsOrigins,
 		ChallengeAttemptRateLimitSec: challengeRateLimit,
 		Version:                      version,

--- a/server/go.mod
+++ b/server/go.mod
@@ -10,7 +10,9 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.50.0
+	golang.org/x/net v0.53.0
 	golang.org/x/time v0.14.0
+	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/sqlite v1.5.6
 	gorm.io/gorm v1.25.12
 )
@@ -45,9 +47,7 @@ require (
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.1 // indirect
 	golang.org/x/arch v0.26.0 // indirect
-	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/server/internal/api/achievement_showcase_public_test.go
+++ b/server/internal/api/achievement_showcase_public_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #1320: the public achievement-showcase read must honour the same
+// block + profile-visibility gate as the public profile/heatmap reads.
+func TestPublicShowcase_RespectsBlock(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	var caller db.User
+	database.Where("username = ?", "apitest").First(&caller)
+
+	other := db.User{Username: "showcase_blocker", Email: "sb@example.com", PasswordHash: "hash", Role: "user"}
+	database.Create(&other)
+	database.Create(&db.UserAchievementShowcase{UserID: other.ID, AchievementRAID: 1, RAGameID: 1, ShowcaseOrder: 0})
+	database.Create(&db.Block{UserID: other.ID, BlockedUserID: caller.ID})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/users/%d/achievements/showcase", other.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code, "blocked user must not read the showcase")
+}
+
+func TestPublicShowcase_RespectsProfileVisibility(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	other := db.User{Username: "showcase_private", Email: "sp@example.com", PasswordHash: "hash", Role: "user", ProfileVisibility: "private"}
+	database.Create(&other)
+	database.Create(&db.UserAchievementShowcase{UserID: other.ID, AchievementRAID: 1, RAGameID: 1, ShowcaseOrder: 0})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/users/%d/achievements/showcase", other.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var entries []ShowcaseEntryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &entries))
+	assert.Empty(t, entries, "private profile showcase must not leak entries")
+}

--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -99,7 +99,7 @@ func steamGridDBAPIKey(database *gorm.DB) string {
 	if err := database.Where("key = ?", "steamgriddb_api_key").First(&setting).Error; err != nil {
 		return ""
 	}
-	return setting.Value
+	return decryptSecretSetting(setting.Value)
 }
 
 // igdbCredentials returns the IGDB client ID and secret.
@@ -121,7 +121,8 @@ func igdbCredentials(database *gorm.DB) (clientID, clientSecret string) {
 	for _, s := range settings {
 		sm[s.Key] = s.Value
 	}
-	return sm["igdb_client_id"], sm["igdb_client_secret"]
+	// igdb_client_id is not secret; igdb_client_secret is encrypted at rest (#1318).
+	return sm["igdb_client_id"], decryptSecretSetting(sm["igdb_client_secret"])
 }
 
 func SteamGridDBSource(database *gorm.DB) string {

--- a/server/internal/api/admin_handler_settings.go
+++ b/server/internal/api/admin_handler_settings.go
@@ -1,10 +1,48 @@
 package api
 
-// secretSettingKeys are settings that should be masked in GET responses.
+import "github.com/spela/server/internal/auth"
+
+// secretSettingKeys are settings that should be masked in GET responses and
+// encrypted at rest (#1318).
 var secretSettingKeys = map[string]bool{
 	"igdb_client_secret":  true,
 	"steamgriddb_api_key": true,
 	"ra_api_key":          true,
+}
+
+// serverSettingsKey is the AES key used to encrypt/decrypt secret server
+// settings at rest. It is process-global (the same key for the lifetime of
+// the server) and set once from NewRouter via setServerSettingsKey. Stored as
+// a package var rather than threaded through the ~7 free functions that read
+// these settings.
+var serverSettingsKey []byte
+
+// setServerSettingsKey records the AES key used for secret settings. Called
+// once during router construction.
+func setServerSettingsKey(key []byte) { serverSettingsKey = key }
+
+// encryptSecretSetting encrypts a secret setting value for storage. Empty
+// values and a missing key pass through unchanged.
+func encryptSecretSetting(value string) (string, error) {
+	if value == "" || len(serverSettingsKey) == 0 {
+		return value, nil
+	}
+	return auth.Encrypt(value, serverSettingsKey)
+}
+
+// decryptSecretSetting decrypts a stored secret setting value. Legacy
+// plaintext (no "enc:" prefix) is returned as-is by auth.Decrypt; on any
+// decryption error we fall back to the raw value so a key mishap degrades to
+// the prior behaviour rather than silently disabling the integration.
+func decryptSecretSetting(value string) string {
+	if value == "" || len(serverSettingsKey) == 0 {
+		return value
+	}
+	plain, err := auth.Decrypt(value, serverSettingsKey)
+	if err != nil {
+		return value
+	}
+	return plain
 }
 
 // secretMaskPlaceholder is the masked value returned for secret settings in GET responses.

--- a/server/internal/api/admin_igdb_test.go
+++ b/server/internal/api/admin_igdb_test.go
@@ -190,10 +190,10 @@ func TestSettingsMasking_IGDBSecret(t *testing.T) {
 	defer cleanup()
 	_, adminToken := createAdminUser(t, database)
 
-	// Store settings including IGDB secret
+	// Store settings including IGDB secret. registration_enabled is already
+	// seeded "true" by setupTestEnv.
 	database.Create(&db.ServerSetting{Key: "igdb_client_id", Value: "my-client-id"})
 	database.Create(&db.ServerSetting{Key: "igdb_client_secret", Value: "super-secret-value"})
-	database.Create(&db.ServerSetting{Key: "registration_enabled", Value: "true"})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/admin/settings", nil)

--- a/server/internal/api/admin_igdb_test.go
+++ b/server/internal/api/admin_igdb_test.go
@@ -263,7 +263,9 @@ func TestSettingsMasking_NewSecretOverwrites(t *testing.T) {
 
 	var setting db.ServerSetting
 	require.NoError(t, database.Where("key = ?", "igdb_client_secret").First(&setting).Error)
-	assert.Equal(t, "brand-new-secret", setting.Value)
+	// Stored encrypted at rest (#1318) but must decrypt to the new secret.
+	assert.NotEqual(t, "brand-new-secret", setting.Value, "secret must not be stored in plaintext")
+	assert.Equal(t, "brand-new-secret", decryptSecretSetting(setting.Value))
 }
 
 func TestSettingsMasking_EmptySecret(t *testing.T) {

--- a/server/internal/api/admin_settings_encryption_test.go
+++ b/server/internal/api/admin_settings_encryption_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #1318: secret server settings must be encrypted at rest, returned
+// masked from the GET endpoint, and transparently decrypted when read back
+// for use.
+func TestAdminSettings_SecretsEncryptedAtRest(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
+
+	const secret = "sgdb-super-secret-key-123"
+	body, _ := json.Marshal(map[string]string{"steamgriddb_api_key": secret})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Stored ciphertext must not contain the plaintext and must carry the
+	// "enc:" marker.
+	var row db.ServerSetting
+	require.NoError(t, database.Where("key = ?", "steamgriddb_api_key").First(&row).Error)
+	assert.NotEqual(t, secret, row.Value, "secret must not be stored in plaintext")
+	assert.True(t, strings.HasPrefix(row.Value, "enc:"), "stored value should be encrypted, got %q", row.Value)
+	assert.NotContains(t, row.Value, secret)
+
+	// Reading it back for use must return the original plaintext.
+	assert.Equal(t, secret, steamGridDBAPIKey(database), "decrypted read must round-trip")
+
+	// The GET endpoint must mask it, never returning the real or encrypted value.
+	gw := httptest.NewRecorder()
+	greq := httptest.NewRequest("GET", "/api/admin/settings", nil)
+	greq.Header.Set("Authorization", "Bearer "+adminToken)
+	router.ServeHTTP(gw, greq)
+	require.Equal(t, http.StatusOK, gw.Code)
+	var settings map[string]string
+	require.NoError(t, json.Unmarshal(gw.Body.Bytes(), &settings))
+	assert.Equal(t, secretMaskPlaceholder, settings["steamgriddb_api_key"])
+	assert.NotContains(t, gw.Body.String(), secret)
+}
+
+// Legacy plaintext values (written before #1318) must still be readable.
+func TestAdminSettings_LegacyPlaintextStillReadable(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	_, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	require.NoError(t, database.Create(&db.ServerSetting{Key: "steamgriddb_api_key", Value: "legacy-plain"}).Error)
+	assert.Equal(t, "legacy-plain", steamGridDBAPIKey(database),
+		"non-enc-prefixed legacy values must pass through unchanged")
+}

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -124,6 +124,13 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 	database.Create(&db.SystemEventCategory{Code: db.CategoryOperational, Name: "Operational"})
 	db.ResetCategoryIDCacheForTest()
 
+	// Registration is closed-by-default since #1319. The handler tests model a
+	// configured server that permits multi-user registration, so enable it
+	// here; tests that need it disabled override the row explicitly.
+	database.Where("key = ?", "registration_enabled").
+		Assign(db.ServerSetting{Value: "true"}).
+		FirstOrCreate(&db.ServerSetting{Key: "registration_enabled"})
+
 	tmpDir := t.TempDir()
 	store, err := storage.NewStorage(tmpDir+"/saves", tmpDir+"/cores", tmpDir+"/images", tmpDir+"/bios")
 	require.NoError(t, err)

--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"math"
 	"net/http"
@@ -18,10 +19,20 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/igdb"
+	"github.com/spela/server/internal/safehttp"
 	"github.com/spela/server/internal/scraper"
 	"github.com/spela/server/internal/storage"
 	"gorm.io/gorm"
 )
+
+// safePreviewImageClient is the SSRF-hardened client used to fetch console
+// preview screenshots from the libretro CDN: scheme allowlist + private-IP
+// rejection on redirects, instead of a raw http.Client (#1317).
+var safePreviewImageClient = safehttp.NewClient(15 * time.Second)
+
+// maxPreviewImageBytes caps a downloaded preview screenshot so a compromised
+// CDN can't stream an unbounded body to disk.
+const maxPreviewImageBytes = 32 << 20 // 32 MB
 
 // previewFallbackGames maps console abbreviations to well-known game titles
 // used as fallback when no local game has a scraped screenshot.
@@ -42,28 +53,28 @@ var previewFallbackGames = map[string]string{
 	"ARCADE": "Street Fighter II - The World Warrior (World 910522)",
 	"PCE":    "Bonk's Adventure (USA)",
 	"A26":    "Pitfall! - Pitfall Harry's Jungle Adventure (USA)",
-	"GG":    "Sonic The Hedgehog (USA, Europe)",
-	"SCD":   "Sonic CD (USA)",
-	"32X":   "Knuckles' Chaotix (Japan, USA)",
-	"DC":    "Sonic Adventure (USA)",
-	"VB":    "Mario's Tennis (USA)",
-	"3DS":   "Super Mario 3D Land",
-	"GC":    "Super Smash Bros. Melee (USA)",
-	"A52":   "Pac-Man (USA)",
-	"A78":   "Ms. Pac-Man (USA)",
-	"LYNX":  "California Games (USA, Europe)",
-	"JAG":   "Tempest 2000 (World)",
-	"NGP":   "SNK vs. Capcom - Card Fighters' Clash (USA, Europe)",
-	"WS":    "Final Fantasy (Japan)",
-	"PCFX":  "Zenki FX - Vajra Fight (Japan)",
-	"CV":    "Donkey Kong (USA)",
-	"PKMN":  "Pokemon Pinball Mini (USA, Europe)",
-	"PS2":   "Grand Theft Auto - San Andreas (USA)",
-	"C64":   "Boulder Dash (USA, Europe)",
-	"DOS":   "DOOM (USA)",
-	"AMIGA": "Lemmings (USA)",
-	"PS3":   "The Last of Us (USA)",
-	"WII":   "Super Mario Galaxy (USA)",
+	"GG":     "Sonic The Hedgehog (USA, Europe)",
+	"SCD":    "Sonic CD (USA)",
+	"32X":    "Knuckles' Chaotix (Japan, USA)",
+	"DC":     "Sonic Adventure (USA)",
+	"VB":     "Mario's Tennis (USA)",
+	"3DS":    "Super Mario 3D Land",
+	"GC":     "Super Smash Bros. Melee (USA)",
+	"A52":    "Pac-Man (USA)",
+	"A78":    "Ms. Pac-Man (USA)",
+	"LYNX":   "California Games (USA, Europe)",
+	"JAG":    "Tempest 2000 (World)",
+	"NGP":    "SNK vs. Capcom - Card Fighters' Clash (USA, Europe)",
+	"WS":     "Final Fantasy (Japan)",
+	"PCFX":   "Zenki FX - Vajra Fight (Japan)",
+	"CV":     "Donkey Kong (USA)",
+	"PKMN":   "Pokemon Pinball Mini (USA, Europe)",
+	"PS2":    "Grand Theft Auto - San Andreas (USA)",
+	"C64":    "Boulder Dash (USA, Europe)",
+	"DOS":    "DOOM (USA)",
+	"AMIGA":  "Lemmings (USA)",
+	"PS3":    "The Last of Us (USA)",
+	"WII":    "Super Mario Galaxy (USA)",
 }
 
 // ConsoleHandler handles console-related endpoints.
@@ -107,8 +118,11 @@ func (h *ConsoleHandler) resolvePreviewScreenshotPath(_ context.Context, console
 	)
 	slog.Info("downloading preview screenshot from CDN", "console", console.Abbreviation, "url", imageURL)
 
-	httpClient := &http.Client{Timeout: 15 * time.Second}
-	resp, err := httpClient.Get(imageURL)
+	if err := safehttp.CheckURL(imageURL); err != nil {
+		slog.Warn("rejecting preview screenshot URL", "console", console.Abbreviation, "error", err)
+		return "", huma.Error404NotFound("failed to download preview")
+	}
+	resp, err := safePreviewImageClient.Get(imageURL)
 	if err != nil {
 		slog.Warn("failed to download preview screenshot", "console", console.Abbreviation, "error", err)
 		return "", huma.Error404NotFound("failed to download preview")
@@ -120,14 +134,13 @@ func (h *ConsoleHandler) resolvePreviewScreenshotPath(_ context.Context, console
 		return "", huma.Error404NotFound("preview not available from CDN")
 	}
 
-	savedPath, err := h.Storage.WriteImage(cachedPath, resp.Body)
+	savedPath, err := h.Storage.WriteImage(cachedPath, io.LimitReader(resp.Body, maxPreviewImageBytes+1))
 	if err != nil {
 		slog.Warn("failed to cache preview screenshot", "console", console.Abbreviation, "error", err)
 		return "", huma.Error500InternalServerError("failed to cache preview")
 	}
 	return "/api/images/" + filepath.ToSlash(savedPath), nil
 }
-
 
 // GetConsoleIcon has been migrated to huma — see HumaGetConsoleIcon in
 // huma_downloads.go.
@@ -188,12 +201,12 @@ func inlineSvgStyles(svg string) string {
 
 // TopRatedGameResponse is the API response for a top-rated IGDB game.
 type TopRatedGameResponse struct {
-	Rank        int     `json:"rank"`
-	Name        string  `json:"name"`
-	CoverUrl    string  `json:"coverUrl"`
+	Rank              int     `json:"rank"`
+	Name              string  `json:"name"`
+	CoverUrl          string  `json:"coverUrl"`
 	IGDBCriticsRating float64 `json:"igdbCriticsRating"`
-	LocalGameId *string `json:"localGameId"`
-	ConsoleName string  `json:"consoleName"`
+	LocalGameId       *string `json:"localGameId"`
+	ConsoleName       string  `json:"consoleName"`
 }
 
 // topRatedStaleness is how long cached top-rated data is considered fresh.
@@ -209,12 +222,12 @@ var demoConsoleAbbreviations = []string{"ADEMO", "DDEMO"}
 // TopListGameResponse is the API response for a top-rated IGDB game that is
 // available locally on the server.
 type TopListGameResponse struct {
-	Rank        int     `json:"rank"`
-	GameId      string  `json:"gameId"`
-	Name        string  `json:"name"`
-	CoverUrl    string  `json:"coverUrl"`
-	ConsoleName string  `json:"consoleName"`
-	ConsoleId   string  `json:"consoleId"`
+	Rank              int     `json:"rank"`
+	GameId            string  `json:"gameId"`
+	Name              string  `json:"name"`
+	CoverUrl          string  `json:"coverUrl"`
+	ConsoleName       string  `json:"consoleName"`
+	ConsoleId         string  `json:"consoleId"`
 	IGDBCriticsRating float64 `json:"igdbCriticsRating"`
 }
 
@@ -250,10 +263,10 @@ func (h *ConsoleHandler) buildTopRatedResponses(cached []db.TopRatedGame, rerank
 		}
 
 		resp := TopRatedGameResponse{
-			Rank:        rank,
-			Name:        tr.Name,
+			Rank:              rank,
+			Name:              tr.Name,
 			IGDBCriticsRating: tr.TotalRating,
-			ConsoleName: consoleName,
+			ConsoleName:       consoleName,
 		}
 
 		// Check for local game match — prefer scraper_id (stable IGDB FK),

--- a/server/internal/api/huma_achievements.go
+++ b/server/internal/api/huma_achievements.go
@@ -326,10 +326,25 @@ func (h *AchievementShowcaseHandler) HumaGetShowcase(ctx context.Context, _ *Get
 }
 
 // HumaGetPublicShowcase is the huma handler for GET /api/users/{id}/achievements/showcase.
-func (h *AchievementShowcaseHandler) HumaGetPublicShowcase(_ context.Context, in *GetPublicShowcaseInput) (*GetPublicShowcaseOutput, error) {
+func (h *AchievementShowcaseHandler) HumaGetPublicShowcase(ctx context.Context, in *GetPublicShowcaseInput) (*GetPublicShowcaseOutput, error) {
 	userID, err := strconv.ParseUint(in.ID, 10, 64)
 	if err != nil {
 		return nil, huma.Error400BadRequest("invalid user ID")
+	}
+
+	// Issue #1320: honour the same block + profile-visibility gate as the
+	// public profile/heatmap reads instead of exposing the showcase to
+	// blocked or private-profile users.
+	var user db.User
+	if err := h.DB.First(&user, uint(userID)).Error; err != nil {
+		return nil, huma.Error404NotFound("user not found")
+	}
+	visible, blocked := publicProfileAccess(h.DB, UserIDFromContext(ctx), user)
+	if blocked {
+		return nil, huma.Error404NotFound("user not found")
+	}
+	if !visible {
+		return &GetPublicShowcaseOutput{Body: []ShowcaseEntryResponse{}}, nil
 	}
 
 	var entries []db.UserAchievementShowcase

--- a/server/internal/api/huma_admin.go
+++ b/server/internal/api/huma_admin.go
@@ -215,7 +215,17 @@ func (h *AdminHandler) HumaUpdateAdminSettings(ctx context.Context, in *UpdateAd
 		if secretSettingKeys[key] && value == secretMaskPlaceholder {
 			continue
 		}
-		setting := db.ServerSetting{Key: key, Value: value}
+		// Encrypt secret values at rest (#1318); non-secret settings are
+		// stored as-is.
+		stored := value
+		if secretSettingKeys[key] {
+			enc, err := encryptSecretSetting(value)
+			if err != nil {
+				return nil, huma.Error500InternalServerError("failed to encrypt setting")
+			}
+			stored = enc
+		}
+		setting := db.ServerSetting{Key: key, Value: stored}
 		h.DB.Where("key = ?", key).Assign(setting).FirstOrCreate(&setting)
 		changedKeys = append(changedKeys, key)
 	}

--- a/server/internal/api/huma_auth_handlers.go
+++ b/server/internal/api/huma_auth_handlers.go
@@ -387,6 +387,22 @@ func (h *AuthHandler) HumaLogin(ctx context.Context, in *AuthLoginInput) (*AuthL
 	}}, nil
 }
 
+// isRegistrationEnabled reports whether self-service registration is allowed.
+// Secure-by-default (#1319): when the registration_enabled setting has never
+// been configured, registration is treated as DISABLED so a freshly deployed,
+// internet-exposed instance doesn't accept account requests until the owner
+// opts in. Existing installs are preserved on upgrade by
+// db.MigratePreserveOpenRegistration, which seeds the flag to "true" when
+// users already exist. (Note: even when enabled, non-owner registrations are
+// held PendingApproval and receive no tokens until an admin approves.)
+func isRegistrationEnabled(database *gorm.DB) bool {
+	var setting db.ServerSetting
+	if err := database.Where("key = ?", "registration_enabled").First(&setting).Error; err != nil {
+		return false
+	}
+	return setting.Value != "false"
+}
+
 // HumaRegister is the huma implementation of POST /api/auth/register. Returns
 // 201 Created with tokens on success, or 202 Accepted with {pending, message}
 // when the new account is awaiting admin approval — matching the raw gin shape.
@@ -428,14 +444,9 @@ func (h *AuthHandler) HumaRegister(ctx context.Context, in *AuthRegisterInput) (
 
 		var totalUsers int64
 		tx.Model(&db.User{}).Count(&totalUsers)
-		if totalUsers > 0 {
-			var setting db.ServerSetting
-			if err := tx.Where("key = ?", "registration_enabled").First(&setting).Error; err == nil {
-				if setting.Value == "false" {
-					txErr = huma.NewError(http.StatusForbidden, "Registration is currently disabled. Please contact an administrator.")
-					return fmt.Errorf("disabled")
-				}
-			}
+		if totalUsers > 0 && !isRegistrationEnabled(tx) {
+			txErr = huma.NewError(http.StatusForbidden, "Registration is currently disabled. Please contact an administrator.")
+			return fmt.Errorf("disabled")
 		}
 
 		role := db.RoleUser
@@ -692,11 +703,7 @@ func (h *AuthHandler) HumaSetupStatus(_ context.Context, _ *SetupStatusInput) (*
 	var gameCount int64
 	h.DB.Model(&db.Game{}).Count(&gameCount)
 
-	registrationEnabled := true
-	var setting db.ServerSetting
-	if err := h.DB.Where("key = ?", "registration_enabled").First(&setting).Error; err == nil {
-		registrationEnabled = setting.Value != "false"
-	}
+	registrationEnabled := isRegistrationEnabled(h.DB)
 
 	return &SetupStatusOutput{Body: SetupStatusResponse{
 		NeedsSetup:          userCount == 0 && !hasMarker,

--- a/server/internal/api/huma_challenges_create.go
+++ b/server/internal/api/huma_challenges_create.go
@@ -154,6 +154,12 @@ func (h *ChallengeHandler) HumaCreateChallenge(ctx context.Context, in *CreateCh
 		return nil, huma.Error400BadRequest(fmt.Sprintf("save file too large (max %d MB)", maxChallengeSaveSize>>20))
 	}
 
+	// Count this challenge's starting save against the creator's storage
+	// quota (#1314) — challenge saves previously bypassed the quota entirely.
+	if err := checkStorageQuota(h.DB, uid, saveFile.Size); err != nil {
+		return nil, huma.Error413RequestEntityTooLarge("storage quota exceeded")
+	}
+
 	// Create DB record first to get ID
 	challenge := db.Challenge{
 		CreatorID:   uid,

--- a/server/internal/api/huma_shared_uploads.go
+++ b/server/internal/api/huma_shared_uploads.go
@@ -152,6 +152,11 @@ func (h *SharedSaveHandler) HumaShareSave(ctx context.Context, in *SharedSaveUpl
 	}
 	defer save.Close()
 
+	// Count this upload against the uploader's storage quota (#1314).
+	if err := checkStorageQuota(h.DB, uid, save.Size); err != nil {
+		return nil, huma.Error413RequestEntityTooLarge("storage quota exceeded")
+	}
+
 	name := body.Name
 	if name == "" {
 		name = save.Filename
@@ -205,6 +210,11 @@ func (h *SharedSessionHandler) HumaUploadSharedSessionSave(ctx context.Context, 
 		return nil, huma.Error400BadRequest("save file required")
 	}
 	defer save.Close()
+
+	// Count this upload against the uploader's storage quota (#1314).
+	if err := checkStorageQuota(h.DB, uid, save.Size); err != nil {
+		return nil, huma.Error413RequestEntityTooLarge("storage quota exceeded")
+	}
 
 	name := body.Name
 	if name == "" {
@@ -267,6 +277,14 @@ func (h *SharedSessionHandler) HumaUploadSharedSessionAutoSave(ctx context.Conte
 		return nil, huma.Error400BadRequest("save file required")
 	}
 	defer save.Close()
+
+	// Count this upload against the uploader's storage quota (#1314). The
+	// auto-save row itself is upserted, but the mirrored SessionSaveState
+	// (below) is created per call, so an unbounded auto-save loop would
+	// otherwise still grow on-disk bytes without limit.
+	if err := checkStorageQuota(h.DB, uid, save.Size); err != nil {
+		return nil, huma.Error413RequestEntityTooLarge("storage quota exceeded")
+	}
 
 	const autoSaveFilename = "autosave.sav"
 	filePath, size, err := h.Storage.WriteSharedSessionSave(ss.ID, autoSaveFilename, save)

--- a/server/internal/api/huma_social.go
+++ b/server/internal/api/huma_social.go
@@ -296,17 +296,14 @@ func (h *SocialHandler) HumaGetPublicProfile(ctx context.Context, in *GetPublicP
 	uid := user.ID
 	callerID := UserIDFromContext(ctx)
 
-	// Issue #1121: respect block relationships in BOTH directions and
-	// the target's profile_visibility setting. If either user has
-	// blocked the other, surface the same 404 we'd return for a
-	// nonexistent user — don't leak existence.
-	if callerID != 0 && callerID != uid && isBlockedEitherWay(h.DB, callerID, uid) {
+	// Issue #1121: respect block relationships in BOTH directions and the
+	// target's profile_visibility setting. A block surfaces the same 404
+	// we'd return for a nonexistent user (don't leak existence); a private
+	// profile yields an empty view. The caller still sees their own profile.
+	visible, blocked := publicProfileAccess(h.DB, callerID, user)
+	if blocked {
 		return nil, huma.Error404NotFound("user not found")
 	}
-
-	// Treat anything other than "public" as private. The caller can
-	// still see their own profile in full.
-	visible := user.ProfileVisibility == "" || user.ProfileVisibility == "public" || callerID == uid
 
 	var agg struct {
 		TotalPlayTime int64
@@ -415,4 +412,19 @@ func isBlockedEitherWay(database *gorm.DB, a, b uint) bool {
 		Where("(user_id = ? AND blocked_user_id = ?) OR (user_id = ? AND blocked_user_id = ?)", a, b, b, a).
 		Count(&count)
 	return count > 0
+}
+
+// publicProfileAccess centralises the #1121 privacy gate for every
+// /api/users/{id}/... read that exposes per-user activity. When blocked is
+// true the caller must return 404 (don't leak existence); when visible is
+// false the target is private and the caller must return an empty/limited
+// view. Issue #1316/#1320: the play-heatmap and achievement-showcase reads
+// previously skipped this gate, so it now lives in one helper called by all
+// three handlers.
+func publicProfileAccess(database *gorm.DB, callerID uint, target db.User) (visible, blocked bool) {
+	if callerID != 0 && callerID != target.ID && isBlockedEitherWay(database, callerID, target.ID) {
+		return false, true
+	}
+	visible = target.ProfileVisibility == "" || target.ProfileVisibility == "public" || callerID == target.ID
+	return visible, false
 }

--- a/server/internal/api/huma_user_extra.go
+++ b/server/internal/api/huma_user_extra.go
@@ -221,11 +221,23 @@ func (h *StatsHandler) HumaGetPlayHeatmap(ctx context.Context, _ *GetPlayHeatmap
 }
 
 // HumaGetPublicPlayHeatmap is the huma handler for GET /api/users/{id}/play-heatmap.
-func (h *StatsHandler) HumaGetPublicPlayHeatmap(_ context.Context, in *GetPublicPlayHeatmapInput) (*GetPublicPlayHeatmapOutput, error) {
+func (h *StatsHandler) HumaGetPublicPlayHeatmap(ctx context.Context, in *GetPublicPlayHeatmapInput) (*GetPublicPlayHeatmapOutput, error) {
 	var user db.User
 	if err := h.DB.First(&user, in.ID).Error; err != nil {
 		return nil, huma.Error404NotFound("user not found")
 	}
+
+	// Issue #1316: this timeline is exactly the "gaming habits" data the
+	// #1121 privacy gate protects on the profile endpoint — apply the same
+	// block + visibility check here.
+	visible, blocked := publicProfileAccess(h.DB, UserIDFromContext(ctx), user)
+	if blocked {
+		return nil, huma.Error404NotFound("user not found")
+	}
+	if !visible {
+		return &GetPublicPlayHeatmapOutput{Body: []HeatmapEntry{}}, nil
+	}
+
 	entries := h.buildHeatmapEntries(user.ID)
 	return &GetPublicPlayHeatmapOutput{Body: entries}, nil
 }

--- a/server/internal/api/middleware.go
+++ b/server/internal/api/middleware.go
@@ -50,14 +50,44 @@ func maxSaveStorageBytes() int64 {
 	return mb << 20
 }
 
+// userStoredBytes sums every on-disk artifact attributed to a user across all
+// the tables that record a file size. Issue #1314: a quota that only counted
+// SessionSaveState let shared saves, shared-session saves, and challenge
+// starting-saves grow without bound, so any authenticated user could exhaust
+// the host disk. Each query is fail-closed — a DB error aborts the check
+// rather than silently treating the table as empty.
+func userStoredBytes(database *gorm.DB, userID uint) (int64, error) {
+	// Each entry: model, the column holding the file size, and the column
+	// that attributes the row to a user.
+	sources := []struct {
+		model    interface{}
+		sizeCol  string
+		ownerCol string
+	}{
+		{&db.SessionSaveState{}, "file_size", "user_id"},
+		{&db.SharedSaveState{}, "file_size", "user_id"},
+		{&db.SharedSessionSave{}, "file_size", "user_id"},
+		{&db.Challenge{}, "save_file_size", "creator_id"},
+	}
+	var total int64
+	for _, s := range sources {
+		var sum int64
+		if err := database.Model(s.model).Where(s.ownerCol+" = ?", userID).
+			Select("COALESCE(SUM(" + s.sizeCol + "), 0)").Scan(&sum).Error; err != nil {
+			return 0, fmt.Errorf("summing %T for quota: %w", s.model, err)
+		}
+		total += sum
+	}
+	return total, nil
+}
+
 // checkStorageQuota verifies that adding additionalBytes would not exceed the user's quota.
 func checkStorageQuota(database *gorm.DB, userID uint, additionalBytes int64) error {
-	var totalBytes int64
 	// Surface DB errors instead of silently treating them as totalBytes=0,
 	// which would let an unbounded payload through whenever the DB is
 	// momentarily unavailable. Prefer to fail closed.
-	if err := database.Model(&db.SessionSaveState{}).Where("user_id = ?", userID).
-		Select("COALESCE(SUM(file_size), 0)").Scan(&totalBytes).Error; err != nil {
+	totalBytes, err := userStoredBytes(database, userID)
+	if err != nil {
 		return fmt.Errorf("checking storage quota: %w", err)
 	}
 	if totalBytes+additionalBytes > maxSaveStorageBytes() {

--- a/server/internal/api/registration_default_test.go
+++ b/server/internal/api/registration_default_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #1319: with no registration_enabled setting configured, self-service
+// registration is closed by default. The first user (owner) is still created,
+// but a second registration is rejected until the owner opts in.
+func TestRegistration_ClosedByDefault(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	// Remove the harness's convenience seed so we exercise the true default.
+	require.NoError(t, database.Where("key = ?", "registration_enabled").Delete(&db.ServerSetting{}).Error)
+
+	register := func(username, email string) *httptest.ResponseRecorder {
+		body, _ := json.Marshal(map[string]string{
+			"username": username,
+			"email":    email,
+			"password": "SecureTestPass!2024",
+		})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	// First user becomes owner regardless of the flag.
+	require.Equal(t, http.StatusCreated, register("owner", "owner@example.com").Code)
+
+	// Second registration is denied because registration is closed by default.
+	w := register("intruder", "intruder@example.com")
+	assert.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+}
+
+// When the owner enables registration, subsequent registrations are accepted
+// (held pending approval).
+func TestRegistration_EnabledAllowsSecondUser(t *testing.T) {
+	database, cfg := setupTestEnv(t) // seeds registration_enabled=true
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	register := func(username, email string) *httptest.ResponseRecorder {
+		body, _ := json.Marshal(map[string]string{
+			"username": username,
+			"email":    email,
+			"password": "SecureTestPass!2024",
+		})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	require.Equal(t, http.StatusCreated, register("owner", "owner@example.com").Code)
+	// Non-owner registration is accepted (202, pending approval) when enabled.
+	w := register("member", "member@example.com")
+	assert.Equal(t, http.StatusAccepted, w.Code, w.Body.String())
+	_ = database
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -163,6 +163,9 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	if len(encryptionKey) == 0 {
 		encryptionKey = auth.DeriveEncryptionKey(cfg.JWTSecret)
 	}
+	// Make the effective key available to the secret-server-setting
+	// encrypt/decrypt helpers (#1318).
+	setServerSettingsKey(encryptionKey)
 	socialHandler := &SocialHandler{DB: cfg.DB, Hub: cfg.Hub}
 	ratingHandler := &RatingHandler{DB: cfg.DB, Hub: cfg.Hub}
 	sharedSaveHandler := &SharedSaveHandler{DB: cfg.DB, Storage: cfg.Storage, Hub: cfg.Hub}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -100,9 +100,14 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		}))
 	}
 
-	// Serve images — save screenshots require auth + ownership; everything else is public
+	// Serve images — save screenshots require auth + ownership; everything else is public.
+	// Per-IP rate limit (#1327): this route is unauthenticated and, on a cache
+	// miss, triggers a DB lookup + outbound CDN fetch + disk write. The limit
+	// is generous so a normal grid of covers loads fine (rate.Limiter bursts up
+	// to the limit) while bounding sustained anonymous amplification.
+	imageLimiter := NewRateLimiter(600, time.Minute)
 	imageHandler := &ImageHandler{ImageDir: cfg.Storage.ImageDir, JWTSecret: cfg.JWTSecret, DB: cfg.DB, Scraper: cfg.Scraper}
-	r.GET("/api/images/*filepath", imageHandler.ServeImage)
+	r.GET("/api/images/*filepath", imageLimiter.RateLimit(), imageHandler.ServeImage)
 
 	// Bootstrap the huma API. Registered handlers below run alongside the raw
 	// gin handlers that follow — the two stacks coexist during the migration.
@@ -442,6 +447,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		downloadLimiter.Close()
 		uploadLimiter.Close()
 		userLimiter.Close()
+		imageLimiter.Close()
 	}
 
 	return r, cleanup

--- a/server/internal/api/stats_handler_test.go
+++ b/server/internal/api/stats_handler_test.go
@@ -450,6 +450,55 @@ func TestHeatmap_PublicNotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+// Issue #1316: a private-profile user's play timeline must not be readable by
+// other users via the public heatmap endpoint — it returns an empty list.
+func TestHeatmap_PublicRespectsProfileVisibility(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	otherUser := db.User{Username: "private_heatmap", Email: "ph@example.com", PasswordHash: "hash", Role: "user", ProfileVisibility: "private"}
+	database.Create(&otherUser)
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	database.Create(&db.DailyPlayActivity{UserID: otherUser.ID, Date: today, PlayTime: 7200})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/users/%d/play-heatmap", otherUser.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var entries []HeatmapEntry
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &entries))
+	assert.Empty(t, entries, "private profile heatmap must not leak activity")
+}
+
+// Issue #1316: a block in either direction hides the heatmap behind a 404,
+// matching the public-profile endpoint's existence-non-disclosure behaviour.
+func TestHeatmap_PublicRespectsBlock(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	var caller db.User
+	database.Where("username = ?", "apitest").First(&caller)
+
+	otherUser := db.User{Username: "blocker_heatmap", Email: "bh@example.com", PasswordHash: "hash", Role: "user"}
+	database.Create(&otherUser)
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	database.Create(&db.DailyPlayActivity{UserID: otherUser.ID, Date: today, PlayTime: 7200})
+	// otherUser blocks the caller.
+	database.Create(&db.Block{UserID: otherUser.ID, BlockedUserID: caller.ID})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/users/%d/play-heatmap", otherUser.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code, "blocked user must not read the heatmap")
+}
+
 func TestCalculateStreaks(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/server/internal/api/storage_quota_test.go
+++ b/server/internal/api/storage_quota_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// checkStorageQuota must account for every on-disk artifact a user can create,
+// not just session save states. Issue #1314: shared saves, shared-session
+// saves, and challenge starting-saves bypassed the quota entirely because the
+// SUM only covered SessionSaveState — letting any authenticated user fill the
+// host disk. This test seeds one row in each user-attributable table and
+// asserts they all count toward the quota.
+func TestCheckStorageQuota_CountsAllArtifactTypes(t *testing.T) {
+	database, _ := setupTestEnv(t)
+	// 1 MB quota.
+	t.Setenv("SPELA_MAX_SAVE_STORAGE_MB", "1")
+	const quota = int64(1) << 20
+
+	user := db.User{Username: "quota-user", Email: "quota@example.com", PasswordHash: "x"}
+	require.NoError(t, database.Create(&user).Error)
+
+	game := db.Game{Title: "Game", ConsoleID: 1, FilePath: "g.rom"}
+	require.NoError(t, database.Create(&game).Error)
+	session := db.GameSession{OwnerID: user.ID, GameID: game.ID, Name: "sess"}
+	require.NoError(t, database.Create(&session).Error)
+	sharedSession := db.SharedSession{OwnerID: user.ID, GameID: game.ID, Name: "shared", Status: "active"}
+	require.NoError(t, database.Create(&sharedSession).Error)
+
+	const each = 200 * 1024 // 200 KB per artifact
+
+	// One row in each table that attributes on-disk bytes to the user.
+	require.NoError(t, database.Create(&db.SessionSaveState{UserID: user.ID, SessionID: session.ID, Name: "s", FilePath: "a", FileSize: each}).Error)
+	require.NoError(t, database.Create(&db.SharedSaveState{UserID: user.ID, GameID: game.ID, Name: "s", FilePath: "b", FileSize: each}).Error)
+	require.NoError(t, database.Create(&db.SharedSessionSave{UserID: user.ID, SharedSessionID: sharedSession.ID, Name: "s", FilePath: "c", FileSize: each}).Error)
+	require.NoError(t, database.Create(&db.Challenge{CreatorID: user.ID, GameID: game.ID, Name: "c", SaveFilePath: "d", SaveFileSize: each}).Error)
+
+	// Total stored is 4 * 200 KB = 800 KB. Adding 300 KB would reach
+	// 1100 KB > 1 MB and must be rejected. With the pre-fix code (which
+	// only summed SessionSaveState = 200 KB) this would wrongly pass.
+	err := checkStorageQuota(database, user.ID, 300*1024)
+	assert.Error(t, err, "quota must count shared saves, shared-session saves, and challenge saves")
+
+	// A small addition that still fits under the 1 MB ceiling is allowed.
+	require.NoError(t, checkStorageQuota(database, user.ID, 100*1024),
+		"800 KB stored + 100 KB = 900 KB is under the 1 MB quota")
+
+	_ = quota
+}
+
+// A user's quota usage must not be inflated by another user's artifacts.
+func TestCheckStorageQuota_ScopedPerUser(t *testing.T) {
+	database, _ := setupTestEnv(t)
+	t.Setenv("SPELA_MAX_SAVE_STORAGE_MB", "1")
+
+	u1 := db.User{Username: "u1", Email: "u1@example.com", PasswordHash: "x"}
+	u2 := db.User{Username: "u2", Email: "u2@example.com", PasswordHash: "x"}
+	require.NoError(t, database.Create(&u1).Error)
+	require.NoError(t, database.Create(&u2).Error)
+
+	game := db.Game{Title: "Game", ConsoleID: 1, FilePath: "g.rom"}
+	require.NoError(t, database.Create(&game).Error)
+
+	// u2 has nearly filled their quota; u1 has nothing.
+	require.NoError(t, database.Create(&db.SharedSaveState{UserID: u2.ID, GameID: game.ID, Name: "s", FilePath: "b", FileSize: 900 * 1024}).Error)
+
+	require.NoError(t, checkStorageQuota(database, u1.ID, 500*1024),
+		"u1 must not be charged for u2's stored bytes")
+	assert.Error(t, checkStorageQuota(database, u2.ID, 500*1024),
+		"u2 is over quota")
+}
+
+// End-to-end enforcement: the challenge-create endpoint (which previously
+// bypassed the quota entirely, #1314) must return 413 once the creator's
+// stored bytes would exceed the quota.
+func TestCreateChallenge_StorageQuotaEnforced(t *testing.T) {
+	t.Setenv("SPELA_MAX_SAVE_STORAGE_MB", "1") // 1 MB quota
+	env := setupChallengeTest(t)
+
+	post := func(name string, saveBytes int) *httptest.ResponseRecorder {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		writer.WriteField("name", name)
+		writer.WriteField("gameId", fmt.Sprintf("%d", env.gameID))
+		part, _ := writer.CreateFormFile("save", "save.state")
+		part.Write(make([]byte, saveBytes))
+		writer.Close()
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/challenges", &buf)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		req.Header.Set("Authorization", "Bearer "+env.token)
+		env.router.ServeHTTP(w, req)
+		return w
+	}
+
+	// First ~700 KB save fits under the 1 MB quota.
+	w1 := post("c1", 700*1024)
+	require.Equal(t, http.StatusCreated, w1.Code, w1.Body.String())
+
+	// Second ~700 KB save would push the total to ~1.4 MB → rejected.
+	w2 := post("c2", 700*1024)
+	require.Equal(t, http.StatusRequestEntityTooLarge, w2.Code, w2.Body.String())
+}

--- a/server/internal/bios/downloader.go
+++ b/server/internal/bios/downloader.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/safehttp"
 	"gorm.io/gorm"
 )
 
@@ -65,7 +66,11 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 	result := DownloadResult{}
 	total := len(entries)
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	// SSRF-hardened client: BIOS sources (archive.org / github / buildbot)
+	// redirect heavily, so re-validate every redirect hop against the
+	// private-IP block list instead of following blindly (#1322). Content is
+	// additionally MD5-gated below.
+	client := safehttp.NewClient(30 * time.Second)
 
 	for i, entry := range entries {
 		progress := DownloadProgress{
@@ -289,11 +294,11 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 				progress.Error = fmt.Sprintf("creating bundle target: %v", err)
 				result.Failed++
 				result.Errors = append(result.Errors, DownloadError{
-				FileName:  entry.FileName,
-				ConsoleID: entry.ConsoleID,
-				URL:       url,
-				Error:     progress.Error,
-			})
+					FileName:  entry.FileName,
+					ConsoleID: entry.ConsoleID,
+					URL:       url,
+					Error:     progress.Error,
+				})
 				if onProgress != nil {
 					onProgress(progress)
 				}
@@ -311,11 +316,11 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 				progress.Error = fmt.Sprintf("extracting bundle: %v", err)
 				result.Failed++
 				result.Errors = append(result.Errors, DownloadError{
-				FileName:  entry.FileName,
-				ConsoleID: entry.ConsoleID,
-				URL:       url,
-				Error:     progress.Error,
-			})
+					FileName:  entry.FileName,
+					ConsoleID: entry.ConsoleID,
+					URL:       url,
+					Error:     progress.Error,
+				})
 				if onProgress != nil {
 					onProgress(progress)
 				}
@@ -331,11 +336,11 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 				progress.Error = fmt.Sprintf("renaming temp file: %v", err)
 				result.Failed++
 				result.Errors = append(result.Errors, DownloadError{
-				FileName:  entry.FileName,
-				ConsoleID: entry.ConsoleID,
-				URL:       url,
-				Error:     progress.Error,
-			})
+					FileName:  entry.FileName,
+					ConsoleID: entry.ConsoleID,
+					URL:       url,
+					Error:     progress.Error,
+				})
 				if onProgress != nil {
 					onProgress(progress)
 				}

--- a/server/internal/bios/downloader.go
+++ b/server/internal/bios/downloader.go
@@ -23,6 +23,14 @@ import (
 // renamed to "Abdess/retrobios" on main branch with manufacturer/system paths.
 const DefaultRepoBaseURL = "https://raw.githubusercontent.com/Abdess/retrobios/main/bios"
 
+// maxBiosDownloadBytes caps a single BIOS file/bundle download and
+// maxBiosBundleBytes caps the total extracted size of a bundle archive, so a
+// compromised source or a decompression bomb can't exhaust the disk (#1325).
+const (
+	maxBiosDownloadBytes = 512 << 20
+	maxBiosBundleBytes   = 512 << 20
+)
+
 // DownloadProgress reports the status of a single file download.
 type DownloadProgress struct {
 	FileName  string `json:"fileName"`
@@ -235,9 +243,28 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 
 		hasher := md5.New()
 		writer := io.MultiWriter(tmpFile, hasher)
-		_, copyErr := io.Copy(writer, resp.Body)
+		// Cap the download so a compromised source can't fill the disk before
+		// the MD5 check runs (#1325). +1 lets us detect an over-cap body.
+		nCopied, copyErr := io.Copy(writer, io.LimitReader(resp.Body, maxBiosDownloadBytes+1))
 		resp.Body.Close()
 		tmpFile.Close()
+
+		if copyErr == nil && nCopied > maxBiosDownloadBytes {
+			os.Remove(tmpPath)
+			progress.Status = "failed"
+			progress.Error = fmt.Sprintf("download exceeded %d-byte cap", maxBiosDownloadBytes)
+			result.Failed++
+			result.Errors = append(result.Errors, DownloadError{
+				FileName:  entry.FileName,
+				ConsoleID: entry.ConsoleID,
+				URL:       url,
+				Error:     progress.Error,
+			})
+			if onProgress != nil {
+				onProgress(progress)
+			}
+			continue
+		}
 
 		if copyErr != nil {
 			os.Remove(tmpPath)
@@ -434,6 +461,8 @@ func extractZipBundle(archivePath, destDir, stripPrefix string) error {
 		return fmt.Errorf("resolving dest dir: %w", err)
 	}
 
+	var extracted int64 // running total of bytes written; bounds zip bombs (#1325)
+
 	for _, zf := range r.File {
 		// Reject absolute paths and traversal.
 		if filepath.IsAbs(zf.Name) || strings.Contains(zf.Name, "..") {
@@ -489,13 +518,17 @@ func extractZipBundle(archivePath, destDir, stripPrefix string) error {
 			out.Close()
 			return fmt.Errorf("opening archive entry %s: %w", zf.Name, err)
 		}
-		if _, err := io.Copy(out, in); err != nil {
-			out.Close()
-			in.Close()
-			return fmt.Errorf("writing %s: %w", target, err)
-		}
+		remaining := maxBiosBundleBytes - extracted
+		n, err := io.Copy(out, io.LimitReader(in, remaining+1))
 		out.Close()
 		in.Close()
+		if err != nil {
+			return fmt.Errorf("writing %s: %w", target, err)
+		}
+		extracted += n
+		if extracted > maxBiosBundleBytes {
+			return fmt.Errorf("bundle extraction exceeded %d-byte cap (possible decompression bomb)", maxBiosBundleBytes)
+		}
 	}
 	return nil
 }

--- a/server/internal/cheats/importer.go
+++ b/server/internal/cheats/importer.go
@@ -145,7 +145,9 @@ func ImportCheatsForGame(database *gorm.DB, game db.Game, console db.Console, ba
 		return fmt.Errorf("unexpected status %d for %s", resp.StatusCode, url)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	// Cap the buffered body so a compromised/MITM'd cheat host can't OOM the
+	// server (#1321); cheat files are small text, 16 MB is ample headroom.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
 	if err != nil {
 		return fmt.Errorf("reading cheat content for %s: %w", game.FileName, err)
 	}

--- a/server/internal/cores/CORE_INTEGRITY.md
+++ b/server/internal/cores/CORE_INTEGRITY.md
@@ -1,0 +1,51 @@
+# Core download integrity & trust model (#1315)
+
+libretro cores are **native executable libraries** (`.so`/`.dylib`/`.dll`)
+that the *player app* downloads from this server and loads into its own
+process. A malicious core is arbitrary code execution on the player device,
+so the integrity of the core-distribution path is security-critical.
+
+## What the server does
+
+`poller.go` keeps `CorePlatformBinary` rows in sync with libretro buildbot
+**nightly** builds:
+
+1. Fetches `https://buildbot.libretro.com/nightly/...` over a
+   `safehttp.NewStrictHTTPSClient` — TLS-authenticated, private-IP-blocked,
+   and **no redirect may downgrade to http** (a downgrade would drop server
+   authentication on a binary we are about to distribute).
+2. Refuses any non-`https://` fetch URL in production (the `http` test hook
+   is `BaseURLOverride`, used only by `poller_test.go`).
+3. Extracts exactly the expected core filename from the zip (size-capped,
+   no zip-slip), records its SHA-256, and audits every change via a
+   `SystemEventCoreUpdated` event (old → new hash).
+
+## The residual trust boundary — read before "fixing" this
+
+The server **cannot** detect a *compromised-but-TLS-valid* upstream. The
+hash it records is computed over the bytes it just downloaded; it is used
+for change-detection and audit, **not** verified against an independent
+trusted reference. There is no such reference to verify against:
+
+- libretro buildbot nightlies **change continuously** and ship **no
+  detached signature and no stable published checksum**. A static in-repo
+  expected-hash manifest (the approach the BIOS registry uses in #1124, for
+  *immutable* BIOS files) would be wrong within a day, breaking auto-update.
+
+So the design is deliberately **trust-on-fetch over authenticated TLS**, the
+same trust model RetroArch itself uses for buildbot cores. Transport is
+hardened; upstream compromise is an accepted, documented risk.
+
+## Options for operators who need stronger guarantees
+
+- **Disable auto-update:** set `SPELA_DISABLE_CORE_POLLER=1`. Cores are then
+  only changed by the explicit admin upload path.
+- **Pin a build:** set a core's `CustomDownloadURL` (the poller skips rows
+  that have one) to a specific, vetted artifact you host and trust.
+
+## If upstream gains signing
+
+If libretro ever publishes detached signatures or a stable signed checksum
+index for nightlies, add verification in `pollOne` between `hashAndSize` and
+the write-through, and reject on mismatch. That is the only change that would
+turn this from trust-on-fetch into verified integrity.

--- a/server/internal/cores/poller.go
+++ b/server/internal/cores/poller.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spela/server/internal/db"
@@ -64,7 +65,13 @@ type Poller struct {
 // NewPoller constructs a Poller with sensible defaults filled in.
 func NewPoller(database *gorm.DB, opts PollerOptions) *Poller {
 	if opts.HTTPClient == nil {
-		opts.HTTPClient = safehttp.NewClient(60 * time.Second)
+		// Strict HTTPS: core binaries are native executables the player
+		// runs, so the transport must never be downgraded to cleartext by
+		// a redirect (#1315). The trust boundary is documented in
+		// CORE_INTEGRITY.md — buildbot nightlies are trust-on-fetch over
+		// authenticated TLS; operators who need stronger guarantees pin a
+		// build or disable the poller via SPELA_DISABLE_CORE_POLLER.
+		opts.HTTPClient = safehttp.NewStrictHTTPSClient(60 * time.Second)
 	}
 	if len(opts.PollMatrix) == 0 {
 		opts.PollMatrix = DefaultPollMatrix
@@ -293,6 +300,12 @@ type fetchedBody struct {
 }
 
 func (p *Poller) fetchZipBody(ctx context.Context, url string) (fetchedBody, error) {
+	// Production fetches must be HTTPS so the upstream is TLS-authenticated
+	// before we execute what it returns (#1315). BaseURLOverride is the
+	// test-only hook that injects an http httptest server.
+	if p.opts.BaseURLOverride == "" && !strings.HasPrefix(url, "https://") {
+		return fetchedBody{}, fmt.Errorf("refusing non-https core URL: %s", url)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fetchedBody{}, fmt.Errorf("building request: %w", err)

--- a/server/internal/cores/poller_test.go
+++ b/server/internal/cores/poller_test.go
@@ -287,3 +287,14 @@ func TestPoller_SkipsCoresWithCustomDownloadURL(t *testing.T) {
 		assert.Equal(t, buildbotCore.ID, row.CoreID, "every row must belong to buildbot_core, not pinned")
 	}
 }
+
+// TestFetchZipBody_RefusesNonHTTPSInProduction verifies that, outside the
+// test-only BaseURLOverride path, the poller refuses to fetch a core binary
+// over a non-https URL — defense in depth for #1315 so no future code path
+// can pull an executable over cleartext.
+func TestFetchZipBody_RefusesNonHTTPSInProduction(t *testing.T) {
+	p := &Poller{opts: PollerOptions{HTTPClient: &http.Client{Timeout: time.Second}}}
+	_, err := p.fetchZipBody(context.Background(), "http://buildbot.libretro.com/nightly/x.zip")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-https")
+}

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -1020,6 +1020,33 @@ func mergeGameMetadata(database *gorm.DB, keeper, dup *Game) {
 // MigrateSharedSessions creates GameSession records for existing SharedSessions that
 // don't have a SessionID, and copies their SharedSessionSave records into
 // SessionSaveState. Guarded by the "relay_sessions_migrated" ServerSetting.
+// MigratePreserveOpenRegistration keeps self-service registration working for
+// installs that existed before #1319 changed the default to closed. If the
+// registration_enabled setting has never been configured AND at least one user
+// already exists (the server was set up before this upgrade), seed the flag to
+// "true" so the prior open-registration behaviour is preserved. Fresh installs
+// (no users yet) are left untouched and default to closed (secure-by-default).
+// Idempotent: a no-op once the setting exists.
+func MigratePreserveOpenRegistration(database *gorm.DB) error {
+	var setting ServerSetting
+	err := database.Where("key = ?", "registration_enabled").First(&setting).Error
+	if err == nil {
+		return nil // already configured — respect the operator's choice
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return fmt.Errorf("checking registration_enabled: %w", err)
+	}
+
+	var userCount int64
+	if err := database.Model(&User{}).Count(&userCount).Error; err != nil {
+		return fmt.Errorf("counting users: %w", err)
+	}
+	if userCount == 0 {
+		return nil // fresh install — leave closed-by-default
+	}
+	return database.Create(&ServerSetting{Key: "registration_enabled", Value: "true"}).Error
+}
+
 func MigrateSharedSessions(database *gorm.DB) error {
 	// Check if already migrated
 	var setting ServerSetting

--- a/server/internal/db/registration_default_migration_test.go
+++ b/server/internal/db/registration_default_migration_test.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func openRegistrationTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&User{}, &ServerSetting{}))
+	return database
+}
+
+func registrationSetting(t *testing.T, database *gorm.DB) (string, bool) {
+	t.Helper()
+	var s ServerSetting
+	err := database.Where("key = ?", "registration_enabled").First(&s).Error
+	if err == gorm.ErrRecordNotFound {
+		return "", false
+	}
+	require.NoError(t, err)
+	return s.Value, true
+}
+
+// Fresh install (no users): the flag stays absent so registration is
+// closed-by-default (#1319).
+func TestMigratePreserveOpenRegistration_FreshInstallLeavesClosed(t *testing.T) {
+	database := openRegistrationTestDB(t)
+	require.NoError(t, MigratePreserveOpenRegistration(database))
+	_, exists := registrationSetting(t, database)
+	assert.False(t, exists, "fresh install must not seed registration_enabled")
+}
+
+// Existing install (users present, flag never configured): preserve the prior
+// open-registration behaviour by seeding the flag to "true".
+func TestMigratePreserveOpenRegistration_ExistingInstallStaysOpen(t *testing.T) {
+	database := openRegistrationTestDB(t)
+	require.NoError(t, database.Create(&User{Username: "owner", Email: "o@example.com", PasswordHash: "x"}).Error)
+
+	require.NoError(t, MigratePreserveOpenRegistration(database))
+
+	val, exists := registrationSetting(t, database)
+	require.True(t, exists, "existing install must seed registration_enabled")
+	assert.Equal(t, "true", val)
+}
+
+// An operator's explicit choice is respected and never overwritten; the
+// migration is idempotent.
+func TestMigratePreserveOpenRegistration_RespectsExplicitSetting(t *testing.T) {
+	database := openRegistrationTestDB(t)
+	require.NoError(t, database.Create(&User{Username: "owner", Email: "o@example.com", PasswordHash: "x"}).Error)
+	require.NoError(t, database.Create(&ServerSetting{Key: "registration_enabled", Value: "false"}).Error)
+
+	require.NoError(t, MigratePreserveOpenRegistration(database))
+	require.NoError(t, MigratePreserveOpenRegistration(database)) // idempotent
+
+	val, _ := registrationSetting(t, database)
+	assert.Equal(t, "false", val, "explicit operator setting must be preserved")
+}

--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -19,6 +19,11 @@ import (
 // the rate-limit window can reset.
 var ErrRateLimit = errors.New("igdb: rate limit")
 
+// maxIGDBResponseBytes caps how much of an upstream response body we buffer
+// into memory, so a compromised/MITM'd endpoint can't OOM the server with an
+// unbounded body (#1321). 16 MB is far above any real IGDB JSON payload.
+const maxIGDBResponseBytes = 16 << 20
+
 // API base URLs (variables for testability).
 var (
 	twitchTokenURL = "https://id.twitch.tv/oauth2/token"
@@ -341,7 +346,7 @@ func (c *Client) fetchToken() error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		return fmt.Errorf("Twitch OAuth returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -378,7 +383,7 @@ func (c *Client) TestCredentials(clientID, clientSecret string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		return fmt.Errorf("authentication failed (HTTP %d): %s", resp.StatusCode, string(body))
 	}
 
@@ -387,23 +392,23 @@ func (c *Client) TestCredentials(clientID, clientSecret string) error {
 
 // Game represents an IGDB game search result.
 type Game struct {
-	ID                int              `json:"id"`
-	Name              string           `json:"name"`
-	Summary           string           `json:"summary"`
-	Storyline         string           `json:"storyline"`
-	Cover             *Image           `json:"cover"`
-	Screenshots       []Image          `json:"screenshots"`
-	Genres            []Genre          `json:"genres"`
+	ID                int               `json:"id"`
+	Name              string            `json:"name"`
+	Summary           string            `json:"summary"`
+	Storyline         string            `json:"storyline"`
+	Cover             *Image            `json:"cover"`
+	Screenshots       []Image           `json:"screenshots"`
+	Genres            []Genre           `json:"genres"`
 	InvolvedCompanies []InvolvedCompany `json:"involved_companies"`
-	FirstReleaseDate  int64            `json:"first_release_date"`
-	AggregatedRating  float64          `json:"aggregated_rating"`
-	TotalRating       float64          `json:"total_rating"`
-	TotalRatingCount  int              `json:"total_rating_count"`
-	IGDBRating        float64          `json:"rating"`
-	IGDBRatingCount   int              `json:"rating_count"`
-	GameModes         []GameMode       `json:"game_modes"`
-	ReleaseDates      []ReleaseDate    `json:"release_dates"`
-	TimeToBeat        *TimeToBeat      `json:"time_to_beat"`
+	FirstReleaseDate  int64             `json:"first_release_date"`
+	AggregatedRating  float64           `json:"aggregated_rating"`
+	TotalRating       float64           `json:"total_rating"`
+	TotalRatingCount  int               `json:"total_rating_count"`
+	IGDBRating        float64           `json:"rating"`
+	IGDBRatingCount   int               `json:"rating_count"`
+	GameModes         []GameMode        `json:"game_modes"`
+	ReleaseDates      []ReleaseDate     `json:"release_dates"`
+	TimeToBeat        *TimeToBeat       `json:"time_to_beat"`
 }
 
 // TimeToBeat represents IGDB time-to-beat data in seconds.
@@ -415,10 +420,10 @@ type TimeToBeat struct {
 
 // ReleaseDate represents an IGDB release date with region info.
 type ReleaseDate struct {
-	ID       int           `json:"id"`
-	Date     int64         `json:"date"`
-	Region   int           `json:"region"`
-	Human    string        `json:"human"`
+	ID       int              `json:"id"`
+	Date     int64            `json:"date"`
+	Region   int              `json:"region"`
+	Human    string           `json:"human"`
 	Platform *ReleasePlatform `json:"platform"`
 }
 
@@ -535,7 +540,7 @@ func (c *Client) SearchGame(name string, platformIDs []int) ([]Game, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
 		}
@@ -602,7 +607,7 @@ func (c *Client) SearchGameExact(name string, platformIDs []int) ([]Game, error)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
 		}
@@ -659,7 +664,7 @@ func (c *Client) GetGameByID(igdbID int) (*Game, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
 		}
@@ -714,7 +719,7 @@ func (c *Client) GetTimeToBeat(igdbGameID int) (*TimeToBeat, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
 		}
@@ -739,15 +744,15 @@ func (c *Client) GetTimeToBeat(igdbGameID int) (*TimeToBeat, error) {
 
 // TopGame represents an IGDB top-rated game result.
 type TopGame struct {
-	ID                    int     `json:"id"`
-	Name                  string  `json:"name"`
-	Cover                 *Image  `json:"cover"`
-	TotalRating           float64 `json:"total_rating"`
-	TotalRatingCount      int     `json:"total_rating_count"`
-	UserRating            float64 `json:"rating"`
-	UserRatingCount       int     `json:"rating_count"`
-	CriticRating          float64 `json:"aggregated_rating"`
-	CriticRatingCount     int     `json:"aggregated_rating_count"`
+	ID                int     `json:"id"`
+	Name              string  `json:"name"`
+	Cover             *Image  `json:"cover"`
+	TotalRating       float64 `json:"total_rating"`
+	TotalRatingCount  int     `json:"total_rating_count"`
+	UserRating        float64 `json:"rating"`
+	UserRatingCount   int     `json:"rating_count"`
+	CriticRating      float64 `json:"aggregated_rating"`
+	CriticRatingCount int     `json:"aggregated_rating_count"`
 }
 
 // GetTopGames fetches the top-rated games for the given IGDB platform(s).
@@ -792,7 +797,7 @@ func (c *Client) GetTopGames(platformIDs []int, limit int) ([]TopGame, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
 		}
@@ -856,7 +861,7 @@ func (c *Client) GetSimilarGames(igdbGameID int) ([]SimilarGame, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
 		}
@@ -934,8 +939,8 @@ type CompanyDetail struct {
 	Description  string `json:"description"`
 	LogoImageID  string `json:"logo_image_id"`
 	Country      int    `json:"country"`
-	StartDate    int64  `json:"start_date"`     // Unix timestamp
-	WebsiteURL   string `json:"website_url"`    // official website
+	StartDate    int64  `json:"start_date"`  // Unix timestamp
+	WebsiteURL   string `json:"website_url"` // official website
 	WikipediaURL string `json:"wikipedia_url"`
 }
 
@@ -982,7 +987,7 @@ func (c *Client) GetCompanyByID(igdbID int) (*CompanyDetail, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
 		}
@@ -1077,7 +1082,7 @@ func (c *Client) SearchCompanyByName(name string) (*CompanyDetail, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
 		}
@@ -1152,8 +1157,8 @@ type GameEnrichment struct {
 	Themes             []EnrichmentNamedItem `json:"themes"`
 	Keywords           []EnrichmentNamedItem `json:"keywords"`
 	PlayerPerspectives []EnrichmentNamedItem `json:"player_perspectives"`
-	Franchises         []int                 `json:"franchises"`       // raw franchise IDs
-	CollectionID       *int                  `json:"collection_id"`    // IGDB collection (series) ID, nil if none
+	Franchises         []int                 `json:"franchises"`    // raw franchise IDs
+	CollectionID       *int                  `json:"collection_id"` // IGDB collection (series) ID, nil if none
 	Artworks           []ArtworkData         `json:"artworks"`
 	Videos             []VideoData           `json:"videos"`
 	LanguageSupports   []LanguageSupportData `json:"language_supports"`
@@ -1232,8 +1237,6 @@ func AgeRatingCategoryName(category int) string {
 	}
 }
 
-
-
 // EnrichmentNamedItem holds an IGDB entity with an ID and name.
 type EnrichmentNamedItem struct {
 	ID   int    `json:"id"`
@@ -1263,8 +1266,8 @@ type CollectionData struct {
 
 // CollectionGameInfo holds basic info about a game within a collection.
 type CollectionGameInfo struct {
-	ID       int    `json:"id"`
-	Name     string `json:"name"`
+	ID           int    `json:"id"`
+	Name         string `json:"name"`
 	CoverImageID string `json:"cover_image_id"`
 }
 
@@ -1303,7 +1306,7 @@ func (c *Client) GetGameEnrichment(igdbID int) (*GameEnrichment, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
 		}
@@ -1425,7 +1428,7 @@ func (c *Client) GetCollection(collectionID int) (*CollectionData, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
 		}
@@ -1483,7 +1486,7 @@ func (c *Client) GetFranchise(franchiseID int) (*FranchiseData, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, fmt.Errorf("IGDB API returned %d: %s: %w", resp.StatusCode, string(body), ErrRateLimit)
 		}
@@ -1555,7 +1558,7 @@ func (c *Client) GetCollectionGames(gameIDs []int) ([]CollectionGameInfo, error)
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, maxIGDBResponseBytes))
 			resp.Body.Close()
 			return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 		}

--- a/server/internal/patcher/bps.go
+++ b/server/internal/patcher/bps.go
@@ -104,6 +104,15 @@ func ApplyBPS(romData, patchData []byte) ([]byte, error) {
 		actionType := data & 3
 		length := int((data >> 2) + 1)
 
+		// Every BPS action writes exactly `length` bytes into the target, so
+		// an action whose length runs past the target buffer is malformed.
+		// Reject it up front (#1324) — without this, a crafted VLQ length
+		// (up to ~2^62) spins the copy loop for billions of no-op iterations
+		// even though the bounded writes below produce nothing.
+		if targetPos+length > len(target) {
+			return nil, fmt.Errorf("BPS action would write past end of target buffer at offset %d", targetPos)
+		}
+
 		switch actionType {
 		case 0: // SourceRead
 			for i := 0; i < length; i++ {
@@ -195,7 +204,7 @@ func decodeVLQ(data []byte) (uint64, int, bool) {
 func decodeSignedVLQ(data []byte) (int, int, bool) {
 	value, n, ok := decodeVLQ(data)
 	if value&1 != 0 {
-		return -int(value >> 1) - 1, n, ok
+		return -int(value>>1) - 1, n, ok
 	}
 	return int(value >> 1), n, ok
 }

--- a/server/internal/patcher/bps_test.go
+++ b/server/internal/patcher/bps_test.go
@@ -60,6 +60,35 @@ func buildBPSPatch(source, target []byte) []byte {
 	return patch
 }
 
+// Issue #1324: a crafted SourceRead action with an enormous VLQ length must be
+// rejected immediately rather than spinning the copy loop for billions of
+// bounded no-op iterations.
+func TestApplyBPS_RejectsOversizedActionLength(t *testing.T) {
+	source := []byte("Hello, World!")
+
+	var patch []byte
+	patch = append(patch, []byte("BPS1")...)
+	patch = append(patch, encodeVLQ(uint64(len(source)))...)
+	patch = append(patch, encodeVLQ(4)...) // target size = 4
+	patch = append(patch, encodeVLQ(0)...) // no metadata
+
+	// SourceRead (type 0) with an absurd length that overruns the 4-byte target.
+	const hugeLength = uint64(1) << 60
+	actionData := (hugeLength-1)<<2 | 0
+	patch = append(patch, encodeVLQ(actionData)...)
+
+	// Footer: correct source/patch CRCs so we reach the action loop; the target
+	// CRC is never verified because we reject first.
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(source))...)
+	patch = append(patch, writeLE32(0)...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(patch))...)
+
+	result, err := ApplyBPS(source, patch)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "past end of target buffer")
+}
+
 func TestApplyBPS_Simple(t *testing.T) {
 	source := []byte("Hello, World!")
 	target := []byte("Hello, Go!!!")

--- a/server/internal/patcher/xdelta.go
+++ b/server/internal/patcher/xdelta.go
@@ -74,6 +74,15 @@ func ApplyXDelta(romData, patchData []byte) ([]byte, error) {
 		return nil, fmt.Errorf("xdelta3 failed: %s: %w", string(output), err)
 	}
 
+	// Bound the output before reading it wholly into memory: a malicious
+	// VCDIFF can declare a huge target window, and os.ReadFile would buffer
+	// all of it (#1325). Cap at the same MaxOutputSize the in-Go parsers use.
+	if fi, err := os.Stat(outFile.Name()); err != nil {
+		return nil, fmt.Errorf("stat xdelta3 output: %w", err)
+	} else if fi.Size() > MaxOutputSize {
+		return nil, fmt.Errorf("xdelta3 output %d exceeds maximum allowed size (%d bytes)", fi.Size(), MaxOutputSize)
+	}
+
 	// Read result
 	result, err := os.ReadFile(outFile.Name())
 	if err != nil {

--- a/server/internal/pouet/client.go
+++ b/server/internal/pouet/client.go
@@ -14,6 +14,10 @@ import (
 // API base URL (variable for testability).
 var apiBase = "https://api.pouet.net/v1"
 
+// maxPouetResponseBytes caps how much of an upstream response we buffer into
+// memory, so a compromised/MITM'd endpoint can't OOM the server (#1321).
+const maxPouetResponseBytes = 16 << 20
+
 // AbbreviationToPouetPlatforms maps Spela console abbreviations to Pouet platform IDs.
 // Pouet has no platform filter on search, so we filter client-side.
 var AbbreviationToPouetPlatforms = map[string][]int{
@@ -77,9 +81,9 @@ type Prod struct {
 	Screenshot string              `json:"screenshot"`
 	Download   string              `json:"download"`
 	Placings   []Placement         `json:"placings"`
-	VoteUp   json.Number `json:"voteup"`
-	VotePig  json.Number `json:"votepig"`
-	VoteDown json.Number `json:"votedown"`
+	VoteUp     json.Number         `json:"voteup"`
+	VotePig    json.Number         `json:"votepig"`
+	VoteDown   json.Number         `json:"votedown"`
 
 	ReleaseDate string `json:"releaseDate"`
 
@@ -118,7 +122,7 @@ func (c *Client) SearchProd(query string) ([]Prod, error) {
 		return nil, fmt.Errorf("pouet search: HTTP %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPouetResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("pouet search: reading body: %w", err)
 	}
@@ -154,7 +158,7 @@ func (c *Client) GetProd(id string) (*Prod, error) {
 		return nil, fmt.Errorf("pouet get prod: HTTP %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPouetResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("pouet get prod: reading body: %w", err)
 	}

--- a/server/internal/retroachievements/client.go
+++ b/server/internal/retroachievements/client.go
@@ -13,6 +13,10 @@ import (
 	"time"
 )
 
+// maxRAResponseBytes caps how much of an upstream response we buffer into
+// memory, so a compromised/MITM'd endpoint can't OOM the server (#1321).
+const maxRAResponseBytes = 16 << 20
+
 // RAClient wraps the RetroAchievements web API.
 type RAClient struct {
 	BaseURL    string
@@ -97,7 +101,7 @@ func (c *RAClient) GetGameExtended(apiKey string, raGameID uint) (*GameInfo, err
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRAResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("reading RA game extended response: %w", err)
 	}
@@ -116,14 +120,14 @@ func (c *RAClient) GetGameExtended(apiKey string, raGameID uint) (*GameInfo, err
 		NumDistinctPlayersCasual   int    `json:"NumDistinctPlayersCasual"`
 		NumDistinctPlayersHardcore int    `json:"NumDistinctPlayersHardcore"`
 		Achievements               map[string]struct {
-			ID                 uint             `json:"ID"`
-			Title              string           `json:"Title"`
-			Description        string           `json:"Description"`
-			Points             int              `json:"Points"`
-			BadgeName          string           `json:"BadgeName"`
-			Type               json.RawMessage  `json:"type"`
-			NumAwarded         int              `json:"NumAwarded"`
-			NumAwardedHardcore int              `json:"NumAwardedHardcore"`
+			ID                 uint            `json:"ID"`
+			Title              string          `json:"Title"`
+			Description        string          `json:"Description"`
+			Points             int             `json:"Points"`
+			BadgeName          string          `json:"BadgeName"`
+			Type               json.RawMessage `json:"type"`
+			NumAwarded         int             `json:"NumAwarded"`
+			NumAwardedHardcore int             `json:"NumAwardedHardcore"`
 		} `json:"Achievements"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
@@ -212,7 +216,7 @@ func (c *RAClient) LoginWithPassword(username, password string) (string, error) 
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRAResponseBytes))
 	if err != nil {
 		return "", fmt.Errorf("reading RA login response: %w", err)
 	}
@@ -257,7 +261,7 @@ func (c *RAClient) GetGameIDFromHash(hash string) (uint, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRAResponseBytes))
 	if err != nil {
 		return 0, fmt.Errorf("reading RA gameid response: %w", err)
 	}
@@ -302,7 +306,7 @@ func (c *RAClient) GetGameInfoAndUserProgress(username, token string, raGameID u
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRAResponseBytes))
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading RA game info response: %w", err)
 	}
@@ -313,11 +317,11 @@ func (c *RAClient) GetGameInfoAndUserProgress(username, token string, raGameID u
 
 	// The RA API returns a flat object with an Achievements map
 	var raw struct {
-		ID                        uint   `json:"ID"`
-		Title                     string `json:"Title"`
-		NumDistinctPlayersCasual  int    `json:"NumDistinctPlayersCasual"`
-		NumDistinctPlayersHardcore int   `json:"NumDistinctPlayersHardcore"`
-		Achievements map[string]struct {
+		ID                         uint   `json:"ID"`
+		Title                      string `json:"Title"`
+		NumDistinctPlayersCasual   int    `json:"NumDistinctPlayersCasual"`
+		NumDistinctPlayersHardcore int    `json:"NumDistinctPlayersHardcore"`
+		Achievements               map[string]struct {
 			ID                 uint   `json:"ID"`
 			Title              string `json:"Title"`
 			Description        string `json:"Description"`
@@ -398,4 +402,3 @@ func (c *RAClient) GetGameInfoAndUserProgress(username, token string, raGameID u
 
 	return gameInfo, progress, nil
 }
-

--- a/server/internal/safehttp/safehttp.go
+++ b/server/internal/safehttp/safehttp.go
@@ -111,6 +111,23 @@ func IsPrivateURL(rawURL string) bool {
 // URL targets a private IP (initial host or redirect target).
 var ErrPrivateURL = errors.New("safehttp: URL targets a private/internal IP")
 
+// Residual DNS-rebinding note (#1323): CheckURL/IsPrivateURL resolve and
+// validate the host, and CheckRedirect re-validates every redirect hop, but
+// the actual TCP connection re-resolves DNS independently. An attacker who
+// controls a hostname with a very short TTL could therefore resolve public at
+// check time and private at connect time (a TOCTOU window).
+//
+// We deliberately do NOT close this with a connect-time IP pin (a custom
+// DialContext that dials only the validated IP). Such a dialer also intercepts
+// the address of an outbound HTTP proxy, and self-hosted operators behind a
+// firewalled/corporate proxy frequently route through a private-range proxy IP
+// — pinning would block that and break all outbound fetching (scraping, cover
+// art, cores, BIOS). The exposure here is low: the only inputs that reach
+// safehttp with attacker influence over the hostname are admin-only (set-hero
+// URL) or an already-compromised upstream metadata provider, both of which are
+// high-privilege positions. If this trade-off ever changes, the fix is a
+// pinning dialer guarded to skip the proxy case.
+
 // ErrUnsupportedScheme is returned when an outbound fetch is rejected
 // because the scheme is not http or https.
 var ErrUnsupportedScheme = errors.New("safehttp: only http/https are allowed")

--- a/server/internal/safehttp/safehttp.go
+++ b/server/internal/safehttp/safehttp.go
@@ -138,6 +138,34 @@ func NewClient(timeout time.Duration) *http.Client {
 	}
 }
 
+// NewStrictHTTPSClient is like NewClient but additionally rejects any
+// redirect hop whose scheme is not https. It is intended for fetching
+// executable artifacts — libretro core binaries (#1315) — where transport
+// authentication must never be silently downgraded to cleartext by a
+// misbehaving or compromised upstream. A redirect from https to http would
+// otherwise let a network attacker serve an arbitrary (malicious) binary
+// over a connection with no server authentication.
+//
+// The initial request URL is the caller's responsibility (the cores poller
+// uses a hardcoded https buildbot constant); this guards the redirect chain.
+func NewStrictHTTPSClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("safehttp: redirect chain exceeds 10 hops")
+			}
+			if req.URL.Scheme != "https" {
+				return fmt.Errorf("redirect to %q scheme: %w", req.URL.Scheme, ErrUnsupportedScheme)
+			}
+			if IsPrivateURL(req.URL.String()) {
+				return fmt.Errorf("redirect to %s: %w", req.URL.Host, ErrPrivateURL)
+			}
+			return nil
+		},
+	}
+}
+
 // CheckURL is a convenience that runs the same checks as NewClient applies
 // before issuing a request — useful for callers that want to gate a URL
 // before passing it to an existing http.Client (where redirect validation

--- a/server/internal/safehttp/safehttp_test.go
+++ b/server/internal/safehttp/safehttp_test.go
@@ -71,3 +71,27 @@ func TestNewClient_RedirectToPrivateRejected(t *testing.T) {
 		t.Fatalf("expected ErrPrivateURL, got: %v", err)
 	}
 }
+
+// TestNewStrictHTTPSClient_RejectsRedirectDowngrade verifies that the strict
+// client refuses an https->http redirect, so a compromised/MITM'd upstream
+// can't downgrade a core-binary fetch to an unauthenticated transport (#1315).
+// The redirect target is a public http host; the scheme check fires before
+// any DNS lookup, so no real network call is made to it.
+func TestNewStrictHTTPSClient_RejectsRedirectDowngrade(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://example.com/evil-core.zip", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	cli := NewStrictHTTPSClient(5 * time.Second)
+	resp, err := cli.Get(srv.URL)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("expected error from https->http redirect downgrade")
+	}
+	if !errors.Is(err, ErrUnsupportedScheme) && !strings.Contains(err.Error(), "scheme") {
+		t.Fatalf("expected ErrUnsupportedScheme, got: %v", err)
+	}
+}

--- a/server/internal/scraper/namecache.go
+++ b/server/internal/scraper/namecache.go
@@ -83,7 +83,9 @@ func (c *nameCache) getOrLoad(system string, httpClient *http.Client) ([]nameEnt
 		return nil, fmt.Errorf("name listing for %s returned status %d", system, resp.StatusCode)
 	}
 
-	bodyBytes, err := io.ReadAll(resp.Body)
+	// Cap the listing read so a compromised/MITM'd CDN can't stream an
+	// unbounded body into memory (#1317).
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxLibRetroListingBytes))
 	if err != nil {
 		return nil, fmt.Errorf("reading name listing for %s: %w", system, err)
 	}

--- a/server/internal/scraper/scraper_libretro.go
+++ b/server/internal/scraper/scraper_libretro.go
@@ -2,12 +2,21 @@ package scraper
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"path/filepath"
 	"strings"
+
+	"github.com/spela/server/internal/safehttp"
 )
+
+// maxLibRetroListingBytes caps the in-memory size of a thumbnail directory
+// listing. The HTML index for even the largest system is well under this;
+// the cap stops a compromised/MITM'd CDN from streaming an unbounded body
+// into memory (#1317).
+const maxLibRetroListingBytes = 16 << 20 // 16 MB
 
 var libRetroThumbnailBase = "https://thumbnails.libretro.com"
 
@@ -27,7 +36,15 @@ func (s *Scraper) tryDownloadImage(system, name, imageType, subpath string) stri
 		url.PathEscape(name),
 	)
 
-	resp, err := s.HTTPClient.Get(imageURL)
+	// Use the SSRF-hardened image client (scheme allowlist, private-IP
+	// rejection on redirects) and cap the body, instead of a raw client +
+	// unbounded io.Copy into WriteImage (#1317).
+	if err := safehttp.CheckURL(imageURL); err != nil {
+		slog.Debug("rejecting LibRetro image URL", "url", imageURL, "error", err)
+		return ""
+	}
+
+	resp, err := safeImageClient.Get(imageURL)
 	if err != nil {
 		slog.Debug("failed to fetch LibRetro image", "url", imageURL, "error", err)
 		return ""
@@ -39,7 +56,8 @@ func (s *Scraper) tryDownloadImage(system, name, imageType, subpath string) stri
 		return ""
 	}
 
-	savedPath, err := s.Storage.WriteImage(subpath, resp.Body)
+	limited := io.LimitReader(resp.Body, maxExternalImageBytes+1)
+	savedPath, err := s.Storage.WriteImage(subpath, limited)
 	resp.Body.Close()
 	if err != nil {
 		slog.Warn("failed to save LibRetro image", "subpath", subpath, "error", err)
@@ -67,7 +85,7 @@ func (s *Scraper) downloadLibRetroImage(system, gameName, imageType, subpath str
 	}
 
 	// Fuzzy matching: prefers USA/World entries via hasPreferredRegion tie-breaking.
-	entries, err := s.cache.getOrLoad(system, s.HTTPClient)
+	entries, err := s.cache.getOrLoad(system, safeImageClient)
 	if err != nil {
 		slog.Warn("failed to load LibRetro name listing", "system", system, "error", err)
 		return ""
@@ -94,7 +112,7 @@ func (s *Scraper) FindRegionalVariants(consoleAbbr, gameName string) []RegionalV
 		return nil
 	}
 
-	entries, err := s.cache.getOrLoad(system, s.HTTPClient)
+	entries, err := s.cache.getOrLoad(system, safeImageClient)
 	if err != nil {
 		slog.Warn("failed to load LibRetro listing for regional variants", "system", system, "error", err)
 		return nil
@@ -164,11 +182,11 @@ func LibRetroThumbnailURL(consoleAbbr, libRetroName string) string {
 // its full game title (e.g. "Metal Slug - Super Vehicle-001").
 //
 // Resolution strategy (in order):
-// 1. DAT file lookup — if a MAME/FBNeo DAT is loaded, the `description`
-//    field provides an authoritative name→title mapping for every ROM.
-// 2. LibRetro fuzzy match — falls back to matching against the LibRetro
-//    thumbnail directory listing (works when short name normalizes close
-//    to the full title, e.g. "akkaarrh" → "Akka Arrh").
+//  1. DAT file lookup — if a MAME/FBNeo DAT is loaded, the `description`
+//     field provides an authoritative name→title mapping for every ROM.
+//  2. LibRetro fuzzy match — falls back to matching against the LibRetro
+//     thumbnail directory listing (works when short name normalizes close
+//     to the full title, e.g. "akkaarrh" → "Akka Arrh").
 func (s *Scraper) ResolveFullTitle(consoleAbbr, shortName string) string {
 	// Strategy 1: DAT file name→description lookup (authoritative, covers all ROMs)
 	if idx, err := s.DATCache.GetIndexForNameLookup(consoleAbbr); err == nil && idx != nil {
@@ -190,7 +208,7 @@ func (s *Scraper) ResolveFullTitle(consoleAbbr, shortName string) string {
 		return ""
 	}
 
-	entries, err := s.cache.getOrLoad(system, s.HTTPClient)
+	entries, err := s.cache.getOrLoad(system, safeImageClient)
 	if err != nil || len(entries) == 0 {
 		return ""
 	}

--- a/server/internal/websocket/netplay_hub.go
+++ b/server/internal/websocket/netplay_hub.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"encoding/json"
 	"log/slog"
+	"net/http"
 	"sync"
 	"time"
 
@@ -20,6 +21,10 @@ const (
 	netplayMsgRateLimit = 60
 	// netplayMsgBurst is the burst allowance for the per-client rate limiter.
 	netplayMsgBurst = 120
+	// maxNetplayRooms caps concurrently active netplay rooms. Each room holds
+	// at most two players, so this bounds total netplay connections (and their
+	// goroutines/memory) regardless of how many sessions clients create (#1328).
+	maxNetplayRooms = 500
 )
 
 // NetplayMessage represents a JSON message in a netplay session.
@@ -71,13 +76,32 @@ func NewNetplayHub(allowedOrigins []string) *NetplayHub {
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  4096,
 			WriteBufferSize: 4096,
-			CheckOrigin: checkOrigin(allowedOrigins),
+			CheckOrigin:     checkOrigin(allowedOrigins),
 		},
 	}
 }
 
+// hasCapacityFor reports whether a connection for sessionID can be accepted:
+// always true when the room already exists (the client is joining), otherwise
+// gated by the global room cap. Soft cap — a brief race may let the count
+// nudge slightly past the limit, which is fine for a DoS guard.
+func (h *NetplayHub) hasCapacityFor(sessionID uint) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.rooms[sessionID]; ok {
+		return true
+	}
+	return len(h.rooms) < maxNetplayRooms
+}
+
 // HandleNetplayWebSocket upgrades the connection and joins the client to a room.
 func (h *NetplayHub) HandleNetplayWebSocket(c *gin.Context, sessionID, userID uint) {
+	// Reject before upgrading when the global room cap is reached (#1328).
+	if !h.hasCapacityFor(sessionID) {
+		http.Error(c.Writer, "netplay capacity reached, try again later", http.StatusServiceUnavailable)
+		return
+	}
+
 	conn, err := h.upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
 		slog.Error("netplay websocket upgrade failed", "error", err, "sessionId", sessionID, "userId", userID)
@@ -215,7 +239,7 @@ func (r *NetplayRoom) sendTo(targetUID uint, data []byte, msgType int) {
 // --- Client message pumps ---
 
 const (
-	netplayPongWait    = 60 * time.Second
+	netplayPongWait     = 60 * time.Second
 	netplayPingInterval = 30 * time.Second
 )
 

--- a/server/internal/websocket/netplay_hub_test.go
+++ b/server/internal/websocket/netplay_hub_test.go
@@ -13,6 +13,17 @@ func TestNewNetplayHub(t *testing.T) {
 	assert.NotNil(t, hub.rooms)
 }
 
+// Issue #1328: once the global room cap is reached, a connection for a NEW
+// session is refused, but joining an existing room is still allowed.
+func TestNetplayHub_RoomCapacity(t *testing.T) {
+	hub := NewNetplayHub(nil)
+	for i := uint(1); i <= maxNetplayRooms; i++ {
+		hub.getOrCreateRoom(i)
+	}
+	assert.False(t, hub.hasCapacityFor(maxNetplayRooms+1), "new room beyond cap must be rejected")
+	assert.True(t, hub.hasCapacityFor(1), "joining an existing room must still be allowed")
+}
+
 func TestNetplayHub_GetOrCreateRoom(t *testing.T) {
 	hub := NewNetplayHub(nil)
 


### PR DESCRIPTION
## Security hardening from the backend audit

Implements fixes for the findings filed under the security-audit tracking issue #1331. One commit per finding; tests added where behavioral.

### High
- **#1314** — storage-quota bypass → disk-exhaustion DoS. The quota only summed `SessionSaveState`; expanded `userStoredBytes` to span shared saves, shared-session saves, and challenge saves, and enforce it on those upload handlers. _(unit + handler tests)_
- **#1315** — libretro core integrity. buildbot nightlies ship no signature/stable hash to pin, so this hardens transport (HTTPS-strict, no redirect downgrade) and documents the trust boundary in `CORE_INTEGRITY.md` rather than implying integrity the design can't provide. _(safehttp + poller tests)_

### Medium
- **#1316 / #1320** — public play-heatmap & achievement-showcase bypassed the #1121 profile-visibility/block gate; factored into a shared `publicProfileAccess` helper applied to all three reads. _(tests)_
- **#1317** — libretro thumbnail + console-preview fetches used raw clients with unbounded reads; routed through `safehttp` + `io.LimitReader`.
- **#1318** — server API keys (IGDB/SGDB/RA) stored plaintext; now AES-GCM encrypted at rest, legacy plaintext still readable. _(round-trip test)_
- **#1319** — registration now closed-by-default for fresh installs; an idempotent migration preserves existing installs. _(default + migration tests)_

### Low
- **#1321** — cap upstream response bodies in RA/Pouet/cheats/IGDB clients.
- **#1322** — BIOS downloader routed through `safehttp` (redirect re-validation).
- **#1323** — documented the residual DNS-rebinding TOCTOU; a connect-time pin was deliberately *not* added (it would break operators behind a private-range proxy).
- **#1324** — BPS patch action-length bound to reject CPU-spin patches. _(test)_
- **#1325** — bounded BIOS bundle extraction + xdelta output size.
- **#1326** — `ReadHeaderTimeout` (Slowloris).
- **#1327** — per-IP rate limit on the public image route.
- **#1328** — global netplay room cap. _(test)_
- **#1329** — global connection cap via `netutil.LimitListener` (`SPELA_MAX_CONNECTIONS`).

### Informational
- **#1330** — refuse `SPELA_TEST_MODE` with `GIN_MODE=release`; seed binary refuses to run against a populated DB.

### Verification
`go build ./...`, `go vet ./...`, and the full `go test ./...` server suite pass locally. No E2E-affecting changes beyond server behavior already covered by the Go suite.

Closes #1314, #1315, #1316, #1317, #1318, #1319, #1320, #1321, #1322, #1323, #1324, #1325, #1326, #1327, #1328, #1329, #1330
