### PR TITLE
Controller positional mapping + detection (#1334)

### DIFF
--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.lifecycle.lifecycleScope
+import com.spela.player.domain.model.ControllerClassifier
 import com.spela.player.domain.repository.PreferencesRepository
 import com.spela.player.libretro.AndroidLibretroController
 import com.spela.player.libretro.GamepadPortManager
@@ -191,13 +192,18 @@ class MainActivity : ComponentActivity() {
         if (!isGamepadInputDevice(device)) return -1
 
         val deviceName = device.name ?: "Gamepad $deviceId"
-        val port = gamepadPortManager.connectDevice(deviceId, deviceName)
+        // Detect the controller style (#1334) so input is normalized positionally
+        // and the identity display is correct. Vendor/product with a name fallback.
+        val style = ControllerClassifier.fromVendorProduct(device.vendorId, device.productId, deviceName)
+        val port = gamepadPortManager.connectDevice(deviceId, deviceName, style)
         if (port >= 0) {
             val consoleId = emulationViewModel.state.value.consoleId
             if (consoleId.isNotEmpty()) {
                 lifecycleScope.launch {
                     try {
-                        gamepadPortManager.loadMappingForPort(port, consoleId)
+                        // Gamepad input now flows through the positional mapping
+                        // layer (key code → GamepadPosition → RetroPad).
+                        gamepadPortManager.loadGamepadMappingForPort(port, consoleId)
                     } catch (_: Exception) {
                         // Best effort
                     }
@@ -267,7 +273,7 @@ class MainActivity : ComponentActivity() {
             val port = ensureDeviceConnected(deviceId)
             if (port < 0) return super.onKeyDown(keyCode, event)
 
-            val buttonId = gamepadPortManager.mapKeyToLibretro(port, keyCode)
+            val buttonId = gamepadPortManager.mapGamepadKeyToLibretro(port, keyCode)
             if (buttonId != null) {
                 androidController?.let {
                     it.setButton(port, buttonId, true)
@@ -367,7 +373,7 @@ class MainActivity : ComponentActivity() {
             val port = gamepadPortManager.getPort(deviceId)
             if (port < 0) return super.onKeyUp(keyCode, event)
 
-            val buttonId = gamepadPortManager.mapKeyToLibretro(port, keyCode)
+            val buttonId = gamepadPortManager.mapGamepadKeyToLibretro(port, keyCode)
             if (buttonId != null) {
                 androidController?.let {
                     it.setButton(port, buttonId, false)

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadConfigTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadConfigTest.kt
@@ -177,6 +177,82 @@ class GamepadConfigTest {
     }
 
     @Test
+    fun detectedControllerStyleShownAsIdentity() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToConsoleSettings(harness, "nes")
+
+        // A PlayStation-detected pad shows its style identity, not the raw name.
+        harness.gamepadPortManager.connectDevice(
+            1,
+            "Sony Interactive Wireless Controller",
+            com.spela.player.domain.model.ControllerStyle.PlayStation,
+        )
+        advance(harness)
+
+        onNodeWithContentDescription("Player 1: PlayStation Controller").assertExists()
+    }
+
+    @Test
+    fun styleOverridePickerChangesIdentity() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToConsoleSettings(harness, "nes")
+
+        harness.gamepadPortManager.connectDevice(
+            1,
+            "Sony Interactive Wireless Controller",
+            com.spela.player.domain.model.ControllerStyle.PlayStation,
+        )
+        advance(harness)
+        onNodeWithContentDescription("Player 1: PlayStation Controller").assertExists()
+
+        // Open the per-controller type picker and override to Xbox.
+        onNodeWithContentDescription("Player 1 controller type").performClick()
+        advance(harness)
+        onNodeWithTag("controller_style_picker").assertExists()
+
+        // "Xbox Controller" text exists only in the picker at this point.
+        onNodeWithText("Xbox Controller").performClick()
+        advance(harness)
+
+        // Identity reflects the override; picker is dismissed.
+        onNodeWithContentDescription("Player 1: Xbox Controller").assertExists()
+        onNodeWithTag("controller_style_picker").assertDoesNotExist()
+    }
+
+    @Test
+    fun styleOverrideAutoRevertsToDetected() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToConsoleSettings(harness, "nes")
+
+        harness.gamepadPortManager.connectDevice(
+            1,
+            "Sony Interactive Wireless Controller",
+            com.spela.player.domain.model.ControllerStyle.PlayStation,
+        )
+        advance(harness)
+
+        // Override to Xbox first.
+        onNodeWithContentDescription("Player 1 controller type").performClick()
+        advance(harness)
+        onNodeWithText("Xbox Controller").performClick()
+        advance(harness)
+        onNodeWithContentDescription("Player 1: Xbox Controller").assertExists()
+
+        // Re-open and choose Auto: identity reverts to the detected style.
+        onNodeWithContentDescription("Player 1 controller type").performClick()
+        advance(harness)
+        onNodeWithText("Auto").performClick()
+        advance(harness)
+        onNodeWithContentDescription("Player 1: PlayStation Controller").assertExists()
+    }
+
+    @Test
     fun portManagerTracksCorrectPortAfterSwap() {
         val harness = createLoggedInHarness()
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadMappingTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadMappingTest.kt
@@ -1,0 +1,91 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+
+/**
+ * E2E tests for the desktop positional gamepad mapping editor (#1334, Phase 3c).
+ *
+ * Verifies the brand-neutral position→action editor: it opens from console
+ * settings, shows the default mapping, lets the user reassign a position to a
+ * different console action, and resets to defaults — all positional, no brand
+ * glyphs.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class GamepadMappingTest {
+
+    private fun createLoggedInHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.authRepo.preSetTokens()
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private fun ComposeUiTest.openGamepadEditor(harness: SpelaTestHarness, consoleId: String) {
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.ConsoleSettings(consoleId)))
+        advance(harness)
+        // The entry is a LazyColumn item below the fold — scroll the list so it
+        // composes before interacting.
+        onNodeWithTag("console-settings-list")
+            .performScrollToNode(hasTestTag("configure_gamepad_buttons"))
+        advance(harness)
+        onNodeWithTag("configure_gamepad_buttons").performClick()
+        advance(harness)
+        onNodeWithTag("gamepad_mapping_dialog").assertExists()
+    }
+
+    @Test
+    fun editorShowsDefaultMappingPositionally() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        openGamepadEditor(harness, "nes")
+
+        // NES default: bottom button = B, right button = A. Brand-neutral labels.
+        // Rows are clickable (semantics merged), so query the value Text unmerged.
+        onNodeWithTag("gamepad_action_SOUTH", useUnmergedTree = true).assertTextEquals("B")
+        onNodeWithTag("gamepad_action_EAST", useUnmergedTree = true).assertTextEquals("A")
+        // West has no NES action by default.
+        onNodeWithTag("gamepad_action_WEST", useUnmergedTree = true).assertTextEquals("—")
+    }
+
+    @Test
+    fun reassigningAPositionPersistsInTheRow() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        openGamepadEditor(harness, "nes")
+
+        // Guiding example: make the bottom button act as NES A.
+        onNodeWithTag("gamepad_pos_SOUTH").performScrollTo().performClick()
+        advance(harness)
+        onNodeWithTag("gamepad_action_picker").assertExists()
+        // The picker's "A" option sets a contentDescription; the row value
+        // Texts don't, so this targets the option unambiguously.
+        onNodeWithContentDescription("A").performClick()
+        advance(harness)
+
+        onNodeWithTag("gamepad_action_picker").assertDoesNotExist()
+        onNodeWithTag("gamepad_action_SOUTH", useUnmergedTree = true).assertTextEquals("A")
+    }
+
+    @Test
+    fun resetToDefaultsRestoresMapping() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        openGamepadEditor(harness, "nes")
+
+        // Reassign, then reset.
+        onNodeWithTag("gamepad_pos_SOUTH").performScrollTo().performClick()
+        advance(harness)
+        onNodeWithContentDescription("A").performClick()
+        advance(harness)
+        onNodeWithTag("gamepad_action_SOUTH", useUnmergedTree = true).assertTextEquals("A")
+
+        onNodeWithTag("gamepad_mapping_reset").performClick()
+        advance(harness)
+        onNodeWithTag("gamepad_action_SOUTH", useUnmergedTree = true).assertTextEquals("B")
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -283,6 +283,7 @@ class SpelaTestHarness(
     val gamepadMappingViewModel = GamepadMappingViewModel(
         gamepadMappingRepository = GamepadMappingRepositoryImpl(testDatabase),
         gamepadPortManager = gamepadPortManager,
+        preferencesRepository = preferencesRepo,
         dispatchers = dispatchers,
         scope = scope,
     )

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.spela.player.data.device.DeviceManager
 import com.spela.player.data.local.SpelaDatabase
+import com.spela.player.data.repository.ControllerStyleOverrideRepositoryImpl
 import com.spela.player.data.remote.ConnectivityMonitor
 import com.spela.player.data.remote.PresenceService
 import com.spela.player.data.remote.SyncEngine
@@ -271,6 +272,7 @@ class SpelaTestHarness(
 
     val gamepadConfigViewModel = GamepadConfigViewModel(
         gamepadPortManager = gamepadPortManager,
+        styleOverrideRepository = ControllerStyleOverrideRepositoryImpl(testDatabase),
         dispatchers = dispatchers,
         scope = scope,
         nowMs = { testDispatcher.scheduler.currentTime },

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -5,6 +5,7 @@ import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.spela.player.data.device.DeviceManager
 import com.spela.player.data.local.SpelaDatabase
 import com.spela.player.data.repository.ControllerStyleOverrideRepositoryImpl
+import com.spela.player.data.repository.GamepadMappingRepositoryImpl
 import com.spela.player.data.remote.ConnectivityMonitor
 import com.spela.player.data.remote.PresenceService
 import com.spela.player.data.remote.SyncEngine
@@ -172,6 +173,7 @@ class SpelaTestHarness(
         keyMappingRepo,
         scope,
         nowMs = { testDispatcher.scheduler.currentTime },
+        gamepadMappingRepository = GamepadMappingRepositoryImpl(testDatabase),
     )
 
     // Achievement fakes are exposed so tests can drive the popup wiring:

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -280,6 +280,13 @@ class SpelaTestHarness(
         nowMs = { testDispatcher.scheduler.currentTime },
     )
 
+    val gamepadMappingViewModel = GamepadMappingViewModel(
+        gamepadMappingRepository = GamepadMappingRepositoryImpl(testDatabase),
+        gamepadPortManager = gamepadPortManager,
+        dispatchers = dispatchers,
+        scope = scope,
+    )
+
     val socialRepo = FakeSocialRepository()
 
     val socialViewModel = SocialViewModel(
@@ -408,6 +415,7 @@ class SpelaTestHarness(
                 settingsViewModel = settingsViewModel,
                 keyMappingViewModel = keyMappingViewModel,
                 gamepadConfigViewModel = gamepadConfigViewModel,
+                gamepadMappingViewModel = gamepadMappingViewModel,
                 socialViewModel = socialViewModel,
                 sharedSessionsViewModel = sharedSessionsViewModel,
                 sharedSessionDetailViewModel = sharedSessionDetailViewModel,

--- a/player/native/src/gamepad_sdl3.c
+++ b/player/native/src/gamepad_sdl3.c
@@ -23,45 +23,52 @@ static SDL_JoystickID controller_instance_ids[MAX_CONTROLLERS];
 static int num_controllers = 0;
 static int initialized = 0;
 
-/* libretro button IDs (matching RETRO_DEVICE_ID_JOYPAD_*) */
-#define RETRO_B      0
-#define RETRO_Y      1
-#define RETRO_SELECT 2
-#define RETRO_START  3
-#define RETRO_UP     4
-#define RETRO_DOWN   5
-#define RETRO_LEFT   6
-#define RETRO_RIGHT  7
-#define RETRO_A      8
-#define RETRO_X      9
-#define RETRO_L     10
-#define RETRO_R     11
-#define RETRO_L2    12
-#define RETRO_R2    13
-#define RETRO_L3    14
-#define RETRO_R3    15
+/* Canonical GamepadPosition ordinals — the INPUT layer of the two-layer model
+ * (#1334). These MUST match the Kotlin enum order in
+ * shared/src/commonMain/kotlin/com/spela/player/domain/model/GamepadPosition.kt
+ * (its "ordinal contract"). The poller reports the per-frame button array
+ * indexed by these ordinals; Kotlin then applies the configurable
+ * GamepadPosition -> RetroPad mapping. Changing one side without the other
+ * silently corrupts desktop input. POS_L2 / POS_R2 are analog triggers, filled
+ * Kotlin-side from the axis values, never here. */
+#define POS_SOUTH       0
+#define POS_EAST        1
+#define POS_WEST        2
+#define POS_NORTH       3
+#define POS_DPAD_UP     4
+#define POS_DPAD_DOWN   5
+#define POS_DPAD_LEFT   6
+#define POS_DPAD_RIGHT  7
+#define POS_L1          8
+#define POS_R1          9
+#define POS_L2         10  /* trigger (axis) — filled in Kotlin */
+#define POS_R2         11  /* trigger (axis) — filled in Kotlin */
+#define POS_L3         12
+#define POS_R3         13
+#define POS_START      14
+#define POS_SELECT     15
 
-/* Number of discrete buttons we track */
+/* Number of discrete positions we track */
 #define NUM_BUTTONS 16
 /* Number of axes we track: LX, LY, RX, RY, TriggerL, TriggerR */
 #define NUM_AXES 6
 
-static int sdl_button_to_retro(SDL_GamepadButton btn) {
+static int sdl_button_to_position(SDL_GamepadButton btn) {
     switch (btn) {
-        case SDL_GAMEPAD_BUTTON_SOUTH:          return RETRO_B;
-        case SDL_GAMEPAD_BUTTON_EAST:           return RETRO_A;
-        case SDL_GAMEPAD_BUTTON_WEST:           return RETRO_Y;
-        case SDL_GAMEPAD_BUTTON_NORTH:          return RETRO_X;
-        case SDL_GAMEPAD_BUTTON_BACK:           return RETRO_SELECT;
-        case SDL_GAMEPAD_BUTTON_START:          return RETRO_START;
-        case SDL_GAMEPAD_BUTTON_LEFT_STICK:     return RETRO_L3;
-        case SDL_GAMEPAD_BUTTON_RIGHT_STICK:    return RETRO_R3;
-        case SDL_GAMEPAD_BUTTON_LEFT_SHOULDER:  return RETRO_L;
-        case SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER: return RETRO_R;
-        case SDL_GAMEPAD_BUTTON_DPAD_UP:        return RETRO_UP;
-        case SDL_GAMEPAD_BUTTON_DPAD_DOWN:      return RETRO_DOWN;
-        case SDL_GAMEPAD_BUTTON_DPAD_LEFT:      return RETRO_LEFT;
-        case SDL_GAMEPAD_BUTTON_DPAD_RIGHT:     return RETRO_RIGHT;
+        case SDL_GAMEPAD_BUTTON_SOUTH:          return POS_SOUTH;
+        case SDL_GAMEPAD_BUTTON_EAST:           return POS_EAST;
+        case SDL_GAMEPAD_BUTTON_WEST:           return POS_WEST;
+        case SDL_GAMEPAD_BUTTON_NORTH:          return POS_NORTH;
+        case SDL_GAMEPAD_BUTTON_BACK:           return POS_SELECT;
+        case SDL_GAMEPAD_BUTTON_START:          return POS_START;
+        case SDL_GAMEPAD_BUTTON_LEFT_STICK:     return POS_L3;
+        case SDL_GAMEPAD_BUTTON_RIGHT_STICK:    return POS_R3;
+        case SDL_GAMEPAD_BUTTON_LEFT_SHOULDER:  return POS_L1;
+        case SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER: return POS_R1;
+        case SDL_GAMEPAD_BUTTON_DPAD_UP:        return POS_DPAD_UP;
+        case SDL_GAMEPAD_BUTTON_DPAD_DOWN:      return POS_DPAD_DOWN;
+        case SDL_GAMEPAD_BUTTON_DPAD_LEFT:      return POS_DPAD_LEFT;
+        case SDL_GAMEPAD_BUTTON_DPAD_RIGHT:     return POS_DPAD_RIGHT;
         default:                                return -1;
     }
 }
@@ -205,9 +212,9 @@ JNIEXPORT jobjectArray JNICALL Java_com_spela_player_libretro_LibretroJni_native
         memset(btnValues, 0, sizeof(btnValues));
 
         for (int b = SDL_GAMEPAD_BUTTON_SOUTH; b <= SDL_GAMEPAD_BUTTON_DPAD_RIGHT; b++) {
-            int retro_id = sdl_button_to_retro((SDL_GamepadButton)b);
-            if (retro_id >= 0 && retro_id < NUM_BUTTONS) {
-                btnValues[retro_id] = SDL_GetGamepadButton(gc, (SDL_GamepadButton)b) ? JNI_TRUE : JNI_FALSE;
+            int position = sdl_button_to_position((SDL_GamepadButton)b);
+            if (position >= 0 && position < NUM_BUTTONS) {
+                btnValues[position] = SDL_GetGamepadButton(gc, (SDL_GamepadButton)b) ? JNI_TRUE : JNI_FALSE;
             }
         }
         (*env)->SetBooleanArrayRegion(env, buttons, 0, NUM_BUTTONS, btnValues);

--- a/player/native/src/gamepad_sdl3.c
+++ b/player/native/src/gamepad_sdl3.c
@@ -179,7 +179,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_spela_player_libretro_LibretroJni_native
     jclass stateClass = (*env)->FindClass(env, "com/spela/player/libretro/GamepadState");
     if (!stateClass) return NULL;
 
-    jmethodID ctor = (*env)->GetMethodID(env, stateClass, "<init>", "(ILjava/lang/String;[Z[I)V");
+    jmethodID ctor = (*env)->GetMethodID(env, stateClass, "<init>", "(ILjava/lang/String;[Z[II)V");
     if (!ctor) return NULL;
 
     int attached_count = 0;
@@ -222,7 +222,8 @@ JNIEXPORT jobjectArray JNICALL Java_com_spela_player_libretro_LibretroJni_native
         axisValues[5] = SDL_GetGamepadAxis(gc, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER);
         (*env)->SetIntArrayRegion(env, axes, 0, NUM_AXES, axisValues);
 
-        jobject stateObj = (*env)->NewObject(env, stateClass, ctor, controllerId, jname, buttons, axes);
+        jint gpType = (jint)SDL_GetRealGamepadType(gc);
+        jobject stateObj = (*env)->NewObject(env, stateClass, ctor, controllerId, jname, buttons, axes, gpType);
         (*env)->SetObjectArrayElement(env, result, out_index, stateObj);
         out_index++;
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleKeyMappingDTO.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleKeyMappingDTO.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param customMapping 
+ * @param positionMappings 
  * @param selectedMapping 
  */
 @Serializable
@@ -31,6 +32,8 @@ import kotlinx.serialization.encoding.*
 data class ConsoleKeyMappingDTO (
 
     @SerialName(value = "customMapping") @Required val customMapping: kotlin.collections.Map<kotlin.String, kotlin.String>,
+
+    @SerialName(value = "positionMappings") @Required val positionMappings: kotlin.collections.Map<kotlin.String, kotlin.Long>,
 
     @SerialName(value = "selectedMapping") @Required val selectedMapping: kotlin.String
 

--- a/player/shared/src/androidMain/kotlin/com/spela/player/domain/model/DeviceDetection.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/domain/model/DeviceDetection.android.kt
@@ -1,13 +1,9 @@
 package com.spela.player.domain.model
 
-import android.os.Build
-
-/** Android: detect device type and return appropriate preset ID. */
-actual fun detectDevicePreset(): String? {
-    val manufacturer = Build.MANUFACTURER.lowercase()
-    return when {
-        manufacturer.contains("ayn") -> "xbox-standard" // Ayn Odin/Thor use standard XInput
-        manufacturer.contains("nintendo") -> "nintendo-standard"
-        else -> "xbox-standard" // Most Android gamepads follow XInput layout
-    }
-}
+/**
+ * Android gamepad input is positional (#1334), so there is no key-code preset to
+ * seed — returning null makes [com.spela.player.domain.repository.KeyMappingRepository.ensureDefaultsApplied]
+ * a no-op on Android. The positional mapping layer's defaults provide the
+ * standard behavior; the keyboard-preset path is desktop-only.
+ */
+actual fun detectDevicePreset(): String? = null

--- a/player/shared/src/androidMain/kotlin/com/spela/player/domain/model/PlatformPresets.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/domain/model/PlatformPresets.android.kt
@@ -1,85 +1,15 @@
 package com.spela.player.domain.model
 
-import android.view.KeyEvent
-import com.spela.player.presentation.viewmodel.LibretroButtons
-
-actual fun getPlatformPresets(): List<KeyMappingPreset> = listOf(
-    XBOX_STANDARD,
-    PLAYSTATION_STANDARD,
-    NINTENDO_STANDARD,
-)
-
-/** Xbox / Standard gamepad: XInput layout. Most Android gamepads follow this. */
-val XBOX_STANDARD = KeyMappingPreset(
-    id = "xbox-standard",
-    displayName = "Xbox / Standard Gamepad",
-    description = "Standard XInput layout used by most Android gamepads",
-    bindings = mapOf(
-        LibretroButtons.UP to KeyEvent.KEYCODE_DPAD_UP,
-        LibretroButtons.DOWN to KeyEvent.KEYCODE_DPAD_DOWN,
-        LibretroButtons.LEFT to KeyEvent.KEYCODE_DPAD_LEFT,
-        LibretroButtons.RIGHT to KeyEvent.KEYCODE_DPAD_RIGHT,
-        LibretroButtons.B to KeyEvent.KEYCODE_BUTTON_A,
-        LibretroButtons.A to KeyEvent.KEYCODE_BUTTON_B,
-        LibretroButtons.Y to KeyEvent.KEYCODE_BUTTON_X,
-        LibretroButtons.X to KeyEvent.KEYCODE_BUTTON_Y,
-        LibretroButtons.START to KeyEvent.KEYCODE_BUTTON_START,
-        LibretroButtons.SELECT to KeyEvent.KEYCODE_BUTTON_SELECT,
-        LibretroButtons.L to KeyEvent.KEYCODE_BUTTON_L1,
-        LibretroButtons.R to KeyEvent.KEYCODE_BUTTON_R1,
-        LibretroButtons.L2 to KeyEvent.KEYCODE_BUTTON_L2,
-        LibretroButtons.R2 to KeyEvent.KEYCODE_BUTTON_R2,
-        LibretroButtons.L3 to KeyEvent.KEYCODE_BUTTON_THUMBL,
-        LibretroButtons.R3 to KeyEvent.KEYCODE_BUTTON_THUMBR,
-    ),
-)
-
-/** PlayStation layout: Cross/Circle mapped to match PS convention. */
-val PLAYSTATION_STANDARD = KeyMappingPreset(
-    id = "playstation-standard",
-    displayName = "PlayStation Gamepad",
-    description = "Cross=B, Circle=A (PlayStation button convention)",
-    bindings = mapOf(
-        LibretroButtons.UP to KeyEvent.KEYCODE_DPAD_UP,
-        LibretroButtons.DOWN to KeyEvent.KEYCODE_DPAD_DOWN,
-        LibretroButtons.LEFT to KeyEvent.KEYCODE_DPAD_LEFT,
-        LibretroButtons.RIGHT to KeyEvent.KEYCODE_DPAD_RIGHT,
-        LibretroButtons.B to KeyEvent.KEYCODE_BUTTON_A, // Cross
-        LibretroButtons.A to KeyEvent.KEYCODE_BUTTON_B, // Circle
-        LibretroButtons.Y to KeyEvent.KEYCODE_BUTTON_X, // Square
-        LibretroButtons.X to KeyEvent.KEYCODE_BUTTON_Y, // Triangle
-        LibretroButtons.START to KeyEvent.KEYCODE_BUTTON_START,
-        LibretroButtons.SELECT to KeyEvent.KEYCODE_BUTTON_SELECT,
-        LibretroButtons.L to KeyEvent.KEYCODE_BUTTON_L1,
-        LibretroButtons.R to KeyEvent.KEYCODE_BUTTON_R1,
-        LibretroButtons.L2 to KeyEvent.KEYCODE_BUTTON_L2,
-        LibretroButtons.R2 to KeyEvent.KEYCODE_BUTTON_R2,
-        LibretroButtons.L3 to KeyEvent.KEYCODE_BUTTON_THUMBL,
-        LibretroButtons.R3 to KeyEvent.KEYCODE_BUTTON_THUMBR,
-    ),
-)
-
-/** Nintendo Pro Controller: A=East, B=South (Nintendo convention). */
-val NINTENDO_STANDARD = KeyMappingPreset(
-    id = "nintendo-standard",
-    displayName = "Nintendo Pro Controller",
-    description = "A=East, B=South (Nintendo button convention)",
-    bindings = mapOf(
-        LibretroButtons.UP to KeyEvent.KEYCODE_DPAD_UP,
-        LibretroButtons.DOWN to KeyEvent.KEYCODE_DPAD_DOWN,
-        LibretroButtons.LEFT to KeyEvent.KEYCODE_DPAD_LEFT,
-        LibretroButtons.RIGHT to KeyEvent.KEYCODE_DPAD_RIGHT,
-        LibretroButtons.B to KeyEvent.KEYCODE_BUTTON_B, // South = B
-        LibretroButtons.A to KeyEvent.KEYCODE_BUTTON_A, // East = A
-        LibretroButtons.Y to KeyEvent.KEYCODE_BUTTON_Y, // West = Y
-        LibretroButtons.X to KeyEvent.KEYCODE_BUTTON_X, // North = X
-        LibretroButtons.START to KeyEvent.KEYCODE_BUTTON_START,
-        LibretroButtons.SELECT to KeyEvent.KEYCODE_BUTTON_SELECT,
-        LibretroButtons.L to KeyEvent.KEYCODE_BUTTON_L1,
-        LibretroButtons.R to KeyEvent.KEYCODE_BUTTON_R1,
-        LibretroButtons.L2 to KeyEvent.KEYCODE_BUTTON_L2,
-        LibretroButtons.R2 to KeyEvent.KEYCODE_BUTTON_R2,
-        LibretroButtons.L3 to KeyEvent.KEYCODE_BUTTON_THUMBL,
-        LibretroButtons.R3 to KeyEvent.KEYCODE_BUTTON_THUMBR,
-    ),
-)
+/**
+ * Android gamepad input is now positional (#1334): physical key codes are
+ * normalized to canonical [GamepadPosition]s and mapped to RetroPad ids via the
+ * synced positional mapping layer. The old per-brand key-code presets
+ * (xbox/playstation/nintendo-standard) only differed by an A/B face-button swap,
+ * which the positional model handles by normalization — so there are no Android
+ * key-code presets anymore.
+ *
+ * One-time behavior change: users previously on "nintendo-standard" (A=East,
+ * B=South) now get the positional default (bottom button = RetroPad B) like
+ * every other pad. They can rebind per console in the positional editor.
+ */
+actual fun getPlatformPresets(): List<KeyMappingPreset> = emptyList()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/local/ExpectedSchema.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/local/ExpectedSchema.kt
@@ -16,6 +16,7 @@ object ExpectedSchema {
         "ShaderOverrideEntity" to setOf("console_id", "shader"),
         "KeyMappingEntity" to setOf("id", "console_id", "port", "platform_key_code", "libretro_button_id"),
         "GameKeyMappingEntity" to setOf("id", "game_id", "libretro_button_id", "platform_key_code"),
+        "GamepadMappingEntity" to setOf("id", "console_id", "port", "gamepad_position", "libretro_button_id"),
         "DeviceInfoEntity" to setOf("id", "device_uuid", "device_name", "server_device_id"),
         "CachedPreferencesEntity" to setOf("id", "json_data", "updated_at"),
         "CachedConsoleEntity" to setOf(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ControllerStyleOverrideRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ControllerStyleOverrideRepositoryImpl.kt
@@ -1,0 +1,44 @@
+package com.spela.player.data.repository
+
+import com.spela.player.data.local.SpelaDatabase
+import com.spela.player.domain.model.ControllerStyle
+import com.spela.player.domain.repository.ControllerStyleOverrideRepository
+
+/**
+ * SQLDelight-backed [ControllerStyleOverrideRepository] using the generic
+ * device-local key-value store ([com.spela.player.SpelaDatabaseQueries]'s
+ * `DeviceSettingEntity`). The key is namespaced per controller identity; the
+ * value is the [ControllerStyle] enum name.
+ *
+ * Rows are tiny and reads hit a primary key, so we don't cache here — callers
+ * that read in a hot loop (e.g. the gamepad-config refresh) cache the result
+ * themselves.
+ *
+ * A stored value that no longer parses to a [ControllerStyle] (e.g. a renamed
+ * enum constant from an old build) is treated as Auto rather than crashing.
+ */
+class ControllerStyleOverrideRepositoryImpl(
+    database: SpelaDatabase,
+) : ControllerStyleOverrideRepository {
+
+    private val queries = database.spelaDatabaseQueries
+
+    override suspend fun getOverride(deviceName: String): ControllerStyle? {
+        val stored = queries.getDeviceSetting(key(deviceName)).executeAsOneOrNull() ?: return null
+        return ControllerStyle.entries.firstOrNull { it.name == stored }
+    }
+
+    override suspend fun setOverride(deviceName: String, style: ControllerStyle?) {
+        if (style == null) {
+            queries.deleteDeviceSetting(key(deviceName))
+        } else {
+            queries.insertDeviceSetting(key(deviceName), style.name)
+        }
+    }
+
+    private fun key(deviceName: String) = "$KEY_PREFIX$deviceName"
+
+    private companion object {
+        const val KEY_PREFIX = "controller_style_override:"
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GamepadMappingRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GamepadMappingRepositoryImpl.kt
@@ -1,0 +1,54 @@
+package com.spela.player.data.repository
+
+import com.spela.player.data.local.SpelaDatabase
+import com.spela.player.domain.model.DefaultGamepadMapping
+import com.spela.player.domain.model.GamepadPosition
+import com.spela.player.domain.repository.GamepadMappingRepository
+
+/**
+ * SQLDelight-backed [GamepadMappingRepository]. Stores only per-console/port
+ * overrides in `GamepadMappingEntity`; the effective mapping layers them on top
+ * of [DefaultGamepadMapping].
+ *
+ * Idempotent: the row id is derived from `(consoleId, port, position)`, so
+ * re-setting the same binding replaces the same row rather than accumulating —
+ * `f(f(x)) = f(x)`. An override whose stored position no longer parses to a
+ * [GamepadPosition] (e.g. a renamed enum constant from an old build) is ignored.
+ */
+class GamepadMappingRepositoryImpl(
+    database: SpelaDatabase,
+) : GamepadMappingRepository {
+
+    private val queries = database.spelaDatabaseQueries
+
+    override suspend fun getEffectiveMapping(consoleId: String, port: Int): Map<GamepadPosition, Int> {
+        val overrides = queries.getGamepadMappingsForConsole(consoleId, port.toLong())
+            .executeAsList()
+            .mapNotNull { row ->
+                val position = GamepadPosition.entries.firstOrNull { it.name == row.gamepad_position }
+                    ?: return@mapNotNull null
+                position to row.libretro_button_id.toInt()
+            }
+            .toMap()
+        return DefaultGamepadMapping.POSITION_TO_RETRO + overrides
+    }
+
+    override suspend fun setBinding(consoleId: String, port: Int, position: GamepadPosition, retroButtonId: Int) {
+        queries.insertGamepadMapping(
+            id = rowId(consoleId, port, position),
+            console_id = consoleId,
+            port = port.toLong(),
+            gamepad_position = position.name,
+            libretro_button_id = retroButtonId.toLong(),
+        )
+    }
+
+    override suspend fun resetToDefault(consoleId: String, port: Int) {
+        queries.deleteGamepadMappingsForConsole(consoleId, port.toLong())
+    }
+
+    override fun getDefaultMapping(): Map<GamepadPosition, Int> = DefaultGamepadMapping.POSITION_TO_RETRO
+
+    private fun rowId(consoleId: String, port: Int, position: GamepadPosition) =
+        "$consoleId:$port:${position.name}"
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
@@ -10,6 +10,8 @@ import com.spela.client.models.UserPreferencesResponse
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.DEFAULT_CONSOLE_ID
 import com.spela.player.domain.model.ShaderPreset
+import com.spela.player.libretro.GamepadMappingMigration
+import com.spela.player.util.currentPlatform
 import com.spela.player.domain.model.UserPreferences
 import com.spela.player.domain.repository.KeyMappingRepository
 import com.spela.player.domain.repository.PreferencesRepository
@@ -26,6 +28,11 @@ class PreferencesRepositoryImpl(
 ) : PreferencesRepository {
 
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    private companion object {
+        /** Device-local flag marking the one-time legacy gamepad keycode → positional migration done. */
+        const val GAMEPAD_MIGRATION_FLAG = "gamepad_positional_migration_v1"
+    }
 
     override suspend fun getPreferences(): Result<UserPreferences> {
         return runCatching {
@@ -170,51 +177,88 @@ class PreferencesRepositoryImpl(
                 }
             }
 
-            // Only populate local DB if it's empty (first-device experience).
-            // Key mappings are platform-specific (Android uses KEYCODE_*, desktop
-            // uses AWT VK_* codes), so we validate that the server's key codes
-            // match this platform's default codes before importing. If they don't
-            // match (e.g. Android codes on desktop), skip the import and let
-            // ensureDefaultsApplied() seed the correct platform codes.
+            // Import keycode mappings only on the first-device experience (empty
+            // local DB). Key codes are platform-specific (Android KEYCODE_*,
+            // desktop AWT VK_*), so validate the server's codes match this
+            // platform before importing. NOTE: this is a nested guard, not an
+            // early return, so the legacy->positional migration below still runs
+            // on existing installs.
             val localMappings = database.spelaDatabaseQueries.getAllKeyMappings().executeAsList()
-            if (localMappings.isNotEmpty()) return
-
-            val platformDefaults = keyMappingRepository.getDefaultMapping()
-            val serverCodes = prefs.customKeyMapping.values.mapNotNull { it.toIntOrNull() }.toSet()
-            val platformCodes = platformDefaults.values.toSet()
-            if (serverCodes.isNotEmpty() && serverCodes.intersect(platformCodes).isEmpty()) {
-                // Server codes don't match this platform — skip import
-                return
-            }
-
-            // Import global default mapping from server
-            for ((retroButtonStr, keyCodeStr) in prefs.customKeyMapping) {
-                val retroButton = retroButtonStr.toIntOrNull() ?: continue
-                val keyCode = keyCodeStr.toIntOrNull() ?: continue
-                database.spelaDatabaseQueries.insertKeyMapping(
-                    id = Uuid.random().toString(),
-                    console_id = DEFAULT_CONSOLE_ID,
-                    port = 0,
-                    platform_key_code = keyCode.toLong(),
-                    libretro_button_id = retroButton.toLong(),
-                )
-            }
-
-            // Import per-console mappings from server
-            for ((consoleId, mapping) in prefs.consoleKeyMappings) {
-                for ((retroButtonStr, keyCodeStr) in mapping.customMapping.orEmpty()) {
-                    val retroButton = retroButtonStr.toIntOrNull() ?: continue
-                    val keyCode = keyCodeStr.toIntOrNull() ?: continue
-                    database.spelaDatabaseQueries.insertKeyMapping(
-                        id = Uuid.random().toString(),
-                        console_id = consoleId,
-                        port = 0,
-                        platform_key_code = keyCode.toLong(),
-                        libretro_button_id = retroButton.toLong(),
-                    )
+            if (localMappings.isEmpty()) {
+                val platformDefaults = keyMappingRepository.getDefaultMapping()
+                val serverCodes = prefs.customKeyMapping.values.mapNotNull { it.toIntOrNull() }.toSet()
+                val platformCodes = platformDefaults.values.toSet()
+                val platformMatches = serverCodes.isEmpty() || serverCodes.intersect(platformCodes).isNotEmpty()
+                if (platformMatches) {
+                    // Import global default mapping from server
+                    for ((retroButtonStr, keyCodeStr) in prefs.customKeyMapping) {
+                        val retroButton = retroButtonStr.toIntOrNull() ?: continue
+                        val keyCode = keyCodeStr.toIntOrNull() ?: continue
+                        database.spelaDatabaseQueries.insertKeyMapping(
+                            id = Uuid.random().toString(),
+                            console_id = DEFAULT_CONSOLE_ID,
+                            port = 0,
+                            platform_key_code = keyCode.toLong(),
+                            libretro_button_id = retroButton.toLong(),
+                        )
+                    }
+                    // Import per-console mappings from server
+                    for ((consoleId, mapping) in prefs.consoleKeyMappings) {
+                        for ((retroButtonStr, keyCodeStr) in mapping.customMapping.orEmpty()) {
+                            val retroButton = retroButtonStr.toIntOrNull() ?: continue
+                            val keyCode = keyCodeStr.toIntOrNull() ?: continue
+                            database.spelaDatabaseQueries.insertKeyMapping(
+                                id = Uuid.random().toString(),
+                                console_id = consoleId,
+                                port = 0,
+                                platform_key_code = keyCode.toLong(),
+                                libretro_button_id = retroButton.toLong(),
+                            )
+                        }
+                    }
                 }
             }
+
+            // Migrate any legacy per-console Android gamepad keycode mappings into
+            // the positional layer (#1334). One-time, Android-only, additive.
+            migrateLegacyGamepadKeycodeMappings()
         }
+    }
+
+    /**
+     * One-time, Android-only migration (#1334): convert legacy per-console
+     * gamepad key-code mappings into the positional layer, preserving genuine
+     * customizations. Additive (never deletes key-code rows nor clobbers an
+     * existing positional override) and guarded by a device-local flag so it
+     * runs at most once. Desktop is skipped — its KeyMappingEntity holds keyboard
+     * codes that must not be normalized as gamepad codes.
+     */
+    private fun migrateLegacyGamepadKeycodeMappings() {
+        if (currentPlatform() != "android") return
+        val queries = database.spelaDatabaseQueries
+        if (queries.getDeviceSetting(GAMEPAD_MIGRATION_FLAG).executeAsOneOrNull() != null) return
+
+        val legacy = queries.getAllKeyMappings().executeAsList().map {
+            GamepadMappingMigration.LegacyRow(
+                consoleId = it.console_id,
+                port = it.port.toInt(),
+                keyCode = it.platform_key_code.toInt(),
+                retroButtonId = it.libretro_button_id.toInt(),
+            )
+        }
+        val existing = queries.getAllGamepadMappings().executeAsList()
+            .map { Triple(it.console_id, it.port, it.gamepad_position) }.toSet()
+        for (entry in GamepadMappingMigration.split(legacy)) {
+            if (Triple(entry.consoleId, entry.port.toLong(), entry.position.name) in existing) continue
+            queries.insertGamepadMapping(
+                id = "${entry.consoleId}:${entry.port}:${entry.position.name}",
+                console_id = entry.consoleId,
+                port = entry.port.toLong(),
+                gamepad_position = entry.position.name,
+                libretro_button_id = entry.retroButtonId.toLong(),
+            )
+        }
+        queries.insertDeviceSetting(GAMEPAD_MIGRATION_FLAG, "done")
     }
 
     override fun getOrientationLock(): String {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
@@ -151,6 +151,25 @@ class PreferencesRepositoryImpl(
         runCatching {
             val prefs = apiClient.getPreferences()
 
+            // Import positional gamepad mappings (#1334) FIRST and independently:
+            // they are platform-independent (GamepadPosition -> RetroPad), so no
+            // key-code validation applies, and the keycode early-return below must
+            // not skip them. Only import when this device has no positional
+            // overrides yet, so a local edit is never clobbered.
+            if (database.spelaDatabaseQueries.getAllGamepadMappings().executeAsList().isEmpty()) {
+                for ((consoleId, mapping) in prefs.consoleKeyMappings) {
+                    for ((positionName, retroId) in mapping.positionMappings) {
+                        database.spelaDatabaseQueries.insertGamepadMapping(
+                            id = "$consoleId:0:$positionName",
+                            console_id = consoleId,
+                            port = 0,
+                            gamepad_position = positionName,
+                            libretro_button_id = retroId,
+                        )
+                    }
+                }
+            }
+
             // Only populate local DB if it's empty (first-device experience).
             // Key mappings are platform-specific (Android uses KEYCODE_*, desktop
             // uses AWT VK_* codes), so we validate that the server's key codes
@@ -235,17 +254,32 @@ class PreferencesRepositoryImpl(
                 .filter { it.console_id == DEFAULT_CONSOLE_ID }
                 .associate { it.libretro_button_id.toString() to it.platform_key_code.toString() }
 
-            // Build per-console mappings
-            val consoleGroups = allMappings
+            // Per-console keycode mappings.
+            val keycodeByConsole = allMappings
                 .filter { it.console_id != DEFAULT_CONSOLE_ID }
                 .groupBy { it.console_id }
+                .mapValues { (_, entities) ->
+                    entities.associate {
+                        it.libretro_button_id.toString() to it.platform_key_code.toString()
+                    }
+                }
 
-            val consoleMappings = consoleGroups.mapValues { (_, entities) ->
+            // Per-console positional gamepad mappings (#1334). Only the stored
+            // diffs from default are synced (port 0 = the synced primary);
+            // platform-independent, so no validation. Value is the RetroPad id.
+            val positionByConsole = database.spelaDatabaseQueries.getAllGamepadMappings().executeAsList()
+                .filter { it.port == 0L }
+                .groupBy { it.console_id }
+                .mapValues { (_, rows) -> rows.associate { it.gamepad_position to it.libretro_button_id } }
+
+            // A console is pushed if it has EITHER layer; the shared DTO requires
+            // both fields, so missing layers are sent empty (never null) and so a
+            // positional edit never wipes the keycode layer and vice-versa.
+            val consoleMappings = (keycodeByConsole.keys + positionByConsole.keys).associateWith { consoleId ->
                 ConsoleKeyMappingDTO(
                     selectedMapping = "",
-                    customMapping = entities.associate {
-                        it.libretro_button_id.toString() to it.platform_key_code.toString()
-                    },
+                    customMapping = keycodeByConsole[consoleId] ?: emptyMap(),
+                    positionMappings = positionByConsole[consoleId] ?: emptyMap(),
                 )
             }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -415,6 +415,14 @@ val commonModule = module {
         )
     }
     factory {
+        GamepadMappingViewModel(
+            gamepadMappingRepository = get(),
+            gamepadPortManager = get(),
+            dispatchers = get(),
+            scope = get(),
+        )
+    }
+    factory {
         SettingsViewModel(
             authRepository = get(),
             downloadRepository = get(),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -71,6 +71,7 @@ val commonModule = module {
     single<PendingSaveUploadRepository> { PendingSaveUploadRepositoryImpl(get()) }
     single<OnboardingRepository> { OnboardingRepositoryImpl(get()) }
     single<ControllerStyleOverrideRepository> { ControllerStyleOverrideRepositoryImpl(get()) }
+    single<GamepadMappingRepository> { GamepadMappingRepositoryImpl(get()) }
     single<SessionRepository> { SessionRepositoryImpl(get(), get()) }
     single<ExploreRepository> { ExploreRepositoryImpl(get()) }
     single<SearchRepository> { SearchRepositoryImpl(get(), get()) }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -418,6 +418,7 @@ val commonModule = module {
         GamepadMappingViewModel(
             gamepadMappingRepository = get(),
             gamepadPortManager = get(),
+            preferencesRepository = get(),
             dispatchers = get(),
             scope = get(),
         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -76,7 +76,7 @@ val commonModule = module {
     single<ExploreRepository> { ExploreRepositoryImpl(get()) }
     single<SearchRepository> { SearchRepositoryImpl(get(), get()) }
     single { BiosRepository(get(), get()) }
-    single { GamepadPortManager(get(), get()) }
+    single { GamepadPortManager(get(), get(), gamepadMappingRepository = get()) }
 
     /* Use Cases */
     factory { LoginUseCase(get(), get()) }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -70,6 +70,7 @@ val commonModule = module {
     single<CheatRepository> { CheatRepositoryImpl(get(), get()) }
     single<PendingSaveUploadRepository> { PendingSaveUploadRepositoryImpl(get()) }
     single<OnboardingRepository> { OnboardingRepositoryImpl(get()) }
+    single<ControllerStyleOverrideRepository> { ControllerStyleOverrideRepositoryImpl(get()) }
     single<SessionRepository> { SessionRepositoryImpl(get(), get()) }
     single<ExploreRepository> { ExploreRepositoryImpl(get()) }
     single<SearchRepository> { SearchRepositoryImpl(get(), get()) }
@@ -407,6 +408,7 @@ val commonModule = module {
     factory {
         GamepadConfigViewModel(
             gamepadPortManager = get(),
+            styleOverrideRepository = get(),
             dispatchers = get(),
             scope = get(),
         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ControllerStyle.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ControllerStyle.kt
@@ -19,6 +19,15 @@ enum class ControllerStyle {
             PlayStation -> "PlayStation Controller"
             Generic -> "Gamepad"
         }
+
+    /** Compact label for chips/affordances (e.g. the "Type: …" override button). */
+    val shortLabel: String
+        get() = when (this) {
+            Xbox -> "Xbox"
+            Nintendo -> "Nintendo"
+            PlayStation -> "PlayStation"
+            Generic -> "Gamepad"
+        }
 }
 
 /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ControllerStyle.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ControllerStyle.kt
@@ -4,7 +4,22 @@ package com.spela.player.domain.model
  * Normalized physical-controller layout family. Drives Android input
  * normalization and the identity display only — never the positional bindings.
  */
-enum class ControllerStyle { Xbox, Nintendo, PlayStation, Generic }
+enum class ControllerStyle {
+    Xbox,
+    Nintendo,
+    PlayStation,
+    Generic,
+    ;
+
+    /** Human-readable identity shown to the user (e.g. "Player 1: Xbox Controller"). */
+    val displayName: String
+        get() = when (this) {
+            Xbox -> "Xbox Controller"
+            Nintendo -> "Nintendo Controller"
+            PlayStation -> "PlayStation Controller"
+            Generic -> "Gamepad"
+        }
+}
 
 /**
  * Classifies a connected controller into a [ControllerStyle] from USB vendor/

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ControllerStyle.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ControllerStyle.kt
@@ -1,0 +1,34 @@
+package com.spela.player.domain.model
+
+/**
+ * Normalized physical-controller layout family. Drives Android input
+ * normalization and the identity display only — never the positional bindings.
+ */
+enum class ControllerStyle { Xbox, Nintendo, PlayStation, Generic }
+
+/**
+ * Classifies a connected controller into a [ControllerStyle] from USB vendor/
+ * product IDs (both Android InputDevice and SDL expose these), with a name-
+ * substring fallback. Pure + platform-agnostic so both platforms share it.
+ */
+object ControllerClassifier {
+    // USB vendor IDs.
+    private const val VENDOR_SONY = 0x054C
+    private const val VENDOR_MICROSOFT = 0x045E
+    private const val VENDOR_NINTENDO = 0x057E
+
+    fun fromVendorProduct(vendorId: Int, productId: Int, name: String): ControllerStyle {
+        when (vendorId) {
+            VENDOR_SONY -> return ControllerStyle.PlayStation
+            VENDOR_MICROSOFT -> return ControllerStyle.Xbox
+            VENDOR_NINTENDO -> return ControllerStyle.Nintendo
+        }
+        val n = name.lowercase()
+        return when {
+            "dualsense" in n || "dualshock" in n || "playstation" in n || "wireless controller" in n -> ControllerStyle.PlayStation
+            "xbox" in n || "xinput" in n -> ControllerStyle.Xbox
+            "switch" in n || "joy-con" in n || "joycon" in n || "pro controller" in n || "nintendo" in n -> ControllerStyle.Nintendo
+            else -> ControllerStyle.Generic
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/GamepadPosition.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/GamepadPosition.kt
@@ -32,6 +32,32 @@ enum class GamepadPosition {
     R3,         // 13 right stick click
     START,      // 14
     SELECT,     // 15
+    ;
+
+    /**
+     * Brand-neutral human label for the mapping UI. Deliberately positional
+     * (no Xbox/Nintendo/PlayStation glyphs or letters) — that neutrality is the
+     * whole point of the input layer (#1334).
+     */
+    val displayName: String
+        get() = when (this) {
+            SOUTH -> "Bottom button"
+            EAST -> "Right button"
+            WEST -> "Left button"
+            NORTH -> "Top button"
+            DPAD_UP -> "D-pad Up"
+            DPAD_DOWN -> "D-pad Down"
+            DPAD_LEFT -> "D-pad Left"
+            DPAD_RIGHT -> "D-pad Right"
+            L1 -> "L1"
+            R1 -> "R1"
+            L2 -> "L2"
+            R2 -> "R2"
+            L3 -> "L3 (left stick)"
+            R3 -> "R3 (right stick)"
+            START -> "Start"
+            SELECT -> "Select"
+        }
 }
 
 /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/GamepadPosition.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/GamepadPosition.kt
@@ -1,0 +1,62 @@
+package com.spela.player.domain.model
+
+import com.spela.player.presentation.viewmodel.LibretroButtons
+
+/**
+ * Canonical, brand- and device-independent physical control position on a
+ * gamepad — *where you press* (SOUTH = bottom face button on any pad), as
+ * distinct from the RetroPad output id — *what the core receives* (#1334).
+ * Conflating the two is the trap that produced the original A/B confusion, so
+ * the input position and the RetroPad output are separate types.
+ *
+ * **Ordinal contract (load-bearing):** the declaration order below is mirrored
+ * by the desktop SDL3 bridge (`player/native/src/gamepad_sdl3.c`), which reports
+ * its per-frame button array indexed by these ordinals. Reordering or inserting
+ * here WITHOUT updating the C `sdl_button_to_position` table silently corrupts
+ * desktop gamepad input. Keep the two in lockstep.
+ */
+enum class GamepadPosition {
+    SOUTH,      // 0  bottom face
+    EAST,       // 1  right face
+    WEST,       // 2  left face
+    NORTH,      // 3  top face
+    DPAD_UP,    // 4
+    DPAD_DOWN,  // 5
+    DPAD_LEFT,  // 6
+    DPAD_RIGHT, // 7
+    L1,         // 8  left shoulder
+    R1,         // 9  right shoulder
+    L2,         // 10 left trigger (digital)
+    R2,         // 11 right trigger (digital)
+    L3,         // 12 left stick click
+    R3,         // 13 right stick click
+    START,      // 14
+    SELECT,     // 15
+}
+
+/**
+ * The default `GamepadPosition` → RetroPad mapping. It reproduces the historical
+ * fixed SDL3 desktop behavior exactly, so adopting the configurable two-layer
+ * model is a no-op until the user rebinds a console. RetroPad face ids are
+ * *named* positionally (B≈south, A≈east) but here they play the **output** role.
+ */
+object DefaultGamepadMapping {
+    val POSITION_TO_RETRO: Map<GamepadPosition, Int> = mapOf(
+        GamepadPosition.SOUTH to LibretroButtons.B,
+        GamepadPosition.EAST to LibretroButtons.A,
+        GamepadPosition.WEST to LibretroButtons.Y,
+        GamepadPosition.NORTH to LibretroButtons.X,
+        GamepadPosition.DPAD_UP to LibretroButtons.UP,
+        GamepadPosition.DPAD_DOWN to LibretroButtons.DOWN,
+        GamepadPosition.DPAD_LEFT to LibretroButtons.LEFT,
+        GamepadPosition.DPAD_RIGHT to LibretroButtons.RIGHT,
+        GamepadPosition.L1 to LibretroButtons.L,
+        GamepadPosition.R1 to LibretroButtons.R,
+        GamepadPosition.L2 to LibretroButtons.L2,
+        GamepadPosition.R2 to LibretroButtons.R2,
+        GamepadPosition.L3 to LibretroButtons.L3,
+        GamepadPosition.R3 to LibretroButtons.R3,
+        GamepadPosition.START to LibretroButtons.START,
+        GamepadPosition.SELECT to LibretroButtons.SELECT,
+    )
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ControllerStyleOverrideRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ControllerStyleOverrideRepository.kt
@@ -1,0 +1,26 @@
+package com.spela.player.domain.repository
+
+import com.spela.player.domain.model.ControllerStyle
+
+/**
+ * Device-local, per-controller "this controller is actually a `<style>`"
+ * override (#1334, component D). Detection (SDL gamepad type / vendor-product)
+ * is usually right, but when it isn't the user can correct it here. Keyed by
+ * the controller's identity (its OS device name) so two pads of the same model
+ * share the correction.
+ *
+ * Never synced: calibrating the physical pad in hand is a device-local concern,
+ * exactly like the device shader override. Backed by the generic
+ * `DeviceSettingEntity` key-value store (no dedicated table / migration).
+ *
+ * Absence of an override means **Auto** — defer to detection. Storing a style
+ * (including [ControllerStyle.Generic]) is an explicit user choice and is
+ * distinct from Auto.
+ */
+interface ControllerStyleOverrideRepository {
+    /** The stored override for this controller, or null when Auto (no override). */
+    suspend fun getOverride(deviceName: String): ControllerStyle?
+
+    /** Store [style] as the override, or pass null to clear it (back to Auto). */
+    suspend fun setOverride(deviceName: String, style: ControllerStyle?)
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/GamepadMappingRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/GamepadMappingRepository.kt
@@ -1,0 +1,28 @@
+package com.spela.player.domain.repository
+
+import com.spela.player.domain.model.GamepadPosition
+
+/**
+ * The **mapping layer** of the two-layer positional gamepad model (#1334):
+ * `GamepadPosition` → libretro RetroPad id, per console/port. Brand-independent
+ * — the input layer normalizes physical buttons to canonical positions first,
+ * so the same positional binding works on any controller.
+ *
+ * Only diffs from [com.spela.player.domain.model.DefaultGamepadMapping] are
+ * persisted; the effective mapping is the default with stored overrides layered
+ * on top. Bindings are device-persisted now and become server-synced in the
+ * Android phase (where the existing mappings are migrated into this layer).
+ */
+interface GamepadMappingRepository {
+    /** Effective position→RetroPad for a console/port: defaults with stored overrides layered on top. */
+    suspend fun getEffectiveMapping(consoleId: String, port: Int): Map<GamepadPosition, Int>
+
+    /** Persist one position→RetroPad binding (idempotent). */
+    suspend fun setBinding(consoleId: String, port: Int, position: GamepadPosition, retroButtonId: Int)
+
+    /** Clear all stored overrides for a console/port (revert to defaults). */
+    suspend fun resetToDefault(consoleId: String, port: Int)
+
+    /** The default position→RetroPad mapping, with no overrides. */
+    fun getDefaultMapping(): Map<GamepadPosition, Int>
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/AndroidGamepadNormalizer.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/AndroidGamepadNormalizer.kt
@@ -1,0 +1,62 @@
+package com.spela.player.libretro
+
+import com.spela.player.domain.model.GamepadPosition
+
+/**
+ * Normalizes an Android `KeyEvent.KEYCODE_*` to a canonical [GamepadPosition]
+ * (the input layer of the two-layer model, #1334). Android gamepad key codes
+ * are nominally positional — `KEYCODE_BUTTON_A` is the bottom face button,
+ * `KEYCODE_BUTTON_B` the right, etc. — so the standard mapping below holds for
+ * spec-compliant controllers of every brand, which is what makes "same physical
+ * button = same console action on any pad" work once the positional mapping
+ * layer is applied.
+ *
+ * Pure + platform-agnostic (the key-code integers are inlined so this lives in
+ * commonMain and is desktop-unit-testable). Constants mirror
+ * `android.view.KeyEvent`.
+ *
+ * Brand note: a few controllers genuinely report swapped face-button codes. We
+ * deliberately do NOT guess per-brand swaps here (that risks breaking compliant
+ * pads); precise per-controller correction belongs to the editable input-layer
+ * calibration (Phase 4), where the user confirms it on real hardware.
+ */
+object AndroidGamepadNormalizer {
+    // android.view.KeyEvent constants.
+    private const val KEYCODE_DPAD_UP = 19
+    private const val KEYCODE_DPAD_DOWN = 20
+    private const val KEYCODE_DPAD_LEFT = 21
+    private const val KEYCODE_DPAD_RIGHT = 22
+    private const val KEYCODE_BUTTON_A = 96
+    private const val KEYCODE_BUTTON_B = 97
+    private const val KEYCODE_BUTTON_X = 99
+    private const val KEYCODE_BUTTON_Y = 100
+    private const val KEYCODE_BUTTON_L1 = 102
+    private const val KEYCODE_BUTTON_R1 = 103
+    private const val KEYCODE_BUTTON_L2 = 104
+    private const val KEYCODE_BUTTON_R2 = 105
+    private const val KEYCODE_BUTTON_THUMBL = 106
+    private const val KEYCODE_BUTTON_THUMBR = 107
+    private const val KEYCODE_BUTTON_START = 108
+    private const val KEYCODE_BUTTON_SELECT = 109
+
+    /** Returns the canonical position for [keyCode], or null if it isn't a gamepad button. */
+    fun normalize(keyCode: Int): GamepadPosition? = when (keyCode) {
+        KEYCODE_DPAD_UP -> GamepadPosition.DPAD_UP
+        KEYCODE_DPAD_DOWN -> GamepadPosition.DPAD_DOWN
+        KEYCODE_DPAD_LEFT -> GamepadPosition.DPAD_LEFT
+        KEYCODE_DPAD_RIGHT -> GamepadPosition.DPAD_RIGHT
+        KEYCODE_BUTTON_A -> GamepadPosition.SOUTH
+        KEYCODE_BUTTON_B -> GamepadPosition.EAST
+        KEYCODE_BUTTON_X -> GamepadPosition.WEST
+        KEYCODE_BUTTON_Y -> GamepadPosition.NORTH
+        KEYCODE_BUTTON_L1 -> GamepadPosition.L1
+        KEYCODE_BUTTON_R1 -> GamepadPosition.R1
+        KEYCODE_BUTTON_L2 -> GamepadPosition.L2
+        KEYCODE_BUTTON_R2 -> GamepadPosition.R2
+        KEYCODE_BUTTON_THUMBL -> GamepadPosition.L3
+        KEYCODE_BUTTON_THUMBR -> GamepadPosition.R3
+        KEYCODE_BUTTON_START -> GamepadPosition.START
+        KEYCODE_BUTTON_SELECT -> GamepadPosition.SELECT
+        else -> null
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadButtonResolver.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadButtonResolver.kt
@@ -1,0 +1,35 @@
+package com.spela.player.libretro
+
+import com.spela.player.domain.model.GamepadPosition
+
+/**
+ * Pure resolution of the two-layer gamepad model's mapping step: given which
+ * canonical [GamepadPosition]s are currently pressed (the input layer) and a
+ * `GamepadPosition` → RetroPad-id mapping (the mapping layer), produce the
+ * per-RetroPad-button pressed state to feed the core.
+ *
+ * **Fan-in safe:** if several positions map to the same RetroPad id, the result
+ * is their OR — a press on any contributing position wins, and releasing one
+ * mapped position never clobbers another's press. (A naive per-position
+ * `setButton` would let a released position turn off a button another position
+ * is still holding.)
+ */
+object GamepadButtonResolver {
+    /** RetroPad face/dpad/shoulder/stick button count (ids 0..15). */
+    const val RETRO_BUTTON_COUNT = 16
+
+    /**
+     * @param positionPressed pressed state indexed by [GamepadPosition.ordinal]
+     * @param mapping position → RetroPad id (e.g. an effective console mapping)
+     * @return BooleanArray of size [RETRO_BUTTON_COUNT]; index = RetroPad id
+     */
+    fun resolve(positionPressed: BooleanArray, mapping: Map<GamepadPosition, Int>): BooleanArray {
+        val out = BooleanArray(RETRO_BUTTON_COUNT)
+        for (position in GamepadPosition.entries) {
+            if (positionPressed.getOrNull(position.ordinal) != true) continue
+            val retroId = mapping[position] ?: continue
+            if (retroId in 0 until RETRO_BUTTON_COUNT) out[retroId] = true
+        }
+        return out
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadMappingMigration.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadMappingMigration.kt
@@ -1,0 +1,36 @@
+package com.spela.player.libretro
+
+import com.spela.player.domain.model.DEFAULT_CONSOLE_ID
+import com.spela.player.domain.model.DefaultGamepadMapping
+import com.spela.player.domain.model.GamepadPosition
+
+/**
+ * One-time, client-side migration (#1334) of legacy Android gamepad key-code
+ * mappings into the positional mapping layer. The risky piece called out in the
+ * spec — kept PURE and idempotent here so it's exhaustively desktop-testable.
+ *
+ * Rules:
+ * - Per-console only (`console_id != __default__`): the global default isn't a
+ *   user binding, and the positional default already reproduces it (this is also
+ *   why "nintendo-standard" users see the documented behavior change).
+ * - Only key codes that normalize to a [GamepadPosition] are converted (a
+ *   keyboard key code on the wrong platform normalizes to null and is dropped).
+ * - Only entries that DIFFER from [DefaultGamepadMapping] are emitted, so the
+ *   positional layer stays clean (no redundant default-equal overrides) and
+ *   genuine customizations are preserved.
+ *
+ * Idempotent: deterministic over its input, and the applier additionally skips
+ * positions already present so re-running never clobbers a later user edit.
+ */
+object GamepadMappingMigration {
+    data class LegacyRow(val consoleId: String, val port: Int, val keyCode: Int, val retroButtonId: Int)
+    data class PositionalEntry(val consoleId: String, val port: Int, val position: GamepadPosition, val retroButtonId: Int)
+
+    fun split(rows: List<LegacyRow>): List<PositionalEntry> =
+        rows.filter { it.consoleId != DEFAULT_CONSOLE_ID }
+            .mapNotNull { row ->
+                val position = AndroidGamepadNormalizer.normalize(row.keyCode) ?: return@mapNotNull null
+                if (DefaultGamepadMapping.POSITION_TO_RETRO[position] == row.retroButtonId) return@mapNotNull null
+                PositionalEntry(row.consoleId, row.port, position, row.retroButtonId)
+            }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
@@ -1,6 +1,7 @@
 package com.spela.player.libretro
 
 import com.spela.player.domain.model.ControllerStyle
+import com.spela.player.domain.model.DefaultGamepadMapping
 import com.spela.player.domain.model.GamepadPosition
 import com.spela.player.domain.repository.GamepadMappingRepository
 import com.spela.player.domain.repository.KeyMappingRepository
@@ -248,6 +249,22 @@ class GamepadPortManager(
     fun getGamepadMapping(port: Int): Map<GamepadPosition, Int>? {
         if (port < 0 || port >= MAX_PORTS) return null
         return portGamepadMappings[port] ?: fallbackGamepadMapping
+    }
+
+    /**
+     * Maps an Android gamepad key code to a libretro RetroPad id for a port via
+     * the two-layer model (#1334): physical key code → canonical
+     * [GamepadPosition] (input layer) → RetroPad id (mapping layer). Falls back
+     * to [DefaultGamepadMapping] when no per-console mapping is loaded, so the
+     * default reproduces the historical behavior. Returns null for non-gamepad
+     * key codes or unmapped positions.
+     */
+    @Synchronized
+    fun mapGamepadKeyToLibretro(port: Int, keyCode: Int): Int? {
+        if (port < 0 || port >= MAX_PORTS) return null
+        val position = AndroidGamepadNormalizer.normalize(keyCode) ?: return null
+        val mapping = portGamepadMappings[port] ?: fallbackGamepadMapping ?: DefaultGamepadMapping.POSITION_TO_RETRO
+        return mapping[position]
     }
 
     /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
@@ -1,6 +1,8 @@
 package com.spela.player.libretro
 
 import com.spela.player.domain.model.ControllerStyle
+import com.spela.player.domain.model.GamepadPosition
+import com.spela.player.domain.repository.GamepadMappingRepository
 import com.spela.player.domain.repository.KeyMappingRepository
 import com.spela.player.presentation.ui.gamepad.InputMode
 import kotlinx.coroutines.CoroutineScope
@@ -31,6 +33,13 @@ class GamepadPortManager(
      * activity-timeout window is deterministic instead of racing real time.
      */
     private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+    /**
+     * Source of the device-local/synced gamepad mapping layer (GamepadPosition →
+     * RetroPad). Null disables per-console gamepad remapping — consumers fall
+     * back to [com.spela.player.domain.model.DefaultGamepadMapping], reproducing
+     * the historical fixed behavior. Desktop wires the real repository (#1334).
+     */
+    private val gamepadMappingRepository: GamepadMappingRepository? = null,
 ) {
     companion object {
         const val MAX_PORTS = 8
@@ -59,6 +68,12 @@ class GamepadPortManager(
 
     /** Fallback mapping used when a port-specific mapping hasn't been loaded yet. */
     private var fallbackKeyMapping: Map<Int, Int>? = null
+
+    /** Per-port gamepad mapping: GamepadPosition -> retroButtonId. Loaded from repository. */
+    private val portGamepadMappings = Array<Map<GamepadPosition, Int>?>(MAX_PORTS) { null }
+
+    /** Fallback gamepad mapping used before a port-specific one is loaded. */
+    private var fallbackGamepadMapping: Map<GamepadPosition, Int>? = null
 
     /** Per-port last-input timestamps (epoch milliseconds). */
     private val lastActivityMs = LongArray(MAX_PORTS)
@@ -130,6 +145,7 @@ class GamepadPortManager(
         val assignment = deviceToPort.remove(deviceId) ?: return
         occupiedPorts[assignment.port] = false
         portKeyMappings[assignment.port] = null
+        portGamepadMappings[assignment.port] = null
         lastActivityMs[assignment.port] = 0L
         _assignments.value = deviceToPort.values.toList()
         _portActivity.value = buildActivityMap()
@@ -191,6 +207,47 @@ class GamepadPortManager(
         for (port in ports) {
             loadMappingForPort(port, consoleId)
         }
+    }
+
+    /**
+     * Loads the gamepad mapping layer (GamepadPosition -> retroButtonId) for a
+     * port from [gamepadMappingRepository]. No-op when no repository is wired.
+     */
+    suspend fun loadGamepadMappingForPort(port: Int, consoleId: String) {
+        if (port < 0 || port >= MAX_PORTS) return
+        val repo = gamepadMappingRepository ?: return
+        val mapping = repo.getEffectiveMapping(consoleId, port)
+        synchronized(this) {
+            portGamepadMappings[port] = mapping
+        }
+    }
+
+    /**
+     * Loads the gamepad mapping layer for all currently assigned ports, plus a
+     * port-0 fallback for devices that connect before their port-specific
+     * mapping is ready. No-op when no repository is wired.
+     */
+    suspend fun loadAllGamepadMappings(consoleId: String) {
+        val repo = gamepadMappingRepository ?: return
+        val fallback = repo.getEffectiveMapping(consoleId, 0)
+        synchronized(this) {
+            fallbackGamepadMapping = fallback
+        }
+        val ports = synchronized(this) { deviceToPort.values.map { it.port } }
+        for (port in ports) {
+            loadGamepadMappingForPort(port, consoleId)
+        }
+    }
+
+    /**
+     * Returns the gamepad mapping (GamepadPosition -> retroButtonId) for a port:
+     * the port-specific mapping if loaded, else the fallback, else null (the
+     * caller should default to [com.spela.player.domain.model.DefaultGamepadMapping]).
+     */
+    @Synchronized
+    fun getGamepadMapping(port: Int): Map<GamepadPosition, Int>? {
+        if (port < 0 || port >= MAX_PORTS) return null
+        return portGamepadMappings[port] ?: fallbackGamepadMapping
     }
 
     /**
@@ -271,6 +328,11 @@ class GamepadPortManager(
         portKeyMappings[portA] = portKeyMappings[portB]
         portKeyMappings[portB] = tmpMapping
 
+        // Swap gamepad mappings
+        val tmpGamepadMapping = portGamepadMappings[portA]
+        portGamepadMappings[portA] = portGamepadMappings[portB]
+        portGamepadMappings[portB] = tmpGamepadMapping
+
         // Swap activity timestamps
         val tmpActivity = lastActivityMs[portA]
         lastActivityMs[portA] = lastActivityMs[portB]
@@ -302,7 +364,9 @@ class GamepadPortManager(
         deviceToPort.clear()
         occupiedPorts.fill(false)
         portKeyMappings.fill(null)
+        portGamepadMappings.fill(null)
         fallbackKeyMapping = null
+        fallbackGamepadMapping = null
         lastActivityMs.fill(0L)
         _assignments.value = emptyList()
         _portActivity.value = emptyMap()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
@@ -1,5 +1,6 @@
 package com.spela.player.libretro
 
+import com.spela.player.domain.model.ControllerStyle
 import com.spela.player.domain.repository.KeyMappingRepository
 import com.spela.player.presentation.ui.gamepad.InputMode
 import kotlinx.coroutines.CoroutineScope
@@ -44,6 +45,7 @@ class GamepadPortManager(
         val deviceId: Int,
         val port: Int,
         val deviceName: String = "",
+        val style: ControllerStyle = ControllerStyle.Generic,
     )
 
     /** Current port assignments, keyed by device ID. */
@@ -90,7 +92,7 @@ class GamepadPortManager(
      * If the device is already assigned, returns its existing port.
      */
     @Synchronized
-    fun connectDevice(deviceId: Int, deviceName: String = ""): Int {
+    fun connectDevice(deviceId: Int, deviceName: String = "", style: ControllerStyle = ControllerStyle.Generic): Int {
         // Already assigned?
         deviceToPort[deviceId]?.let { return it.port }
 
@@ -99,7 +101,7 @@ class GamepadPortManager(
         if (port == -1) return -1
 
         occupiedPorts[port] = true
-        val assignment = PortAssignment(deviceId = deviceId, port = port, deviceName = deviceName)
+        val assignment = PortAssignment(deviceId = deviceId, port = port, deviceName = deviceName, style = style)
         deviceToPort[deviceId] = assignment
         _assignments.value = deviceToPort.values.toList()
         emitControllerStatus()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/App.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/App.kt
@@ -29,6 +29,7 @@ import com.spela.player.presentation.viewmodel.CollectionsViewModel
 import com.spela.player.presentation.viewmodel.SocialViewModel
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
+import com.spela.player.presentation.viewmodel.GamepadMappingViewModel
 import com.spela.player.presentation.viewmodel.GlobalSearchViewModel
 import com.spela.player.presentation.viewmodel.StatsViewModel
 import com.spela.player.presentation.viewmodel.TopListsViewModel
@@ -70,6 +71,7 @@ fun App() {
     val exploreViewModel: ExploreViewModel = koinInject()
     val topListsViewModel: TopListsViewModel = koinInject()
     val gamepadConfigViewModel: GamepadConfigViewModel = koinInject()
+    val gamepadMappingViewModel: GamepadMappingViewModel = koinInject()
     val scrapeService: ScrapeService = koinInject()
     val downloadRepository: com.spela.player.domain.repository.DownloadRepository = koinInject()
     val preferencesRepository: com.spela.player.domain.repository.PreferencesRepository = koinInject()
@@ -105,6 +107,7 @@ fun App() {
             exploreViewModel = exploreViewModel,
             topListsViewModel = topListsViewModel,
             gamepadConfigViewModel = gamepadConfigViewModel,
+            gamepadMappingViewModel = gamepadMappingViewModel,
             scrapeService = scrapeService,
             downloadRepository = downloadRepository,
             preferencesRepository = preferencesRepository,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/ScreenRouter.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/ScreenRouter.kt
@@ -763,6 +763,7 @@ fun ScreenRouter(
                                     settingsViewModel = settingsViewModel,
                                     keyMappingViewModel = keyMappingViewModel,
                                     gamepadConfigViewModel = gamepadConfigViewModel,
+                                    gamepadMappingViewModel = gamepadMappingViewModel,
                                     onBack = {
                                         navigationViewModel.onIntent(NavigationIntent.GoBack)
                                     },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaAppDependencies.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaAppDependencies.kt
@@ -18,6 +18,7 @@ import com.spela.player.presentation.viewmodel.ExploreViewModel
 import com.spela.player.presentation.viewmodel.GameDetailViewModel
 import com.spela.player.presentation.viewmodel.GameListViewModel
 import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
+import com.spela.player.presentation.viewmodel.GamepadMappingViewModel
 import com.spela.player.presentation.viewmodel.GlobalSearchViewModel
 import com.spela.player.presentation.viewmodel.KeyMappingViewModel
 import com.spela.player.presentation.viewmodel.LibretroController
@@ -86,6 +87,7 @@ data class SpelaAppDependencies(
     // signature. Keeping them nullable so tests + simpler host
     // apps can omit services the scenario doesn't exercise.
     val gamepadConfigViewModel: GamepadConfigViewModel? = null,
+    val gamepadMappingViewModel: GamepadMappingViewModel? = null,
     val sessionDetailViewModel: SessionDetailViewModel? = null,
     val topListsViewModel: TopListsViewModel? = null,
     val exploreViewModel: ExploreViewModel? = null,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/ControllerStylePickerDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/ControllerStylePickerDialog.kt
@@ -1,0 +1,60 @@
+package com.spela.player.presentation.ui.components.gamepad
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.spela.player.domain.model.ControllerStyle
+import com.spela.player.presentation.ui.components.SpDialog
+import com.spela.player.presentation.ui.components.SpRadioOption
+import com.spela.player.presentation.ui.feature.settings.SettingsDivider
+
+/**
+ * Per-controller style override picker (#1334, component D). Lets the user
+ * correct the detected controller type for a connected pad. "Auto" clears the
+ * override and defers to detection; any explicit choice (including Gamepad /
+ * Generic) is stored device-local.
+ *
+ * Brand-neutral by design: the entries are plain text identities, no glyphs.
+ *
+ * @param detectedStyle the auto-detected style, surfaced as the "Auto" subtitle
+ * @param currentOverride the stored override, or null when Auto is in effect
+ * @param onSelect invoked with the chosen style, or null to clear to Auto
+ */
+@Composable
+fun ControllerStylePickerDialog(
+    detectedStyle: ControllerStyle,
+    currentOverride: ControllerStyle?,
+    onSelect: (ControllerStyle?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    SpDialog(
+        title = "Controller type",
+        onDismiss = onDismiss,
+        confirmText = "Done",
+        onConfirm = onDismiss,
+        modifier = Modifier.testTag("controller_style_picker"),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            SpRadioOption(
+                title = "Auto",
+                description = "Use the detected type (${detectedStyle.displayName})",
+                isSelected = currentOverride == null,
+                onClick = { onSelect(null) },
+            )
+            SettingsDivider()
+            ControllerStyle.entries.forEachIndexed { index, style ->
+                SpRadioOption(
+                    title = style.displayName,
+                    description = "Treat this controller as ${style.displayName}",
+                    isSelected = currentOverride == style,
+                    onClick = { onSelect(style) },
+                )
+                if (index < ControllerStyle.entries.size - 1) {
+                    SettingsDivider()
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigDialog.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.spela.player.domain.model.ControllerStyle
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.viewmodel.GamepadConfigState
@@ -25,6 +26,7 @@ fun GamepadConfigDialog(
     onConfigurePort: (Int) -> Unit,
     onSwapUp: ((Int) -> Unit)? = null,
     onSwapDown: ((Int) -> Unit)? = null,
+    onSetStyleOverride: ((Int, ControllerStyle?) -> Unit)? = null,
     onDismiss: () -> Unit,
 ) {
     Dialog(
@@ -49,6 +51,7 @@ fun GamepadConfigDialog(
                     onConfigurePort = onConfigurePort,
                     onSwapUp = onSwapUp,
                     onSwapDown = onSwapDown,
+                    onSetStyleOverride = onSetStyleOverride,
                 )
             }
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigDialog.kt
@@ -27,6 +27,7 @@ fun GamepadConfigDialog(
     onSwapUp: ((Int) -> Unit)? = null,
     onSwapDown: ((Int) -> Unit)? = null,
     onSetStyleOverride: ((Int, ControllerStyle?) -> Unit)? = null,
+    showConfigureButton: Boolean = true,
     onDismiss: () -> Unit,
 ) {
     Dialog(
@@ -52,6 +53,7 @@ fun GamepadConfigDialog(
                     onSwapUp = onSwapUp,
                     onSwapDown = onSwapDown,
                     onSetStyleOverride = onSetStyleOverride,
+                    showConfigureButton = showConfigureButton,
                 )
             }
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigScreen.kt
@@ -123,7 +123,7 @@ private fun ControllerRow(
     onConfigure: (() -> Unit)?,
     onSwapUp: (() -> Unit)?,
     onSwapDown: (() -> Unit)?,
-    onPickStyle: (() -> Unit) ? = null,
+    onPickStyle: (() -> Unit)? = null,
 ) {
     // Show the effective controller identity (e.g. "Xbox Controller"). For an
     // unrecognized pad fall back to the raw OS device name. (#1334)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigScreen.kt
@@ -23,6 +23,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -51,8 +54,12 @@ fun GamepadConfigScreen(
     onConfigurePort: (Int) -> Unit,
     onSwapUp: ((Int) -> Unit)? = null,
     onSwapDown: ((Int) -> Unit)? = null,
+    onSetStyleOverride: ((Int, ControllerStyle?) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
+    // Port whose controller-type picker is open, or null when closed.
+    var stylePickerPort by remember { mutableStateOf<Int?>(null) }
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -79,11 +86,28 @@ fun GamepadConfigScreen(
                 onSwapDown = if (port < 3 && assignment != null) {
                     { onSwapDown?.invoke(port) }
                 } else null,
+                onPickStyle = if (assignment != null && onSetStyleOverride != null) {
+                    { stylePickerPort = port }
+                } else null,
             )
             if (port < 3) {
                 Spacer(Modifier.height(SpSpacing.Small))
             }
         }
+    }
+
+    val pickerPort = stylePickerPort
+    val pickerAssignment = pickerPort?.let { p -> state.portAssignments.find { it.port == p } }
+    if (pickerPort != null && pickerAssignment != null && onSetStyleOverride != null) {
+        ControllerStylePickerDialog(
+            detectedStyle = pickerAssignment.detectedStyle,
+            currentOverride = pickerAssignment.styleOverride,
+            onSelect = { style ->
+                onSetStyleOverride(pickerPort, style)
+                stylePickerPort = null
+            },
+            onDismiss = { stylePickerPort = null },
+        )
     }
 }
 
@@ -94,12 +118,16 @@ private fun ControllerRow(
     onConfigure: () -> Unit,
     onSwapUp: (() -> Unit)?,
     onSwapDown: (() -> Unit)?,
+    onPickStyle: (() -> Unit)? = null,
 ) {
-    // Show the detected controller identity (e.g. "Xbox Controller"). For an
+    // Show the effective controller identity (e.g. "Xbox Controller"). For an
     // unrecognized pad fall back to the raw OS device name. (#1334)
     val identity = assignment?.let {
         if (it.style == ControllerStyle.Generic) it.deviceName else it.style.displayName
     }
+    // Compact label for the type-override affordance: "Auto" when deferring to
+    // detection, else the chosen style's short name.
+    val styleLabel = assignment?.styleOverride?.name ?: "Auto"
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -125,13 +153,25 @@ private fun ControllerRow(
 
         Spacer(Modifier.width(SpSpacing.Medium))
 
-        // Controller identity (brand when detected, else raw device name)
-        Text(
-            text = identity ?: "No controller",
-            style = SpTypography.BodyMedium,
-            color = if (assignment != null) SpColor.OnCard else SpColor.OnBackgroundTertiary,
-            modifier = Modifier.weight(1f),
-        )
+        // Controller identity (detected/overridden style, else raw device name)
+        // plus the per-controller type-override affordance.
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = identity ?: "No controller",
+                style = SpTypography.BodyMedium,
+                color = if (assignment != null) SpColor.OnCard else SpColor.OnBackgroundTertiary,
+            )
+            if (assignment != null && onPickStyle != null) {
+                SpButton(
+                    text = "Type: $styleLabel",
+                    onClick = onPickStyle,
+                    style = SpButtonStyle.Ghost,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Player ${port + 1} controller type"
+                    },
+                )
+            }
+        }
 
         // Activity indicator
         if (assignment != null) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigScreen.kt
@@ -126,8 +126,9 @@ private fun ControllerRow(
         if (it.style == ControllerStyle.Generic) it.deviceName else it.style.displayName
     }
     // Compact label for the type-override affordance: "Auto" when deferring to
-    // detection, else the chosen style's short name.
-    val styleLabel = assignment?.styleOverride?.name ?: "Auto"
+    // detection, else the chosen style's short name (matches the picker wording,
+    // e.g. Generic → "Gamepad").
+    val styleLabel = assignment?.styleOverride?.shortLabel ?: "Auto"
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigScreen.kt
@@ -55,6 +55,9 @@ fun GamepadConfigScreen(
     onSwapUp: ((Int) -> Unit)? = null,
     onSwapDown: ((Int) -> Unit)? = null,
     onSetStyleOverride: ((Int, ControllerStyle?) -> Unit)? = null,
+    /** Shows the per-port "Configure" (keyboard key-mapping) button. Hidden on
+     *  Android, where gamepad input is positional and there's no keyboard. */
+    showConfigureButton: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     // Port whose controller-type picker is open, or null when closed.
@@ -79,7 +82,9 @@ fun GamepadConfigScreen(
             ControllerRow(
                 port = port,
                 assignment = assignment,
-                onConfigure = { onConfigurePort(port) },
+                onConfigure = if (showConfigureButton) {
+                    { onConfigurePort(port) }
+                } else null,
                 onSwapUp = if (port > 0 && assignment != null) {
                     { onSwapUp?.invoke(port) }
                 } else null,
@@ -115,10 +120,10 @@ fun GamepadConfigScreen(
 private fun ControllerRow(
     port: Int,
     assignment: PortAssignmentUi?,
-    onConfigure: () -> Unit,
+    onConfigure: (() -> Unit)?,
     onSwapUp: (() -> Unit)?,
     onSwapDown: (() -> Unit)?,
-    onPickStyle: (() -> Unit)? = null,
+    onPickStyle: (() -> Unit) ? = null,
 ) {
     // Show the effective controller identity (e.g. "Xbox Controller"). For an
     // unrecognized pad fall back to the raw OS device name. (#1334)
@@ -201,8 +206,8 @@ private fun ControllerRow(
             Spacer(Modifier.width(SpSpacing.Small))
         }
 
-        // Configure button
-        if (assignment != null) {
+        // Configure (keyboard key-mapping) button — omitted when onConfigure is null.
+        if (assignment != null && onConfigure != null) {
             SpSecondaryButton(
                 text = "Configure",
                 onClick = onConfigure,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigScreen.kt
@@ -35,6 +35,7 @@ import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.domain.model.ControllerStyle
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.viewmodel.GamepadConfigState
@@ -94,6 +95,11 @@ private fun ControllerRow(
     onSwapUp: (() -> Unit)?,
     onSwapDown: (() -> Unit)?,
 ) {
+    // Show the detected controller identity (e.g. "Xbox Controller"). For an
+    // unrecognized pad fall back to the raw OS device name. (#1334)
+    val identity = assignment?.let {
+        if (it.style == ControllerStyle.Generic) it.deviceName else it.style.displayName
+    }
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -102,7 +108,7 @@ private fun ControllerRow(
             .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Medium)
             .semantics {
                 contentDescription = if (assignment != null) {
-                    "Player ${port + 1}: ${assignment.deviceName}" +
+                    "Player ${port + 1}: $identity" +
                         if (assignment.isActive) ", active" else ""
                 } else {
                     "Player ${port + 1}: No controller"
@@ -119,9 +125,9 @@ private fun ControllerRow(
 
         Spacer(Modifier.width(SpSpacing.Medium))
 
-        // Device name
+        // Controller identity (brand when detected, else raw device name)
         Text(
-            text = assignment?.deviceName ?: "No controller",
+            text = identity ?: "No controller",
             style = SpTypography.BodyMedium,
             color = if (assignment != null) SpColor.OnCard else SpColor.OnBackgroundTertiary,
             modifier = Modifier.weight(1f),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadMappingDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadMappingDialog.kt
@@ -1,0 +1,223 @@
+package com.spela.player.presentation.ui.components.gamepad
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.spela.player.domain.model.GamepadPosition
+import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpButtonStyle
+import com.spela.player.presentation.ui.components.SpDialog
+import com.spela.player.presentation.ui.components.SpRadioOption
+import com.spela.player.presentation.ui.feature.settings.SettingsDivider
+import com.spela.player.presentation.ui.gamepad.gamepadFocusable
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.GamepadMappingState
+
+/**
+ * Desktop gamepad mapping editor (#1334, component C — gamepad mode). For the
+ * current console it lists each physical [GamepadPosition] and the console
+ * action it triggers, and lets the user reassign by position. Brand-neutral:
+ * positions are physical ("Bottom button"), actions are the console's own
+ * labels — no Xbox/Nintendo glyphs.
+ *
+ * @param state the effective position→action mapping + console outputs
+ * @param onSetBinding assign a console action (RetroPad id) to a position
+ * @param onResetToDefaults clear all overrides for this console
+ * @param onDismiss close the editor
+ */
+@Composable
+fun GamepadMappingDialog(
+    state: GamepadMappingState,
+    onSetBinding: (GamepadPosition, Int) -> Unit,
+    onResetToDefaults: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var editingPosition by remember { mutableStateOf<GamepadPosition?>(null) }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Scrim),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth(0.9f)
+                    .heightIn(max = 560.dp)
+                    .clip(RoundedCornerShape(SpSpacing.RadiusPill))
+                    .background(SpColor.SurfaceElevated)
+                    .padding(SpSpacing.XLarge)
+                    .testTag("gamepad_mapping_dialog"),
+            ) {
+                Text(
+                    text = "Controller buttons — ${state.displayName}",
+                    style = SpTypography.HeadlineSmall,
+                    color = SpColor.OnBackground,
+                )
+                Text(
+                    text = "Choose what each physical button does on this console.",
+                    style = SpTypography.BodySmall,
+                    color = SpColor.OnBackgroundTertiary,
+                )
+
+                Spacer(Modifier.height(SpSpacing.Medium))
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 360.dp)
+                        .verticalScroll(rememberScrollState()),
+                ) {
+                    GamepadPosition.entries.forEachIndexed { index, position ->
+                        PositionRow(
+                            position = position,
+                            actionLabel = actionLabelFor(state, position),
+                            onClick = { editingPosition = position },
+                        )
+                        if (index < GamepadPosition.entries.size - 1) {
+                            SettingsDivider()
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(SpSpacing.Default))
+
+                SpButton(
+                    text = "Reset to defaults",
+                    onClick = onResetToDefaults,
+                    style = SpButtonStyle.Secondary,
+                    modifier = Modifier.fillMaxWidth().testTag("gamepad_mapping_reset"),
+                )
+                Spacer(Modifier.height(SpSpacing.Small))
+                SpButton(
+                    text = "Done",
+                    onClick = onDismiss,
+                    style = SpButtonStyle.Primary,
+                    modifier = Modifier.fillMaxWidth().testTag("gamepad_mapping_done"),
+                )
+            }
+        }
+    }
+
+    val editing = editingPosition
+    if (editing != null) {
+        GamepadActionPickerDialog(
+            position = editing,
+            state = state,
+            onSelect = { retroButtonId ->
+                onSetBinding(editing, retroButtonId)
+                editingPosition = null
+            },
+            onDismiss = { editingPosition = null },
+        )
+    }
+}
+
+/** A settings-style row: physical position on the left, its console action on
+ *  the right. Tapping opens the action picker. */
+@Composable
+private fun PositionRow(
+    position: GamepadPosition,
+    actionLabel: String,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick,
+            )
+            .gamepadFocusable(
+                shape = RoundedCornerShape(SpSpacing.RadiusLarge),
+                interactionSource = interactionSource,
+                addFocusable = false,
+            )
+            .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Medium)
+            .testTag("gamepad_pos_${position.name}"),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = position.displayName,
+            style = SpTypography.BodyMedium,
+            color = SpColor.OnCard,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = actionLabel,
+            style = SpTypography.TitleMedium,
+            color = if (actionLabel == "—") SpColor.OnBackgroundTertiary else SpColor.Primary,
+            modifier = Modifier.testTag("gamepad_action_${position.name}"),
+        )
+    }
+}
+
+/** Picker of the console's actions to assign to a single physical position. */
+@Composable
+private fun GamepadActionPickerDialog(
+    position: GamepadPosition,
+    state: GamepadMappingState,
+    onSelect: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val current = state.mapping[position]
+    SpDialog(
+        title = position.displayName,
+        onDismiss = onDismiss,
+        confirmText = "Done",
+        onConfirm = onDismiss,
+        modifier = Modifier.testTag("gamepad_action_picker"),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            state.outputs.forEachIndexed { index, output ->
+                SpRadioOption(
+                    title = output.label,
+                    description = "Make the ${position.displayName.lowercase()} act as ${output.label}",
+                    isSelected = current == output.retroButtonId,
+                    onClick = { onSelect(output.retroButtonId) },
+                )
+                if (index < state.outputs.size - 1) {
+                    SettingsDivider()
+                }
+            }
+        }
+    }
+}
+
+private fun actionLabelFor(state: GamepadMappingState, position: GamepadPosition): String {
+    val retroId = state.mapping[position] ?: return "—"
+    return state.outputs.firstOrNull { it.retroButtonId == retroId }?.label ?: "—"
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadMappingDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadMappingDialog.kt
@@ -82,7 +82,7 @@ fun GamepadMappingDialog(
             ) {
                 Text(
                     text = "Controller buttons — ${state.displayName}",
-                    style = SpTypography.HeadlineSmall,
+                    style = SpTypography.HeadlineMedium,
                     color = SpColor.OnBackground,
                 )
                 Text(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
@@ -316,15 +316,18 @@ fun ConsoleSettingsScreen(
                                     GamepadConfigIntent.SetStyleOverride(port, style)
                                 )
                             },
+                            // Keyboard key-mapping is desktop-only; on Android the
+                            // positional "Controller buttons" editor is used instead.
+                            showConfigureButton = currentPlatform() != "android",
                         )
                     }
                 }
             }
 
-            // Desktop gamepad button remapping (#1334). Gated to desktop —
-            // Android's gamepad input isn't routed through the positional
-            // mapping layer yet (that lands with the Android phase).
-            if (gamepadMappingViewModel != null && currentPlatform() != "android") {
+            // Positional gamepad button remapping (#1334). Available on both
+            // platforms now that Android input also flows through the positional
+            // mapping layer.
+            if (gamepadMappingViewModel != null) {
                 item {
                     val gamepadMappingState by gamepadMappingViewModel.state.collectAsState()
                     var showGamepadMapping by remember { mutableStateOf(false) }
@@ -371,48 +374,54 @@ fun ConsoleSettingsScreen(
                 }
             }
 
-            item {
-                val selectedPort = gamepadConfigViewModel?.state?.collectAsState()?.value?.selectedPort
-                val portAssignment = gamepadConfigViewModel?.state?.collectAsState()?.value
-                    ?.portAssignments?.find { it.port == selectedPort }
-                val portLabel = if (selectedPort != null && portAssignment != null) {
-                    "Player ${selectedPort + 1} \u2014 ${portAssignment.deviceName}"
-                } else null
+            // Keyboard key mapping (keycode \u2192 RetroPad). Desktop-only: there's no
+            // keyboard on Android, and Android gamepad input is positional (the
+            // "Controller buttons" editor above), so the keycode editor would be
+            // dead there. (#1334)
+            if (currentPlatform() != "android") {
+                item {
+                    val selectedPort = gamepadConfigViewModel?.state?.collectAsState()?.value?.selectedPort
+                    val portAssignment = gamepadConfigViewModel?.state?.collectAsState()?.value
+                        ?.portAssignments?.find { it.port == selectedPort }
+                    val portLabel = if (selectedPort != null && portAssignment != null) {
+                        "Player ${selectedPort + 1} \u2014 ${portAssignment.deviceName}"
+                    } else null
 
-                SpCard(onGradient = true) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(560.dp)
-                            .padding(SpSpacing.Small)
-                            .testTag("key-mapping-card"),
-                    ) {
-                        KeyMappingScreen(
-                            layout = layout,
-                            state = keyMappingState,
-                            onButtonClick = { retroButtonId ->
-                                keyMappingViewModel.onIntent(
-                                    KeyMappingIntent.StartSingleButtonMap(retroButtonId)
-                                )
-                            },
-                            onStartWizard = {
-                                keyMappingViewModel.onIntent(
-                                    KeyMappingIntent.StartWizard(consoleId)
-                                )
-                            },
-                            onResetToDefaults = {
-                                keyMappingViewModel.onIntent(KeyMappingIntent.ResetAll)
-                            },
-                            onCancelMapping = {
-                                keyMappingViewModel.onIntent(KeyMappingIntent.CancelMapping)
-                            },
-                            onClearBinding = {
-                                keyMappingViewModel.onIntent(KeyMappingIntent.ClearCurrentBinding)
-                            },
-                            keyNameResolver = ::platformKeyName,
-                            portLabel = portLabel,
-                            modifier = Modifier.padding(SpSpacing.ScreenHorizontal),
-                        )
+                    SpCard(onGradient = true) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(560.dp)
+                                .padding(SpSpacing.Small)
+                                .testTag("key-mapping-card"),
+                        ) {
+                            KeyMappingScreen(
+                                layout = layout,
+                                state = keyMappingState,
+                                onButtonClick = { retroButtonId ->
+                                    keyMappingViewModel.onIntent(
+                                        KeyMappingIntent.StartSingleButtonMap(retroButtonId)
+                                    )
+                                },
+                                onStartWizard = {
+                                    keyMappingViewModel.onIntent(
+                                        KeyMappingIntent.StartWizard(consoleId)
+                                    )
+                                },
+                                onResetToDefaults = {
+                                    keyMappingViewModel.onIntent(KeyMappingIntent.ResetAll)
+                                },
+                                onCancelMapping = {
+                                    keyMappingViewModel.onIntent(KeyMappingIntent.CancelMapping)
+                                },
+                                onClearBinding = {
+                                    keyMappingViewModel.onIntent(KeyMappingIntent.ClearCurrentBinding)
+                                },
+                                keyNameResolver = ::platformKeyName,
+                                portLabel = portLabel,
+                                modifier = Modifier.padding(SpSpacing.ScreenHorizontal),
+                            )
+                        }
                     }
                 }
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
@@ -303,6 +303,11 @@ fun ConsoleSettingsScreen(
                                     GamepadConfigIntent.SwapPorts(port, port + 1)
                                 )
                             },
+                            onSetStyleOverride = { port, style ->
+                                gamepadConfigViewModel.onIntent(
+                                    GamepadConfigIntent.SetStyleOverride(port, style)
+                                )
+                            },
                         )
                     }
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
@@ -24,7 +24,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -38,22 +40,27 @@ import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.components.ShaderPreview
 import com.spela.player.presentation.ui.components.ShaderPreviewDialog
 import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.components.SpRadioOption
 import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpScreenTopSpacer
 import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.components.gamepad.GamepadConfigScreen
+import com.spela.player.presentation.ui.components.gamepad.GamepadMappingDialog
 import com.spela.player.presentation.ui.components.keymapping.KeyMappingScreen
 import com.spela.player.presentation.ui.components.keymapping.platformKeyName
 import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.viewmodel.GamepadConfigIntent
 import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
+import com.spela.player.presentation.viewmodel.GamepadMappingIntent
+import com.spela.player.presentation.viewmodel.GamepadMappingViewModel
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
 import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.focusRestoreItem
 import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import androidx.compose.runtime.CompositionLocalProvider
+import com.spela.player.util.currentPlatform
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -70,6 +77,7 @@ fun ConsoleSettingsScreen(
     settingsViewModel: SettingsViewModel,
     keyMappingViewModel: KeyMappingViewModel,
     gamepadConfigViewModel: GamepadConfigViewModel? = null,
+    gamepadMappingViewModel: GamepadMappingViewModel? = null,
     onBack: () -> Unit,
 ) {
     PlatformBackHandler { onBack() }
@@ -308,6 +316,56 @@ fun ConsoleSettingsScreen(
                                     GamepadConfigIntent.SetStyleOverride(port, style)
                                 )
                             },
+                        )
+                    }
+                }
+            }
+
+            // Desktop gamepad button remapping (#1334). Gated to desktop —
+            // Android's gamepad input isn't routed through the positional
+            // mapping layer yet (that lands with the Android phase).
+            if (gamepadMappingViewModel != null && currentPlatform() != "android") {
+                item {
+                    val gamepadMappingState by gamepadMappingViewModel.state.collectAsState()
+                    var showGamepadMapping by remember { mutableStateOf(false) }
+
+                    SpCard(onGradient = true) {
+                        Column(modifier = Modifier.fillMaxWidth().padding(SpSpacing.Default)) {
+                            Text(
+                                text = "Gamepad buttons",
+                                style = SpTypography.TitleMedium,
+                                color = SpColor.OnCard,
+                            )
+                            Spacer(Modifier.height(SpSpacing.Small))
+                            Text(
+                                text = "Remap what each physical controller button does on $consoleName.",
+                                style = SpTypography.BodySmall,
+                                color = SpColor.OnBackgroundTertiary,
+                            )
+                            Spacer(Modifier.height(SpSpacing.Medium))
+                            SpSecondaryButton(
+                                text = "Configure gamepad buttons",
+                                onClick = {
+                                    gamepadMappingViewModel.onIntent(GamepadMappingIntent.Load(consoleId))
+                                    showGamepadMapping = true
+                                },
+                                modifier = Modifier.testTag("configure_gamepad_buttons"),
+                            )
+                        }
+                    }
+
+                    if (showGamepadMapping) {
+                        GamepadMappingDialog(
+                            state = gamepadMappingState,
+                            onSetBinding = { position, retroButtonId ->
+                                gamepadMappingViewModel.onIntent(
+                                    GamepadMappingIntent.SetBinding(position, retroButtonId)
+                                )
+                            },
+                            onResetToDefaults = {
+                                gamepadMappingViewModel.onIntent(GamepadMappingIntent.ResetAll)
+                            },
+                            onDismiss = { showGamepadMapping = false },
                         )
                     }
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
@@ -332,7 +332,7 @@ fun ConsoleSettingsScreen(
                     SpCard(onGradient = true) {
                         Column(modifier = Modifier.fillMaxWidth().padding(SpSpacing.Default)) {
                             Text(
-                                text = "Gamepad buttons",
+                                text = "Controller buttons",
                                 style = SpTypography.TitleMedium,
                                 color = SpColor.OnCard,
                             )
@@ -344,7 +344,7 @@ fun ConsoleSettingsScreen(
                             )
                             Spacer(Modifier.height(SpSpacing.Medium))
                             SpSecondaryButton(
-                                text = "Configure gamepad buttons",
+                                text = "Configure controller buttons",
                                 onClick = {
                                     gamepadMappingViewModel.onIntent(GamepadMappingIntent.Load(consoleId))
                                     showGamepadMapping = true

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
@@ -380,6 +380,9 @@ fun ConsoleSettingsScreen(
             // dead there. (#1334)
             if (currentPlatform() != "android") {
                 item {
+                    SettingsSectionHeader(title = "Keyboard")
+                }
+                item {
                     val selectedPort = gamepadConfigViewModel?.state?.collectAsState()?.value?.selectedPort
                     val portAssignment = gamepadConfigViewModel?.state?.collectAsState()?.value
                         ?.portAssignments?.find { it.port == selectedPort }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -42,6 +42,7 @@ import com.spela.player.presentation.ui.components.keymapping.PresetPickerDialog
 import com.spela.player.presentation.ui.components.keymapping.platformKeyName
 import com.spela.player.presentation.viewmodel.EmulationViewModel
 import com.spela.player.presentation.viewmodel.GamepadConfigIntent
+import com.spela.player.util.currentPlatform
 import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
 import com.spela.player.presentation.viewmodel.KeyMappingViewModel
 
@@ -481,6 +482,8 @@ fun InGameOverlay(
             onSetStyleOverride = { port, style ->
                 gamepadConfigViewModel.onIntent(GamepadConfigIntent.SetStyleOverride(port, style))
             },
+            // Keyboard key-mapping is desktop-only (Android gamepad input is positional).
+            showConfigureButton = currentPlatform() != "android",
             onDismiss = {
                 viewModel.onIntent(EmulationIntent.HideGamepadConfig)
             },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -478,6 +478,9 @@ fun InGameOverlay(
             onSwapDown = { port ->
                 gamepadConfigViewModel.onIntent(GamepadConfigIntent.SwapPorts(port, port + 1))
             },
+            onSetStyleOverride = { port, style ->
+                gamepadConfigViewModel.onIntent(GamepadConfigIntent.SetStyleOverride(port, style))
+            },
             onDismiss = {
                 viewModel.onIntent(EmulationIntent.HideGamepadConfig)
             },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -159,6 +159,11 @@ class EmulationViewModel(
                             } else {
                                 gamepadPortManager.loadAllMappings(consoleId)
                             }
+                            // Positional gamepad mapping layer (#1334). Inert
+                            // until the user rebinds (defaults reproduce the
+                            // historical behavior); no-op when no repository is
+                            // wired (e.g. Android until its phase lands).
+                            gamepadPortManager.loadAllGamepadMappings(consoleId)
                         } catch (e: kotlinx.coroutines.CancellationException) {
                             // Re-throw so cooperative cancellation works.
                             // Pre-#963 the broad `catch (_: Exception)` below

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModel.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.viewmodel
 
+import com.spela.player.domain.model.ControllerStyle
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
@@ -23,6 +24,7 @@ data class PortAssignmentUi(
     val deviceId: Int,
     val isActive: Boolean,
     val hasCustomMapping: Boolean,
+    val style: ControllerStyle = ControllerStyle.Generic,
 )
 
 sealed interface GamepadConfigIntent {
@@ -95,6 +97,7 @@ class GamepadConfigViewModel(
                 deviceId = assignment.deviceId,
                 isActive = isActive,
                 hasCustomMapping = gamepadPortManager.getKeyMapping(assignment.port) != null,
+                style = assignment.style,
             )
         }.sortedBy { it.port }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModel.kt
@@ -1,6 +1,7 @@
 package com.spela.player.presentation.viewmodel
 
 import com.spela.player.domain.model.ControllerStyle
+import com.spela.player.domain.repository.ControllerStyleOverrideRepository
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
@@ -24,17 +25,29 @@ data class PortAssignmentUi(
     val deviceId: Int,
     val isActive: Boolean,
     val hasCustomMapping: Boolean,
+    /** Effective controller style: the user's override if set, else detection. */
     val style: ControllerStyle = ControllerStyle.Generic,
+    /** Raw detected style, independent of any override (labels the "Auto" choice). */
+    val detectedStyle: ControllerStyle = ControllerStyle.Generic,
+    /** The user's explicit style override, or null when Auto (defer to detection). */
+    val styleOverride: ControllerStyle? = null,
 )
 
 sealed interface GamepadConfigIntent {
     data class SwapPorts(val portA: Int, val portB: Int) : GamepadConfigIntent
     data class SelectPortForMapping(val port: Int) : GamepadConfigIntent
     data object DeselectPort : GamepadConfigIntent
+
+    /**
+     * Set (or, with style == null, clear back to Auto) the device-local
+     * controller-style override for the controller on [port].
+     */
+    data class SetStyleOverride(val port: Int, val style: ControllerStyle?) : GamepadConfigIntent
 }
 
 class GamepadConfigViewModel(
     private val gamepadPortManager: GamepadPortManager,
+    private val styleOverrideRepository: ControllerStyleOverrideRepository,
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
     /**
@@ -51,6 +64,18 @@ class GamepadConfigViewModel(
 
     private val _state = MutableStateFlow(GamepadConfigState())
     val state: StateFlow<GamepadConfigState> = _state.asStateFlow()
+
+    /**
+     * In-memory cache of device-local style overrides, keyed by controller
+     * device name. Loaded lazily when a controller first appears (so the
+     * 200 ms refresh loop never touches the DB) and updated on
+     * [GamepadConfigIntent.SetStyleOverride].
+     */
+    private val _overrides = MutableStateFlow<Map<String, ControllerStyle>>(emptyMap())
+
+    /** Device names whose override load has been requested. Only mutated from
+     *  the single refresh coroutine, so it needs no synchronization. */
+    private val requestedLoads = mutableSetOf<String>()
 
     private var refreshJob: Job? = null
 
@@ -70,6 +95,20 @@ class GamepadConfigViewModel(
             GamepadConfigIntent.DeselectPort -> {
                 _state.update { it.copy(selectedPort = null) }
             }
+            is GamepadConfigIntent.SetStyleOverride -> {
+                val deviceName = gamepadPortManager.assignments.value
+                    .find { it.port == intent.port }
+                    ?.deviceName
+                    ?.takeIf { it.isNotEmpty() }
+                    ?: return
+                scope.launch(dispatchers.io) {
+                    styleOverrideRepository.setOverride(deviceName, intent.style)
+                    _overrides.update { current ->
+                        if (intent.style == null) current - deviceName
+                        else current + (deviceName to intent.style)
+                    }
+                }
+            }
         }
     }
 
@@ -86,18 +125,34 @@ class GamepadConfigViewModel(
     private fun refreshState() {
         val assignments = gamepadPortManager.assignments.value
         val activity = gamepadPortManager.portActivity.value
+        val overrides = _overrides.value
         val now = nowMs()
+
+        // Lazily load the override for any controller we haven't looked up yet.
+        // The result lands in [_overrides] and is reflected on the next tick.
+        for (assignment in assignments) {
+            val name = assignment.deviceName
+            if (name.isNotEmpty() && requestedLoads.add(name)) {
+                scope.launch(dispatchers.io) {
+                    val stored = styleOverrideRepository.getOverride(name) ?: return@launch
+                    _overrides.update { it + (name to stored) }
+                }
+            }
+        }
 
         val portAssignments = assignments.map { assignment ->
             val lastActivity = activity[assignment.port] ?: 0L
             val isActive = lastActivity > 0L && (now - lastActivity) < ACTIVITY_TIMEOUT_MS
+            val override = overrides[assignment.deviceName]
             PortAssignmentUi(
                 port = assignment.port,
                 deviceName = assignment.deviceName.ifEmpty { "Controller ${assignment.port + 1}" },
                 deviceId = assignment.deviceId,
                 isActive = isActive,
                 hasCustomMapping = gamepadPortManager.getKeyMapping(assignment.port) != null,
-                style = assignment.style,
+                style = override ?: assignment.style,
+                detectedStyle = assignment.style,
+                styleOverride = override,
             )
         }.sortedBy { it.port }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadMappingViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadMappingViewModel.kt
@@ -1,0 +1,97 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.domain.model.ButtonInfo
+import com.spela.player.domain.model.DefaultKeyMappings
+import com.spela.player.domain.model.GamepadPosition
+import com.spela.player.domain.repository.GamepadMappingRepository
+import com.spela.player.libretro.GamepadButtonResolver
+import com.spela.player.libretro.GamepadPortManager
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class GamepadMappingState(
+    val consoleId: String = "",
+    val port: Int = 0,
+    val displayName: String = "",
+    /** Effective position → RetroPad id (defaults + stored overrides). */
+    val mapping: Map<GamepadPosition, Int> = emptyMap(),
+    /** The console's RetroPad outputs (digital only), for the action picker. */
+    val outputs: List<ButtonInfo> = emptyList(),
+    val isLoading: Boolean = true,
+)
+
+sealed interface GamepadMappingIntent {
+    data class Load(val consoleId: String, val port: Int = 0) : GamepadMappingIntent
+    data class SetBinding(val position: GamepadPosition, val retroButtonId: Int) : GamepadMappingIntent
+    data object ResetAll : GamepadMappingIntent
+}
+
+/**
+ * Edits the positional gamepad mapping layer (`GamepadPosition` → RetroPad) for
+ * a console (#1334, desktop gamepad mode of component C). Brand-neutral: the UI
+ * shows physical positions and the console's actions, never brand glyphs.
+ *
+ * Writes go through [GamepadMappingRepository]; after each change the live
+ * [GamepadPortManager] mapping is reloaded so a running game picks it up
+ * immediately.
+ */
+class GamepadMappingViewModel(
+    private val gamepadMappingRepository: GamepadMappingRepository,
+    private val gamepadPortManager: GamepadPortManager,
+    private val dispatchers: DispatcherProvider,
+    private val scope: CoroutineScope,
+) {
+    private val _state = MutableStateFlow(GamepadMappingState())
+    val state: StateFlow<GamepadMappingState> = _state.asStateFlow()
+
+    fun onIntent(intent: GamepadMappingIntent) {
+        when (intent) {
+            is GamepadMappingIntent.Load -> load(intent.consoleId, intent.port)
+            is GamepadMappingIntent.SetBinding -> {
+                val s = _state.value
+                if (s.consoleId.isEmpty()) return
+                scope.launch(dispatchers.io) {
+                    gamepadMappingRepository.setBinding(s.consoleId, s.port, intent.position, intent.retroButtonId)
+                    applyAndRefresh(s.consoleId, s.port)
+                }
+            }
+            GamepadMappingIntent.ResetAll -> {
+                val s = _state.value
+                if (s.consoleId.isEmpty()) return
+                scope.launch(dispatchers.io) {
+                    gamepadMappingRepository.resetToDefault(s.consoleId, s.port)
+                    applyAndRefresh(s.consoleId, s.port)
+                }
+            }
+        }
+    }
+
+    private fun load(consoleId: String, port: Int) {
+        _state.update { it.copy(consoleId = consoleId, port = port, isLoading = true) }
+        scope.launch(dispatchers.io) {
+            val layout = DefaultKeyMappings.getLayoutForConsole(consoleId)
+            val mapping = gamepadMappingRepository.getEffectiveMapping(consoleId, port)
+            val outputs = layout.buttons.filter { it.retroButtonId in 0 until GamepadButtonResolver.RETRO_BUTTON_COUNT }
+            _state.update {
+                it.copy(
+                    displayName = layout.displayName,
+                    mapping = mapping,
+                    outputs = outputs,
+                    isLoading = false,
+                )
+            }
+        }
+    }
+
+    /** Reload the live port mapping and refresh the displayed effective mapping. */
+    private suspend fun applyAndRefresh(consoleId: String, port: Int) {
+        gamepadPortManager.loadAllGamepadMappings(consoleId)
+        val mapping = gamepadMappingRepository.getEffectiveMapping(consoleId, port)
+        _state.update { it.copy(mapping = mapping) }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadMappingViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadMappingViewModel.kt
@@ -4,6 +4,7 @@ import com.spela.player.domain.model.ButtonInfo
 import com.spela.player.domain.model.DefaultKeyMappings
 import com.spela.player.domain.model.GamepadPosition
 import com.spela.player.domain.repository.GamepadMappingRepository
+import com.spela.player.domain.repository.PreferencesRepository
 import com.spela.player.libretro.GamepadButtonResolver
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.util.DispatcherProvider
@@ -43,6 +44,7 @@ sealed interface GamepadMappingIntent {
 class GamepadMappingViewModel(
     private val gamepadMappingRepository: GamepadMappingRepository,
     private val gamepadPortManager: GamepadPortManager,
+    private val preferencesRepository: PreferencesRepository,
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
 ) {
@@ -88,10 +90,12 @@ class GamepadMappingViewModel(
         }
     }
 
-    /** Reload the live port mapping and refresh the displayed effective mapping. */
+    /** Reload the live port mapping, refresh the displayed mapping, and sync the
+     *  positional layer to the server (best-effort) so it follows the user. */
     private suspend fun applyAndRefresh(consoleId: String, port: Int) {
         gamepadPortManager.loadAllGamepadMappings(consoleId)
         val mapping = gamepadMappingRepository.getEffectiveMapping(consoleId, port)
         _state.update { it.copy(mapping = mapping) }
+        preferencesRepository.pushKeyMappingsToServer()
     }
 }

--- a/player/shared/src/commonMain/sqldelight/com/spela/player/SpelaDatabase.sq
+++ b/player/shared/src/commonMain/sqldelight/com/spela/player/SpelaDatabase.sq
@@ -196,6 +196,37 @@ DELETE FROM GameKeyMappingEntity WHERE game_id = ?;
 hasGameKeyMappings:
 SELECT COUNT(*) FROM GameKeyMappingEntity WHERE game_id = ?;
 
+-- Positional gamepad mappings (#1334): the mapping layer of the two-layer
+-- model — GamepadPosition (string enum name) -> libretro RetroPad id, per
+-- console/port. Distinct from KeyMappingEntity (physical key code -> RetroPad):
+-- this layer is brand-independent because the input layer normalizes physical
+-- buttons to canonical positions first. Only diffs from the default mapping are
+-- stored; the effective mapping is default + these overrides.
+CREATE TABLE GamepadMappingEntity (
+    id TEXT NOT NULL PRIMARY KEY,
+    console_id TEXT NOT NULL,
+    port INTEGER NOT NULL DEFAULT 0,
+    gamepad_position TEXT NOT NULL,
+    libretro_button_id INTEGER NOT NULL,
+    UNIQUE(console_id, port, gamepad_position)
+);
+
+insertGamepadMapping:
+INSERT OR REPLACE INTO GamepadMappingEntity(id, console_id, port, gamepad_position, libretro_button_id)
+VALUES (?, ?, ?, ?, ?);
+
+getGamepadMappingsForConsole:
+SELECT * FROM GamepadMappingEntity WHERE console_id = ? AND port = ?;
+
+deleteGamepadMappingsForConsole:
+DELETE FROM GamepadMappingEntity WHERE console_id = ? AND port = ?;
+
+deleteGamepadMappingForPosition:
+DELETE FROM GamepadMappingEntity WHERE console_id = ? AND port = ? AND gamepad_position = ?;
+
+getAllGamepadMappings:
+SELECT * FROM GamepadMappingEntity;
+
 -- Device info (singleton row for this device's identity)
 CREATE TABLE DeviceInfoEntity (
     id INTEGER PRIMARY KEY DEFAULT 1,

--- a/player/shared/src/commonMain/sqldelight/com/spela/player/migrations/5.sqm
+++ b/player/shared/src/commonMain/sqldelight/com/spela/player/migrations/5.sqm
@@ -1,0 +1,13 @@
+-- Migration from schema version 5 to 6: add GamepadMappingEntity, the mapping
+-- layer of the two-layer positional gamepad model (#1334). Stores
+-- GamepadPosition -> libretro RetroPad id per console/port, brand-independent
+-- (the input layer normalizes physical buttons to canonical positions first).
+-- Only diffs from the default mapping are stored.
+CREATE TABLE GamepadMappingEntity (
+    id TEXT NOT NULL PRIMARY KEY,
+    console_id TEXT NOT NULL,
+    port INTEGER NOT NULL DEFAULT 0,
+    gamepad_position TEXT NOT NULL,
+    libretro_button_id INTEGER NOT NULL,
+    UNIQUE(console_id, port, gamepad_position)
+);

--- a/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/ControllerStyleTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/ControllerStyleTest.kt
@@ -24,4 +24,14 @@ class ControllerStyleTest {
         assertEquals("PlayStation Controller", ControllerStyle.PlayStation.displayName)
         assertEquals("Gamepad", ControllerStyle.Generic.displayName)
     }
+
+    @Test
+    fun shortLabels() {
+        assertEquals("Xbox", ControllerStyle.Xbox.shortLabel)
+        assertEquals("Nintendo", ControllerStyle.Nintendo.shortLabel)
+        assertEquals("PlayStation", ControllerStyle.PlayStation.shortLabel)
+        // Generic's short label matches its displayName so the "Type: …"
+        // affordance and the picker never disagree.
+        assertEquals("Gamepad", ControllerStyle.Generic.shortLabel)
+    }
 }

--- a/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/ControllerStyleTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/ControllerStyleTest.kt
@@ -1,0 +1,19 @@
+package com.spela.player.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ControllerStyleTest {
+    @Test
+    fun classifiesKnownVendors() {
+        assertEquals(ControllerStyle.PlayStation, ControllerClassifier.fromVendorProduct(0x054C, 0x0CE6, ""))
+        assertEquals(ControllerStyle.Xbox, ControllerClassifier.fromVendorProduct(0x045E, 0x02FD, ""))
+        assertEquals(ControllerStyle.Nintendo, ControllerClassifier.fromVendorProduct(0x057E, 0x2009, ""))
+    }
+
+    @Test
+    fun unknownVendorFallsBackToNameThenGeneric() {
+        assertEquals(ControllerStyle.Nintendo, ControllerClassifier.fromVendorProduct(0x0000, 0x0000, "Pro Controller"))
+        assertEquals(ControllerStyle.Generic, ControllerClassifier.fromVendorProduct(0x1234, 0x5678, "Some USB Gamepad"))
+    }
+}

--- a/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/ControllerStyleTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/ControllerStyleTest.kt
@@ -16,4 +16,12 @@ class ControllerStyleTest {
         assertEquals(ControllerStyle.Nintendo, ControllerClassifier.fromVendorProduct(0x0000, 0x0000, "Pro Controller"))
         assertEquals(ControllerStyle.Generic, ControllerClassifier.fromVendorProduct(0x1234, 0x5678, "Some USB Gamepad"))
     }
+
+    @Test
+    fun displayNames() {
+        assertEquals("Xbox Controller", ControllerStyle.Xbox.displayName)
+        assertEquals("Nintendo Controller", ControllerStyle.Nintendo.displayName)
+        assertEquals("PlayStation Controller", ControllerStyle.PlayStation.displayName)
+        assertEquals("Gamepad", ControllerStyle.Generic.displayName)
+    }
 }

--- a/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/GamepadPositionTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/domain/model/GamepadPositionTest.kt
@@ -1,0 +1,65 @@
+package com.spela.player.domain.model
+
+import com.spela.player.presentation.viewmodel.LibretroButtons
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GamepadPositionTest {
+
+    /**
+     * Guards the ordinal contract shared with the C bridge
+     * (player/native/src/gamepad_sdl3.c). If this fails, the C
+     * `sdl_button_to_position` table must be updated in lockstep.
+     */
+    @Test
+    fun ordinalContractIsStable() {
+        assertEquals(0, GamepadPosition.SOUTH.ordinal)
+        assertEquals(1, GamepadPosition.EAST.ordinal)
+        assertEquals(2, GamepadPosition.WEST.ordinal)
+        assertEquals(3, GamepadPosition.NORTH.ordinal)
+        assertEquals(4, GamepadPosition.DPAD_UP.ordinal)
+        assertEquals(5, GamepadPosition.DPAD_DOWN.ordinal)
+        assertEquals(6, GamepadPosition.DPAD_LEFT.ordinal)
+        assertEquals(7, GamepadPosition.DPAD_RIGHT.ordinal)
+        assertEquals(8, GamepadPosition.L1.ordinal)
+        assertEquals(9, GamepadPosition.R1.ordinal)
+        assertEquals(10, GamepadPosition.L2.ordinal)
+        assertEquals(11, GamepadPosition.R2.ordinal)
+        assertEquals(12, GamepadPosition.L3.ordinal)
+        assertEquals(13, GamepadPosition.R3.ordinal)
+        assertEquals(14, GamepadPosition.START.ordinal)
+        assertEquals(15, GamepadPosition.SELECT.ordinal)
+        assertEquals(16, GamepadPosition.entries.size)
+    }
+
+    /** The default map must reproduce the historical fixed SDL3 desktop mapping. */
+    @Test
+    fun defaultMapReproducesHistoricalSdlBehavior() {
+        val m = DefaultGamepadMapping.POSITION_TO_RETRO
+        assertEquals(LibretroButtons.B, m[GamepadPosition.SOUTH])
+        assertEquals(LibretroButtons.A, m[GamepadPosition.EAST])
+        assertEquals(LibretroButtons.Y, m[GamepadPosition.WEST])
+        assertEquals(LibretroButtons.X, m[GamepadPosition.NORTH])
+        assertEquals(LibretroButtons.UP, m[GamepadPosition.DPAD_UP])
+        assertEquals(LibretroButtons.DOWN, m[GamepadPosition.DPAD_DOWN])
+        assertEquals(LibretroButtons.LEFT, m[GamepadPosition.DPAD_LEFT])
+        assertEquals(LibretroButtons.RIGHT, m[GamepadPosition.DPAD_RIGHT])
+        assertEquals(LibretroButtons.L, m[GamepadPosition.L1])
+        assertEquals(LibretroButtons.R, m[GamepadPosition.R1])
+        assertEquals(LibretroButtons.L2, m[GamepadPosition.L2])
+        assertEquals(LibretroButtons.R2, m[GamepadPosition.R2])
+        assertEquals(LibretroButtons.L3, m[GamepadPosition.L3])
+        assertEquals(LibretroButtons.R3, m[GamepadPosition.R3])
+        assertEquals(LibretroButtons.START, m[GamepadPosition.START])
+        assertEquals(LibretroButtons.SELECT, m[GamepadPosition.SELECT])
+    }
+
+    /** Every position has a default; the mapping covers the full enum. */
+    @Test
+    fun everyPositionHasADefault() {
+        assertEquals(
+            GamepadPosition.entries.toSet(),
+            DefaultGamepadMapping.POSITION_TO_RETRO.keys,
+        )
+    }
+}

--- a/player/shared/src/commonTest/kotlin/com/spela/player/libretro/GamepadButtonResolverTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/libretro/GamepadButtonResolverTest.kt
@@ -1,0 +1,64 @@
+package com.spela.player.libretro
+
+import com.spela.player.domain.model.DefaultGamepadMapping
+import com.spela.player.domain.model.GamepadPosition
+import com.spela.player.presentation.viewmodel.LibretroButtons
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GamepadButtonResolverTest {
+
+    private fun pressed(vararg positions: GamepadPosition): BooleanArray {
+        val a = BooleanArray(GamepadPosition.entries.size)
+        positions.forEach { a[it.ordinal] = true }
+        return a
+    }
+
+    @Test
+    fun defaultMappingRoutesSouthToB() {
+        val out = GamepadButtonResolver.resolve(pressed(GamepadPosition.SOUTH), DefaultGamepadMapping.POSITION_TO_RETRO)
+        assertTrue(out[LibretroButtons.B])
+        assertFalse(out[LibretroButtons.A])
+    }
+
+    @Test
+    fun guidingExampleSouthToANesA() {
+        // Remap SOUTH→A (NES A), WEST→B (NES B).
+        val mapping = DefaultGamepadMapping.POSITION_TO_RETRO + mapOf(
+            GamepadPosition.SOUTH to LibretroButtons.A,
+            GamepadPosition.WEST to LibretroButtons.B,
+        )
+        val south = GamepadButtonResolver.resolve(pressed(GamepadPosition.SOUTH), mapping)
+        assertTrue(south[LibretroButtons.A])
+        val west = GamepadButtonResolver.resolve(pressed(GamepadPosition.WEST), mapping)
+        assertTrue(west[LibretroButtons.B])
+    }
+
+    @Test
+    fun fanInOrsPressesToSameRetroButton() {
+        // Two positions mapped to the same RetroPad id: pressing either presses it.
+        val mapping = mapOf(
+            GamepadPosition.SOUTH to LibretroButtons.A,
+            GamepadPosition.EAST to LibretroButtons.A,
+        )
+        assertTrue(GamepadButtonResolver.resolve(pressed(GamepadPosition.SOUTH), mapping)[LibretroButtons.A])
+        assertTrue(GamepadButtonResolver.resolve(pressed(GamepadPosition.EAST), mapping)[LibretroButtons.A])
+        // Pressing SOUTH while EAST is released still reports A pressed (no clobber).
+        assertTrue(GamepadButtonResolver.resolve(pressed(GamepadPosition.SOUTH), mapping)[LibretroButtons.A])
+    }
+
+    @Test
+    fun unmappedPositionProducesNoPress() {
+        val mapping = emptyMap<GamepadPosition, Int>()
+        val out = GamepadButtonResolver.resolve(pressed(GamepadPosition.SOUTH), mapping)
+        assertFalse(out.any { it })
+    }
+
+    @Test
+    fun nothingPressedProducesAllFalse() {
+        val out = GamepadButtonResolver.resolve(BooleanArray(16), DefaultGamepadMapping.POSITION_TO_RETRO)
+        assertFalse(out.any { it })
+    }
+}

--- a/player/shared/src/commonTest/kotlin/com/spela/player/libretro/GamepadMappingMigrationTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/libretro/GamepadMappingMigrationTest.kt
@@ -1,0 +1,57 @@
+package com.spela.player.libretro
+
+import com.spela.player.domain.model.DEFAULT_CONSOLE_ID
+import com.spela.player.domain.model.GamepadPosition
+import com.spela.player.presentation.viewmodel.LibretroButtons
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GamepadMappingMigrationTest {
+
+    // android.view.KeyEvent values.
+    private val BUTTON_A = 96 // -> SOUTH
+    private val BUTTON_B = 97 // -> EAST
+    private val VOLUME_UP = 24 // not a gamepad key
+
+    private fun row(console: String, keyCode: Int, retro: Int) =
+        GamepadMappingMigration.LegacyRow(console, 0, keyCode, retro)
+
+    @Test
+    fun convertsGenuinePerConsoleCustomization() {
+        // NES bottom button customized to RetroPad A (default is B) -> migrate.
+        val out = GamepadMappingMigration.split(listOf(row("nes", BUTTON_A, LibretroButtons.A)))
+        assertEquals(1, out.size)
+        assertEquals(GamepadPosition.SOUTH, out[0].position)
+        assertEquals(LibretroButtons.A, out[0].retroButtonId)
+        assertEquals("nes", out[0].consoleId)
+    }
+
+    @Test
+    fun skipsDefaultEqualMappings() {
+        // BUTTON_A -> RetroPad B equals the positional default for SOUTH: no override needed.
+        assertTrue(GamepadMappingMigration.split(listOf(row("nes", BUTTON_A, LibretroButtons.B))).isEmpty())
+        assertTrue(GamepadMappingMigration.split(listOf(row("nes", BUTTON_B, LibretroButtons.A))).isEmpty())
+    }
+
+    @Test
+    fun skipsGlobalDefaultConsole() {
+        // The global default isn't a user binding; the positional default covers it.
+        assertTrue(GamepadMappingMigration.split(listOf(row(DEFAULT_CONSOLE_ID, BUTTON_A, LibretroButtons.A))).isEmpty())
+    }
+
+    @Test
+    fun dropsNonGamepadKeyCodes() {
+        // e.g. a desktop keyboard code on the wrong platform normalizes to null.
+        assertTrue(GamepadMappingMigration.split(listOf(row("nes", VOLUME_UP, LibretroButtons.A))).isEmpty())
+    }
+
+    @Test
+    fun isIdempotentOverInput() {
+        val rows = listOf(
+            row("nes", BUTTON_A, LibretroButtons.A),
+            row("snes", BUTTON_B, LibretroButtons.X),
+        )
+        assertEquals(GamepadMappingMigration.split(rows), GamepadMappingMigration.split(rows))
+    }
+}

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/domain/model/ControllerClassifier.desktop.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/domain/model/ControllerClassifier.desktop.kt
@@ -1,0 +1,15 @@
+package com.spela.player.domain.model
+
+/**
+ * Maps an SDL_GamepadType integer (from SDL_GetRealGamepadType, carried on
+ * GamepadState.type) to a ControllerStyle. Values per SDL3 3.2.x SDL_gamepad.h:
+ *   0 UNKNOWN, 1 STANDARD, 2 XBOX360, 3 XBOXONE, 4 PS3, 5 PS4, 6 PS5,
+ *   7 NINTENDO_SWITCH_PRO, 8 JOYCON_LEFT, 9 JOYCON_RIGHT, 10 JOYCON_PAIR.
+ * Verify these constants against the pinned SDL3 header if SDL is bumped.
+ */
+fun controllerStyleFromSdlType(sdlType: Int): ControllerStyle = when (sdlType) {
+    2, 3 -> ControllerStyle.Xbox        // also covers XBOXSERIES if a later SDL adds it (extend then)
+    4, 5, 6 -> ControllerStyle.PlayStation
+    7, 8, 9, 10 -> ControllerStyle.Nintendo
+    else -> ControllerStyle.Generic     // 0 UNKNOWN, 1 STANDARD, and anything unmapped
+}

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
@@ -1,9 +1,10 @@
 package com.spela.player.libretro
 
+import com.spela.player.domain.model.DefaultGamepadMapping
+import com.spela.player.domain.model.GamepadPosition
 import com.spela.player.domain.model.controllerStyleFromSdlType
 import com.spela.player.presentation.navigation.NavigationEventBus
 import com.spela.player.presentation.ui.gamepad.InputMode
-import com.spela.player.presentation.viewmodel.LibretroButtons
 import com.spela.player.presentation.viewmodel.LibretroController
 import java.util.concurrent.Executors
 import kotlinx.coroutines.CoroutineScope
@@ -33,9 +34,6 @@ class DesktopGamepadPoller(
 
         /** Axis dead zone (SDL range is -32768..32767, ~15% dead zone). */
         private const val AXIS_DEADZONE = 4800
-
-        /** Number of discrete buttons from SDL GameController. */
-        private const val NUM_BUTTONS = 16
 
         /** Number of axes: LX, LY, RX, RY, TriggerL, TriggerR. */
         private const val NUM_AXES = 6
@@ -120,33 +118,41 @@ class DesktopGamepadPoller(
 
             var hasInput = false
 
-            // Route button states
-            for (buttonId in 0 until minOf(NUM_BUTTONS, state.buttons.size)) {
-                desktopController.setButton(port, buttonId, state.buttons[buttonId])
-                if (state.buttons[buttonId]) hasInput = true
+            // state.buttons is indexed by GamepadPosition ordinal (input layer).
+            // Triggers are analog (axes 4/5) — fold them into the L2/R2 position
+            // slots, which the C bridge leaves unset.
+            val positionPressed = BooleanArray(GamepadPosition.entries.size)
+            for (i in 0 until minOf(positionPressed.size, state.buttons.size)) {
+                positionPressed[i] = state.buttons[i]
+            }
+            if (state.axes.size >= NUM_AXES) {
+                positionPressed[GamepadPosition.L2.ordinal] = state.axes[4] > TRIGGER_THRESHOLD
+                positionPressed[GamepadPosition.R2.ordinal] = state.axes[5] > TRIGGER_THRESHOLD
             }
 
-            // Route analog axes
+            // Apply the configurable mapping layer (position -> RetroPad), with
+            // fan-in handled so a released position can't clobber another's press.
+            val mapping = gamepadPortManager.getGamepadMapping(port)
+                ?: DefaultGamepadMapping.POSITION_TO_RETRO
+            val retroPressed = GamepadButtonResolver.resolve(positionPressed, mapping)
+            for (retroId in retroPressed.indices) {
+                desktopController.setButton(port, retroId, retroPressed[retroId])
+                if (retroPressed[retroId]) hasInput = true
+            }
+
+            // Route analog stick axes (unmapped — sticks are not positional buttons).
             if (state.axes.size >= NUM_AXES) {
                 val lx = applyDeadzone(state.axes[0])
                 val ly = applyDeadzone(state.axes[1])
                 val rx = applyDeadzone(state.axes[2])
                 val ry = applyDeadzone(state.axes[3])
-                val triggerL = state.axes[4]
-                val triggerR = state.axes[5]
 
                 desktopController.setAnalog(port, 0, 0, lx.toShort())
                 desktopController.setAnalog(port, 0, 1, ly.toShort())
                 desktopController.setAnalog(port, 1, 0, rx.toShort())
                 desktopController.setAnalog(port, 1, 1, ry.toShort())
 
-                // Digital trigger buttons (L2/R2)
-                desktopController.setButton(port, LibretroButtons.L2, triggerL > TRIGGER_THRESHOLD)
-                desktopController.setButton(port, LibretroButtons.R2, triggerR > TRIGGER_THRESHOLD)
-
-                if (lx != 0 || ly != 0 || rx != 0 || ry != 0 ||
-                    triggerL > TRIGGER_THRESHOLD || triggerR > TRIGGER_THRESHOLD
-                ) {
+                if (lx != 0 || ly != 0 || rx != 0 || ry != 0) {
                     hasInput = true
                 }
             }

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
@@ -1,5 +1,6 @@
 package com.spela.player.libretro
 
+import com.spela.player.domain.model.controllerStyleFromSdlType
 import com.spela.player.presentation.navigation.NavigationEventBus
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.viewmodel.LibretroButtons
@@ -107,7 +108,11 @@ class DesktopGamepadPoller(
             // Connect new devices
             if (state.controllerId !in knownControllers) {
                 knownControllers.add(state.controllerId)
-                gamepadPortManager.connectDevice(state.controllerId, state.name)
+                gamepadPortManager.connectDevice(
+                    state.controllerId,
+                    state.name,
+                    controllerStyleFromSdlType(state.type),
+                )
             }
 
             val port = gamepadPortManager.getPort(state.controllerId)

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadState.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadState.kt
@@ -5,7 +5,10 @@ package com.spela.player.libretro
  *
  * @param controllerId SDL instance ID for this controller
  * @param name Human-readable controller name (e.g. "Xbox Controller")
- * @param buttons Button states indexed by libretro button ID (0..15)
+ * @param buttons Button states indexed by [com.spela.player.domain.model.GamepadPosition]
+ *   ordinal (0..15) — the input layer's canonical positions, NOT libretro ids.
+ *   The L2/R2 trigger slots are filled Kotlin-side from [axes], not by the C bridge.
+ *   Kotlin applies the configurable GamepadPosition→RetroPad mapping (#1334).
  * @param axes Axis values: [LX, LY, RX, RY, TriggerL, TriggerR] in SDL range (-32768..32767)
  * @param type SDL_GamepadType (SDL_GetRealGamepadType) integer for the connected pad; 0 = unknown
  */

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadState.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadState.kt
@@ -7,12 +7,14 @@ package com.spela.player.libretro
  * @param name Human-readable controller name (e.g. "Xbox Controller")
  * @param buttons Button states indexed by libretro button ID (0..15)
  * @param axes Axis values: [LX, LY, RX, RY, TriggerL, TriggerR] in SDL range (-32768..32767)
+ * @param type SDL_GamepadType (SDL_GetRealGamepadType) integer for the connected pad; 0 = unknown
  */
 data class GamepadState(
     val controllerId: Int,
     val name: String,
     val buttons: BooleanArray,
     val axes: IntArray,
+    val type: Int,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -20,7 +22,8 @@ data class GamepadState(
         return controllerId == other.controllerId &&
             name == other.name &&
             buttons.contentEquals(other.buttons) &&
-            axes.contentEquals(other.axes)
+            axes.contentEquals(other.axes) &&
+            type == other.type
     }
 
     override fun hashCode(): Int {
@@ -28,6 +31,7 @@ data class GamepadState(
         result = 31 * result + name.hashCode()
         result = 31 * result + buttons.contentHashCode()
         result = 31 * result + axes.contentHashCode()
+        result = 31 * result + type
         return result
     }
 }

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadUiNavigator.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadUiNavigator.kt
@@ -1,8 +1,8 @@
 package com.spela.player.libretro
 
+import com.spela.player.domain.model.GamepadPosition
 import com.spela.player.presentation.navigation.NavigationEvent
 import com.spela.player.presentation.navigation.NavigationEventBus
-import com.spela.player.presentation.viewmodel.LibretroButtons
 import java.awt.Robot
 import java.awt.event.KeyEvent
 
@@ -48,10 +48,17 @@ class GamepadUiNavigator(
         private const val REPEAT_INITIAL_DELAY_TICKS = 45 // ~360ms at the 8ms poll rate
         private const val REPEAT_INTERVAL_TICKS = 8       // ~64ms between repeats
 
-        /** Libretro button ids that count as UI navigation input. */
+        /**
+         * GamepadPosition ordinals that count as UI navigation input. Menu
+         * navigation is positional — it reads the input layer directly (not the
+         * per-console GamepadPosition→RetroPad mapping), so remapping game
+         * bindings never changes how the controller drives menus.
+         */
         private val NAV_BUTTONS = intArrayOf(
-            LibretroButtons.UP, LibretroButtons.DOWN, LibretroButtons.LEFT, LibretroButtons.RIGHT,
-            LibretroButtons.B, LibretroButtons.A, LibretroButtons.L, LibretroButtons.R,
+            GamepadPosition.DPAD_UP.ordinal, GamepadPosition.DPAD_DOWN.ordinal,
+            GamepadPosition.DPAD_LEFT.ordinal, GamepadPosition.DPAD_RIGHT.ordinal,
+            GamepadPosition.SOUTH.ordinal, GamepadPosition.EAST.ordinal,
+            GamepadPosition.L1.ordinal, GamepadPosition.R1.ordinal,
         )
     }
 
@@ -60,12 +67,13 @@ class GamepadUiNavigator(
     private var prevConfirm = false
     private var prevBack = false
 
-    /** Poll ticks each d-pad direction has been held (0 = released), for auto-repeat. */
+    /** Poll ticks each d-pad direction has been held (0 = released), for auto-repeat.
+     *  Keyed by GamepadPosition ordinal (input layer). */
     private val dpadHoldTicks = mutableMapOf(
-        LibretroButtons.UP to 0,
-        LibretroButtons.DOWN to 0,
-        LibretroButtons.LEFT to 0,
-        LibretroButtons.RIGHT to 0,
+        GamepadPosition.DPAD_UP.ordinal to 0,
+        GamepadPosition.DPAD_DOWN.ordinal to 0,
+        GamepadPosition.DPAD_LEFT.ordinal to 0,
+        GamepadPosition.DPAD_RIGHT.ordinal to 0,
     )
 
     /** Lazily-created AWT Robot used when no [synthesizeKey] sink is injected. */
@@ -93,9 +101,9 @@ class GamepadUiNavigator(
         if (anyNavInput) onGamepadInput()
 
         // L1/R1 -> section switching (via the navigation bus).
-        // buttons is indexed by libretro button id, so use L (10) / R (11).
-        val leftShoulder = first.buttons.getOrNull(LibretroButtons.L) == true
-        val rightShoulder = first.buttons.getOrNull(LibretroButtons.R) == true
+        // buttons is indexed by GamepadPosition ordinal.
+        val leftShoulder = first.buttons.getOrNull(GamepadPosition.L1.ordinal) == true
+        val rightShoulder = first.buttons.getOrNull(GamepadPosition.R1.ordinal) == true
         if (leftShoulder && !prevLeftShoulder) {
             navigationEventBus.emit(NavigationEvent.PreviousSection)
         }
@@ -106,14 +114,14 @@ class GamepadUiNavigator(
         prevRightShoulder = rightShoulder
 
         // D-pad -> arrow keys with hold-to-repeat. Confirm (bottom face button =
-        // RETRO_B) -> Enter and back (right face button = RETRO_A) -> Escape are
-        // single-press only.
-        repeatOnHold(first, LibretroButtons.UP, KeyEvent.VK_UP)
-        repeatOnHold(first, LibretroButtons.DOWN, KeyEvent.VK_DOWN)
-        repeatOnHold(first, LibretroButtons.LEFT, KeyEvent.VK_LEFT)
-        repeatOnHold(first, LibretroButtons.RIGHT, KeyEvent.VK_RIGHT)
-        prevConfirm = synthOnEdge(first, LibretroButtons.B, prevConfirm, KeyEvent.VK_ENTER)
-        prevBack = synthOnEdge(first, LibretroButtons.A, prevBack, KeyEvent.VK_ESCAPE)
+        // SOUTH) -> Enter and back (right face button = EAST) -> Escape are
+        // single-press only. Positional, so it's brand-consistent on any pad.
+        repeatOnHold(first, GamepadPosition.DPAD_UP.ordinal, KeyEvent.VK_UP)
+        repeatOnHold(first, GamepadPosition.DPAD_DOWN.ordinal, KeyEvent.VK_DOWN)
+        repeatOnHold(first, GamepadPosition.DPAD_LEFT.ordinal, KeyEvent.VK_LEFT)
+        repeatOnHold(first, GamepadPosition.DPAD_RIGHT.ordinal, KeyEvent.VK_RIGHT)
+        prevConfirm = synthOnEdge(first, GamepadPosition.SOUTH.ordinal, prevConfirm, KeyEvent.VK_ENTER)
+        prevBack = synthOnEdge(first, GamepadPosition.EAST.ordinal, prevBack, KeyEvent.VK_ESCAPE)
     }
 
     /**

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/ControllerStyleOverrideRepositoryImplTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/ControllerStyleOverrideRepositoryImplTest.kt
@@ -1,0 +1,56 @@
+package com.spela.player.data.repository
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.spela.player.data.local.SpelaDatabase
+import com.spela.player.domain.model.ControllerStyle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ControllerStyleOverrideRepositoryImplTest {
+
+    private lateinit var database: SpelaDatabase
+    private lateinit var repo: ControllerStyleOverrideRepositoryImpl
+
+    @BeforeTest
+    fun setup() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        SpelaDatabase.Schema.create(driver)
+        database = SpelaDatabase(driver)
+        repo = ControllerStyleOverrideRepositoryImpl(database)
+    }
+
+    @Test
+    fun absentOverrideIsAuto() = runTest {
+        assertNull(repo.getOverride("Xbox Wireless Controller"))
+    }
+
+    @Test
+    fun setThenGetRoundTrips() = runTest {
+        repo.setOverride("Wireless Controller", ControllerStyle.Nintendo)
+        assertEquals(ControllerStyle.Nintendo, repo.getOverride("Wireless Controller"))
+    }
+
+    @Test
+    fun explicitGenericIsStoredNotAuto() = runTest {
+        repo.setOverride("Some USB Gamepad", ControllerStyle.Generic)
+        assertEquals(ControllerStyle.Generic, repo.getOverride("Some USB Gamepad"))
+    }
+
+    @Test
+    fun setNullClearsOverride() = runTest {
+        repo.setOverride("Pad", ControllerStyle.Xbox)
+        repo.setOverride("Pad", null)
+        assertNull(repo.getOverride("Pad"))
+    }
+
+    @Test
+    fun overridesAreKeyedPerController() = runTest {
+        repo.setOverride("Pad A", ControllerStyle.Xbox)
+        repo.setOverride("Pad B", ControllerStyle.PlayStation)
+        assertEquals(ControllerStyle.Xbox, repo.getOverride("Pad A"))
+        assertEquals(ControllerStyle.PlayStation, repo.getOverride("Pad B"))
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GamepadMappingRepositoryImplTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GamepadMappingRepositoryImplTest.kt
@@ -1,0 +1,82 @@
+package com.spela.player.data.repository
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.spela.player.data.local.SpelaDatabase
+import com.spela.player.domain.model.DefaultGamepadMapping
+import com.spela.player.domain.model.GamepadPosition
+import com.spela.player.presentation.viewmodel.LibretroButtons
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GamepadMappingRepositoryImplTest {
+
+    private lateinit var database: SpelaDatabase
+    private lateinit var repo: GamepadMappingRepositoryImpl
+
+    @BeforeTest
+    fun setup() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        SpelaDatabase.Schema.create(driver)
+        database = SpelaDatabase(driver)
+        repo = GamepadMappingRepositoryImpl(database)
+    }
+
+    @Test
+    fun emptyMappingResolvesToDefault() = runTest {
+        assertEquals(
+            DefaultGamepadMapping.POSITION_TO_RETRO,
+            repo.getEffectiveMapping("nes", 0),
+        )
+    }
+
+    @Test
+    fun setBindingOverridesOnlyThatPosition() = runTest {
+        repo.setBinding("nes", 0, GamepadPosition.SOUTH, LibretroButtons.A)
+        val m = repo.getEffectiveMapping("nes", 0)
+        assertEquals(LibretroButtons.A, m[GamepadPosition.SOUTH])
+        // Everything else stays at default.
+        assertEquals(LibretroButtons.A, m[GamepadPosition.EAST])
+        assertEquals(LibretroButtons.Y, m[GamepadPosition.WEST])
+        assertEquals(LibretroButtons.UP, m[GamepadPosition.DPAD_UP])
+    }
+
+    @Test
+    fun guidingExampleNesAToSouthBToWest() = runTest {
+        // NES A → south, NES B → west (RetroPad A=8, B=0).
+        repo.setBinding("nes", 0, GamepadPosition.SOUTH, LibretroButtons.A)
+        repo.setBinding("nes", 0, GamepadPosition.WEST, LibretroButtons.B)
+        val m = repo.getEffectiveMapping("nes", 0)
+        assertEquals(LibretroButtons.A, m[GamepadPosition.SOUTH])
+        assertEquals(LibretroButtons.B, m[GamepadPosition.WEST])
+    }
+
+    @Test
+    fun setBindingIsIdempotent() = runTest {
+        repo.setBinding("nes", 0, GamepadPosition.SOUTH, LibretroButtons.A)
+        repo.setBinding("nes", 0, GamepadPosition.SOUTH, LibretroButtons.A)
+        repo.setBinding("nes", 0, GamepadPosition.SOUTH, LibretroButtons.X)
+        // One row survives; the latest value wins.
+        assertEquals(1, database.spelaDatabaseQueries.getAllGamepadMappings().executeAsList().size)
+        assertEquals(LibretroButtons.X, repo.getEffectiveMapping("nes", 0)[GamepadPosition.SOUTH])
+    }
+
+    @Test
+    fun mappingsAreScopedPerConsoleAndPort() = runTest {
+        repo.setBinding("nes", 0, GamepadPosition.SOUTH, LibretroButtons.A)
+        // A different console and a different port keep defaults.
+        assertEquals(LibretroButtons.B, repo.getEffectiveMapping("snes", 0)[GamepadPosition.SOUTH])
+        assertEquals(LibretroButtons.B, repo.getEffectiveMapping("nes", 1)[GamepadPosition.SOUTH])
+    }
+
+    @Test
+    fun resetToDefaultClearsOverrides() = runTest {
+        repo.setBinding("nes", 0, GamepadPosition.SOUTH, LibretroButtons.A)
+        repo.resetToDefault("nes", 0)
+        assertEquals(
+            DefaultGamepadMapping.POSITION_TO_RETRO,
+            repo.getEffectiveMapping("nes", 0),
+        )
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GamepadMappingSyncTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GamepadMappingSyncTest.kt
@@ -1,0 +1,125 @@
+package com.spela.player.data.repository
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.spela.client.models.ConsoleKeyMappingDTO
+import com.spela.client.models.UserPreferencesResponse
+import com.spela.player.data.device.DeviceManager
+import com.spela.player.data.local.SpelaDatabase
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.interceptor.TokenManager
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the player side of the synced positional gamepad mapping layer
+ * (#1334, Slice B): push assembles `positionMappings` from GamepadMappingEntity
+ * (merged with keycode mappings), and pull imports the server's positional
+ * mappings into GamepadMappingEntity.
+ */
+class GamepadMappingSyncTest {
+
+    private fun database(): SpelaDatabase {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        SpelaDatabase.Schema.create(driver)
+        return SpelaDatabase(driver)
+    }
+
+    private suspend fun repo(db: SpelaDatabase, engineFactory: HttpClientEngineFactory<MockEngineConfig>): PreferencesRepositoryImpl {
+        val apiClient = SpelaApiClient(engineFactory, TokenManager().also { it.setTokens("a", "r") })
+            .also { it.setBaseUrl("http://localhost:8080") }
+        return PreferencesRepositoryImpl(
+            apiClient = apiClient,
+            database = db,
+            deviceManager = DeviceManager(db, apiClient),
+            keyMappingRepository = KeyMappingRepositoryImpl(db, emptyMap()),
+        )
+    }
+
+    @Test
+    fun pushIncludesPositionMappings() = runTest {
+        val db = database()
+        // A console with only a positional override (no keyboard preset).
+        db.spelaDatabaseQueries.insertGamepadMapping("nes:0:SOUTH", "nes", 0, "SOUTH", 8)
+        db.spelaDatabaseQueries.insertGamepadMapping("nes:0:WEST", "nes", 0, "WEST", 0)
+
+        var capturedBody: String? = null
+        val factory = object : HttpClientEngineFactory<MockEngineConfig> {
+            override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine =
+                MockEngine(MockEngineConfig().apply {
+                    addHandler { request ->
+                        capturedBody = request.body.toByteArray().decodeToString()
+                        respond("{}", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+                    }
+                    block()
+                })
+        }
+
+        repo(db, factory).pushKeyMappingsToServer()
+
+        val body = capturedBody ?: error("no request captured")
+        assertTrue(body.contains("positionMappings"), "push body carries positionMappings: $body")
+        assertTrue(body.contains("\"SOUTH\":8"), "push body carries SOUTH->8: $body")
+        assertTrue(body.contains("\"WEST\":0"), "push body carries WEST->0: $body")
+    }
+
+    @Test
+    fun syncImportsPositionMappings() = runTest {
+        val db = database()
+        val prefsJson = Json.encodeToString(
+            UserPreferencesResponse.serializer(),
+            UserPreferencesResponse(
+                autoLoadSaveEnabled = false,
+                autoSaveEnabled = false,
+                autoUpdateCoresEnabled = false,
+                consoleKeyMappings = mapOf(
+                    "nes" to ConsoleKeyMappingDTO(
+                        selectedMapping = "",
+                        customMapping = emptyMap(),
+                        positionMappings = mapOf("SOUTH" to 8L, "WEST" to 0L),
+                    ),
+                ),
+                consoleSaveStatePolicies = emptyMap(),
+                consoleShaders = emptyMap(),
+                customKeyMapping = emptyMap(),
+                defaultSecondScreenPage = "",
+                gameSaveStatePolicies = emptyMap(),
+                preferredRegions = emptyList(),
+                raHardcoreEnabled = false,
+                raLinked = false,
+                raUsername = "",
+                selectedKeyMapping = "",
+                selectedShader = "none",
+                selectedTheme = "",
+                showPerformanceOverlay = false,
+            ),
+        )
+        val factory = object : HttpClientEngineFactory<MockEngineConfig> {
+            override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine =
+                MockEngine(MockEngineConfig().apply {
+                    addHandler {
+                        respond(prefsJson, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+                    }
+                    block()
+                })
+        }
+
+        repo(db, factory).syncKeyMappingsFromServer()
+
+        val rows = db.spelaDatabaseQueries.getAllGamepadMappings().executeAsList()
+            .associate { it.gamepad_position to it.libretro_button_id }
+        assertEquals(8L, rows["SOUTH"])
+        assertEquals(0L, rows["WEST"])
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/domain/model/SdlTypeClassifierTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/domain/model/SdlTypeClassifierTest.kt
@@ -1,0 +1,20 @@
+package com.spela.player.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SdlTypeClassifierTest {
+    @Test
+    fun mapsSdlGamepadTypes() {
+        // SDL_GamepadType values (verified against SDL3 3.2.30 SDL_gamepad.h)
+        assertEquals(ControllerStyle.Xbox, controllerStyleFromSdlType(2))          // XBOX360
+        assertEquals(ControllerStyle.Xbox, controllerStyleFromSdlType(3))          // XBOXONE
+        assertEquals(ControllerStyle.PlayStation, controllerStyleFromSdlType(4))   // PS3
+        assertEquals(ControllerStyle.PlayStation, controllerStyleFromSdlType(5))   // PS4
+        assertEquals(ControllerStyle.PlayStation, controllerStyleFromSdlType(6))   // PS5
+        assertEquals(ControllerStyle.Nintendo, controllerStyleFromSdlType(7))      // SWITCH_PRO
+        assertEquals(ControllerStyle.Nintendo, controllerStyleFromSdlType(10))     // JOYCON_PAIR
+        assertEquals(ControllerStyle.Generic, controllerStyleFromSdlType(0))       // UNKNOWN
+        assertEquals(ControllerStyle.Generic, controllerStyleFromSdlType(1))       // STANDARD
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/AndroidGamepadNormalizerTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/AndroidGamepadNormalizerTest.kt
@@ -1,0 +1,99 @@
+package com.spela.player.libretro
+
+import com.spela.player.domain.model.DefaultGamepadMapping
+import com.spela.player.domain.model.GamepadPosition
+import com.spela.player.domain.model.KeyMappingPreset
+import com.spela.player.domain.model.KeyMappingProfile
+import com.spela.player.domain.repository.GamepadMappingRepository
+import com.spela.player.domain.repository.KeyMappingRepository
+import com.spela.player.presentation.viewmodel.LibretroButtons
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AndroidGamepadNormalizerTest {
+
+    // android.view.KeyEvent values.
+    private val BUTTON_A = 96
+    private val BUTTON_B = 97
+    private val BUTTON_X = 99
+    private val BUTTON_Y = 100
+    private val DPAD_UP = 19
+    private val VOLUME_UP = 24 // not a gamepad button
+
+    @Test
+    fun mapsStandardFaceButtonsPositionally() {
+        assertEquals(GamepadPosition.SOUTH, AndroidGamepadNormalizer.normalize(BUTTON_A))
+        assertEquals(GamepadPosition.EAST, AndroidGamepadNormalizer.normalize(BUTTON_B))
+        assertEquals(GamepadPosition.WEST, AndroidGamepadNormalizer.normalize(BUTTON_X))
+        assertEquals(GamepadPosition.NORTH, AndroidGamepadNormalizer.normalize(BUTTON_Y))
+        assertEquals(GamepadPosition.DPAD_UP, AndroidGamepadNormalizer.normalize(DPAD_UP))
+    }
+
+    @Test
+    fun ignoresNonGamepadKeys() {
+        assertNull(AndroidGamepadNormalizer.normalize(VOLUME_UP))
+    }
+
+    @Test
+    fun defaultPathReproducesHistoricalAndroidMapping() {
+        // Historically Android KEYCODE_BUTTON_A -> RetroPad B, BUTTON_B -> RetroPad A.
+        val mgr = GamepadPortManager(FakeKeyMappingRepo())
+        mgr.connectDevice(deviceId = 1, deviceName = "Pad")
+        // No per-console mapping loaded -> defaults apply.
+        assertEquals(LibretroButtons.B, mgr.mapGamepadKeyToLibretro(0, BUTTON_A))
+        assertEquals(LibretroButtons.A, mgr.mapGamepadKeyToLibretro(0, BUTTON_B))
+        assertNull(mgr.mapGamepadKeyToLibretro(0, VOLUME_UP))
+    }
+
+    /**
+     * The guiding example as a brand-independence regression: with a per-console
+     * mapping of SOUTH->A and WEST->B, the standard positional key codes (which
+     * any spec-compliant pad reports for those physical buttons) yield the NES
+     * remap through the Android path — proving the positional layer is brand-neutral.
+     */
+    @Test
+    fun guidingExampleNesSouthToAWestToB() = runTest {
+        val guidingMapping = DefaultGamepadMapping.POSITION_TO_RETRO + mapOf(
+            GamepadPosition.SOUTH to LibretroButtons.A,
+            GamepadPosition.WEST to LibretroButtons.B,
+        )
+        val mgr = GamepadPortManager(
+            FakeKeyMappingRepo(),
+            gamepadMappingRepository = FakeGamepadMappingRepo(guidingMapping),
+        )
+        mgr.connectDevice(deviceId = 1, deviceName = "Pad")
+        mgr.loadGamepadMappingForPort(0, "nes")
+
+        // Bottom physical button (KEYCODE_BUTTON_A = SOUTH) -> NES A.
+        assertEquals(LibretroButtons.A, mgr.mapGamepadKeyToLibretro(0, BUTTON_A))
+        // Left physical button (KEYCODE_BUTTON_X = WEST) -> NES B.
+        assertEquals(LibretroButtons.B, mgr.mapGamepadKeyToLibretro(0, BUTTON_X))
+    }
+
+    private class FakeGamepadMappingRepo(
+        private val mapping: Map<GamepadPosition, Int>,
+    ) : GamepadMappingRepository {
+        override suspend fun getEffectiveMapping(consoleId: String, port: Int) = mapping
+        override suspend fun setBinding(consoleId: String, port: Int, position: GamepadPosition, retroButtonId: Int) {}
+        override suspend fun resetToDefault(consoleId: String, port: Int) {}
+        override fun getDefaultMapping() = DefaultGamepadMapping.POSITION_TO_RETRO
+    }
+
+    private class FakeKeyMappingRepo : KeyMappingRepository {
+        override suspend fun getMappingForConsole(consoleId: String, port: Int): KeyMappingProfile? = null
+        override suspend fun setBinding(consoleId: String, port: Int, retroButtonId: Int, platformKeyCode: Int) {}
+        override suspend fun resetToDefault(consoleId: String, port: Int) {}
+        override suspend fun clearBinding(consoleId: String, port: Int, retroButtonId: Int) {}
+        override suspend fun getEffectiveMapping(consoleId: String, port: Int): Map<Int, Int> = emptyMap()
+        override fun getDefaultMapping(): Map<Int, Int> = emptyMap()
+        override fun getAvailablePresets(): List<KeyMappingPreset> = emptyList()
+        override suspend fun applyPreset(presetId: String) {}
+        override suspend fun ensureDefaultsApplied() {}
+        override suspend fun getEffectiveMappingForGame(gameId: String, consoleId: String, port: Int): Map<Int, Int> = emptyMap()
+        override suspend fun setGameMapping(gameId: String, bindings: Map<Int, Int>) {}
+        override suspend fun clearGameMapping(gameId: String) {}
+        override suspend fun hasGameMapping(gameId: String): Boolean = false
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
@@ -1,5 +1,6 @@
 package com.spela.player.libretro
 
+import com.spela.player.domain.model.ControllerStyle
 import com.spela.player.domain.model.KeyMappingProfile
 import com.spela.player.domain.repository.KeyMappingRepository
 import kotlinx.coroutines.test.runTest
@@ -19,6 +20,20 @@ class GamepadPortManagerTest {
     fun connectFirstDeviceAssignsPort0() {
         val port = manager.connectDevice(100, "Xbox Controller")
         assertEquals(0, port)
+    }
+
+    @Test
+    fun connectDeviceRecordsStyleOnAssignment() {
+        manager.connectDevice(deviceId = 1, deviceName = "Xbox Wireless Controller", style = ControllerStyle.Xbox)
+        val a = manager.assignments.value.single()
+        assertEquals(ControllerStyle.Xbox, a.style)
+        assertEquals("Xbox Wireless Controller", a.deviceName)
+    }
+
+    @Test
+    fun styleDefaultsToGeneric() {
+        manager.connectDevice(deviceId = 2, deviceName = "")
+        assertEquals(ControllerStyle.Generic, manager.assignments.value.single().style)
     }
 
     @Test

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadUiNavigatorTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadUiNavigatorTest.kt
@@ -27,10 +27,10 @@ class GamepadUiNavigatorTest {
     private fun pressed(vararg buttonIds: Int): Array<GamepadState> {
         val buttons = BooleanArray(16)
         buttonIds.forEach { buttons[it] = true }
-        return arrayOf(GamepadState(0, "Test Controller", buttons, IntArray(6)))
+        return arrayOf(GamepadState(0, "Test Controller", buttons, IntArray(6), 0))
     }
 
-    private val released = arrayOf(GamepadState(0, "Test Controller", BooleanArray(16), IntArray(6)))
+    private val released = arrayOf(GamepadState(0, "Test Controller", BooleanArray(16), IntArray(6), 0))
 
     @Test
     fun dpadDirectionsMapToArrowKeys() {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadUiNavigatorTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadUiNavigatorTest.kt
@@ -1,8 +1,8 @@
 package com.spela.player.libretro
 
+import com.spela.player.domain.model.GamepadPosition
 import com.spela.player.presentation.navigation.NavigationEvent
 import com.spela.player.presentation.navigation.NavigationEventBus
-import com.spela.player.presentation.viewmodel.LibretroButtons
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -23,10 +23,11 @@ class GamepadUiNavigatorTest {
         synthesizeKey = { keys.add(it) },
     )
 
-    /** A one-frame controller state with the given libretro button ids pressed. */
-    private fun pressed(vararg buttonIds: Int): Array<GamepadState> {
+    /** A one-frame controller state with the given GamepadPositions pressed.
+     *  buttons is indexed by GamepadPosition ordinal (the input layer). */
+    private fun pressed(vararg positions: GamepadPosition): Array<GamepadState> {
         val buttons = BooleanArray(16)
-        buttonIds.forEach { buttons[it] = true }
+        positions.forEach { buttons[it.ordinal] = true }
         return arrayOf(GamepadState(0, "Test Controller", buttons, IntArray(6), 0))
     }
 
@@ -34,10 +35,10 @@ class GamepadUiNavigatorTest {
 
     @Test
     fun dpadDirectionsMapToArrowKeys() {
-        nav.handle(pressed(LibretroButtons.UP)); nav.handle(released)
-        nav.handle(pressed(LibretroButtons.DOWN)); nav.handle(released)
-        nav.handle(pressed(LibretroButtons.LEFT)); nav.handle(released)
-        nav.handle(pressed(LibretroButtons.RIGHT)); nav.handle(released)
+        nav.handle(pressed(GamepadPosition.DPAD_UP)); nav.handle(released)
+        nav.handle(pressed(GamepadPosition.DPAD_DOWN)); nav.handle(released)
+        nav.handle(pressed(GamepadPosition.DPAD_LEFT)); nav.handle(released)
+        nav.handle(pressed(GamepadPosition.DPAD_RIGHT)); nav.handle(released)
 
         assertEquals(
             listOf(KeyEvent.VK_UP, KeyEvent.VK_DOWN, KeyEvent.VK_LEFT, KeyEvent.VK_RIGHT),
@@ -47,31 +48,31 @@ class GamepadUiNavigatorTest {
 
     @Test
     fun confirmMapsToEnterAndBackMapsToEscape() {
-        // RETRO_B (0) = bottom face button = confirm; RETRO_A (8) = right = back.
-        nav.handle(pressed(LibretroButtons.B)); nav.handle(released)
-        nav.handle(pressed(LibretroButtons.A)); nav.handle(released)
+        // SOUTH = bottom face button = confirm; EAST = right face = back.
+        nav.handle(pressed(GamepadPosition.SOUTH)); nav.handle(released)
+        nav.handle(pressed(GamepadPosition.EAST)); nav.handle(released)
 
         assertEquals(listOf(KeyEvent.VK_ENTER, KeyEvent.VK_ESCAPE), keys)
     }
 
     @Test
     fun confirmDoesNotRepeatWhileHeld() {
-        repeat(100) { nav.handle(pressed(LibretroButtons.B)) }
+        repeat(100) { nav.handle(pressed(GamepadPosition.SOUTH)) }
         assertEquals(listOf(KeyEvent.VK_ENTER), keys)
     }
 
     @Test
     fun dpadAutoRepeatsAfterInitialDelay() {
         // Tick 0 fires immediately; no repeat through the initial-delay window.
-        repeat(45) { nav.handle(pressed(LibretroButtons.RIGHT)) }
+        repeat(45) { nav.handle(pressed(GamepadPosition.DPAD_RIGHT)) }
         assertEquals(1, keys.size, "only the initial press should have fired during the delay")
 
         // First repeat fires once the hold passes the initial delay.
-        nav.handle(pressed(LibretroButtons.RIGHT))
+        nav.handle(pressed(GamepadPosition.DPAD_RIGHT))
         assertEquals(2, keys.size)
 
         // Then one more repeat per interval.
-        repeat(8) { nav.handle(pressed(LibretroButtons.RIGHT)) }
+        repeat(8) { nav.handle(pressed(GamepadPosition.DPAD_RIGHT)) }
         assertEquals(3, keys.size)
 
         keys.forEach { assertEquals(KeyEvent.VK_RIGHT, it) }
@@ -79,16 +80,16 @@ class GamepadUiNavigatorTest {
 
     @Test
     fun releasingResetsAutoRepeat() {
-        nav.handle(pressed(LibretroButtons.RIGHT)) // fire 1
-        nav.handle(released)                        // reset
-        nav.handle(pressed(LibretroButtons.RIGHT)) // fire 2 (fresh press, not a repeat)
+        nav.handle(pressed(GamepadPosition.DPAD_RIGHT)) // fire 1
+        nav.handle(released)                            // reset
+        nav.handle(pressed(GamepadPosition.DPAD_RIGHT)) // fire 2 (fresh press, not a repeat)
         assertEquals(2, keys.size)
     }
 
     @Test
     fun noSynthWhileInGame() {
         inGame = true
-        repeat(10) { nav.handle(pressed(LibretroButtons.RIGHT)) }
+        repeat(10) { nav.handle(pressed(GamepadPosition.DPAD_RIGHT)) }
         assertTrue(keys.isEmpty())
     }
 
@@ -100,10 +101,10 @@ class GamepadUiNavigatorTest {
             bus.events.collect { received.add(it) }
         }
 
-        // L (10) -> previous, R (11) -> next. Guards against the old bug that read
-        // indices 9/10 (X / L1) instead of the libretro L/R ids.
-        nav.handle(pressed(LibretroButtons.R)); nav.handle(released)
-        nav.handle(pressed(LibretroButtons.L)); nav.handle(released)
+        // L1 -> previous, R1 -> next. Positional reads (input layer), independent
+        // of any per-console GamepadPosition->RetroPad remapping.
+        nav.handle(pressed(GamepadPosition.R1)); nav.handle(released)
+        nav.handle(pressed(GamepadPosition.L1)); nav.handle(released)
         advanceUntilIdle()
 
         assertEquals(

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModelTest.kt
@@ -63,6 +63,19 @@ class GamepadConfigViewModelTest {
     }
 
     @Test
+    fun detectedStyleSurfacesInState() = runTest(testDispatcher) {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = createViewModel(scope)
+        gamepadPortManager.connectDevice(1, "Wireless Controller", com.spela.player.domain.model.ControllerStyle.PlayStation)
+        advanceTimeBy(300)
+
+        val assignments = vm.state.value.portAssignments
+        assertEquals(1, assignments.size)
+        assertEquals(com.spela.player.domain.model.ControllerStyle.PlayStation, assignments[0].style)
+        scope.cancel()
+    }
+
+    @Test
     fun multipleDevicesAppearSortedByPort() = runTest(testDispatcher) {
         val scope = CoroutineScope(testDispatcher + Job())
         val vm = createViewModel(scope)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModelTest.kt
@@ -29,10 +29,12 @@ class GamepadConfigViewModelTest {
 
     private val fakeRepo = FakeKeyMappingRepo()
     private val gamepadPortManager = GamepadPortManager(fakeRepo)
+    private val styleOverrideRepo = FakeControllerStyleOverrideRepo()
 
     private fun createViewModel(scope: CoroutineScope): GamepadConfigViewModel {
         return GamepadConfigViewModel(
             gamepadPortManager = gamepadPortManager,
+            styleOverrideRepository = styleOverrideRepo,
             dispatchers = dispatchers,
             scope = scope,
         )
@@ -72,6 +74,56 @@ class GamepadConfigViewModelTest {
         val assignments = vm.state.value.portAssignments
         assertEquals(1, assignments.size)
         assertEquals(com.spela.player.domain.model.ControllerStyle.PlayStation, assignments[0].style)
+        scope.cancel()
+    }
+
+    @Test
+    fun storedOverrideWinsOverDetectedStyle() = runTest(testDispatcher) {
+        styleOverrideRepo.overrides["Wireless Controller"] = com.spela.player.domain.model.ControllerStyle.Nintendo
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = createViewModel(scope)
+        gamepadPortManager.connectDevice(1, "Wireless Controller", com.spela.player.domain.model.ControllerStyle.PlayStation)
+        advanceTimeBy(600)
+
+        val a = vm.state.value.portAssignments.single()
+        assertEquals(com.spela.player.domain.model.ControllerStyle.Nintendo, a.style)
+        assertEquals(com.spela.player.domain.model.ControllerStyle.PlayStation, a.detectedStyle)
+        assertEquals(com.spela.player.domain.model.ControllerStyle.Nintendo, a.styleOverride)
+        scope.cancel()
+    }
+
+    @Test
+    fun setStyleOverridePersistsAndResolves() = runTest(testDispatcher) {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = createViewModel(scope)
+        gamepadPortManager.connectDevice(1, "Wireless Controller", com.spela.player.domain.model.ControllerStyle.PlayStation)
+        advanceTimeBy(300)
+        assertEquals(com.spela.player.domain.model.ControllerStyle.PlayStation, vm.state.value.portAssignments.single().style)
+
+        vm.onIntent(GamepadConfigIntent.SetStyleOverride(0, com.spela.player.domain.model.ControllerStyle.Xbox))
+        advanceTimeBy(300)
+
+        assertEquals(com.spela.player.domain.model.ControllerStyle.Xbox, vm.state.value.portAssignments.single().style)
+        assertEquals(com.spela.player.domain.model.ControllerStyle.Xbox, styleOverrideRepo.overrides["Wireless Controller"])
+        scope.cancel()
+    }
+
+    @Test
+    fun clearStyleOverrideRevertsToDetected() = runTest(testDispatcher) {
+        styleOverrideRepo.overrides["Wireless Controller"] = com.spela.player.domain.model.ControllerStyle.Xbox
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = createViewModel(scope)
+        gamepadPortManager.connectDevice(1, "Wireless Controller", com.spela.player.domain.model.ControllerStyle.PlayStation)
+        advanceTimeBy(600)
+        assertEquals(com.spela.player.domain.model.ControllerStyle.Xbox, vm.state.value.portAssignments.single().style)
+
+        vm.onIntent(GamepadConfigIntent.SetStyleOverride(0, null))
+        advanceTimeBy(300)
+
+        val a = vm.state.value.portAssignments.single()
+        assertEquals(com.spela.player.domain.model.ControllerStyle.PlayStation, a.style)
+        assertNull(a.styleOverride)
+        assertNull(styleOverrideRepo.overrides["Wireless Controller"])
         scope.cancel()
     }
 
@@ -154,6 +206,18 @@ class GamepadConfigViewModelTest {
         advanceTimeBy(300)
         assertTrue(vm.state.value.portAssignments.isEmpty())
         scope.cancel()
+    }
+
+    private class FakeControllerStyleOverrideRepo :
+        com.spela.player.domain.repository.ControllerStyleOverrideRepository {
+        val overrides = mutableMapOf<String, com.spela.player.domain.model.ControllerStyle>()
+        override suspend fun getOverride(deviceName: String) = overrides[deviceName]
+        override suspend fun setOverride(
+            deviceName: String,
+            style: com.spela.player.domain.model.ControllerStyle?,
+        ) {
+            if (style == null) overrides.remove(deviceName) else overrides[deviceName] = style
+        }
     }
 
     private class FakeKeyMappingRepo : KeyMappingRepository {

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -827,6 +827,63 @@ func TestUpdatePreferences_SetConsoleShader(t *testing.T) {
 	assert.Equal(t, "crt-royale", consoleShaders["nes"])
 }
 
+// TestUpdatePreferences_SetConsolePositionMappings verifies the #1334 positional
+// gamepad mapping layer round-trips through PUT/GET, and that a console carrying
+// ONLY positional mappings (no keyboard preset) is preserved, not deleted.
+func TestUpdatePreferences_SetConsolePositionMappings(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	// NES guiding example: SOUTH -> RetroPad A (8), WEST -> RetroPad B (0).
+	// selectedMapping intentionally empty (positional-only console row).
+	// ConsoleKeyMappingDTO is shared request/response, so all fields are
+	// required by Huma — send the full DTO (empty keycode layers + the
+	// positional layer).
+	body, _ := json.Marshal(map[string]interface{}{
+		"consoleKeyMappings": map[string]interface{}{
+			"nes": map[string]interface{}{
+				"selectedMapping":  "",
+				"customMapping":    map[string]string{},
+				"positionMappings": map[string]int{"SOUTH": 8, "WEST": 0},
+			},
+		},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	assertPositionMappings := func(prefs map[string]interface{}) {
+		ckm, ok := prefs["consoleKeyMappings"].(map[string]interface{})
+		assert.True(t, ok, "consoleKeyMappings present")
+		nes, ok := ckm["nes"].(map[string]interface{})
+		assert.True(t, ok, "nes mapping present (positional-only row not deleted)")
+		pm, ok := nes["positionMappings"].(map[string]interface{})
+		assert.True(t, ok, "positionMappings present")
+		assert.Equal(t, float64(8), pm["SOUTH"])
+		assert.Equal(t, float64(0), pm["WEST"])
+	}
+
+	var prefs map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &prefs)
+	assertPositionMappings(prefs)
+
+	// GET to verify persistence.
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/user/preferences", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	prefs = map[string]interface{}{}
+	json.Unmarshal(w.Body.Bytes(), &prefs)
+	assertPositionMappings(prefs)
+}
+
 func TestUpdatePreferences_RemoveConsoleShader(t *testing.T) {
 	_, cfg := setupTestEnv(t)
 	router, cleanup := NewRouter(*cfg)

--- a/server/internal/api/huma_user_mutations.go
+++ b/server/internal/api/huma_user_mutations.go
@@ -356,7 +356,11 @@ func (h *UserHandler) HumaUpdatePreferences(ctx context.Context, in *UpdatePrefe
 			if err := h.DB.Where("LOWER(abbreviation) = LOWER(?)", consoleAbbr).First(&console).Error; err != nil {
 				continue
 			}
-			if km.SelectedMapping == "" {
+			// Only delete the row when the user has cleared BOTH layers: the
+			// keycode mapping (empty selectedMapping) and the positional gamepad
+			// mapping (#1334). A console may carry positional bindings with no
+			// keyboard preset, so selectedMapping alone must not wipe the row.
+			if km.SelectedMapping == "" && len(km.PositionMappings) == 0 {
 				h.DB.Unscoped().Where("user_id = ? AND console_id = ?", uid, console.ID).
 					Delete(&db.ConsoleKeyMappingPreference{})
 			} else {
@@ -365,19 +369,26 @@ func (h *UserHandler) HumaUpdatePreferences(ctx context.Context, in *UpdatePrefe
 					b, _ := json.Marshal(km.CustomMapping)
 					customJSON = string(b)
 				}
+				positionJSON := ""
+				if km.PositionMappings != nil {
+					b, _ := json.Marshal(km.PositionMappings)
+					positionJSON = string(b)
+				}
 				var existing db.ConsoleKeyMappingPreference
 				result := h.DB.Unscoped().Where("user_id = ? AND console_id = ?", uid, console.ID).First(&existing)
 				if result.Error == nil {
 					existing.SelectedMapping = km.SelectedMapping
 					existing.CustomMapping = customJSON
+					existing.PositionMappings = positionJSON
 					existing.DeletedAt = gorm.DeletedAt{}
 					h.DB.Unscoped().Save(&existing)
 				} else {
 					h.DB.Create(&db.ConsoleKeyMappingPreference{
-						UserID:          uid,
-						ConsoleID:       console.ID,
-						SelectedMapping: km.SelectedMapping,
-						CustomMapping:   customJSON,
+						UserID:           uid,
+						ConsoleID:        console.ID,
+						SelectedMapping:  km.SelectedMapping,
+						CustomMapping:    customJSON,
+						PositionMappings: positionJSON,
 					})
 				}
 			}

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -1150,6 +1150,10 @@ type UserPreferencesResponse struct {
 type ConsoleKeyMappingDTO struct {
 	SelectedMapping string            `json:"selectedMapping"`
 	CustomMapping   map[string]string `json:"customMapping"`
+	// PositionMappings is the brand-independent positional gamepad mapping layer
+	// (#1334): GamepadPosition name -> libretro RetroPad id. Always present in
+	// responses (empty map when unset); platform-independent so it syncs as-is.
+	PositionMappings map[string]int `json:"positionMappings"`
 }
 
 // UserStatsResponse is the response for GET /api/user/stats.

--- a/server/internal/api/user_handler.go
+++ b/server/internal/api/user_handler.go
@@ -146,8 +146,9 @@ func (h *UserHandler) buildConsoleKeyMappingMap(userID uint) map[string]ConsoleK
 	for _, p := range prefs {
 		if abbr, ok := abbrMap[p.ConsoleID]; ok {
 			m[abbr] = ConsoleKeyMappingDTO{
-				SelectedMapping: p.SelectedMapping,
-				CustomMapping:   parseJSONMap(p.CustomMapping),
+				SelectedMapping:  p.SelectedMapping,
+				CustomMapping:    parseJSONMap(p.CustomMapping),
+				PositionMappings: parseJSONIntMap(p.PositionMappings),
 			}
 		}
 	}
@@ -162,6 +163,18 @@ func parseJSONMap(s string) map[string]string {
 	var m map[string]string
 	if err := json.Unmarshal([]byte(s), &m); err != nil {
 		return map[string]string{}
+	}
+	return m
+}
+
+// parseJSONIntMap parses a JSON string into a map[string]int, returning an empty map on error.
+func parseJSONIntMap(s string) map[string]int {
+	if s == "" {
+		return map[string]int{}
+	}
+	var m map[string]int
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return map[string]int{}
 	}
 	return m
 }

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -589,7 +589,11 @@ type ConsoleKeyMappingPreference struct {
 	User            User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 	ConsoleID       uint           `gorm:"uniqueIndex:idx_user_console_keymapping;not null" json:"consoleId"`
 	SelectedMapping string         `gorm:"size:64;not null" json:"selectedMapping"`
-	CustomMapping   string         `gorm:"type:text" json:"customMapping"` // JSON
+	CustomMapping   string         `gorm:"type:text" json:"customMapping"` // JSON map[string]string (retroId -> keycode)
+	// PositionMappings is the brand-independent positional gamepad mapping layer
+	// (#1334): JSON map[string]int of GamepadPosition name -> libretro RetroPad id.
+	// Platform-independent, so it syncs across devices without keycode validation.
+	PositionMappings string `gorm:"type:text" json:"positionMappings"` // JSON map[string]int
 }
 
 // Device represents a registered user device.

--- a/web/src/features/play/hooks/__tests__/use-resolved-game-preferences.test.ts
+++ b/web/src/features/play/hooks/__tests__/use-resolved-game-preferences.test.ts
@@ -78,7 +78,7 @@ describe("useResolvedGamePreferences", () => {
         preferences: prefs({
           selectedKeyMapping: "arrows-left",
           consoleKeyMappings: {
-            snes: { selectedMapping: "wasd-left", customMapping: {} },
+            snes: { selectedMapping: "wasd-left", customMapping: {}, positionMappings: {} },
           },
         }),
         consoleId: "snes",
@@ -101,6 +101,7 @@ describe("useResolvedGamePreferences", () => {
             snes: {
               selectedMapping: "custom",
               customMapping: consoleCustom,
+              positionMappings: {},
             },
           },
         }),
@@ -132,7 +133,7 @@ describe("useResolvedGamePreferences", () => {
           selectedKeyMapping: "custom",
           customKeyMapping: { button_a: "K" },
           consoleKeyMappings: {
-            snes: { selectedMapping: "custom", customMapping: {} },
+            snes: { selectedMapping: "custom", customMapping: {}, positionMappings: {} },
           },
         }),
         consoleId: "gba",

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -5925,6 +5925,9 @@ export interface components {
             customMapping: {
                 [key: string]: string;
             };
+            positionMappings: {
+                [key: string]: number;
+            };
             selectedMapping: string;
         };
         ConsoleResponse: {

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -1954,13 +1954,21 @@
             },
             "type": "object"
           },
+          "positionMappings": {
+            "additionalProperties": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "type": "object"
+          },
           "selectedMapping": {
             "type": "string"
           }
         },
         "required": [
           "selectedMapping",
-          "customMapping"
+          "customMapping",
+          "positionMappings"
         ],
         "type": "object"
       },
@@ -10800,7 +10808,7 @@
             "schema": {
               "description": "BIOS file name.",
               "maxLength": 128,
-              "pattern": "^[A-Za-z0-9._()\\[\\] +-]+$",
+              "pattern": "^[A-Za-z0-9._()\\[\\],'\u0026! +-]+$",
               "type": "string"
             }
           }
@@ -13951,7 +13959,7 @@
             "schema": {
               "description": "Sentinel filename of the bundle entry (matches registry FileName).",
               "maxLength": 128,
-              "pattern": "^[A-Za-z0-9._()\\[\\] +-]+$",
+              "pattern": "^[A-Za-z0-9._()\\[\\],'\u0026! +-]+$",
               "type": "string"
             }
           }
@@ -13995,7 +14003,7 @@
             "schema": {
               "description": "BIOS file name.",
               "maxLength": 128,
-              "pattern": "^[A-Za-z0-9._()\\[\\] +-]+$",
+              "pattern": "^[A-Za-z0-9._()\\[\\],'\u0026! +-]+$",
               "type": "string"
             }
           }
@@ -19026,7 +19034,7 @@
             "schema": {
               "description": "Optional download filename — server ignores it; lets clients control the saved filename.",
               "maxLength": 128,
-              "pattern": "^[A-Za-z0-9._()\\[\\] +-]+$",
+              "pattern": "^[A-Za-z0-9._()\\[\\],'\u0026! +-]+$",
               "type": "string"
             }
           },
@@ -19091,7 +19099,7 @@
             "schema": {
               "description": "Optional download filename — server ignores it; lets clients control the saved filename.",
               "maxLength": 128,
-              "pattern": "^[A-Za-z0-9._()\\[\\] +-]+$",
+              "pattern": "^[A-Za-z0-9._()\\[\\],'\u0026! +-]+$",
               "type": "string"
             }
           },

--- a/web/src/pages/preferences-page.tsx
+++ b/web/src/pages/preferences-page.tsx
@@ -108,7 +108,7 @@ export function PreferencesPage() {
 
   function handleConsoleKeyMappingChange(consoleId: string, mapping: string) {
     updatePreferences.mutate(
-      { consoleKeyMappings: { [consoleId]: { selectedMapping: mapping, customMapping: {} } } },
+      { consoleKeyMappings: { [consoleId]: { selectedMapping: mapping, customMapping: {}, positionMappings: {} } } },
       { onError: (err) => toast("error", err.message) },
     );
   }


### PR DESCRIPTION
## Summary

Makes gamepad button mapping **positional, brand-independent, and user-configurable on desktop and Android**, and **detects the controller type** to normalize physical buttons and show the user which controller they're holding. Resolves the original complaints: "I can't tell if I have Xbox or Nintendo buttons" and "the A/B mapping feels wrong / changes between controllers."

Closes #1334 (workstream A: detection & identity). Part of epic #1333.

## The model — two layers

- **Input layer** (`physical → GamepadPosition`): brand/device-independent canonical positions (SOUTH = bottom button on any pad). Desktop: SDL3 emits positions 1:1; Android: standard key-code→position normalization. The `GamepadPosition` ordinal order is a **load-bearing contract mirrored in `gamepad_sdl3.c`** (guarded by a test).
- **Mapping layer** (`GamepadPosition → RetroPad`, per console, **synced**): the user's portable game-control preference (e.g. NES SOUTH→A). Defaults reproduce historical behavior exactly, so everything is inert until a console is rebound.

This split is why "the same physical button performs the same console action on any pad" holds.

## What's included

- **Detection + identity + style override:** SDL3 gamepad type → `ControllerStyle`; per-port identity ("Player 1: Xbox Controller"); device-local style-override picker (brand-neutral, no glyphs).
- **Desktop gamepad remapping:** the SDL3 C bridge now emits canonical positions; `DesktopGamepadPoller` applies a configurable, fan-in-safe `GamepadPosition→RetroPad` mapping; brand-neutral per-console editor in console settings.
- **Android positional input:** key-code → `GamepadPosition` → RetroPad; per-brand key-code presets removed (positional model handles brand differences); style detected from `InputDevice`.
- **Cross-device sync:** new `positionMappings` on the per-console preferences contract — Go column + `ConsoleKeyMappingDTO` field, **regenerated OpenAPI spec, web TS types, and Kotlin client**. Platform-independent, so it syncs without key-code validation.
- **Idempotent legacy→positional migration:** one-time, Android-only, additive client-side migration of existing per-console gamepad key-code customizations into the positional layer.
- **UI:** positional editor on both platforms; the keycode editor is now scoped to desktop ("Keyboard"); two ui-agent review passes.

## Testing

CI-green: **1586 player desktop tests + full Go suite + web build**, all passing. The NES guiding example (A→south, B→west) is a regression test at four layers (button resolver, mapping repository, Android key-code path, editor E2E). The legacy→migration split is unit-tested for idempotency.

### ⚠️ Requires hardware verification before merge (cannot run on macOS CI)

- [ ] **Desktop**: real controller remap behavior (the SDL/native path is build-verified only).
- [ ] **AYN Thor (Android)**: bottom button → correct action on an Xbox-style **and** a Nintendo-style pad produce the **same** console action (brand independence).
- [ ] **AYN Thor**: legacy gamepad key-code customizations survive the upgrade (migration).
- [ ] **Cross-device**: rebind on one device → syncs to another (positional layer round-trip).

## Follow-ups (deferred, tracked)

- #1340 — in-game overlay positional gamepad editor on Android.
- #1341 — editable input-layer calibration (for misreporting controllers).

## Notes

- One-time behavior change: users previously on the Android "nintendo-standard" preset now get the positional default (bottom button = RetroPad B) like every other pad; rebindable per console.
- Built on the merged SDL3 migration (#1337).
