### PR TITLE
Controller detection — Phase 1a: detect controller type (#1334)

### DIFF
--- a/player/native/src/gamepad_sdl3.c
+++ b/player/native/src/gamepad_sdl3.c
@@ -179,7 +179,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_spela_player_libretro_LibretroJni_native
     jclass stateClass = (*env)->FindClass(env, "com/spela/player/libretro/GamepadState");
     if (!stateClass) return NULL;
 
-    jmethodID ctor = (*env)->GetMethodID(env, stateClass, "<init>", "(ILjava/lang/String;[Z[I)V");
+    jmethodID ctor = (*env)->GetMethodID(env, stateClass, "<init>", "(ILjava/lang/String;[Z[II)V");
     if (!ctor) return NULL;
 
     int attached_count = 0;
@@ -222,7 +222,8 @@ JNIEXPORT jobjectArray JNICALL Java_com_spela_player_libretro_LibretroJni_native
         axisValues[5] = SDL_GetGamepadAxis(gc, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER);
         (*env)->SetIntArrayRegion(env, axes, 0, NUM_AXES, axisValues);
 
-        jobject stateObj = (*env)->NewObject(env, stateClass, ctor, controllerId, jname, buttons, axes);
+        jint gpType = (jint)SDL_GetRealGamepadType(gc);
+        jobject stateObj = (*env)->NewObject(env, stateClass, ctor, controllerId, jname, buttons, axes, gpType);
         (*env)->SetObjectArrayElement(env, result, out_index, stateObj);
         out_index++;
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ControllerStyle.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ControllerStyle.kt
@@ -1,0 +1,34 @@
+package com.spela.player.domain.model
+
+/**
+ * Normalized physical-controller layout family. Drives Android input
+ * normalization and the identity display only — never the positional bindings.
+ */
+enum class ControllerStyle { Xbox, Nintendo, PlayStation, Generic }
+
+/**
+ * Classifies a connected controller into a [ControllerStyle] from USB vendor/
+ * product IDs (both Android InputDevice and SDL expose these), with a name-
+ * substring fallback. Pure + platform-agnostic so both platforms share it.
+ */
+object ControllerClassifier {
+    // USB vendor IDs.
+    private const val VENDOR_SONY = 0x054C
+    private const val VENDOR_MICROSOFT = 0x045E
+    private const val VENDOR_NINTENDO = 0x057E
+
+    fun fromVendorProduct(vendorId: Int, productId: Int, name: String): ControllerStyle {
+        when (vendorId) {
+            VENDOR_SONY -> return ControllerStyle.PlayStation
+            VENDOR_MICROSOFT -> return ControllerStyle.Xbox
+            VENDOR_NINTENDO -> return ControllerStyle.Nintendo
+        }
+        val n = name.lowercase()
+        return when {
+            "dualsense" in n || "dualshock" in n || "playstation" in n || "wireless controller" in n -> ControllerStyle.PlayStation
+            "xbox" in n || "xinput" in n -> ControllerStyle.Xbox
+            "switch" in n || "joy-con" in n || "joycon" in n || "pro controller" in n || "nintendo" in n -> ControllerStyle.Nintendo
+            else -> ControllerStyle.Generic
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
@@ -1,5 +1,6 @@
 package com.spela.player.libretro
 
+import com.spela.player.domain.model.ControllerStyle
 import com.spela.player.domain.repository.KeyMappingRepository
 import com.spela.player.presentation.ui.gamepad.InputMode
 import kotlinx.coroutines.CoroutineScope
@@ -44,6 +45,7 @@ class GamepadPortManager(
         val deviceId: Int,
         val port: Int,
         val deviceName: String = "",
+        val style: ControllerStyle = ControllerStyle.Generic,
     )
 
     /** Current port assignments, keyed by device ID. */
@@ -90,7 +92,7 @@ class GamepadPortManager(
      * If the device is already assigned, returns its existing port.
      */
     @Synchronized
-    fun connectDevice(deviceId: Int, deviceName: String = ""): Int {
+    fun connectDevice(deviceId: Int, deviceName: String = "", style: ControllerStyle = ControllerStyle.Generic): Int {
         // Already assigned?
         deviceToPort[deviceId]?.let { return it.port }
 
@@ -99,7 +101,7 @@ class GamepadPortManager(
         if (port == -1) return -1
 
         occupiedPorts[port] = true
-        val assignment = PortAssignment(deviceId = deviceId, port = port, deviceName = deviceName)
+        val assignment = PortAssignment(deviceId = deviceId, port = port, deviceName = deviceName, style = style)
         deviceToPort[deviceId] = assignment
         _assignments.value = deviceToPort.values.toList()
         emitControllerStatus()

--- a/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/ControllerStyleTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/ControllerStyleTest.kt
@@ -1,0 +1,19 @@
+package com.spela.player.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ControllerStyleTest {
+    @Test
+    fun classifiesKnownVendors() {
+        assertEquals(ControllerStyle.PlayStation, ControllerClassifier.fromVendorProduct(0x054C, 0x0CE6, ""))
+        assertEquals(ControllerStyle.Xbox, ControllerClassifier.fromVendorProduct(0x045E, 0x02FD, ""))
+        assertEquals(ControllerStyle.Nintendo, ControllerClassifier.fromVendorProduct(0x057E, 0x2009, ""))
+    }
+
+    @Test
+    fun unknownVendorFallsBackToNameThenGeneric() {
+        assertEquals(ControllerStyle.Nintendo, ControllerClassifier.fromVendorProduct(0x0000, 0x0000, "Pro Controller"))
+        assertEquals(ControllerStyle.Generic, ControllerClassifier.fromVendorProduct(0x1234, 0x5678, "Some USB Gamepad"))
+    }
+}

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/domain/model/ControllerClassifier.desktop.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/domain/model/ControllerClassifier.desktop.kt
@@ -1,0 +1,15 @@
+package com.spela.player.domain.model
+
+/**
+ * Maps an SDL_GamepadType integer (from SDL_GetRealGamepadType, carried on
+ * GamepadState.type) to a ControllerStyle. Values per SDL3 3.2.x SDL_gamepad.h:
+ *   0 UNKNOWN, 1 STANDARD, 2 XBOX360, 3 XBOXONE, 4 PS3, 5 PS4, 6 PS5,
+ *   7 NINTENDO_SWITCH_PRO, 8 JOYCON_LEFT, 9 JOYCON_RIGHT, 10 JOYCON_PAIR.
+ * Verify these constants against the pinned SDL3 header if SDL is bumped.
+ */
+fun controllerStyleFromSdlType(sdlType: Int): ControllerStyle = when (sdlType) {
+    2, 3 -> ControllerStyle.Xbox        // also covers XBOXSERIES if a later SDL adds it (extend then)
+    4, 5, 6 -> ControllerStyle.PlayStation
+    7, 8, 9, 10 -> ControllerStyle.Nintendo
+    else -> ControllerStyle.Generic     // 0 UNKNOWN, 1 STANDARD, and anything unmapped
+}

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
@@ -1,5 +1,6 @@
 package com.spela.player.libretro
 
+import com.spela.player.domain.model.controllerStyleFromSdlType
 import com.spela.player.presentation.navigation.NavigationEventBus
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.viewmodel.LibretroButtons
@@ -107,7 +108,11 @@ class DesktopGamepadPoller(
             // Connect new devices
             if (state.controllerId !in knownControllers) {
                 knownControllers.add(state.controllerId)
-                gamepadPortManager.connectDevice(state.controllerId, state.name)
+                gamepadPortManager.connectDevice(
+                    state.controllerId,
+                    state.name,
+                    controllerStyleFromSdlType(state.type),
+                )
             }
 
             val port = gamepadPortManager.getPort(state.controllerId)

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadState.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadState.kt
@@ -7,12 +7,14 @@ package com.spela.player.libretro
  * @param name Human-readable controller name (e.g. "Xbox Controller")
  * @param buttons Button states indexed by libretro button ID (0..15)
  * @param axes Axis values: [LX, LY, RX, RY, TriggerL, TriggerR] in SDL range (-32768..32767)
+ * @param type SDL_GamepadType (SDL_GetRealGamepadType) integer for the connected pad; 0 = unknown
  */
 data class GamepadState(
     val controllerId: Int,
     val name: String,
     val buttons: BooleanArray,
     val axes: IntArray,
+    val type: Int,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -20,7 +22,8 @@ data class GamepadState(
         return controllerId == other.controllerId &&
             name == other.name &&
             buttons.contentEquals(other.buttons) &&
-            axes.contentEquals(other.axes)
+            axes.contentEquals(other.axes) &&
+            type == other.type
     }
 
     override fun hashCode(): Int {
@@ -28,6 +31,7 @@ data class GamepadState(
         result = 31 * result + name.hashCode()
         result = 31 * result + buttons.contentHashCode()
         result = 31 * result + axes.contentHashCode()
+        result = 31 * result + type
         return result
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/domain/model/SdlTypeClassifierTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/domain/model/SdlTypeClassifierTest.kt
@@ -1,0 +1,20 @@
+package com.spela.player.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SdlTypeClassifierTest {
+    @Test
+    fun mapsSdlGamepadTypes() {
+        // SDL_GamepadType values (verified against SDL3 3.2.30 SDL_gamepad.h)
+        assertEquals(ControllerStyle.Xbox, controllerStyleFromSdlType(2))          // XBOX360
+        assertEquals(ControllerStyle.Xbox, controllerStyleFromSdlType(3))          // XBOXONE
+        assertEquals(ControllerStyle.PlayStation, controllerStyleFromSdlType(4))   // PS3
+        assertEquals(ControllerStyle.PlayStation, controllerStyleFromSdlType(5))   // PS4
+        assertEquals(ControllerStyle.PlayStation, controllerStyleFromSdlType(6))   // PS5
+        assertEquals(ControllerStyle.Nintendo, controllerStyleFromSdlType(7))      // SWITCH_PRO
+        assertEquals(ControllerStyle.Nintendo, controllerStyleFromSdlType(10))     // JOYCON_PAIR
+        assertEquals(ControllerStyle.Generic, controllerStyleFromSdlType(0))       // UNKNOWN
+        assertEquals(ControllerStyle.Generic, controllerStyleFromSdlType(1))       // STANDARD
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
@@ -1,5 +1,6 @@
 package com.spela.player.libretro
 
+import com.spela.player.domain.model.ControllerStyle
 import com.spela.player.domain.model.KeyMappingProfile
 import com.spela.player.domain.repository.KeyMappingRepository
 import kotlinx.coroutines.test.runTest
@@ -19,6 +20,20 @@ class GamepadPortManagerTest {
     fun connectFirstDeviceAssignsPort0() {
         val port = manager.connectDevice(100, "Xbox Controller")
         assertEquals(0, port)
+    }
+
+    @Test
+    fun connectDeviceRecordsStyleOnAssignment() {
+        manager.connectDevice(deviceId = 1, deviceName = "Xbox Wireless Controller", style = ControllerStyle.Xbox)
+        val a = manager.assignments.value.single()
+        assertEquals(ControllerStyle.Xbox, a.style)
+        assertEquals("Xbox Wireless Controller", a.deviceName)
+    }
+
+    @Test
+    fun styleDefaultsToGeneric() {
+        manager.connectDevice(deviceId = 2, deviceName = "")
+        assertEquals(ControllerStyle.Generic, manager.assignments.value.single().style)
     }
 
     @Test

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadUiNavigatorTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadUiNavigatorTest.kt
@@ -27,10 +27,10 @@ class GamepadUiNavigatorTest {
     private fun pressed(vararg buttonIds: Int): Array<GamepadState> {
         val buttons = BooleanArray(16)
         buttonIds.forEach { buttons[it] = true }
-        return arrayOf(GamepadState(0, "Test Controller", buttons, IntArray(6)))
+        return arrayOf(GamepadState(0, "Test Controller", buttons, IntArray(6), 0))
     }
 
-    private val released = arrayOf(GamepadState(0, "Test Controller", BooleanArray(16), IntArray(6)))
+    private val released = arrayOf(GamepadState(0, "Test Controller", BooleanArray(16), IntArray(6), 0))
 
     @Test
     fun dpadDirectionsMapToArrowKeys() {


### PR DESCRIPTION
Part of #1334 (controller layout/brand detection); builds on the merged SDL3 migration (#1337). Epic #1333.

## Summary
Phase 1a — the **detection core**. The app can now determine the connected controller's type; nothing user-facing changes yet (UI, storage, input-normalization, and remapping are later phases).

- Carry the **SDL3 gamepad type** across the JNI bridge — `SDL_GetRealGamepadType` on a new `GamepadState.type` field (the field deferred from #1337).
- New shared **`ControllerStyle`** (Xbox/Nintendo/PlayStation/Generic) + **`ControllerClassifier.fromVendorProduct`** (vendor/product table + name fallback) in `commonMain`.
- Desktop **`controllerStyleFromSdlType`** mapping (verified against SDL3 3.2.30 `SDL_gamepad.h` enum values).
- Detected style is **exposed per port** via `GamepadPortManager.PortAssignment.style` (desktop poller wires it from the SDL type).

## Test Plan
- [x] Native lib builds (JNI ctor descriptor `(ILjava/lang/String;[Z[II)V` matches the 5-arg `GamepadState`; `SDL_GetRealGamepadType` resolves).
- [x] Unit tests: vendor/product → style; SDL-type → style; `connectDevice(style)` records it on the assignment (defaults to Generic).
- [x] Existing `GamepadPortManager` / `GamepadConfig` / `GamepadUiNavigator` tests pass (new `style` params default — no regressions).
- [ ] CI Desktop E2E (full suite) green.

Does not close #1334 — later phases (1b identity display + device-local input-layer store/view; 2 Android normalization; 3 desktop gamepad remapping; 4 positional mapping UI) remain.
