### PR TITLE
feat(server): federation Phase 0 — identity, pairing & observability fabric (#1345)

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -361,6 +361,7 @@ func main() {
 		CORSOrigins:                  corsOrigins,
 		ChallengeAttemptRateLimitSec: challengeRateLimit,
 		Version:                      version,
+		PublicBaseURL:                os.Getenv("SPELA_PUBLIC_URL"),
 		TestMode:                     testMode,
 	})
 

--- a/server/internal/api/federation_client.go
+++ b/server/internal/api/federation_client.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/spela/server/internal/federation"
+)
+
+// federationHTTPTimeout bounds outbound federation calls.
+const federationHTTPTimeout = 15 * time.Second
+
+func fedHTTPClient() *http.Client { return &http.Client{Timeout: federationHTTPTimeout} }
+
+// signedFederationHeaders builds the signed headers for an outbound
+// server-to-server request, matching what VerifyFederationRequest expects.
+func signedFederationHeaders(id federation.Identity, method, path, requestID string, body []byte) map[string]string {
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	bodyHash := sha256.Sum256(body)
+	sig := id.Sign(signedRequestMessage(method, path, ts, hex.EncodeToString(bodyHash[:])))
+	return map[string]string{
+		headerFedFingerprint: id.Fingerprint(),
+		headerFedTimestamp:   ts,
+		headerFedSignature:   base64.StdEncoding.EncodeToString(sig),
+		headerFedRequestID:   requestID,
+	}
+}
+
+// httpPairClient is the production pairClient: POST {baseURL}/api/federation/pair.
+type httpPairClient struct{}
+
+func (httpPairClient) Pair(baseURL string, body PairRequestBody) (PairResponseBody, error) {
+	reqBody, _ := json.Marshal(body)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/api/federation/pair", bytes.NewReader(reqBody))
+	if err != nil {
+		return PairResponseBody{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := fedHTTPClient().Do(req)
+	if err != nil {
+		return PairResponseBody{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return PairResponseBody{}, fmt.Errorf("remote returned %d", resp.StatusCode)
+	}
+	var out PairResponseBody
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return PairResponseBody{}, err
+	}
+	return out, nil
+}
+
+// PingResult is the outcome of an outbound connection test to a peer (#1350).
+type PingResult struct {
+	Reachable        bool   `json:"reachable"`
+	PeerFingerprint  string `json:"peerFingerprint"`
+	FingerprintMatch bool   `json:"fingerprintMatch"`
+	PeerUnixTime     int64  `json:"peerUnixTime"`
+	ClockSkewSeconds int64  `json:"clockSkewSeconds"`
+	LatencyMs        int64  `json:"latencyMs"`
+	Error            string `json:"error"`
+}
+
+// peerPinger performs an outbound signed ping to a peer (test-connection).
+type peerPinger interface {
+	Ping(baseURL, requestID string, id federation.Identity, expectFingerprint string) PingResult
+}
+
+type httpPeerPinger struct{}
+
+func (httpPeerPinger) Ping(baseURL, requestID string, id federation.Identity, expectFingerprint string) PingResult {
+	const path = "/api/federation/ping"
+	req, err := http.NewRequest(http.MethodGet, baseURL+path, nil)
+	if err != nil {
+		return PingResult{Error: err.Error()}
+	}
+	for k, v := range signedFederationHeaders(id, http.MethodGet, path, requestID, nil) {
+		req.Header.Set(k, v)
+	}
+	start := time.Now()
+	resp, err := fedHTTPClient().Do(req)
+	if err != nil {
+		return PingResult{Error: err.Error()}
+	}
+	defer resp.Body.Close()
+	latency := time.Since(start).Milliseconds()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return PingResult{LatencyMs: latency, Error: fmt.Sprintf("remote returned %d: %s", resp.StatusCode, string(body))}
+	}
+	var pong struct {
+		Fingerprint string `json:"fingerprint"`
+		UnixTime    int64  `json:"unixTime"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&pong); err != nil {
+		return PingResult{LatencyMs: latency, Error: "bad pong: " + err.Error()}
+	}
+	return PingResult{
+		Reachable:        true,
+		PeerFingerprint:  pong.Fingerprint,
+		FingerprintMatch: pong.Fingerprint == expectFingerprint,
+		PeerUnixTime:     pong.UnixTime,
+		ClockSkewSeconds: time.Now().Unix() - pong.UnixTime,
+		LatencyMs:        latency,
+	}
+}

--- a/server/internal/api/federation_mw.go
+++ b/server/internal/api/federation_mw.go
@@ -38,6 +38,12 @@ const fedPeerContextKey = "federationPeer"
 // server-to-server request: method, path, timestamp, and body hash. Both the
 // signer (outbound client) and verifier (this middleware) must build it
 // identically.
+//
+// NOTE: this does NOT bind the recipient server's identity, so a signed request
+// is replayable to any other server the same peer is paired with, within the
+// timestamp skew window. Harmless in Phase 0 (the only signed endpoint is the
+// read-only /ping). Before any *mutating* federated endpoint lands (Phase 1,
+// #1346), bind the recipient fingerprint into this payload.
 func signedRequestMessage(method, path, timestamp, bodyHashHex string) []byte {
 	return []byte(fmt.Sprintf("%s\n%s\n%s\n%s", method, path, timestamp, bodyHashHex))
 }

--- a/server/internal/api/federation_mw.go
+++ b/server/internal/api/federation_mw.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+	"gorm.io/gorm"
+)
+
+// Federation request headers for signed server-to-server calls (#1343, #1350).
+const (
+	headerFedFingerprint = "X-Spela-Fingerprint"
+	headerFedTimestamp   = "X-Spela-Timestamp"
+	headerFedSignature   = "X-Spela-Signature"
+	headerFedRequestID   = "X-Spela-Request-Id"
+)
+
+// federationTimestampSkew is the maximum age of a signed federation request
+// (replay protection).
+const federationTimestampSkew = 5 * time.Minute
+
+// fedPeerContextKey is where the verified peer is stashed for handlers.
+const fedPeerContextKey = "federationPeer"
+
+// signedRequestMessage is the canonical byte string a peer signs for a
+// server-to-server request: method, path, timestamp, and body hash. Both the
+// signer (outbound client) and verifier (this middleware) must build it
+// identically.
+func signedRequestMessage(method, path, timestamp, bodyHashHex string) []byte {
+	return []byte(fmt.Sprintf("%s\n%s\n%s\n%s", method, path, timestamp, bodyHashHex))
+}
+
+// VerifyFederationRequest authenticates server-to-server requests: it requires a
+// known, active peer whose Ed25519 signature covers method, path, timestamp, and
+// body hash, within the allowed clock skew. On success the verified peer is set
+// on the gin context under fedPeerContextKey. Rejections are logged (not written
+// to the ledger) to avoid a hostile peer flooding storage.
+func VerifyFederationRequest(database *gorm.DB) gin.HandlerFunc {
+	store := federation.PeerStore{DB: database}
+	return func(c *gin.Context) {
+		fp := c.GetHeader(headerFedFingerprint)
+		tsStr := c.GetHeader(headerFedTimestamp)
+		sigB64 := c.GetHeader(headerFedSignature)
+		reqID := c.GetHeader(headerFedRequestID)
+
+		reject := func(reason string) {
+			slog.Warn("federation: rejected inbound request",
+				"component", "federation", "request_id", reqID,
+				"peer", federation.ShortFingerprint(fp), "path", c.Request.URL.Path,
+				"reason", reason)
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": reason})
+		}
+
+		if fp == "" || tsStr == "" || sigB64 == "" {
+			reject("missing federation auth headers")
+			return
+		}
+
+		ts, err := strconv.ParseInt(tsStr, 10, 64)
+		if err != nil || absDuration(time.Since(time.Unix(ts, 0))) > federationTimestampSkew {
+			reject("stale or invalid timestamp")
+			return
+		}
+
+		peer, err := store.GetByFingerprint(fp)
+		if err != nil || peer.Status != db.PeerStatusActive {
+			reject("unknown or inactive peer")
+			return
+		}
+
+		pub, err := base64.StdEncoding.DecodeString(peer.PublicKey)
+		if err != nil || len(pub) != ed25519.PublicKeySize {
+			reject("corrupt peer key")
+			return
+		}
+
+		// Hash the body without consuming it for the handler.
+		bodyBytes, _ := io.ReadAll(c.Request.Body)
+		c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		bodyHash := sha256.Sum256(bodyBytes)
+
+		sig, err := base64.StdEncoding.DecodeString(sigB64)
+		if err != nil {
+			reject("invalid signature encoding")
+			return
+		}
+		msg := signedRequestMessage(c.Request.Method, c.Request.URL.Path, tsStr, hex.EncodeToString(bodyHash[:]))
+		if !federation.Verify(pub, msg, sig) {
+			reject("signature verification failed")
+			return
+		}
+
+		c.Set(fedPeerContextKey, peer)
+		c.Next()
+	}
+}
+
+// federationPeerFromGin returns the verified peer set by VerifyFederationRequest.
+func federationPeerFromGin(c *gin.Context) (*db.FederationPeer, bool) {
+	v, ok := c.Get(fedPeerContextKey)
+	if !ok {
+		return nil, false
+	}
+	peer, ok := v.(*db.FederationPeer)
+	return peer, ok
+}
+
+func absDuration(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
+}

--- a/server/internal/api/federation_mw_test.go
+++ b/server/internal/api/federation_mw_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/federation"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+// signedFedRequest builds a signed server-to-server request for tests.
+func signedFedRequest(id federation.Identity, method, path, body string, ts time.Time) *http.Request {
+	bodyHash := sha256.Sum256([]byte(body))
+	tsStr := strconv.FormatInt(ts.Unix(), 10)
+	msg := signedRequestMessage(method, path, tsStr, hex.EncodeToString(bodyHash[:]))
+	sig := id.Sign(msg)
+
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set(headerFedFingerprint, id.Fingerprint())
+	req.Header.Set(headerFedTimestamp, tsStr)
+	req.Header.Set(headerFedSignature, base64.StdEncoding.EncodeToString(sig))
+	return req
+}
+
+func fedMWRouter(database *gorm.DB) *gin.Engine {
+	r := gin.New()
+	r.Use(VerifyFederationRequest(database))
+	r.GET("/api/federation/test", func(c *gin.Context) {
+		peer, ok := federationPeerFromGin(c)
+		if !ok {
+			c.String(http.StatusInternalServerError, "no peer in context")
+			return
+		}
+		c.String(http.StatusOK, peer.Fingerprint)
+	})
+	return r
+}
+
+func TestFederationMW_AllowsValidSignedRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	database := openAPIFedTestDB(t)
+	peerID, _ := federation.GenerateIdentity()
+	activePeer(t, database, peerID, "Peer", "https://peer")
+
+	w := httptest.NewRecorder()
+	fedMWRouter(database).ServeHTTP(w, signedFedRequest(peerID, http.MethodGet, "/api/federation/test", "", time.Now()))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, peerID.Fingerprint(), w.Body.String())
+}
+
+func TestFederationMW_RejectsUnknownPeer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	database := openAPIFedTestDB(t)
+	stranger, _ := federation.GenerateIdentity()
+
+	w := httptest.NewRecorder()
+	fedMWRouter(database).ServeHTTP(w, signedFedRequest(stranger, http.MethodGet, "/api/federation/test", "", time.Now()))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestFederationMW_RejectsStaleTimestamp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	database := openAPIFedTestDB(t)
+	peerID, _ := federation.GenerateIdentity()
+	activePeer(t, database, peerID, "Peer", "https://peer")
+
+	w := httptest.NewRecorder()
+	old := time.Now().Add(-10 * time.Minute)
+	fedMWRouter(database).ServeHTTP(w, signedFedRequest(peerID, http.MethodGet, "/api/federation/test", "", old))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestFederationMW_RejectsTamperedPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	database := openAPIFedTestDB(t)
+	peerID, _ := federation.GenerateIdentity()
+	activePeer(t, database, peerID, "Peer", "https://peer")
+
+	// Sign for one path, send to another → signature must fail.
+	req := signedFedRequest(peerID, http.MethodGet, "/api/federation/other", "", time.Now())
+	req2 := httptest.NewRequest(http.MethodGet, "/api/federation/test", nil)
+	for k, v := range req.Header {
+		req2.Header[k] = v
+	}
+	w := httptest.NewRecorder()
+	fedMWRouter(database).ServeHTTP(w, req2)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestFederationMW_RejectsInactivePeer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	database := openAPIFedTestDB(t)
+	peerID, _ := federation.GenerateIdentity()
+	store := activePeer(t, database, peerID, "Peer", "https://peer")
+	_ = store.SetStatus(peerID.Fingerprint(), "pending")
+
+	w := httptest.NewRecorder()
+	fedMWRouter(database).ServeHTTP(w, signedFedRequest(peerID, http.MethodGet, "/api/federation/test", "", time.Now()))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/server/internal/api/federation_testutil_test.go
+++ b/server/internal/api/federation_testutil_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// openAPIFedTestDB returns an in-memory DB migrated with the tables the
+// federation API handlers and middleware touch.
+func openAPIFedTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(
+		&db.ServerSetting{},
+		&db.FederationPeer{},
+		&db.FederationInviteNonce{},
+		&db.FederationExchange{},
+	))
+	return database
+}
+
+// b64 is a test helper for base64-std encoding a byte slice.
+func b64(b []byte) string { return base64.StdEncoding.EncodeToString(b) }
+
+// activePeer upserts an active peer for the given identity and returns its store.
+func activePeer(t *testing.T, database *gorm.DB, id federation.Identity, name, baseURL string) federation.PeerStore {
+	t.Helper()
+	store := federation.PeerStore{DB: database}
+	require.NoError(t, store.Upsert(&db.FederationPeer{
+		Fingerprint: id.Fingerprint(),
+		PublicKey:   b64(id.PublicKey),
+		Name:        name,
+		BaseURL:     baseURL,
+		Status:      db.PeerStatusActive,
+	}))
+	return store
+}

--- a/server/internal/api/huma_federation.go
+++ b/server/internal/api/huma_federation.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+	"gorm.io/gorm"
+)
+
+// FederationHandler serves the pairing bootstrap + ping endpoints and the admin
+// federation endpoints (epic #1343).
+type FederationHandler struct {
+	DB       *gorm.DB
+	Identity federation.Identity
+	Peers    federation.PeerStore
+	BaseURL  string // this server's own reachable federation endpoint
+	// PairClient performs the outbound pairing callback to a friend. Defaults to
+	// httpPairClient when nil; overridden in tests.
+	PairClient pairClient
+}
+
+// pairClient performs the outbound pairing callback to a friend.
+type pairClient interface {
+	Pair(baseURL string, body PairRequestBody) (PairResponseBody, error)
+}
+
+// PairRequestBody is a peer's signed pairing bundle.
+type PairRequestBody struct {
+	Fingerprint string `json:"fingerprint"`
+	PublicKey   string `json:"publicKey"` // base64 std ed25519 public key
+	BaseURL     string `json:"baseUrl"`
+	Nonce       string `json:"nonce"` // echoes the invite nonce we issued
+	Signature   string `json:"sig"`   // base64 std signature over pairBundleBytes
+}
+
+// PairResponseBody is our own bundle, returned so the caller can mark us active.
+type PairResponseBody struct {
+	Fingerprint string `json:"fingerprint"`
+	PublicKey   string `json:"publicKey"`
+	BaseURL     string `json:"baseUrl"`
+	Status      string `json:"status"`
+}
+
+// PairInput / PairOutput are the huma request/response envelopes.
+type PairInput struct {
+	RequestID string `header:"X-Spela-Request-Id"`
+	Body      PairRequestBody
+}
+type PairOutput struct {
+	Body PairResponseBody
+}
+
+// pairBundleBytes is the canonical signed payload of a pairing bundle.
+func pairBundleBytes(fingerprint, publicKey, baseURL, nonce string) []byte {
+	return []byte(fmt.Sprintf("spela-pair\nfp=%s\npk=%s\nurl=%s\nnonce=%s",
+		fingerprint, publicKey, baseURL, nonce))
+}
+
+// HumaPair handles POST /api/federation/pair: a peer that holds an invite we
+// issued calls us back with its signed bundle. We verify and store it active,
+// recording the interaction in the exchange ledger (#1350).
+func (h *FederationHandler) HumaPair(_ context.Context, in *PairInput) (*PairOutput, error) {
+	started := time.Now()
+	b := in.Body
+	reqID := in.RequestID
+	if reqID == "" {
+		reqID = federation.NewRequestID()
+	}
+
+	fail := func(status string, httpErr error) error {
+		federation.RecordExchange(h.DB, federation.ExchangeRecord{
+			RequestID: reqID, PeerFingerprint: b.Fingerprint, Direction: db.ExchangeInbound,
+			Operation: "pair", Status: status, StartedAt: started, Error: httpErr.Error(),
+		})
+		return httpErr
+	}
+
+	// 1. Verify the bundle signature and fingerprint<->key binding.
+	pub, err := base64.StdEncoding.DecodeString(b.PublicKey)
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return nil, fail(db.ExchangeRejected, huma.Error400BadRequest("invalid public key"))
+	}
+	if federation.Fingerprint(pub) != b.Fingerprint {
+		return nil, fail(db.ExchangeRejected, huma.Error400BadRequest("fingerprint does not match public key"))
+	}
+	sig, err := base64.StdEncoding.DecodeString(b.Signature)
+	if err != nil {
+		return nil, fail(db.ExchangeRejected, huma.Error400BadRequest("invalid signature encoding"))
+	}
+	if !federation.Verify(pub, pairBundleBytes(b.Fingerprint, b.PublicKey, b.BaseURL, b.Nonce), sig) {
+		return nil, fail(db.ExchangeRejected, huma.Error401Unauthorized("bundle signature verification failed"))
+	}
+
+	// 2. Consume the nonce: it must be one we issued, unexpired, unused.
+	if err := h.consumeNonce(b.Nonce); err != nil {
+		return nil, fail(db.ExchangeRejected, huma.Error401Unauthorized("invalid or already-used pairing nonce"))
+	}
+
+	// 3. Store the peer as active.
+	if err := h.Peers.Upsert(&db.FederationPeer{
+		Fingerprint: b.Fingerprint,
+		PublicKey:   b.PublicKey,
+		BaseURL:     b.BaseURL,
+		Status:      db.PeerStatusActive,
+	}); err != nil {
+		return nil, fail(db.ExchangeError, huma.Error500InternalServerError("failed to store peer"))
+	}
+
+	federation.RecordExchange(h.DB, federation.ExchangeRecord{
+		RequestID: reqID, PeerFingerprint: b.Fingerprint, Direction: db.ExchangeInbound,
+		Operation: "pair", Status: db.ExchangeOK, StartedAt: started,
+	})
+
+	return &PairOutput{Body: PairResponseBody{
+		Fingerprint: h.Identity.Fingerprint(),
+		PublicKey:   base64.StdEncoding.EncodeToString(h.Identity.PublicKey),
+		BaseURL:     h.BaseURL,
+		Status:      db.PeerStatusActive,
+	}}, nil
+}
+
+// consumeNonce atomically marks a valid, unexpired, unused nonce as used.
+func (h *FederationHandler) consumeNonce(nonce string) error {
+	return h.DB.Transaction(func(tx *gorm.DB) error {
+		var n db.FederationInviteNonce
+		if err := tx.Where("nonce = ?", nonce).First(&n).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("nonce not found")
+			}
+			return err
+		}
+		if n.Used || time.Now().After(n.ExpiresAt) {
+			return fmt.Errorf("nonce used or expired")
+		}
+		return tx.Model(&n).Update("used", true).Error
+	})
+}

--- a/server/internal/api/huma_federation.go
+++ b/server/internal/api/huma_federation.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/base64"
-	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -77,33 +77,36 @@ func (h *FederationHandler) HumaPair(_ context.Context, in *PairInput) (*PairOut
 		reqID = federation.NewRequestID()
 	}
 
-	fail := func(status string, httpErr error) error {
-		federation.RecordExchange(h.DB, federation.ExchangeRecord{
-			RequestID: reqID, PeerFingerprint: b.Fingerprint, Direction: db.ExchangeInbound,
-			Operation: "pair", Status: status, StartedAt: started, Error: httpErr.Error(),
-		})
+	// Rejections are logged, not written to the ledger: /api/federation/pair is
+	// public, so recording a row per failed attempt would let an attacker flood
+	// the exchange table. The slog line keeps failures diagnosable during
+	// testing (the operator initiating accept also sees the HTTP error).
+	fail := func(httpErr error) error {
+		slog.Warn("federation: rejected inbound pairing", "component", "federation",
+			"request_id", reqID, "peer", federation.ShortFingerprint(b.Fingerprint),
+			"error", httpErr.Error())
 		return httpErr
 	}
 
 	// 1. Verify the bundle signature and fingerprint<->key binding.
 	pub, err := base64.StdEncoding.DecodeString(b.PublicKey)
 	if err != nil || len(pub) != ed25519.PublicKeySize {
-		return nil, fail(db.ExchangeRejected, huma.Error400BadRequest("invalid public key"))
+		return nil, fail(huma.Error400BadRequest("invalid public key"))
 	}
 	if federation.Fingerprint(pub) != b.Fingerprint {
-		return nil, fail(db.ExchangeRejected, huma.Error400BadRequest("fingerprint does not match public key"))
+		return nil, fail(huma.Error400BadRequest("fingerprint does not match public key"))
 	}
 	sig, err := base64.StdEncoding.DecodeString(b.Signature)
 	if err != nil {
-		return nil, fail(db.ExchangeRejected, huma.Error400BadRequest("invalid signature encoding"))
+		return nil, fail(huma.Error400BadRequest("invalid signature encoding"))
 	}
 	if !federation.Verify(pub, pairBundleBytes(b.Fingerprint, b.PublicKey, b.BaseURL, b.Nonce), sig) {
-		return nil, fail(db.ExchangeRejected, huma.Error401Unauthorized("bundle signature verification failed"))
+		return nil, fail(huma.Error401Unauthorized("bundle signature verification failed"))
 	}
 
 	// 2. Consume the nonce: it must be one we issued, unexpired, unused.
 	if err := h.consumeNonce(b.Nonce); err != nil {
-		return nil, fail(db.ExchangeRejected, huma.Error401Unauthorized("invalid or already-used pairing nonce"))
+		return nil, fail(huma.Error401Unauthorized("invalid or already-used pairing nonce"))
 	}
 
 	// 3. Store the peer as active.
@@ -113,7 +116,7 @@ func (h *FederationHandler) HumaPair(_ context.Context, in *PairInput) (*PairOut
 		BaseURL:     b.BaseURL,
 		Status:      db.PeerStatusActive,
 	}); err != nil {
-		return nil, fail(db.ExchangeError, huma.Error500InternalServerError("failed to store peer"))
+		return nil, fail(huma.Error500InternalServerError("failed to store peer"))
 	}
 
 	federation.RecordExchange(h.DB, federation.ExchangeRecord{
@@ -129,19 +132,18 @@ func (h *FederationHandler) HumaPair(_ context.Context, in *PairInput) (*PairOut
 	}}, nil
 }
 
-// consumeNonce atomically marks a valid, unexpired, unused nonce as used.
+// consumeNonce atomically marks a valid, unexpired, unused nonce as used. The
+// single conditional UPDATE (rather than SELECT-then-UPDATE) is race-safe:
+// exactly one of two concurrent callers with the same nonce sees RowsAffected==1.
 func (h *FederationHandler) consumeNonce(nonce string) error {
-	return h.DB.Transaction(func(tx *gorm.DB) error {
-		var n db.FederationInviteNonce
-		if err := tx.Where("nonce = ?", nonce).First(&n).Error; err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return fmt.Errorf("nonce not found")
-			}
-			return err
-		}
-		if n.Used || time.Now().After(n.ExpiresAt) {
-			return fmt.Errorf("nonce used or expired")
-		}
-		return tx.Model(&n).Update("used", true).Error
-	})
+	res := h.DB.Model(&db.FederationInviteNonce{}).
+		Where("nonce = ? AND used = ? AND expires_at > ?", nonce, false, time.Now()).
+		Update("used", true)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("nonce not found, already used, or expired")
+	}
+	return nil
 }

--- a/server/internal/api/huma_federation.go
+++ b/server/internal/api/huma_federation.go
@@ -24,6 +24,9 @@ type FederationHandler struct {
 	// PairClient performs the outbound pairing callback to a friend. Defaults to
 	// httpPairClient when nil; overridden in tests.
 	PairClient pairClient
+	// Pinger performs the outbound connection-test ping. Defaults to
+	// httpPeerPinger when nil; overridden in tests.
+	Pinger peerPinger
 }
 
 // pairClient performs the outbound pairing callback to a friend.

--- a/server/internal/api/huma_federation_admin.go
+++ b/server/internal/api/huma_federation_admin.go
@@ -41,7 +41,7 @@ func (h *FederationHandler) HumaIssueInvite(_ context.Context, _ *IssueInviteInp
 
 type AcceptInviteBody struct {
 	Invite string `json:"invite"`
-	Name   string `json:"name"`
+	Name   string `json:"name" maxLength:"128"`
 }
 type AcceptInviteInput struct {
 	Body AcceptInviteBody
@@ -87,17 +87,35 @@ func (h *FederationHandler) HumaAcceptInvite(_ context.Context, in *AcceptInvite
 		return nil, huma.Error502BadGateway("pairing callback failed: " + err.Error())
 	}
 
+	// Trust the invite's verified identity, NOT the response body. The invite
+	// was signature-verified (VerifyInvite binds fingerprint == SHA-256(pubkey)
+	// and checks the signature), so inv.Fingerprint/PublicKey/BaseURL are
+	// trustworthy. The response is only a success confirmation; a hostile or
+	// misconfigured remote must not be able to inject a different peer's
+	// identity. Mismatch => abort.
+	if resp.Fingerprint != inv.Fingerprint {
+		federation.RecordExchange(h.DB, federation.ExchangeRecord{
+			RequestID: reqID, PeerFingerprint: inv.Fingerprint, PeerName: in.Body.Name,
+			Direction: db.ExchangeOutbound, Operation: "pair", Status: db.ExchangeRejected,
+			StartedAt: started, Error: "remote returned a mismatched fingerprint",
+		})
+		return nil, huma.Error502BadGateway("remote returned a mismatched fingerprint")
+	}
+
 	if err := h.Peers.Upsert(&db.FederationPeer{
-		Fingerprint: resp.Fingerprint, PublicKey: resp.PublicKey,
-		Name: in.Body.Name, BaseURL: resp.BaseURL, Status: db.PeerStatusActive,
+		Fingerprint: inv.Fingerprint, PublicKey: inv.PublicKey,
+		Name: in.Body.Name, BaseURL: inv.BaseURL, Status: db.PeerStatusActive,
 	}); err != nil {
 		return nil, huma.Error500InternalServerError("failed to store peer")
 	}
 	federation.RecordExchange(h.DB, federation.ExchangeRecord{
-		RequestID: reqID, PeerFingerprint: resp.Fingerprint, PeerName: in.Body.Name,
+		RequestID: reqID, PeerFingerprint: inv.Fingerprint, PeerName: in.Body.Name,
 		Direction: db.ExchangeOutbound, Operation: "pair", Status: db.ExchangeOK, StartedAt: started,
 	})
-	return &AcceptInviteOutput{Body: resp}, nil
+	return &AcceptInviteOutput{Body: PairResponseBody{
+		Fingerprint: inv.Fingerprint, PublicKey: inv.PublicKey,
+		BaseURL: inv.BaseURL, Status: db.PeerStatusActive,
+	}}, nil
 }
 
 // --- List peers (with health) ----------------------------------------------

--- a/server/internal/api/huma_federation_admin.go
+++ b/server/internal/api/huma_federation_admin.go
@@ -1,0 +1,328 @@
+package api
+
+import (
+	"context"
+	"encoding/base64"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+	"gorm.io/gorm"
+)
+
+// --- Issue invite ----------------------------------------------------------
+
+type IssueInviteInput struct{}
+type IssueInviteOutput struct {
+	Body struct {
+		Invite string `json:"invite"`
+	}
+}
+
+// HumaIssueInvite records a one-time nonce and returns a signed, encoded invite
+// for the operator to hand to a friend out-of-band.
+func (h *FederationHandler) HumaIssueInvite(_ context.Context, _ *IssueInviteInput) (*IssueInviteOutput, error) {
+	nonce := federation.NewRequestID() + federation.NewRequestID()
+	expires := time.Now().Add(30 * time.Minute)
+	if err := h.DB.Create(&db.FederationInviteNonce{Nonce: nonce, ExpiresAt: expires}).Error; err != nil {
+		return nil, huma.Error500InternalServerError("failed to record invite nonce")
+	}
+	inv := h.Identity.NewInvite(h.BaseURL, nonce, expires)
+	out := &IssueInviteOutput{}
+	out.Body.Invite = federation.EncodeInvite(inv)
+	return out, nil
+}
+
+// --- Accept invite ---------------------------------------------------------
+
+type AcceptInviteBody struct {
+	Invite string `json:"invite"`
+	Name   string `json:"name"`
+}
+type AcceptInviteInput struct {
+	Body AcceptInviteBody
+}
+type AcceptInviteOutput struct {
+	Body PairResponseBody
+}
+
+// HumaAcceptInvite verifies a friend's invite, calls the friend back with our
+// signed bundle, and stores the friend as an active peer.
+func (h *FederationHandler) HumaAcceptInvite(_ context.Context, in *AcceptInviteInput) (*AcceptInviteOutput, error) {
+	started := time.Now()
+	reqID := federation.NewRequestID()
+
+	inv, err := federation.DecodeInvite(in.Body.Invite)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid invite")
+	}
+	ok, err := federation.VerifyInvite(inv, time.Now())
+	if err != nil || !ok {
+		return nil, huma.Error400BadRequest("invite failed verification")
+	}
+
+	pubB64 := base64.StdEncoding.EncodeToString(h.Identity.PublicKey)
+	fp := h.Identity.Fingerprint()
+	sig := h.Identity.Sign(pairBundleBytes(fp, pubB64, h.BaseURL, inv.Nonce))
+	bundle := PairRequestBody{
+		Fingerprint: fp, PublicKey: pubB64, BaseURL: h.BaseURL,
+		Nonce: inv.Nonce, Signature: base64.StdEncoding.EncodeToString(sig),
+	}
+
+	client := h.PairClient
+	if client == nil {
+		client = httpPairClient{}
+	}
+	resp, err := client.Pair(inv.BaseURL, bundle)
+	if err != nil {
+		federation.RecordExchange(h.DB, federation.ExchangeRecord{
+			RequestID: reqID, PeerFingerprint: inv.Fingerprint, PeerName: in.Body.Name,
+			Direction: db.ExchangeOutbound, Operation: "pair", Status: db.ExchangeError,
+			StartedAt: started, Error: err.Error(),
+		})
+		return nil, huma.Error502BadGateway("pairing callback failed: " + err.Error())
+	}
+
+	if err := h.Peers.Upsert(&db.FederationPeer{
+		Fingerprint: resp.Fingerprint, PublicKey: resp.PublicKey,
+		Name: in.Body.Name, BaseURL: resp.BaseURL, Status: db.PeerStatusActive,
+	}); err != nil {
+		return nil, huma.Error500InternalServerError("failed to store peer")
+	}
+	federation.RecordExchange(h.DB, federation.ExchangeRecord{
+		RequestID: reqID, PeerFingerprint: resp.Fingerprint, PeerName: in.Body.Name,
+		Direction: db.ExchangeOutbound, Operation: "pair", Status: db.ExchangeOK, StartedAt: started,
+	})
+	return &AcceptInviteOutput{Body: resp}, nil
+}
+
+// --- List peers (with health) ----------------------------------------------
+
+type ListPeersInput struct{}
+type ListPeersOutput struct {
+	Body struct {
+		Peers []db.FederationPeer `json:"peers"`
+	}
+}
+
+func (h *FederationHandler) HumaListPeers(_ context.Context, _ *ListPeersInput) (*ListPeersOutput, error) {
+	peers, err := h.Peers.List()
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to list peers")
+	}
+	out := &ListPeersOutput{}
+	out.Body.Peers = peers
+	return out, nil
+}
+
+// --- Revoke peer -----------------------------------------------------------
+
+type RevokePeerInput struct {
+	Fingerprint string `path:"fingerprint" pattern:"^[a-z2-7]{52}$" maxLength:"64" doc:"Peer fingerprint (base32)."`
+}
+type RevokePeerOutput struct {
+	Body struct {
+		Revoked bool `json:"revoked"`
+	}
+}
+
+func (h *FederationHandler) HumaRevokePeer(_ context.Context, in *RevokePeerInput) (*RevokePeerOutput, error) {
+	if err := h.Peers.Remove(in.Fingerprint); err != nil {
+		return nil, huma.Error500InternalServerError("failed to revoke peer")
+	}
+	slog.Info("federation: revoked peer", "component", "federation",
+		"peer", federation.ShortFingerprint(in.Fingerprint))
+	out := &RevokePeerOutput{}
+	out.Body.Revoked = true
+	return out, nil
+}
+
+// --- Test connection (active diagnostic) -----------------------------------
+
+type TestPeerInput struct {
+	Fingerprint string `path:"fingerprint" pattern:"^[a-z2-7]{52}$" maxLength:"64" doc:"Peer fingerprint (base32)."`
+}
+type TestPeerOutput struct {
+	Body PingResult
+}
+
+// HumaTestPeer performs a signed ping round-trip to a peer and returns a
+// per-step diagnostic (reachable, latency, clock skew, fingerprint match). The
+// outcome is folded into the peer's health via the exchange ledger.
+func (h *FederationHandler) HumaTestPeer(_ context.Context, in *TestPeerInput) (*TestPeerOutput, error) {
+	peer, err := h.Peers.GetByFingerprint(in.Fingerprint)
+	if err != nil {
+		return nil, huma.Error404NotFound("peer not found")
+	}
+	reqID := federation.NewRequestID()
+	started := time.Now()
+
+	pinger := h.Pinger
+	if pinger == nil {
+		pinger = httpPeerPinger{}
+	}
+	res := pinger.Ping(peer.BaseURL, reqID, h.Identity, peer.Fingerprint)
+
+	status := db.ExchangeOK
+	if !res.Reachable {
+		status = db.ExchangeError
+	}
+	federation.RecordExchange(h.DB, federation.ExchangeRecord{
+		RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+		Direction: db.ExchangeOutbound, Operation: "ping", Status: status,
+		StartedAt: started, Error: res.Error,
+	})
+	return &TestPeerOutput{Body: res}, nil
+}
+
+// --- List exchange ledger --------------------------------------------------
+
+type ListExchangesInput struct {
+	Peer      string `query:"peer"`
+	Direction string `query:"direction"`
+	Status    string `query:"status"`
+	Limit     int    `query:"limit"`
+}
+type ListExchangesOutput struct {
+	Body struct {
+		Exchanges []db.FederationExchange `json:"exchanges"`
+	}
+}
+
+func (h *FederationHandler) HumaListExchanges(_ context.Context, in *ListExchangesInput) (*ListExchangesOutput, error) {
+	q := h.DB.Model(&db.FederationExchange{}).Order("created_at DESC")
+	if in.Peer != "" {
+		q = q.Where("peer_fingerprint = ?", in.Peer)
+	}
+	if in.Direction != "" {
+		q = q.Where("direction = ?", in.Direction)
+	}
+	if in.Status != "" {
+		q = q.Where("status = ?", in.Status)
+	}
+	limit := in.Limit
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	var rows []db.FederationExchange
+	if err := q.Limit(limit).Find(&rows).Error; err != nil {
+		return nil, huma.Error500InternalServerError("failed to list exchanges")
+	}
+	out := &ListExchangesOutput{}
+	out.Body.Exchanges = rows
+	return out, nil
+}
+
+// --- Ping (inbound, gin route behind VerifyFederationRequest) ---------------
+
+// ginPing answers a peer's signed connection test with our fingerprint and
+// clock, and records the inbound exchange.
+func (h *FederationHandler) ginPing(c *gin.Context) {
+	reqID := c.GetHeader(headerFedRequestID)
+	if reqID == "" {
+		reqID = federation.NewRequestID()
+	}
+	fp, name := "", ""
+	if peer, ok := federationPeerFromGin(c); ok {
+		fp, name = peer.Fingerprint, peer.Name
+	}
+	federation.RecordExchange(h.DB, federation.ExchangeRecord{
+		RequestID: reqID, PeerFingerprint: fp, PeerName: name,
+		Direction: db.ExchangeInbound, Operation: "ping", Status: db.ExchangeOK,
+	})
+	c.JSON(http.StatusOK, gin.H{
+		"fingerprint": h.Identity.Fingerprint(),
+		"unixTime":    time.Now().Unix(),
+	})
+}
+
+// --- Registration ----------------------------------------------------------
+
+// RegisterFederationRoutes wires the huma federation endpoints. The pair
+// endpoint is public (bootstrap, invite-nonce-gated); admin endpoints require
+// admin auth.
+func RegisterFederationRoutes(api huma.API, h *FederationHandler, jwtSecret string, database *gorm.DB, userLimiter *RateLimiter) {
+	requireAuth := RequireAuth(jwtSecret, database)
+	rateLimit := UserRateLimitMiddleware(userLimiter)
+	requireAdmin := RequireAdmin(api)
+	adminMW := huma.Middlewares{requireAuth, rateLimit, requireAdmin}
+	sec := []map[string][]string{{"bearer": {}}}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "federationPair",
+		Method:      http.MethodPost,
+		Path:        "/api/federation/pair",
+		Summary:     "Pairing callback (server-to-server bootstrap)",
+		Tags:        []string{"federation"},
+	}, h.HumaPair)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "federationIssueInvite",
+		Method:      http.MethodPost,
+		Path:        "/api/admin/federation/invite",
+		Summary:     "Issue a federation pairing invite",
+		Tags:        []string{"federation", "admin"},
+		Middlewares: adminMW,
+		Security:    sec,
+	}, h.HumaIssueInvite)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "federationAcceptInvite",
+		Method:      http.MethodPost,
+		Path:        "/api/admin/federation/peers/accept",
+		Summary:     "Accept a friend's invite and pair",
+		Tags:        []string{"federation", "admin"},
+		Middlewares: adminMW,
+		Security:    sec,
+	}, h.HumaAcceptInvite)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "federationListPeers",
+		Method:      http.MethodGet,
+		Path:        "/api/admin/federation/peers",
+		Summary:     "List federation peers (with health)",
+		Tags:        []string{"federation", "admin"},
+		Middlewares: adminMW,
+		Security:    sec,
+	}, h.HumaListPeers)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "federationTestPeer",
+		Method:      http.MethodPost,
+		Path:        "/api/admin/federation/peers/{fingerprint}/test",
+		Summary:     "Test connection to a peer",
+		Tags:        []string{"federation", "admin"},
+		Middlewares: adminMW,
+		Security:    sec,
+	}, h.HumaTestPeer)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "federationRevokePeer",
+		Method:      http.MethodDelete,
+		Path:        "/api/admin/federation/peers/{fingerprint}",
+		Summary:     "Revoke a federation peer",
+		Tags:        []string{"federation", "admin"},
+		Middlewares: adminMW,
+		Security:    sec,
+	}, h.HumaRevokePeer)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "federationListExchanges",
+		Method:      http.MethodGet,
+		Path:        "/api/admin/federation/exchanges",
+		Summary:     "List the federation exchange ledger (observability)",
+		Tags:        []string{"federation", "admin"},
+		Middlewares: adminMW,
+		Security:    sec,
+	}, h.HumaListExchanges)
+}
+
+// RegisterFederationGinRoutes wires raw-gin federation routes: the signed ping
+// used by the connection-test diagnostic.
+func RegisterFederationGinRoutes(r *gin.Engine, h *FederationHandler) {
+	r.GET("/api/federation/ping", VerifyFederationRequest(h.DB), h.ginPing)
+}

--- a/server/internal/api/huma_federation_admin_test.go
+++ b/server/internal/api/huma_federation_admin_test.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePairClient returns a canned bundle from the remote friend.
+type fakePairClient struct {
+	remote federation.Identity
+	called bool
+}
+
+func (f *fakePairClient) Pair(baseURL string, _ PairRequestBody) (PairResponseBody, error) {
+	f.called = true
+	return PairResponseBody{
+		Fingerprint: f.remote.Fingerprint(),
+		PublicKey:   b64(f.remote.PublicKey),
+		BaseURL:     baseURL,
+		Status:      db.PeerStatusActive,
+	}, nil
+}
+
+// fakePinger returns a canned ping result.
+type fakePinger struct{ res PingResult }
+
+func (f fakePinger) Ping(_, _ string, _ federation.Identity, _ string) PingResult { return f.res }
+
+func TestIssueInvite_StoresNonceAndSignsInvite(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self"}
+
+	out, err := h.HumaIssueInvite(context.Background(), &IssueInviteInput{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.Body.Invite)
+
+	decoded, err := federation.DecodeInvite(out.Body.Invite)
+	require.NoError(t, err)
+	assert.Equal(t, selfID.Fingerprint(), decoded.Fingerprint)
+
+	var count int64
+	database.Model(&db.FederationInviteNonce{}).Count(&count)
+	assert.Equal(t, int64(1), count, "issuing an invite records its nonce")
+}
+
+func TestAcceptInvite_PairsAndStoresPeer(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	remoteID, _ := federation.GenerateIdentity()
+	fake := &fakePairClient{remote: remoteID}
+	h := &FederationHandler{
+		DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database},
+		BaseURL: "https://self", PairClient: fake,
+	}
+
+	inv := remoteID.NewInvite("https://remote", "remote-nonce", time.Unix(4_000_000_000, 0))
+	out, err := h.HumaAcceptInvite(context.Background(), &AcceptInviteInput{
+		Body: AcceptInviteBody{Invite: federation.EncodeInvite(inv), Name: "Bob"},
+	})
+	require.NoError(t, err)
+	assert.True(t, fake.called, "accept must call the friend back")
+	assert.Equal(t, db.PeerStatusActive, out.Body.Status)
+
+	stored, err := h.Peers.GetByFingerprint(remoteID.Fingerprint())
+	require.NoError(t, err)
+	assert.Equal(t, "Bob", stored.Name)
+	assert.Equal(t, db.PeerStatusActive, stored.Status)
+}
+
+func TestRevokePeer_RemovesIt(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	store := federation.PeerStore{DB: database}
+	require.NoError(t, store.Upsert(&db.FederationPeer{
+		Fingerprint: "fp-x", PublicKey: "k", BaseURL: "https://x", Status: db.PeerStatusActive,
+	}))
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: store, BaseURL: "https://self"}
+
+	_, err := h.HumaRevokePeer(context.Background(), &RevokePeerInput{Fingerprint: "fp-x"})
+	require.NoError(t, err)
+	_, err = store.GetByFingerprint("fp-x")
+	assert.Error(t, err)
+}
+
+func TestTestPeer_RunsDiagnosticAndUpdatesHealth(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	remoteID, _ := federation.GenerateIdentity()
+	store := activePeer(t, database, remoteID, "Bob", "https://remote")
+	h := &FederationHandler{
+		DB: database, Identity: selfID, Peers: store, BaseURL: "https://self",
+		Pinger: fakePinger{res: PingResult{
+			Reachable: true, PeerFingerprint: remoteID.Fingerprint(), FingerprintMatch: true, LatencyMs: 5,
+		}},
+	}
+
+	out, err := h.HumaTestPeer(context.Background(), &TestPeerInput{Fingerprint: remoteID.Fingerprint()})
+	require.NoError(t, err)
+	assert.True(t, out.Body.Reachable)
+	assert.True(t, out.Body.FingerprintMatch)
+
+	got, err := store.GetByFingerprint(remoteID.Fingerprint())
+	require.NoError(t, err)
+	assert.True(t, got.Reachable)
+	require.NotNil(t, got.LastSuccessAt)
+}
+
+func TestTestPeer_RecordsErrorWhenUnreachable(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	remoteID, _ := federation.GenerateIdentity()
+	store := activePeer(t, database, remoteID, "Bob", "https://remote")
+	h := &FederationHandler{
+		DB: database, Identity: selfID, Peers: store, BaseURL: "https://self",
+		Pinger: fakePinger{res: PingResult{Reachable: false, Error: "connection refused"}},
+	}
+
+	out, err := h.HumaTestPeer(context.Background(), &TestPeerInput{Fingerprint: remoteID.Fingerprint()})
+	require.NoError(t, err)
+	assert.False(t, out.Body.Reachable)
+
+	got, err := store.GetByFingerprint(remoteID.Fingerprint())
+	require.NoError(t, err)
+	assert.False(t, got.Reachable)
+	assert.Equal(t, "connection refused", got.LastError)
+}
+
+func TestTestPeer_NotFound(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self"}
+	_, err := h.HumaTestPeer(context.Background(), &TestPeerInput{Fingerprint: "nope"})
+	assert.Error(t, err)
+}
+
+func TestListExchanges_ReturnsAndFiltersLedger(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self"}
+
+	federation.RecordExchange(database, federation.ExchangeRecord{
+		RequestID: "a", PeerFingerprint: "p1", Direction: db.ExchangeOutbound, Operation: "ping", Status: db.ExchangeOK,
+	})
+	federation.RecordExchange(database, federation.ExchangeRecord{
+		RequestID: "b", PeerFingerprint: "p2", Direction: db.ExchangeInbound, Operation: "pair", Status: db.ExchangeRejected,
+	})
+
+	all, err := h.HumaListExchanges(context.Background(), &ListExchangesInput{})
+	require.NoError(t, err)
+	assert.Len(t, all.Body.Exchanges, 2)
+
+	rejected, err := h.HumaListExchanges(context.Background(), &ListExchangesInput{Status: db.ExchangeRejected})
+	require.NoError(t, err)
+	require.Len(t, rejected.Body.Exchanges, 1)
+	assert.Equal(t, "p2", rejected.Body.Exchanges[0].PeerFingerprint)
+}

--- a/server/internal/api/huma_federation_admin_test.go
+++ b/server/internal/api/huma_federation_admin_test.go
@@ -11,16 +11,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakePairClient returns a canned bundle from the remote friend.
+// fakePairClient returns a canned bundle from the remote friend. respFingerprint
+// overrides the returned fingerprint (empty = the remote's real one) so tests
+// can simulate a hostile/misconfigured remote.
 type fakePairClient struct {
-	remote federation.Identity
-	called bool
+	remote          federation.Identity
+	respFingerprint string
+	called          bool
 }
 
 func (f *fakePairClient) Pair(baseURL string, _ PairRequestBody) (PairResponseBody, error) {
 	f.called = true
+	fp := f.remote.Fingerprint()
+	if f.respFingerprint != "" {
+		fp = f.respFingerprint
+	}
 	return PairResponseBody{
-		Fingerprint: f.remote.Fingerprint(),
+		Fingerprint: fp,
 		PublicKey:   b64(f.remote.PublicKey),
 		BaseURL:     baseURL,
 		Status:      db.PeerStatusActive,
@@ -72,6 +79,33 @@ func TestAcceptInvite_PairsAndStoresPeer(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Bob", stored.Name)
 	assert.Equal(t, db.PeerStatusActive, stored.Status)
+}
+
+func TestAcceptInvite_RejectsMismatchedFingerprint(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	remoteID, _ := federation.GenerateIdentity()
+	attacker, _ := federation.GenerateIdentity()
+
+	// The remote responds with a fingerprint different from the invite it signed.
+	fake := &fakePairClient{remote: remoteID, respFingerprint: attacker.Fingerprint()}
+	h := &FederationHandler{
+		DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database},
+		BaseURL: "https://self", PairClient: fake,
+	}
+	inv := remoteID.NewInvite("https://remote", "n", time.Unix(4_000_000_000, 0))
+
+	_, err := h.HumaAcceptInvite(context.Background(), &AcceptInviteInput{
+		Body: AcceptInviteBody{Invite: federation.EncodeInvite(inv), Name: "Bob"},
+	})
+	assert.Error(t, err, "must reject a response whose fingerprint differs from the verified invite")
+
+	// Neither the real remote nor the injected attacker identity is stored.
+	store := federation.PeerStore{DB: database}
+	_, e1 := store.GetByFingerprint(remoteID.Fingerprint())
+	_, e2 := store.GetByFingerprint(attacker.Fingerprint())
+	assert.Error(t, e1)
+	assert.Error(t, e2)
 }
 
 func TestRevokePeer_RemovesIt(t *testing.T) {

--- a/server/internal/api/huma_federation_test.go
+++ b/server/internal/api/huma_federation_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// signedBundle builds a peer's pairing bundle echoing the given nonce.
+func signedBundle(id federation.Identity, baseURL, nonce string) PairRequestBody {
+	pubB64 := base64.StdEncoding.EncodeToString(id.PublicKey)
+	fp := id.Fingerprint()
+	sig := id.Sign(pairBundleBytes(fp, pubB64, baseURL, nonce))
+	return PairRequestBody{
+		Fingerprint: fp,
+		PublicKey:   pubB64,
+		BaseURL:     baseURL,
+		Nonce:       nonce,
+		Signature:   base64.StdEncoding.EncodeToString(sig),
+	}
+}
+
+func TestPair_StoresPeerActive_OnValidBundleAndNonce(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self"}
+
+	// A (self) issued an invite with this nonce.
+	require.NoError(t, database.Create(&db.FederationInviteNonce{
+		Nonce: "n-good", ExpiresAt: time.Now().Add(time.Hour),
+	}).Error)
+
+	caller, _ := federation.GenerateIdentity() // B
+	body := signedBundle(caller, "https://b.example", "n-good")
+
+	out, err := h.HumaPair(context.Background(), &PairInput{Body: body})
+	require.NoError(t, err)
+	assert.Equal(t, selfID.Fingerprint(), out.Body.Fingerprint)
+	assert.Equal(t, db.PeerStatusActive, out.Body.Status)
+
+	stored, err := federation.PeerStore{DB: database}.GetByFingerprint(caller.Fingerprint())
+	require.NoError(t, err)
+	assert.Equal(t, db.PeerStatusActive, stored.Status)
+
+	// An exchange-ledger row was written for the pairing.
+	var exchanges int64
+	database.Model(&db.FederationExchange{}).Where("operation = ? AND status = ?", "pair", db.ExchangeOK).Count(&exchanges)
+	assert.Equal(t, int64(1), exchanges)
+
+	// Nonce is now consumed: a replay must fail.
+	_, err = h.HumaPair(context.Background(), &PairInput{Body: body})
+	assert.Error(t, err)
+}
+
+func TestPair_RejectsUnknownNonce(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self"}
+
+	caller, _ := federation.GenerateIdentity()
+	body := signedBundle(caller, "https://b.example", "n-never-issued")
+
+	_, err := h.HumaPair(context.Background(), &PairInput{Body: body})
+	assert.Error(t, err, "pairing without a matching issued nonce must be rejected")
+
+	// A rejected exchange row is recorded for diagnosis.
+	var rejected int64
+	database.Model(&db.FederationExchange{}).Where("status = ?", db.ExchangeRejected).Count(&rejected)
+	assert.Equal(t, int64(1), rejected)
+}
+
+func TestPair_RejectsBadSignature(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self"}
+	require.NoError(t, database.Create(&db.FederationInviteNonce{
+		Nonce: "n", ExpiresAt: time.Now().Add(time.Hour),
+	}).Error)
+
+	caller, _ := federation.GenerateIdentity()
+	body := signedBundle(caller, "https://b.example", "n")
+	body.Signature = base64.StdEncoding.EncodeToString([]byte("not-a-valid-ed25519-signature-of-the-right-length-000000000000000"))
+
+	_, err := h.HumaPair(context.Background(), &PairInput{Body: body})
+	assert.Error(t, err)
+}
+
+func TestPair_RejectsFingerprintKeyMismatch(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self"}
+	require.NoError(t, database.Create(&db.FederationInviteNonce{
+		Nonce: "n", ExpiresAt: time.Now().Add(time.Hour),
+	}).Error)
+
+	caller, _ := federation.GenerateIdentity()
+	other, _ := federation.GenerateIdentity()
+	body := signedBundle(caller, "https://b.example", "n")
+	body.Fingerprint = other.Fingerprint() // no longer matches PublicKey
+
+	_, err := h.HumaPair(context.Background(), &PairInput{Body: body})
+	assert.Error(t, err)
+}

--- a/server/internal/api/huma_federation_test.go
+++ b/server/internal/api/huma_federation_test.go
@@ -69,10 +69,11 @@ func TestPair_RejectsUnknownNonce(t *testing.T) {
 	_, err := h.HumaPair(context.Background(), &PairInput{Body: body})
 	assert.Error(t, err, "pairing without a matching issued nonce must be rejected")
 
-	// A rejected exchange row is recorded for diagnosis.
-	var rejected int64
-	database.Model(&db.FederationExchange{}).Where("status = ?", db.ExchangeRejected).Count(&rejected)
-	assert.Equal(t, int64(1), rejected)
+	// Rejections on the public pair endpoint are logged, NOT written to the
+	// ledger (anti-flood) — no exchange row should exist.
+	var rows int64
+	database.Model(&db.FederationExchange{}).Count(&rows)
+	assert.Equal(t, int64(0), rows)
 }
 
 func TestPair_RejectsBadSignature(t *testing.T) {

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/auth"
 	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
 	"github.com/spela/server/internal/igdb"
 	"github.com/spela/server/internal/retroachievements"
 	"github.com/spela/server/internal/scanner"
@@ -40,7 +41,11 @@ type Config struct {
 	RAClient                     *retroachievements.RAClient // optional; defaults to production RA client
 	ChallengeAttemptRateLimitSec int                         // 0 = disabled; default 30 in production
 	Version                      string
-	TestMode                     bool // when true, registers POST /api/test/reset for E2E test isolation
+	// PublicBaseURL is this server's own externally-reachable base URL, embedded
+	// as the callback URL in federation invites (#1343). Empty if unset, in
+	// which case issued invites carry no usable callback URL.
+	PublicBaseURL string
+	TestMode      bool // when true, registers POST /api/test/reset for E2E test isolation
 }
 
 // NewRouter creates and configures the Gin router with all endpoints.
@@ -171,6 +176,22 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	// Make the effective key available to the secret-server-setting
 	// encrypt/decrypt helpers (#1318).
 	setServerSettingsKey(encryptionKey)
+
+	// Federation identity + handler (epic #1343). The identity keypair is
+	// created on first startup and persisted (private key encrypted at rest).
+	fedIdentity, fedErr := federation.LoadOrCreateIdentity(cfg.DB, encryptionKey)
+	if fedErr != nil {
+		slog.Error("federation: failed to initialize identity", "error", fedErr)
+	} else {
+		slog.Info("federation: identity ready", "fingerprint", federation.ShortFingerprint(fedIdentity.Fingerprint()))
+	}
+	federationHandler := &FederationHandler{
+		DB:       cfg.DB,
+		Identity: fedIdentity,
+		Peers:    federation.PeerStore{DB: cfg.DB},
+		BaseURL:  cfg.PublicBaseURL,
+	}
+
 	socialHandler := &SocialHandler{DB: cfg.DB, Hub: cfg.Hub}
 	ratingHandler := &RatingHandler{DB: cfg.DB, Hub: cfg.Hub}
 	sharedSaveHandler := &SharedSaveHandler{DB: cfg.DB, Storage: cfg.Storage, Hub: cfg.Hub}
@@ -231,6 +252,8 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterMakerRoutes(humaAPI, makerHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterCoreRoutes(humaAPI, coreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterStatsRoutes(humaAPI, statsHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterFederationRoutes(humaAPI, federationHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterFederationGinRoutes(r, federationHandler)
 	RegisterConsoleRoutes(humaAPI, consoleHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterUserRoutes(humaAPI, userHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterUserMutationRoutes(humaAPI, userHandler, cfg.JWTSecret, cfg.DB, userLimiter, authLimiter)

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -232,6 +232,11 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&ScrapeQueueItem{},
 		// Privacy: per-user block list (issue #1121)
 		&Block{},
+		// Federation (epic #1343): friend registry, pairing nonces, and the
+		// observability exchange ledger (#1350).
+		&FederationPeer{},
+		&FederationInviteNonce{},
+		&FederationExchange{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running migrations: %w", err)

--- a/server/internal/db/federation_models_test.go
+++ b/server/internal/db/federation_models_test.go
@@ -1,0 +1,54 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func openFederationModelTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(
+		&FederationPeer{}, &FederationInviteNonce{}, &FederationExchange{},
+	))
+	return database
+}
+
+func TestFederationPeer_FingerprintUnique(t *testing.T) {
+	database := openFederationModelTestDB(t)
+	require.NoError(t, database.Create(&FederationPeer{
+		Fingerprint: "abc", PublicKey: "k", BaseURL: "https://a", Status: PeerStatusActive,
+	}).Error)
+
+	err := database.Create(&FederationPeer{
+		Fingerprint: "abc", PublicKey: "k2", BaseURL: "https://b", Status: PeerStatusActive,
+	}).Error
+	assert.Error(t, err, "duplicate fingerprint must violate the unique index")
+}
+
+func TestFederationInviteNonce_NonceUnique(t *testing.T) {
+	database := openFederationModelTestDB(t)
+	require.NoError(t, database.Create(&FederationInviteNonce{Nonce: "n1"}).Error)
+	assert.Error(t, database.Create(&FederationInviteNonce{Nonce: "n1"}).Error)
+}
+
+func TestFederationExchange_Persists(t *testing.T) {
+	database := openFederationModelTestDB(t)
+	require.NoError(t, database.Create(&FederationExchange{
+		RequestID: "r1", PeerFingerprint: "abc", Direction: ExchangeOutbound,
+		Operation: "handshake", Status: ExchangeOK,
+	}).Error)
+
+	var got FederationExchange
+	require.NoError(t, database.Where("request_id = ?", "r1").First(&got).Error)
+	assert.Equal(t, ExchangeOutbound, got.Direction)
+	assert.Equal(t, ExchangeOK, got.Status)
+}

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -30,15 +30,15 @@ func IsAdminOrOwner(role UserRole) bool {
 
 // User represents an application user.
 type User struct {
-	ID           uint           `gorm:"primarykey" json:"id"`
-	CreatedAt    time.Time      `json:"createdAt"`
-	UpdatedAt    time.Time      `json:"updatedAt"`
-	DeletedAt    gorm.DeletedAt `gorm:"index" json:"-"`
-	Username     string         `gorm:"uniqueIndex;size:64;not null" json:"username"`
-	Email        string         `gorm:"uniqueIndex;size:255;not null" json:"email"`
-	PasswordHash string         `gorm:"not null" json:"-"`
-	Role         UserRole       `gorm:"size:16;default:user" json:"role"`
-	AvatarURL    string         `gorm:"size:512" json:"avatarUrl"`
+	ID                  uint           `gorm:"primarykey" json:"id"`
+	CreatedAt           time.Time      `json:"createdAt"`
+	UpdatedAt           time.Time      `json:"updatedAt"`
+	DeletedAt           gorm.DeletedAt `gorm:"index" json:"-"`
+	Username            string         `gorm:"uniqueIndex;size:64;not null" json:"username"`
+	Email               string         `gorm:"uniqueIndex;size:255;not null" json:"email"`
+	PasswordHash        string         `gorm:"not null" json:"-"`
+	Role                UserRole       `gorm:"size:16;default:user" json:"role"`
+	AvatarURL           string         `gorm:"size:512" json:"avatarUrl"`
 	TokenVersion        int            `gorm:"default:0" json:"-"`
 	Disabled            bool           `gorm:"default:false" json:"disabled"`
 	PendingApproval     bool           `gorm:"default:false" json:"pendingApproval"`
@@ -50,20 +50,20 @@ type User struct {
 	// When false, the player trusts its local cache even if the server
 	// has a newer build — session pinning keeps long-running saves
 	// loadable without a version mismatch. See #555 Phase 2.
-	AutoUpdateCoresEnabled bool           `gorm:"default:true" json:"autoUpdateCoresEnabled"`
-	SelectedShader      string         `gorm:"size:64;default:none" json:"selectedShader"`
-	SelectedTheme       string         `gorm:"size:64;default:default-dark" json:"selectedTheme"`
-	SelectedKeyMapping  string         `gorm:"size:64;default:arrows-left" json:"selectedKeyMapping"`
-	CustomKeyMapping         string         `gorm:"type:text" json:"customKeyMapping"` // JSON: {"0":"z","1":"x",...}
-	DefaultSecondScreenPage string         `gorm:"size:64;default:art" json:"defaultSecondScreenPage"`
-	PreferredRegions         string         `gorm:"size:255" json:"preferredRegions"` // comma-separated ordered list, e.g. "USA,Europe,World"
+	AutoUpdateCoresEnabled  bool   `gorm:"default:true" json:"autoUpdateCoresEnabled"`
+	SelectedShader          string `gorm:"size:64;default:none" json:"selectedShader"`
+	SelectedTheme           string `gorm:"size:64;default:default-dark" json:"selectedTheme"`
+	SelectedKeyMapping      string `gorm:"size:64;default:arrows-left" json:"selectedKeyMapping"`
+	CustomKeyMapping        string `gorm:"type:text" json:"customKeyMapping"` // JSON: {"0":"z","1":"x",...}
+	DefaultSecondScreenPage string `gorm:"size:64;default:art" json:"defaultSecondScreenPage"`
+	PreferredRegions        string `gorm:"size:255" json:"preferredRegions"` // comma-separated ordered list, e.g. "USA,Europe,World"
 	// ProfileVisibility controls whether the user's public profile
 	// exposes detailed activity (current game, recent games, top
 	// played, play time). Issue #1121: previously every authenticated
 	// user could scrape every other user's gaming habits in real time.
 	// Values: "public" (default), "private". The "friends" tier is
 	// reserved for a future friend graph.
-	ProfileVisibility       string         `gorm:"size:16;default:public" json:"profileVisibility"`
+	ProfileVisibility string `gorm:"size:16;default:public" json:"profileVisibility"`
 }
 
 // Block represents a one-way "I do not want to interact with this user"
@@ -83,9 +83,9 @@ type Block struct {
 
 // LoginAttempt tracks failed login attempts per username for account lockout.
 type LoginAttempt struct {
-	ID          uint      `gorm:"primarykey"`
-	Username    string    `gorm:"size:64;uniqueIndex"`
-	FailedCount int       `gorm:"default:0"`
+	ID          uint   `gorm:"primarykey"`
+	Username    string `gorm:"size:64;uniqueIndex"`
+	FailedCount int    `gorm:"default:0"`
 	LockedUntil time.Time
 	UpdatedAt   time.Time
 }
@@ -135,23 +135,23 @@ const (
 
 // Console represents a detected game console/platform.
 type Console struct {
-	ID             uint           `gorm:"primarykey" json:"id"`
-	CreatedAt      time.Time      `json:"createdAt"`
-	UpdatedAt      time.Time      `json:"updatedAt"`
-	DeletedAt      gorm.DeletedAt `gorm:"index" json:"-"`
-	Name           string         `gorm:"uniqueIndex;size:128;not null" json:"name"`
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"createdAt"`
+	UpdatedAt time.Time      `json:"updatedAt"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	Name      string         `gorm:"uniqueIndex;size:128;not null" json:"name"`
 	// Abbreviation is the canonical short identifier (e.g. "NES", "SNES",
 	// "PS2"). Every seed function and backfill loop in database.go uses
 	// `WHERE abbreviation = ?` as the lookup key, so the schema must
 	// enforce uniqueness — otherwise a race or bug could insert two
 	// rows for the same abbreviation and subsequent `First()` calls
 	// would silently pick whichever SQLite returns first. See #970.
-	Abbreviation   string         `gorm:"uniqueIndex;size:16;not null" json:"abbreviation"`
-	Extensions     string         `gorm:"size:255;not null" json:"extensions"` // comma-separated
-	DefaultCore    string         `gorm:"size:128" json:"defaultCore"`
-	EmulatorJSCore string         `gorm:"size:64" json:"emulatorJsCore"`
-	FolderName     string         `gorm:"size:64" json:"folderName"`
-	CoverAspect    string         `gorm:"size:16;default:3:4" json:"coverAspect"`
+	Abbreviation   string `gorm:"uniqueIndex;size:16;not null" json:"abbreviation"`
+	Extensions     string `gorm:"size:255;not null" json:"extensions"` // comma-separated
+	DefaultCore    string `gorm:"size:128" json:"defaultCore"`
+	EmulatorJSCore string `gorm:"size:64" json:"emulatorJsCore"`
+	FolderName     string `gorm:"size:64" json:"folderName"`
+	CoverAspect    string `gorm:"size:16;default:3:4" json:"coverAspect"`
 	// LogoAspectRatio is the intrinsic width/height ratio of this
 	// console's logo asset, computed once at seed time from the SVG's
 	// viewBox. The player app uses it to size the logo container
@@ -160,10 +160,10 @@ type Console struct {
 	// decoded, producing a visible size-A → size-B jump on the
 	// console-detail hero. Null is acceptable (clients fall back to
 	// the legacy fluid sizing). See #1166.
-	LogoAspectRatio  *float64       `json:"logoAspectRatio"`
-	ColorTheme       string         `gorm:"size:7;default:#6366f1" json:"colorTheme"`
-	Generation       int            `gorm:"default:0" json:"generation"`
-	SaveStateSupport bool           `gorm:"default:true" json:"saveStateSupport"`
+	LogoAspectRatio  *float64 `json:"logoAspectRatio"`
+	ColorTheme       string   `gorm:"size:7;default:#6366f1" json:"colorTheme"`
+	Generation       int      `gorm:"default:0" json:"generation"`
+	SaveStateSupport bool     `gorm:"default:true" json:"saveStateSupport"`
 	// Size tier driving retention/slot/UX behaviour for save states on
 	// this console. See [SaveStatePolicy]. The column has NO default
 	// at the schema level — empty is the "needs seeding" sentinel that
@@ -171,79 +171,79 @@ type Console struct {
 	// override (which it must preserve). The API response falls back
 	// to "small" so clients still see a closed-set value. See #804
 	// phase 3.
-	SaveStatePolicy  SaveStatePolicy `gorm:"type:varchar(16);not null;default:''" json:"saveStatePolicy"`
-	Playable         bool           `gorm:"default:true" json:"playable"`
-	Code             *string        `gorm:"uniqueIndex;size:32" json:"code"`
-	HardwareMakerID  *uint          `json:"hardwareMakerId"`
-	HardwareMaker    *HardwareMaker `gorm:"foreignKey:HardwareMakerID" json:"hardwareMaker"`
-	MediaTypeID      *uint          `json:"mediaTypeId"`
-	MediaType        *MediaType     `gorm:"foreignKey:MediaTypeID" json:"mediaType"`
-	ReleaseYear      *int           `json:"releaseYear"`
-	UnitsSold        *int64         `json:"unitsSold"`
-	Summary          *string        `gorm:"type:text" json:"summary"`
-	Games            []Game         `gorm:"foreignKey:ConsoleID" json:"games"`
-	GameCount      int            `gorm:"-" json:"gameCount"`
+	SaveStatePolicy SaveStatePolicy `gorm:"type:varchar(16);not null;default:''" json:"saveStatePolicy"`
+	Playable        bool            `gorm:"default:true" json:"playable"`
+	Code            *string         `gorm:"uniqueIndex;size:32" json:"code"`
+	HardwareMakerID *uint           `json:"hardwareMakerId"`
+	HardwareMaker   *HardwareMaker  `gorm:"foreignKey:HardwareMakerID" json:"hardwareMaker"`
+	MediaTypeID     *uint           `json:"mediaTypeId"`
+	MediaType       *MediaType      `gorm:"foreignKey:MediaTypeID" json:"mediaType"`
+	ReleaseYear     *int            `json:"releaseYear"`
+	UnitsSold       *int64          `json:"unitsSold"`
+	Summary         *string         `gorm:"type:text" json:"summary"`
+	Games           []Game          `gorm:"foreignKey:ConsoleID" json:"games"`
+	GameCount       int             `gorm:"-" json:"gameCount"`
 }
 
 // Game represents a detected ROM/game file.
 type Game struct {
-	ID            uint           `gorm:"primarykey" json:"id"`
-	CreatedAt     time.Time      `json:"createdAt"`
-	UpdatedAt     time.Time      `json:"updatedAt"`
-	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
-	ConsoleID     uint           `gorm:"index;not null;index:idx_console_group_key,priority:1;index:idx_console_is_primary,priority:1" json:"consoleId"`
-	Console       Console        `gorm:"foreignKey:ConsoleID" json:"console"`
-	Title         string         `gorm:"size:255;not null" json:"title"`
-	FileName      string         `gorm:"size:512;not null" json:"fileName"`
-	FilePath      string         `gorm:"uniqueIndex;size:1024;not null" json:"-"`
-	FileSize      int64          `json:"fileSize"`
-	DiscCount     int            `json:"discCount"`                                    // 0 = single-disc legacy, 2+ = multi-disc
-	Discs         []GameDisc     `gorm:"foreignKey:GameID" json:"discs"`
-	Description   string         `gorm:"type:text" json:"description"`
-	CoverURL      string         `gorm:"size:512" json:"coverUrl"`
-	ScreenshotURL string         `gorm:"size:512" json:"screenshotUrl"`
-	Developer     string         `gorm:"size:255" json:"developer"`
-	Publisher     string         `gorm:"size:255" json:"publisher"`
-	ReleaseDate   string         `gorm:"size:32" json:"releaseDate"`
-	Genre         string         `gorm:"size:512" json:"genre"`
-	GameModes            string  `gorm:"size:255" json:"gameModes"`
-	Storyline            string  `gorm:"type:text" json:"storyline"`
-	TotalRating          float64 `json:"totalRating"`
-	TotalRatingCount     int     `json:"totalRatingCount"`
-	IGDBUserRating       float64 `json:"igdbUserRating"`
-	IGDBUserRatingCount  int     `json:"igdbUserRatingCount"`
-	TimeToBeatHastily    int     `json:"timeToBeatHastily"`
-	TimeToBeatNormally   int     `json:"timeToBeatNormally"`
-	TimeToBeatCompletely int     `json:"timeToBeatCompletely"`
-	Players              int     `json:"players"`
-	IGDBCriticsRating    float64 `gorm:"column:rating" json:"igdbCriticsRating"`
-	CoreOverride         string  `gorm:"size:128" json:"coreOverride"`
-	LibRetroCoverURL    string         `gorm:"size:512" json:"-"`
-	IGDBCoverURL        string         `gorm:"size:512" json:"-"`
-	CoverManuallySet    bool           `gorm:"default:false" json:"-"`
-	ScrapeAttempts      int            `json:"scrapeAttempts"`
-	ScraperID           string         `gorm:"size:128" json:"scraperId"`
-	AchievementsWarning string         `gorm:"size:512" json:"achievementsWarning"`
-	VerificationStatus  string         `gorm:"size:32" json:"verificationStatus"`
-	VerificationTag     string         `gorm:"size:128" json:"verificationTag"`
-	Region              string         `gorm:"size:128" json:"region"`
-	Revision            string         `gorm:"size:64" json:"revision"`
-	Tags                string         `gorm:"size:255" json:"tags"`
-	IsPreRelease        bool           `gorm:"default:false;index:idx_game_is_pre_release" json:"isPreRelease"`
-	GroupKey            string         `gorm:"size:255;index:idx_game_group_key;index:idx_console_group_key,priority:2" json:"groupKey"`
-	IsPrimary           bool           `gorm:"default:false;index:idx_game_is_primary;index:idx_console_is_primary,priority:2" json:"isPrimary"`
-	PrimaryGameID       *uint          `json:"primaryGameId"`
-	ParentGameID        *uint          `gorm:"index:idx_game_parent" json:"parentGameId"` // links standalone ROM hacks to their base game
-	PartyInfo           string         `gorm:"size:512" json:"partyInfo"`                // Demo party and placement, e.g. "Assembly 1993, 1st place"
-	CRC32               string         `gorm:"size:16" json:"-"`
-	RAGameID            uint           `gorm:"index" json:"-"` // RetroAchievements game ID (cached from hash lookup)
+	ID                   uint           `gorm:"primarykey" json:"id"`
+	CreatedAt            time.Time      `json:"createdAt"`
+	UpdatedAt            time.Time      `json:"updatedAt"`
+	DeletedAt            gorm.DeletedAt `gorm:"index" json:"-"`
+	ConsoleID            uint           `gorm:"index;not null;index:idx_console_group_key,priority:1;index:idx_console_is_primary,priority:1" json:"consoleId"`
+	Console              Console        `gorm:"foreignKey:ConsoleID" json:"console"`
+	Title                string         `gorm:"size:255;not null" json:"title"`
+	FileName             string         `gorm:"size:512;not null" json:"fileName"`
+	FilePath             string         `gorm:"uniqueIndex;size:1024;not null" json:"-"`
+	FileSize             int64          `json:"fileSize"`
+	DiscCount            int            `json:"discCount"` // 0 = single-disc legacy, 2+ = multi-disc
+	Discs                []GameDisc     `gorm:"foreignKey:GameID" json:"discs"`
+	Description          string         `gorm:"type:text" json:"description"`
+	CoverURL             string         `gorm:"size:512" json:"coverUrl"`
+	ScreenshotURL        string         `gorm:"size:512" json:"screenshotUrl"`
+	Developer            string         `gorm:"size:255" json:"developer"`
+	Publisher            string         `gorm:"size:255" json:"publisher"`
+	ReleaseDate          string         `gorm:"size:32" json:"releaseDate"`
+	Genre                string         `gorm:"size:512" json:"genre"`
+	GameModes            string         `gorm:"size:255" json:"gameModes"`
+	Storyline            string         `gorm:"type:text" json:"storyline"`
+	TotalRating          float64        `json:"totalRating"`
+	TotalRatingCount     int            `json:"totalRatingCount"`
+	IGDBUserRating       float64        `json:"igdbUserRating"`
+	IGDBUserRatingCount  int            `json:"igdbUserRatingCount"`
+	TimeToBeatHastily    int            `json:"timeToBeatHastily"`
+	TimeToBeatNormally   int            `json:"timeToBeatNormally"`
+	TimeToBeatCompletely int            `json:"timeToBeatCompletely"`
+	Players              int            `json:"players"`
+	IGDBCriticsRating    float64        `gorm:"column:rating" json:"igdbCriticsRating"`
+	CoreOverride         string         `gorm:"size:128" json:"coreOverride"`
+	LibRetroCoverURL     string         `gorm:"size:512" json:"-"`
+	IGDBCoverURL         string         `gorm:"size:512" json:"-"`
+	CoverManuallySet     bool           `gorm:"default:false" json:"-"`
+	ScrapeAttempts       int            `json:"scrapeAttempts"`
+	ScraperID            string         `gorm:"size:128" json:"scraperId"`
+	AchievementsWarning  string         `gorm:"size:512" json:"achievementsWarning"`
+	VerificationStatus   string         `gorm:"size:32" json:"verificationStatus"`
+	VerificationTag      string         `gorm:"size:128" json:"verificationTag"`
+	Region               string         `gorm:"size:128" json:"region"`
+	Revision             string         `gorm:"size:64" json:"revision"`
+	Tags                 string         `gorm:"size:255" json:"tags"`
+	IsPreRelease         bool           `gorm:"default:false;index:idx_game_is_pre_release" json:"isPreRelease"`
+	GroupKey             string         `gorm:"size:255;index:idx_game_group_key;index:idx_console_group_key,priority:2" json:"groupKey"`
+	IsPrimary            bool           `gorm:"default:false;index:idx_game_is_primary;index:idx_console_is_primary,priority:2" json:"isPrimary"`
+	PrimaryGameID        *uint          `json:"primaryGameId"`
+	ParentGameID         *uint          `gorm:"index:idx_game_parent" json:"parentGameId"` // links standalone ROM hacks to their base game
+	PartyInfo            string         `gorm:"size:512" json:"partyInfo"`                 // Demo party and placement, e.g. "Assembly 1993, 1st place"
+	CRC32                string         `gorm:"size:16" json:"-"`
+	RAGameID             uint           `gorm:"index" json:"-"` // RetroAchievements game ID (cached from hash lookup)
 	// RAHashChecked + RAGameID sentinel logic:
 	//   RAHashChecked=false, RAGameID=0  → Not yet looked up. Compute ROM MD5 and query RA.
 	//   RAHashChecked=true,  RAGameID=0  → Looked up, but RA doesn't have this game. Do NOT retry.
 	//   RAHashChecked=true,  RAGameID>0  → Valid RA game ID cached.
 	// RAHashChecked is ONLY set to true after a successful API response (even if RA returned no match).
 	// Transient errors (network, 403) leave RAHashChecked=false so the next visit retries.
-	RAHashChecked       bool           `gorm:"default:false" json:"-"`
+	RAHashChecked    bool                  `gorm:"default:false" json:"-"`
 	Screenshots      []GameScreenshot      `gorm:"foreignKey:GameID" json:"-"`
 	ReleaseDates     []GameReleaseDate     `gorm:"foreignKey:GameID" json:"-"`
 	Videos           []GameVideo           `gorm:"foreignKey:GameID" json:"-"`
@@ -334,10 +334,10 @@ type PlayHistory struct {
 	// (UserID, GameID) so SQLite cannot use it for queries that filter
 	// by GameID alone (GET /api/games/{id}/stats and the top-player JOIN
 	// were full-scanning play_histories).
-	GameID    uint           `gorm:"uniqueIndex:idx_user_game_play_history;not null;index:idx_play_history_game" json:"gameId"`
-	Game      Game           `gorm:"foreignKey:GameID" json:"game"`
-	LastPlayed time.Time     `json:"lastPlayed"`
-	PlayTime   int64         `json:"playTime"` // seconds
+	GameID     uint      `gorm:"uniqueIndex:idx_user_game_play_history;not null;index:idx_play_history_game" json:"gameId"`
+	Game       Game      `gorm:"foreignKey:GameID" json:"game"`
+	LastPlayed time.Time `json:"lastPlayed"`
+	PlayTime   int64     `json:"playTime"` // seconds
 }
 
 // DailyPlayActivity aggregates play time per user per day for heatmap display.
@@ -351,7 +351,7 @@ type DailyPlayActivity struct {
 
 // RefreshToken stores issued refresh tokens.
 type RefreshToken struct {
-	ID          uint           `gorm:"primarykey"`
+	ID          uint `gorm:"primarykey"`
 	CreatedAt   time.Time
 	DeletedAt   gorm.DeletedAt `gorm:"index"`
 	UserID      uint           `gorm:"index;not null"`
@@ -359,7 +359,7 @@ type RefreshToken struct {
 	Token       string         `gorm:"uniqueIndex;size:512;not null"`
 	ExpiresAt   time.Time      `gorm:"not null;index"`
 	TokenFamily string         `gorm:"size:64;index"` // groups related tokens for replay detection
-	Consumed    bool           `gorm:"default:false"`  // marked true on rotation instead of deleted
+	Consumed    bool           `gorm:"default:false"` // marked true on rotation instead of deleted
 }
 
 // TokenBlacklist stores revoked access tokens until they expire naturally.
@@ -500,11 +500,11 @@ type SystemEvent struct {
 	// SET NULL not CASCADE: SystemEvent is the audit log. Deleting a
 	// user must not erase the record of what they did. We keep the
 	// event row and null the FK so nothing dangles.
-	User          *User               `gorm:"foreignKey:UserID;constraint:OnDelete:SET NULL"`
-	IP            string              `gorm:"size:64;index"`
-	Path          string              `gorm:"size:256"`
-	Metadata      string              `gorm:"type:text"`
-	DismissedAt   *time.Time          `gorm:"index"`
+	User        *User      `gorm:"foreignKey:UserID;constraint:OnDelete:SET NULL"`
+	IP          string     `gorm:"size:64;index"`
+	Path        string     `gorm:"size:256"`
+	Metadata    string     `gorm:"type:text"`
+	DismissedAt *time.Time `gorm:"index"`
 }
 
 // ServerSetting stores key-value server configuration.
@@ -589,18 +589,18 @@ type FederationExchange struct {
 	CreatedAt time.Time `gorm:"index" json:"createdAt"`
 	// RequestID correlates both ends of one logical operation (also emitted in
 	// logs and propagated via the X-Spela-Request-Id header).
-	RequestID       string `gorm:"size:64;index" json:"requestId"`
-	PeerFingerprint string `gorm:"size:64;index" json:"peerFingerprint"`
-	PeerName        string `gorm:"size:128" json:"peerName"`
-	Direction       string `gorm:"size:16;index" json:"direction"`
-	Operation       string `gorm:"size:64;index" json:"operation"`
-	DataClass       string `gorm:"size:32" json:"dataClass"`
-	MaxHops         int    `json:"maxHops"`
-	Status          string `gorm:"size:16;index" json:"status"`
-	HTTPStatus      int    `json:"httpStatus"`
-	ItemCount       int    `json:"itemCount"`
-	Bytes           int64  `json:"bytes"`
-	DurationMs      int64  `json:"durationMs"`
+	RequestID       string    `gorm:"size:64;index" json:"requestId"`
+	PeerFingerprint string    `gorm:"size:64;index" json:"peerFingerprint"`
+	PeerName        string    `gorm:"size:128" json:"peerName"`
+	Direction       string    `gorm:"size:16;index" json:"direction"`
+	Operation       string    `gorm:"size:64;index" json:"operation"`
+	DataClass       string    `gorm:"size:32" json:"dataClass"`
+	MaxHops         int       `json:"maxHops"`
+	Status          string    `gorm:"size:16;index" json:"status"`
+	HTTPStatus      int       `json:"httpStatus"`
+	ItemCount       int       `json:"itemCount"`
+	Bytes           int64     `json:"bytes"`
+	DurationMs      int64     `json:"durationMs"`
 	StartedAt       time.Time `json:"startedAt"`
 	FinishedAt      time.Time `json:"finishedAt"`
 	Error           string    `gorm:"size:512" json:"error"`
@@ -802,22 +802,22 @@ type ActivityEvent struct {
 	// stored, but with FK enforcement enabled the FK to games(id=0)
 	// fails. SET NULL on Game so deleting a game preserves the activity
 	// row but disconnects the FK.
-	GameID    *uint          `gorm:"index" json:"gameId"`
-	Game      Game           `gorm:"foreignKey:GameID;constraint:OnDelete:SET NULL" json:"-"`
-	Metadata  string         `gorm:"type:text" json:"metadata"` // JSON
+	GameID   *uint  `gorm:"index" json:"gameId"`
+	Game     Game   `gorm:"foreignKey:GameID;constraint:OnDelete:SET NULL" json:"-"`
+	Metadata string `gorm:"type:text" json:"metadata"` // JSON
 }
 
 // GameCollection represents a user-created collection of games.
 type GameCollection struct {
-	ID          uint           `gorm:"primarykey" json:"id"`
-	CreatedAt   time.Time      `json:"createdAt"`
-	UpdatedAt   time.Time      `json:"updatedAt"`
-	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
-	UserID      uint           `gorm:"index;not null" json:"userId"`
-	User        User           `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
-	Name        string         `gorm:"size:255;not null" json:"name"`
-	Description string         `gorm:"type:text" json:"description"`
-	IsPublic    bool           `gorm:"default:false" json:"isPublic"`
+	ID          uint             `gorm:"primarykey" json:"id"`
+	CreatedAt   time.Time        `json:"createdAt"`
+	UpdatedAt   time.Time        `json:"updatedAt"`
+	DeletedAt   gorm.DeletedAt   `gorm:"index" json:"-"`
+	UserID      uint             `gorm:"index;not null" json:"userId"`
+	User        User             `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
+	Name        string           `gorm:"size:255;not null" json:"name"`
+	Description string           `gorm:"type:text" json:"description"`
+	IsPublic    bool             `gorm:"default:false" json:"isPublic"`
 	Items       []CollectionItem `gorm:"foreignKey:CollectionID" json:"items"`
 }
 
@@ -846,23 +846,23 @@ type PlayLaterItem struct {
 
 // SharedSession represents a shared play session where friends take turns playing a game.
 type SharedSession struct {
-	ID           uint                   `gorm:"primarykey" json:"id"`
-	CreatedAt    time.Time              `json:"createdAt"`
-	UpdatedAt    time.Time              `json:"updatedAt"`
-	DeletedAt    gorm.DeletedAt         `gorm:"index" json:"-"`
-	OwnerID      uint                   `gorm:"index;not null" json:"ownerId"`
-	Owner        User                   `gorm:"foreignKey:OwnerID;constraint:OnDelete:CASCADE" json:"-"`
-	GameID       uint                   `gorm:"index;not null" json:"gameId"`
-	Game         Game                   `gorm:"foreignKey:GameID" json:"-"`
-	Name         string                 `gorm:"size:255;not null" json:"name"`
-	Status       string                 `gorm:"size:32;default:active;not null" json:"status"` // "active", "completed", "archived"
-	ActiveUserID *uint                  `json:"activeUserId"`
-	TurnToken    string                 `gorm:"size:64" json:"-"`
-	TurnTakenAt  *time.Time             `json:"turnTakenAt"`
-	CoreName     string                 `gorm:"size:128" json:"coreName"`
-	SessionID    *uint                  `gorm:"index" json:"sessionId"`
-	Session      *GameSession           `json:"-"`
-	Members      []SharedSessionMember  `gorm:"foreignKey:SharedSessionID" json:"members"`
+	ID           uint                  `gorm:"primarykey" json:"id"`
+	CreatedAt    time.Time             `json:"createdAt"`
+	UpdatedAt    time.Time             `json:"updatedAt"`
+	DeletedAt    gorm.DeletedAt        `gorm:"index" json:"-"`
+	OwnerID      uint                  `gorm:"index;not null" json:"ownerId"`
+	Owner        User                  `gorm:"foreignKey:OwnerID;constraint:OnDelete:CASCADE" json:"-"`
+	GameID       uint                  `gorm:"index;not null" json:"gameId"`
+	Game         Game                  `gorm:"foreignKey:GameID" json:"-"`
+	Name         string                `gorm:"size:255;not null" json:"name"`
+	Status       string                `gorm:"size:32;default:active;not null" json:"status"` // "active", "completed", "archived"
+	ActiveUserID *uint                 `json:"activeUserId"`
+	TurnToken    string                `gorm:"size:64" json:"-"`
+	TurnTakenAt  *time.Time            `json:"turnTakenAt"`
+	CoreName     string                `gorm:"size:128" json:"coreName"`
+	SessionID    *uint                 `gorm:"index" json:"sessionId"`
+	Session      *GameSession          `json:"-"`
+	Members      []SharedSessionMember `gorm:"foreignKey:SharedSessionID" json:"members"`
 }
 
 // SharedSessionMember represents a user's membership in a shared session.
@@ -922,7 +922,7 @@ type NetplaySession struct {
 	GameID       uint           `gorm:"index;not null" json:"gameId"`
 	Game         Game           `gorm:"foreignKey:GameID" json:"-"`
 	Status       string         `gorm:"size:32;default:waiting;not null" json:"status"` // "waiting", "in_progress", "ended"
-	EndReason    string         `gorm:"size:32" json:"endReason"`              // "host_left", "client_left", "timeout", "completed"
+	EndReason    string         `gorm:"size:32" json:"endReason"`                       // "host_left", "client_left", "timeout", "completed"
 	InputDelay   int            `gorm:"default:3" json:"inputDelay"`
 	CoreName     string         `gorm:"size:128" json:"coreName"`
 	InviteCode   string         `gorm:"uniqueIndex;size:6;not null" json:"inviteCode"`
@@ -956,9 +956,9 @@ type Challenge struct {
 	Game            Game           `gorm:"foreignKey:GameID" json:"-"`
 	Name            string         `gorm:"size:255;not null" json:"name"`
 	Description     string         `gorm:"type:text" json:"description"`
-	Type            string         `gorm:"size:32;not null;default:completion" json:"type"`       // "completion", "speedrun", "survival"
-	Difficulty      string         `gorm:"size:32;not null;default:medium" json:"difficulty"`     // "easy", "medium", "hard"
-	Status          string         `gorm:"size:32;not null;default:active;index" json:"status"`   // "active", "closed", "expired"
+	Type            string         `gorm:"size:32;not null;default:completion" json:"type"`     // "completion", "speedrun", "survival"
+	Difficulty      string         `gorm:"size:32;not null;default:medium" json:"difficulty"`   // "easy", "medium", "hard"
+	Status          string         `gorm:"size:32;not null;default:active;index" json:"status"` // "active", "closed", "expired"
 	SaveFilePath    string         `gorm:"size:1024;not null" json:"-"`
 	SaveFileSize    int64          `json:"saveFileSize"`
 	ScreenshotPath  string         `gorm:"size:512" json:"-"`
@@ -1017,15 +1017,15 @@ type TopRatedGame struct {
 
 // SimilarGame caches IGDB similar games for a local game.
 type SimilarGame struct {
-	ID           uint           `gorm:"primarykey" json:"id"`
-	CreatedAt    time.Time      `json:"createdAt"`
-	UpdatedAt    time.Time      `json:"updatedAt"`
-	DeletedAt    gorm.DeletedAt `gorm:"index" json:"-"`
-	GameID       uint           `gorm:"index;not null" json:"gameId"`
-	Game         Game           `gorm:"foreignKey:GameID" json:"-"`
-	IGDBGameID   int            `gorm:"not null" json:"igdbGameId"`
-	Name         string         `gorm:"size:255;not null" json:"name"`
-	CoverImageID   string         `gorm:"size:128" json:"coverImageId"`
+	ID                uint           `gorm:"primarykey" json:"id"`
+	CreatedAt         time.Time      `json:"createdAt"`
+	UpdatedAt         time.Time      `json:"updatedAt"`
+	DeletedAt         gorm.DeletedAt `gorm:"index" json:"-"`
+	GameID            uint           `gorm:"index;not null" json:"gameId"`
+	Game              Game           `gorm:"foreignKey:GameID" json:"-"`
+	IGDBGameID        int            `gorm:"not null" json:"igdbGameId"`
+	Name              string         `gorm:"size:255;not null" json:"name"`
+	CoverImageID      string         `gorm:"size:128" json:"coverImageId"`
 	CoverLocalPath    string         `gorm:"size:512" json:"-"`
 	IGDBCriticsRating float64        `gorm:"column:rating" json:"igdbCriticsRating"`
 	LocalGameID       *uint          `json:"localGameId"`
@@ -1077,9 +1077,9 @@ type Core struct {
 	// staleness check on the player), see CorePlatformBinary. The manifest
 	// endpoint falls back to these when no per-platform row exists, so
 	// existing admin upload flows keep working without changes.
-	Sha256    string     `gorm:"size:64" json:"sha256"`    // hex sha256 of the cached binary
-	SizeBytes int64      `json:"sizeBytes"`                // byte length of the cached binary
-	FetchedAt *time.Time `json:"fetchedAt"`                // when the binary was last downloaded
+	Sha256    string     `gorm:"size:64" json:"sha256"`      // hex sha256 of the cached binary
+	SizeBytes int64      `json:"sizeBytes"`                  // byte length of the cached binary
+	FetchedAt *time.Time `json:"fetchedAt"`                  // when the binary was last downloaded
 	SourceURL string     `gorm:"size:1024" json:"sourceUrl"` // URL we pulled the binary from
 }
 
@@ -1123,21 +1123,21 @@ type CheatCode struct {
 // GameSession represents a user's play session for a game.
 // Each session groups save states and SRAM data together as a "playthrough".
 type GameSession struct {
-	ID             uint           `gorm:"primarykey" json:"id"`
-	CreatedAt      time.Time      `json:"createdAt"`
-	UpdatedAt      time.Time      `json:"updatedAt"`
-	DeletedAt      gorm.DeletedAt `gorm:"index" json:"-"`
-	OwnerID        uint           `gorm:"index;not null" json:"ownerId"`
-	Owner          User           `gorm:"foreignKey:OwnerID" json:"-"`
-	GameID         uint           `gorm:"index;not null" json:"gameId"`
-	Game           Game           `gorm:"foreignKey:GameID" json:"-"`
-	Name           string         `gorm:"size:255;not null" json:"name"`
-	LastPlayedAt   *time.Time     `json:"lastPlayedAt"`
-	LastPlayedBy   *uint          `json:"lastPlayedBy"`
-	TotalPlayTime  int64          `gorm:"default:0" json:"totalPlayTime"` // seconds
-	ScreenshotURL  string         `gorm:"size:512" json:"screenshotUrl"`
-	CoreName       string         `gorm:"size:128" json:"coreName"`
-	CheatsEnabled  bool           `gorm:"default:false" json:"cheatsEnabled"`
+	ID            uint           `gorm:"primarykey" json:"id"`
+	CreatedAt     time.Time      `json:"createdAt"`
+	UpdatedAt     time.Time      `json:"updatedAt"`
+	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
+	OwnerID       uint           `gorm:"index;not null" json:"ownerId"`
+	Owner         User           `gorm:"foreignKey:OwnerID" json:"-"`
+	GameID        uint           `gorm:"index;not null" json:"gameId"`
+	Game          Game           `gorm:"foreignKey:GameID" json:"-"`
+	Name          string         `gorm:"size:255;not null" json:"name"`
+	LastPlayedAt  *time.Time     `json:"lastPlayedAt"`
+	LastPlayedBy  *uint          `json:"lastPlayedBy"`
+	TotalPlayTime int64          `gorm:"default:0" json:"totalPlayTime"` // seconds
+	ScreenshotURL string         `gorm:"size:512" json:"screenshotUrl"`
+	CoreName      string         `gorm:"size:128" json:"coreName"`
+	CheatsEnabled bool           `gorm:"default:false" json:"cheatsEnabled"`
 	// PinnedCoreSha256 is the sha256 of the libretro core binary this session
 	// was first manually saved with. Set lazily on the first manual save (or
 	// auto-save) once we can resolve the matching Core row by name; never
@@ -1192,15 +1192,15 @@ type SessionSaveState struct {
 	// the specific binary that wrote the save) and — eventually — for
 	// rollback UX that offers the exact core version the save was made
 	// with. Empty when the player didn't supply one. See #555 Phase 3.
-	CoreSha256    string         `gorm:"size:64" json:"coreSha256"`
-	Notes         string         `gorm:"type:text" json:"notes"`
-	Slot          *int           `json:"slot"`
+	CoreSha256 string `gorm:"size:64" json:"coreSha256"`
+	Notes      string `gorm:"type:text" json:"notes"`
+	Slot       *int   `json:"slot"`
 	// Compression algorithm applied to the bytes at FilePath. Empty
 	// string = uncompressed (the only case for pre-#804 saves). Known
 	// values: "" | "gzip". Players that don't recognise a value should
 	// reject the save with a "newer client required" error rather than
 	// load garbage. See #804 phase 2.
-	Compression   string         `gorm:"size:16" json:"compression"`
+	Compression string `gorm:"size:16" json:"compression"`
 }
 
 // SessionSaveData represents SRAM/battery save data within a game session.
@@ -1419,15 +1419,15 @@ type StagedUpload struct {
 	PossibleConsoles string         `gorm:"size:512" json:"possibleConsoles"` // JSON array of abbreviations
 	Status           string         `gorm:"size:32;not null;default:pending_console" json:"status"`
 	// Scrape results
-	Title       string  `gorm:"size:255" json:"title"`
-	CoverURL    string  `gorm:"size:512" json:"coverUrl"`
+	Title             string  `gorm:"size:255" json:"title"`
+	CoverURL          string  `gorm:"size:512" json:"coverUrl"`
 	Description       string  `gorm:"type:text" json:"description"`
 	IGDBCriticsRating float64 `gorm:"column:rating" json:"igdbCriticsRating"`
 	Developer         string  `gorm:"size:255" json:"developer"`
-	Publisher   string  `gorm:"size:255" json:"publisher"`
-	Genre       string  `gorm:"size:128" json:"genre"`
-	Players     int     `json:"players"`
-	ReleaseDate string  `gorm:"size:32" json:"releaseDate"`
+	Publisher         string  `gorm:"size:255" json:"publisher"`
+	Genre             string  `gorm:"size:128" json:"genre"`
+	Players           int     `json:"players"`
+	ReleaseDate       string  `gorm:"size:32" json:"releaseDate"`
 	// Verification
 	VerificationStatus string `gorm:"size:32" json:"verificationStatus"` // verified, unverified, not_applicable
 	CRC32              string `gorm:"size:16" json:"crc32"`

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -513,6 +513,99 @@ type ServerSetting struct {
 	Value string `gorm:"type:text" json:"value"`
 }
 
+// --- Federation (epic #1343) ------------------------------------------------
+
+// Peer pairing status values.
+const (
+	PeerStatusPending = "pending" // invite accepted locally, awaiting mutual confirmation
+	PeerStatusActive  = "active"  // mutually confirmed; federation requests honored
+)
+
+// FederationPeer is a friend server we have paired with. We communicate ONLY
+// with direct peers in this table; transitive reach is achieved by peers
+// re-serving (relaying/aggregating) on our behalf. A peer is identified by its
+// key fingerprint, not its address. See docs/federation-mesh-exploration.md.
+type FederationPeer struct {
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"createdAt"`
+	UpdatedAt time.Time      `json:"updatedAt"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	// Fingerprint is the peer's stable anonymous origin ID (base32 of
+	// SHA-256 of its public key).
+	Fingerprint string `gorm:"uniqueIndex;size:64;not null" json:"fingerprint"`
+	// PublicKey is the peer's Ed25519 public key, base64 (std) encoded.
+	PublicKey string `gorm:"size:128;not null" json:"publicKey"`
+	// Name is an operator-chosen label for the friend.
+	Name string `gorm:"size:128" json:"name"`
+	// BaseURL is the peer's reachable federation endpoint (direct friends only).
+	BaseURL string `gorm:"size:512;not null" json:"baseUrl"`
+	// Status is "pending" or "active".
+	Status string `gorm:"size:16;not null;default:pending" json:"status"`
+	// SharePolicy / ConsumePolicy are JSON maps of data-class -> bool: what we
+	// expose to this peer, and what we accept from it (bidirectional per-class
+	// consent). Empty/absent = deny.
+	SharePolicy   string `gorm:"type:text" json:"sharePolicy"`
+	ConsumePolicy string `gorm:"type:text" json:"consumePolicy"`
+
+	// --- Observability: per-peer health (#1350) ---
+	// LastContactAt is the last time we exchanged anything with the peer
+	// (success or failure); LastSuccessAt only on success. LastError captures
+	// the most recent failure reason for the admin health view.
+	LastContactAt *time.Time `json:"lastContactAt"`
+	LastSuccessAt *time.Time `json:"lastSuccessAt"`
+	LastError     string     `gorm:"size:512" json:"lastError"`
+	LastErrorAt   *time.Time `json:"lastErrorAt"`
+	// Reachable is the latest known reachability (true after a successful
+	// exchange, false after a failure).
+	Reachable bool `gorm:"default:false" json:"reachable"`
+}
+
+// FederationInviteNonce records a nonce embedded in an invite this server
+// issued, so the pairing callback can prove it holds a genuine invite from us.
+type FederationInviteNonce struct {
+	ID        uint      `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time `json:"createdAt"`
+	Nonce     string    `gorm:"uniqueIndex;size:64;not null" json:"nonce"`
+	ExpiresAt time.Time `gorm:"not null;index" json:"expiresAt"`
+	Used      bool      `gorm:"default:false" json:"used"`
+}
+
+// Exchange direction and outcome values for FederationExchange (#1350).
+const (
+	ExchangeOutbound = "outbound" // we initiated the request to a peer
+	ExchangeInbound  = "inbound"  // a peer initiated the request to us
+
+	ExchangeOK       = "ok"       // completed successfully
+	ExchangeError    = "error"    // failed (network, peer error, internal)
+	ExchangeRejected = "rejected" // refused (bad signature, policy, expired nonce)
+)
+
+// FederationExchange is the per-interaction ledger powering admin visibility:
+// one row per cross-server interaction (handshake, stats pull, relay, ...), with
+// timing and outcome. High-volume by design — pruned on a retention window. The
+// "what data is being fetched, from whom, and when" record. See #1350.
+type FederationExchange struct {
+	ID        uint      `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time `gorm:"index" json:"createdAt"`
+	// RequestID correlates both ends of one logical operation (also emitted in
+	// logs and propagated via the X-Spela-Request-Id header).
+	RequestID       string `gorm:"size:64;index" json:"requestId"`
+	PeerFingerprint string `gorm:"size:64;index" json:"peerFingerprint"`
+	PeerName        string `gorm:"size:128" json:"peerName"`
+	Direction       string `gorm:"size:16;index" json:"direction"`
+	Operation       string `gorm:"size:64;index" json:"operation"`
+	DataClass       string `gorm:"size:32" json:"dataClass"`
+	MaxHops         int    `json:"maxHops"`
+	Status          string `gorm:"size:16;index" json:"status"`
+	HTTPStatus      int    `json:"httpStatus"`
+	ItemCount       int    `json:"itemCount"`
+	Bytes           int64  `json:"bytes"`
+	DurationMs      int64  `json:"durationMs"`
+	StartedAt       time.Time `json:"startedAt"`
+	FinishedAt      time.Time `json:"finishedAt"`
+	Error           string    `gorm:"size:512" json:"error"`
+}
+
 // ConsoleSaveStateChoice is the user's per-console save-state opt-out
 // state. Drives whether the in-game overlay shows the save/load
 // buttons or grays them out, and whether the first-launch prompt

--- a/server/internal/federation/exchange.go
+++ b/server/internal/federation/exchange.go
@@ -1,0 +1,137 @@
+package federation
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// NewRequestID returns a short random correlation id for one logical federation
+// operation. It is logged on both ends and propagated via X-Spela-Request-Id so
+// a single exchange can be traced across servers (#1350).
+func NewRequestID() string {
+	b := make([]byte, 12)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// ExchangeRecord is the parameter bag for recording a federation interaction.
+// Direction/Status use the db.Exchange* constants.
+type ExchangeRecord struct {
+	RequestID       string
+	PeerFingerprint string
+	PeerName        string
+	Direction       string
+	Operation       string
+	DataClass       string
+	MaxHops         int
+	Status          string
+	HTTPStatus      int
+	ItemCount       int
+	Bytes           int64
+	StartedAt       time.Time
+	FinishedAt      time.Time
+	Error           string
+}
+
+// RecordExchange persists one ledger row and emits a structured slog line. It
+// also updates the peer's health (last contact/success/error, reachability) so
+// the admin peers view reflects reality. Best-effort: a DB failure is logged but
+// never blocks the caller — observability must not break federation.
+func RecordExchange(database *gorm.DB, rec ExchangeRecord) {
+	if rec.FinishedAt.IsZero() {
+		rec.FinishedAt = time.Now()
+	}
+	if rec.StartedAt.IsZero() {
+		rec.StartedAt = rec.FinishedAt
+	}
+	durationMs := rec.FinishedAt.Sub(rec.StartedAt).Milliseconds()
+
+	logExchange(rec, durationMs)
+
+	row := db.FederationExchange{
+		RequestID:       rec.RequestID,
+		PeerFingerprint: rec.PeerFingerprint,
+		PeerName:        rec.PeerName,
+		Direction:       rec.Direction,
+		Operation:       rec.Operation,
+		DataClass:       rec.DataClass,
+		MaxHops:         rec.MaxHops,
+		Status:          rec.Status,
+		HTTPStatus:      rec.HTTPStatus,
+		ItemCount:       rec.ItemCount,
+		Bytes:           rec.Bytes,
+		DurationMs:      durationMs,
+		StartedAt:       rec.StartedAt,
+		FinishedAt:      rec.FinishedAt,
+		Error:           rec.Error,
+	}
+	if err := database.Create(&row).Error; err != nil {
+		slog.Warn("federation: failed to persist exchange", "request_id", rec.RequestID, "error", err)
+	}
+
+	updatePeerHealth(database, rec)
+}
+
+// updatePeerHealth folds the exchange outcome into the peer's health columns.
+func updatePeerHealth(database *gorm.DB, rec ExchangeRecord) {
+	if rec.PeerFingerprint == "" {
+		return
+	}
+	now := rec.FinishedAt
+	updates := map[string]any{"last_contact_at": now}
+	if rec.Status == db.ExchangeOK {
+		updates["last_success_at"] = now
+		updates["reachable"] = true
+	} else {
+		updates["last_error"] = truncate(rec.Error, 512)
+		updates["last_error_at"] = now
+		updates["reachable"] = false
+	}
+	// Best-effort; only touches an existing peer row.
+	if err := database.Model(&db.FederationPeer{}).
+		Where("fingerprint = ?", rec.PeerFingerprint).
+		Updates(updates).Error; err != nil {
+		slog.Warn("federation: failed to update peer health", "peer", ShortFingerprint(rec.PeerFingerprint), "error", err)
+	}
+}
+
+func logExchange(rec ExchangeRecord, durationMs int64) {
+	args := []any{
+		"component", "federation",
+		"request_id", rec.RequestID,
+		"peer", ShortFingerprint(rec.PeerFingerprint),
+		"direction", rec.Direction,
+		"op", rec.Operation,
+		"status", rec.Status,
+		"duration_ms", durationMs,
+	}
+	if rec.DataClass != "" {
+		args = append(args, "data_class", rec.DataClass)
+	}
+	if rec.ItemCount != 0 {
+		args = append(args, "items", rec.ItemCount)
+	}
+	if rec.Bytes != 0 {
+		args = append(args, "bytes", rec.Bytes)
+	}
+	if rec.Error != "" {
+		args = append(args, "error", rec.Error)
+	}
+	if rec.Status == db.ExchangeOK {
+		slog.Info("federation-exchange", args...)
+	} else {
+		slog.Warn("federation-exchange", args...)
+	}
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max]
+}

--- a/server/internal/federation/exchange.go
+++ b/server/internal/federation/exchange.go
@@ -84,10 +84,18 @@ func updatePeerHealth(database *gorm.DB, rec ExchangeRecord) {
 	}
 	now := rec.FinishedAt
 	updates := map[string]any{"last_contact_at": now}
-	if rec.Status == db.ExchangeOK {
+	switch rec.Status {
+	case db.ExchangeOK:
 		updates["last_success_at"] = now
 		updates["reachable"] = true
-	} else {
+	case db.ExchangeRejected:
+		// We DID communicate with the peer — they're reachable — but the
+		// request was refused (bad signature / policy / nonce). Record the
+		// error without flipping reachability to false.
+		updates["last_error"] = truncate(rec.Error, 512)
+		updates["last_error_at"] = now
+		updates["reachable"] = true
+	default: // ExchangeError: failed to reach the peer / transport or remote error
 		updates["last_error"] = truncate(rec.Error, 512)
 		updates["last_error_at"] = now
 		updates["reachable"] = false

--- a/server/internal/federation/exchange_test.go
+++ b/server/internal/federation/exchange_test.go
@@ -1,0 +1,72 @@
+package federation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRequestID_UniqueNonEmpty(t *testing.T) {
+	a := NewRequestID()
+	b := NewRequestID()
+	assert.NotEmpty(t, a)
+	assert.NotEqual(t, a, b)
+}
+
+func TestRecordExchange_WritesLedgerRow(t *testing.T) {
+	database := openFedTestDB(t)
+	start := time.Now().Add(-50 * time.Millisecond)
+
+	RecordExchange(database, ExchangeRecord{
+		RequestID: "req-1", PeerFingerprint: "fp-a", PeerName: "Alice",
+		Direction: db.ExchangeOutbound, Operation: "handshake",
+		Status: db.ExchangeOK, ItemCount: 3, StartedAt: start, FinishedAt: time.Now(),
+	})
+
+	var row db.FederationExchange
+	require.NoError(t, database.Where("request_id = ?", "req-1").First(&row).Error)
+	assert.Equal(t, db.ExchangeOK, row.Status)
+	assert.Equal(t, 3, row.ItemCount)
+	assert.GreaterOrEqual(t, row.DurationMs, int64(0))
+}
+
+func TestRecordExchange_UpdatesPeerHealthOnSuccess(t *testing.T) {
+	database := openFedTestDB(t)
+	store := PeerStore{DB: database}
+	require.NoError(t, store.Upsert(&db.FederationPeer{
+		Fingerprint: "fp-h", PublicKey: "k", BaseURL: "https://h", Status: db.PeerStatusActive,
+	}))
+
+	RecordExchange(database, ExchangeRecord{
+		RequestID: "r", PeerFingerprint: "fp-h", Direction: db.ExchangeOutbound,
+		Operation: "stats_pull", Status: db.ExchangeOK,
+	})
+
+	got, err := store.GetByFingerprint("fp-h")
+	require.NoError(t, err)
+	assert.True(t, got.Reachable)
+	require.NotNil(t, got.LastSuccessAt)
+	require.NotNil(t, got.LastContactAt)
+}
+
+func TestRecordExchange_UpdatesPeerHealthOnError(t *testing.T) {
+	database := openFedTestDB(t)
+	store := PeerStore{DB: database}
+	require.NoError(t, store.Upsert(&db.FederationPeer{
+		Fingerprint: "fp-e", PublicKey: "k", BaseURL: "https://e", Status: db.PeerStatusActive, Reachable: true,
+	}))
+
+	RecordExchange(database, ExchangeRecord{
+		RequestID: "r", PeerFingerprint: "fp-e", Direction: db.ExchangeOutbound,
+		Operation: "stats_pull", Status: db.ExchangeError, Error: "connection refused",
+	})
+
+	got, err := store.GetByFingerprint("fp-e")
+	require.NoError(t, err)
+	assert.False(t, got.Reachable)
+	assert.Equal(t, "connection refused", got.LastError)
+	require.NotNil(t, got.LastErrorAt)
+}

--- a/server/internal/federation/identity.go
+++ b/server/internal/federation/identity.go
@@ -1,0 +1,49 @@
+package federation
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base32"
+	"fmt"
+	"strings"
+)
+
+// Identity is this server's federation identity. The public key's fingerprint
+// is the stable, anonymous origin ID used across the mesh; the private key
+// signs invites and federation requests.
+type Identity struct {
+	PrivateKey ed25519.PrivateKey
+	PublicKey  ed25519.PublicKey
+}
+
+// GenerateIdentity creates a fresh Ed25519 identity.
+func GenerateIdentity() (Identity, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return Identity{}, fmt.Errorf("generating ed25519 key: %w", err)
+	}
+	return Identity{PrivateKey: priv, PublicKey: pub}, nil
+}
+
+// fingerprintEncoding is lowercase base32 without padding — URL/header safe and
+// case-insensitive friendly.
+var fingerprintEncoding = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// Fingerprint returns the stable, anonymous origin ID for a public key:
+// lowercase base32 of SHA-256(pubkey). Recognizable, not contactable.
+func Fingerprint(pub ed25519.PublicKey) string {
+	sum := sha256.Sum256(pub)
+	return strings.ToLower(fingerprintEncoding.EncodeToString(sum[:]))
+}
+
+// Fingerprint returns the identity's own fingerprint.
+func (id Identity) Fingerprint() string { return Fingerprint(id.PublicKey) }
+
+// ShortFingerprint returns a truncated fingerprint for log lines.
+func ShortFingerprint(fp string) string {
+	if len(fp) <= 10 {
+		return fp
+	}
+	return fp[:10]
+}

--- a/server/internal/federation/identity_store.go
+++ b/server/internal/federation/identity_store.go
@@ -1,0 +1,77 @@
+package federation
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	"github.com/spela/server/internal/auth"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+const (
+	settingKeyPrivateKey = "federation_identity_private"
+	settingKeyPublicKey  = "federation_identity_public"
+)
+
+// LoadOrCreateIdentity returns the server's persisted federation identity,
+// generating and storing a new one on first call. The private key is encrypted
+// at rest with aesKey (the same key used for other secret settings).
+func LoadOrCreateIdentity(database *gorm.DB, aesKey []byte) (Identity, error) {
+	privEnc, err := readSetting(database, settingKeyPrivateKey)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return Identity{}, fmt.Errorf("reading stored identity: %w", err)
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) || privEnc == "" {
+		return createAndStoreIdentity(database, aesKey)
+	}
+
+	privB64, err := auth.Decrypt(privEnc, aesKey)
+	if err != nil {
+		return Identity{}, fmt.Errorf("decrypting identity private key: %w", err)
+	}
+	privBytes, err := base64.StdEncoding.DecodeString(privB64)
+	if err != nil {
+		return Identity{}, fmt.Errorf("decoding identity private key: %w", err)
+	}
+	if len(privBytes) != ed25519.PrivateKeySize {
+		return Identity{}, fmt.Errorf("stored private key has wrong size %d", len(privBytes))
+	}
+	priv := ed25519.PrivateKey(privBytes)
+	return Identity{PrivateKey: priv, PublicKey: priv.Public().(ed25519.PublicKey)}, nil
+}
+
+func createAndStoreIdentity(database *gorm.DB, aesKey []byte) (Identity, error) {
+	id, err := GenerateIdentity()
+	if err != nil {
+		return Identity{}, err
+	}
+	privB64 := base64.StdEncoding.EncodeToString(id.PrivateKey)
+	privEnc, err := auth.Encrypt(privB64, aesKey)
+	if err != nil {
+		return Identity{}, fmt.Errorf("encrypting identity private key: %w", err)
+	}
+	pubB64 := base64.StdEncoding.EncodeToString(id.PublicKey)
+
+	if err := writeSetting(database, settingKeyPrivateKey, privEnc); err != nil {
+		return Identity{}, err
+	}
+	if err := writeSetting(database, settingKeyPublicKey, pubB64); err != nil {
+		return Identity{}, err
+	}
+	return id, nil
+}
+
+func readSetting(database *gorm.DB, key string) (string, error) {
+	var s db.ServerSetting
+	if err := database.Where("key = ?", key).First(&s).Error; err != nil {
+		return "", err
+	}
+	return s.Value, nil
+}
+
+func writeSetting(database *gorm.DB, key, value string) error {
+	return database.Save(&db.ServerSetting{Key: key, Value: value}).Error
+}

--- a/server/internal/federation/identity_store_test.go
+++ b/server/internal/federation/identity_store_test.go
@@ -1,0 +1,34 @@
+package federation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadOrCreateIdentity_CreatesThenReloadsSameKey(t *testing.T) {
+	database := openFedTestDB(t)
+
+	first, err := LoadOrCreateIdentity(database, testAESKey)
+	require.NoError(t, err)
+	assert.NotEmpty(t, first.Fingerprint())
+
+	// A second call must return the SAME identity, not generate a new one.
+	second, err := LoadOrCreateIdentity(database, testAESKey)
+	require.NoError(t, err)
+	assert.Equal(t, first.Fingerprint(), second.Fingerprint())
+	assert.Equal(t, []byte(first.PrivateKey), []byte(second.PrivateKey))
+}
+
+func TestLoadOrCreateIdentity_PrivateKeyEncryptedAtRest(t *testing.T) {
+	database := openFedTestDB(t)
+	_, err := LoadOrCreateIdentity(database, testAESKey)
+	require.NoError(t, err)
+
+	stored, err := readSetting(database, settingKeyPrivateKey)
+	require.NoError(t, err)
+	// auth.Encrypt prefixes ciphertext with "enc:". The raw stored value must
+	// not be the plaintext base64 key.
+	assert.True(t, len(stored) > 4 && stored[:4] == "enc:", "private key must be stored encrypted")
+}

--- a/server/internal/federation/identity_test.go
+++ b/server/internal/federation/identity_test.go
@@ -1,0 +1,42 @@
+package federation
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateIdentity_ProducesUsableKeypair(t *testing.T) {
+	id, err := GenerateIdentity()
+	require.NoError(t, err)
+	assert.Len(t, id.PublicKey, ed25519.PublicKeySize)
+	assert.Len(t, id.PrivateKey, ed25519.PrivateKeySize)
+}
+
+func TestFingerprint_StableAndDeterministic(t *testing.T) {
+	id, err := GenerateIdentity()
+	require.NoError(t, err)
+
+	fp1 := id.Fingerprint()
+	fp2 := Fingerprint(id.PublicKey)
+
+	assert.Equal(t, fp1, fp2, "fingerprint must be deterministic for the same key")
+	assert.NotEmpty(t, fp1)
+	// base32 (no padding) of a 32-byte digest is 52 lowercase chars.
+	assert.Len(t, fp1, 52)
+}
+
+func TestFingerprint_DiffersAcrossKeys(t *testing.T) {
+	a, _ := GenerateIdentity()
+	b, _ := GenerateIdentity()
+	assert.NotEqual(t, a.Fingerprint(), b.Fingerprint())
+}
+
+func TestShortFingerprint(t *testing.T) {
+	id, _ := GenerateIdentity()
+	short := ShortFingerprint(id.Fingerprint())
+	assert.Len(t, short, 10)
+	assert.Equal(t, "short", ShortFingerprint("short"))
+}

--- a/server/internal/federation/invite.go
+++ b/server/internal/federation/invite.go
@@ -1,0 +1,87 @@
+package federation
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Invite is a signed pairing offer. The operator transmits the encoded form
+// out-of-band (paste/QR/link) to the friend they want to pair with.
+type Invite struct {
+	Fingerprint string `json:"fingerprint"`
+	PublicKey   string `json:"publicKey"` // base64 std of ed25519 public key
+	BaseURL     string `json:"baseUrl"`
+	Nonce       string `json:"nonce"`
+	ExpiresUnix int64  `json:"expiresUnix"`
+	Signature   string `json:"sig"` // base64 std of signature over canonical bytes
+}
+
+// canonicalInviteBytes is the deterministic byte string that gets signed. Field
+// order and separators are fixed so signing and verification agree.
+func canonicalInviteBytes(fingerprint, publicKey, baseURL, nonce string, expiresUnix int64) []byte {
+	return []byte(fmt.Sprintf("spela-invite\nfp=%s\npk=%s\nurl=%s\nnonce=%s\nexp=%d",
+		fingerprint, publicKey, baseURL, nonce, expiresUnix))
+}
+
+// NewInvite builds and signs an invite from this identity.
+func (id Identity) NewInvite(baseURL, nonce string, expiresAt time.Time) Invite {
+	pubB64 := base64.StdEncoding.EncodeToString(id.PublicKey)
+	fp := id.Fingerprint()
+	exp := expiresAt.Unix()
+	sig := id.Sign(canonicalInviteBytes(fp, pubB64, baseURL, nonce, exp))
+	return Invite{
+		Fingerprint: fp,
+		PublicKey:   pubB64,
+		BaseURL:     baseURL,
+		Nonce:       nonce,
+		ExpiresUnix: exp,
+		Signature:   base64.StdEncoding.EncodeToString(sig),
+	}
+}
+
+// EncodeInvite serializes an invite to a single base64 string for copy-paste.
+func EncodeInvite(inv Invite) string {
+	b, _ := json.Marshal(inv)
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// DecodeInvite parses an encoded invite string.
+func DecodeInvite(s string) (Invite, error) {
+	raw, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return Invite{}, fmt.Errorf("decoding invite: %w", err)
+	}
+	var inv Invite
+	if err := json.Unmarshal(raw, &inv); err != nil {
+		return Invite{}, fmt.Errorf("parsing invite: %w", err)
+	}
+	return inv, nil
+}
+
+// VerifyInvite checks the invite's signature, fingerprint<->key binding, and
+// expiry (against now). It does NOT check the nonce against any local store —
+// that is the receiver's job during pairing.
+func VerifyInvite(inv Invite, now time.Time) (bool, error) {
+	pub, err := base64.StdEncoding.DecodeString(inv.PublicKey)
+	if err != nil {
+		return false, fmt.Errorf("decoding public key: %w", err)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		return false, nil
+	}
+	if Fingerprint(pub) != inv.Fingerprint {
+		return false, nil // fingerprint must be derived from the embedded key
+	}
+	if now.Unix() > inv.ExpiresUnix {
+		return false, nil
+	}
+	sig, err := base64.StdEncoding.DecodeString(inv.Signature)
+	if err != nil {
+		return false, fmt.Errorf("decoding signature: %w", err)
+	}
+	msg := canonicalInviteBytes(inv.Fingerprint, inv.PublicKey, inv.BaseURL, inv.Nonce, inv.ExpiresUnix)
+	return Verify(pub, msg, sig), nil
+}

--- a/server/internal/federation/invite_test.go
+++ b/server/internal/federation/invite_test.go
@@ -1,0 +1,55 @@
+package federation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvite_EncodeDecodeVerify(t *testing.T) {
+	id, _ := GenerateIdentity()
+	exp := time.Unix(2_000_000_000, 0)
+
+	inv := id.NewInvite("https://alice.example", "nonce-123", exp)
+	encoded := EncodeInvite(inv)
+	assert.NotEmpty(t, encoded)
+
+	decoded, err := DecodeInvite(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, id.Fingerprint(), decoded.Fingerprint)
+	assert.Equal(t, "https://alice.example", decoded.BaseURL)
+	assert.Equal(t, "nonce-123", decoded.Nonce)
+
+	ok, err := VerifyInvite(decoded, time.Unix(1_900_000_000, 0))
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestVerifyInvite_RejectsExpired(t *testing.T) {
+	id, _ := GenerateIdentity()
+	inv := id.NewInvite("https://a", "n", time.Unix(1000, 0))
+	ok, err := VerifyInvite(inv, time.Unix(2000, 0))
+	require.NoError(t, err)
+	assert.False(t, ok, "expired invite must not verify")
+}
+
+func TestVerifyInvite_RejectsTamperedBaseURL(t *testing.T) {
+	id, _ := GenerateIdentity()
+	inv := id.NewInvite("https://a", "n", time.Unix(2_000_000_000, 0))
+	inv.BaseURL = "https://evil"
+	ok, err := VerifyInvite(inv, time.Unix(1000, 0))
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestVerifyInvite_RejectsFingerprintKeyMismatch(t *testing.T) {
+	id, _ := GenerateIdentity()
+	other, _ := GenerateIdentity()
+	inv := id.NewInvite("https://a", "n", time.Unix(2_000_000_000, 0))
+	inv.Fingerprint = other.Fingerprint() // fingerprint no longer matches PublicKey
+	ok, err := VerifyInvite(inv, time.Unix(1000, 0))
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/server/internal/federation/peer_store.go
+++ b/server/internal/federation/peer_store.go
@@ -1,0 +1,51 @@
+package federation
+
+import (
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// PeerStore is the friend registry: CRUD over db.FederationPeer.
+type PeerStore struct {
+	DB *gorm.DB
+}
+
+// Upsert creates or updates a peer keyed by Fingerprint.
+func (s PeerStore) Upsert(peer *db.FederationPeer) error {
+	return s.DB.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "fingerprint"}},
+		DoUpdates: clause.AssignmentColumns([]string{"public_key", "name", "base_url", "status", "share_policy", "consume_policy", "updated_at"}),
+	}).Create(peer).Error
+}
+
+// GetByFingerprint returns the peer with the given fingerprint, or
+// gorm.ErrRecordNotFound.
+func (s PeerStore) GetByFingerprint(fp string) (*db.FederationPeer, error) {
+	var peer db.FederationPeer
+	if err := s.DB.Where("fingerprint = ?", fp).First(&peer).Error; err != nil {
+		return nil, err
+	}
+	return &peer, nil
+}
+
+// List returns all peers ordered by name.
+func (s PeerStore) List() ([]db.FederationPeer, error) {
+	var peers []db.FederationPeer
+	if err := s.DB.Order("name ASC").Find(&peers).Error; err != nil {
+		return nil, err
+	}
+	return peers, nil
+}
+
+// SetStatus updates a peer's pairing status.
+func (s PeerStore) SetStatus(fp, status string) error {
+	return s.DB.Model(&db.FederationPeer{}).Where("fingerprint = ?", fp).
+		Update("status", status).Error
+}
+
+// Remove hard-deletes a peer (revocation). After this, signed requests from the
+// peer no longer verify.
+func (s PeerStore) Remove(fp string) error {
+	return s.DB.Unscoped().Where("fingerprint = ?", fp).Delete(&db.FederationPeer{}).Error
+}

--- a/server/internal/federation/peer_store.go
+++ b/server/internal/federation/peer_store.go
@@ -46,6 +46,11 @@ func (s PeerStore) SetStatus(fp, status string) error {
 
 // Remove hard-deletes a peer (revocation). After this, signed requests from the
 // peer no longer verify.
+//
+// The hard delete (Unscoped) is load-bearing: FederationPeer has a soft-delete
+// column, and the unique index is on `fingerprint` alone. A soft delete would
+// leave a row that (a) blocks re-pairing via Upsert's OnConflict and (b) could
+// be silently resurrected as active. Do not switch this to a soft delete.
 func (s PeerStore) Remove(fp string) error {
 	return s.DB.Unscoped().Where("fingerprint = ?", fp).Delete(&db.FederationPeer{}).Error
 }

--- a/server/internal/federation/peer_store_test.go
+++ b/server/internal/federation/peer_store_test.go
@@ -1,0 +1,58 @@
+package federation
+
+import (
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeerStore_UpsertGetList(t *testing.T) {
+	store := PeerStore{DB: openFedTestDB(t)}
+
+	require.NoError(t, store.Upsert(&db.FederationPeer{
+		Fingerprint: "fp1", PublicKey: "k1", Name: "Alice", BaseURL: "https://a", Status: db.PeerStatusActive,
+	}))
+
+	got, err := store.GetByFingerprint("fp1")
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", got.Name)
+
+	// Upsert with the same fingerprint updates rather than duplicates.
+	require.NoError(t, store.Upsert(&db.FederationPeer{
+		Fingerprint: "fp1", PublicKey: "k1", Name: "Alice Renamed", BaseURL: "https://a", Status: db.PeerStatusActive,
+	}))
+	list, err := store.List()
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "Alice Renamed", list[0].Name)
+}
+
+func TestPeerStore_RemoveRevokes(t *testing.T) {
+	store := PeerStore{DB: openFedTestDB(t)}
+	require.NoError(t, store.Upsert(&db.FederationPeer{
+		Fingerprint: "fp2", PublicKey: "k", BaseURL: "https://b", Status: db.PeerStatusActive,
+	}))
+	require.NoError(t, store.Remove("fp2"))
+
+	_, err := store.GetByFingerprint("fp2")
+	assert.Error(t, err, "removed peer must no longer be found")
+}
+
+func TestPeerStore_GetByFingerprint_NotFound(t *testing.T) {
+	store := PeerStore{DB: openFedTestDB(t)}
+	_, err := store.GetByFingerprint("missing")
+	assert.Error(t, err)
+}
+
+func TestPeerStore_SetStatus(t *testing.T) {
+	store := PeerStore{DB: openFedTestDB(t)}
+	require.NoError(t, store.Upsert(&db.FederationPeer{
+		Fingerprint: "fp3", PublicKey: "k", BaseURL: "https://c", Status: db.PeerStatusPending,
+	}))
+	require.NoError(t, store.SetStatus("fp3", db.PeerStatusActive))
+	got, err := store.GetByFingerprint("fp3")
+	require.NoError(t, err)
+	assert.Equal(t, db.PeerStatusActive, got.Status)
+}

--- a/server/internal/federation/policy.go
+++ b/server/internal/federation/policy.go
@@ -1,0 +1,69 @@
+package federation
+
+import (
+	"encoding/json"
+
+	"github.com/spela/server/internal/db"
+)
+
+// DataClass enumerates federated data categories, each with its own reach and
+// consent policy. See the matrix in docs/federation-mesh-exploration.md.
+type DataClass string
+
+const (
+	DataClassStats       DataClass = "stats"        // aggregate top-lists / playtime
+	DataClassTopPlayers  DataClass = "top_players"  // personal leaderboards
+	DataClassCatalog     DataClass = "catalog"      // game availability metadata
+	DataClassDownload    DataClass = "download"     // ROM relay
+	DataClassPresence    DataClass = "presence"     // who's playing now
+	DataClassReviews     DataClass = "reviews"      // ratings/reviews
+	DataClassAchievement DataClass = "achievements" // achievements/challenges
+)
+
+// AllDataClasses is the canonical list, for UI enumeration and defaults.
+var AllDataClasses = []DataClass{
+	DataClassStats, DataClassTopPlayers, DataClassCatalog, DataClassDownload,
+	DataClassPresence, DataClassReviews, DataClassAchievement,
+}
+
+// MarshalPolicy serializes a data-class -> allowed map to JSON for storage.
+func MarshalPolicy(p map[DataClass]bool) (string, error) {
+	if p == nil {
+		p = map[DataClass]bool{}
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// ParsePolicy parses a stored policy JSON string. Empty string => deny-all.
+func ParsePolicy(s string) (map[DataClass]bool, error) {
+	out := map[DataClass]bool{}
+	if s == "" {
+		return out, nil
+	}
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// CanShare reports whether we expose the given class to this peer.
+func CanShare(peer db.FederationPeer, class DataClass) bool {
+	p, err := ParsePolicy(peer.SharePolicy)
+	if err != nil {
+		return false
+	}
+	return p[class]
+}
+
+// CanConsume reports whether we accept the given class from this peer.
+func CanConsume(peer db.FederationPeer, class DataClass) bool {
+	p, err := ParsePolicy(peer.ConsumePolicy)
+	if err != nil {
+		return false
+	}
+	return p[class]
+}

--- a/server/internal/federation/policy_test.go
+++ b/server/internal/federation/policy_test.go
@@ -1,0 +1,37 @@
+package federation
+
+import (
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyRoundTrip(t *testing.T) {
+	in := map[DataClass]bool{DataClassStats: true, DataClassCatalog: false}
+	encoded, err := MarshalPolicy(in)
+	require.NoError(t, err)
+
+	out, err := ParsePolicy(encoded)
+	require.NoError(t, err)
+	assert.True(t, out[DataClassStats])
+	assert.False(t, out[DataClassCatalog])
+}
+
+func TestParsePolicy_EmptyDeniesAll(t *testing.T) {
+	out, err := ParsePolicy("")
+	require.NoError(t, err)
+	assert.False(t, out[DataClassStats])
+}
+
+func TestCanConsumeAndShare(t *testing.T) {
+	share, _ := MarshalPolicy(map[DataClass]bool{DataClassStats: true})
+	consume, _ := MarshalPolicy(map[DataClass]bool{DataClassCatalog: true})
+	peer := db.FederationPeer{SharePolicy: share, ConsumePolicy: consume}
+
+	assert.True(t, CanShare(peer, DataClassStats))
+	assert.False(t, CanShare(peer, DataClassCatalog))
+	assert.True(t, CanConsume(peer, DataClassCatalog))
+	assert.False(t, CanConsume(peer, DataClassStats))
+}

--- a/server/internal/federation/sign.go
+++ b/server/internal/federation/sign.go
@@ -1,0 +1,16 @@
+package federation
+
+import "crypto/ed25519"
+
+// Sign signs msg with this identity's private key.
+func (id Identity) Sign(msg []byte) []byte {
+	return ed25519.Sign(id.PrivateKey, msg)
+}
+
+// Verify reports whether sig is a valid signature of msg under pub.
+func Verify(pub ed25519.PublicKey, msg, sig []byte) bool {
+	if len(pub) != ed25519.PublicKeySize {
+		return false
+	}
+	return ed25519.Verify(pub, msg, sig)
+}

--- a/server/internal/federation/sign_test.go
+++ b/server/internal/federation/sign_test.go
@@ -1,0 +1,31 @@
+package federation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignVerify_RoundTrip(t *testing.T) {
+	id, err := GenerateIdentity()
+	require.NoError(t, err)
+
+	msg := []byte("federation: hello")
+	sig := id.Sign(msg)
+
+	assert.True(t, Verify(id.PublicKey, msg, sig), "valid signature must verify")
+}
+
+func TestVerify_RejectsTamperedMessage(t *testing.T) {
+	id, _ := GenerateIdentity()
+	sig := id.Sign([]byte("original"))
+	assert.False(t, Verify(id.PublicKey, []byte("tampered"), sig))
+}
+
+func TestVerify_RejectsWrongKey(t *testing.T) {
+	a, _ := GenerateIdentity()
+	b, _ := GenerateIdentity()
+	sig := a.Sign([]byte("msg"))
+	assert.False(t, Verify(b.PublicKey, []byte("msg"), sig))
+}

--- a/server/internal/federation/testutil_test.go
+++ b/server/internal/federation/testutil_test.go
@@ -1,0 +1,31 @@
+package federation
+
+import (
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// openFedTestDB returns an in-memory SQLite DB migrated with the federation
+// tables plus ServerSetting (used for identity persistence).
+func openFedTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(
+		&db.ServerSetting{},
+		&db.FederationPeer{},
+		&db.FederationInviteNonce{},
+		&db.FederationExchange{},
+	))
+	return database
+}
+
+// testAESKey is a fixed 32-byte AES key for deterministic encryption tests.
+var testAESKey = []byte("0123456789abcdef0123456789abcdef")


### PR DESCRIPTION
## Federation Phase 0 — Identity & Trust Fabric

First slice of the federation mesh (epic #1343): the dependency-free foundation that lets a Spela server prove its identity, pair with a friend server, and revoke it. **No application data crosses the wire yet** — this is purely the trust + observability machinery everything else builds on.

Design context: `docs/federation-mesh-exploration.md`.

### What's included
- **`internal/federation` package** — Ed25519 server identity (persisted in `ServerSetting`, private key encrypted at rest via `auth.Encrypt`), anonymous fingerprint (base32 of SHA-256 of the pubkey), sign/verify, the peer-registry store, bidirectional per-class share/consume policy, signed pairing invites, and the exchange recorder.
- **Models + migration** — `FederationPeer` (with per-peer health columns), `FederationInviteNonce`, and the `FederationExchange` observability ledger.
- **Invite-gated, mutually-confirmed pairing** — `POST /api/admin/federation/invite` → friend `POST /api/admin/federation/peers/accept` → callback to the public bootstrap `POST /api/federation/pair` → both sides end up `active`. You can only pair with someone holding an invite you issued (nonce check).
- **Signed-request middleware** (`VerifyFederationRequest`) — replay-protected Ed25519 auth (method + path + timestamp + body hash) for all future server-to-server data calls; exercised in Phase 0 by the signed `GET /api/federation/ping`.
- **Admin endpoints** — issue/accept invite, list peers (with health), revoke, **connection-test diagnostic**, and the exchange-ledger read.
- **Wiring** — identity initializes on boot; `SPELA_PUBLIC_URL` sets the invite callback URL.

### Observability (built in from the first interaction, #1350)
Federation is distributed and will be flaky at first, so every cross-server interaction is diagnosable three ways:
- **Structured logs** — `component=federation request_id=… peer=… direction=… op=… status=… duration_ms=… error=…`, with the `request_id` propagated via `X-Spela-Request-Id` so one operation can be traced across both servers.
- **`FederationExchange` ledger** — one row per interaction, queryable at `GET /api/admin/federation/exchanges` (filter by peer/direction/status).
- **Per-peer health** — `reachable`, last success/error, surfaced in the peers list.
- **Active connection test** — `POST /api/admin/federation/peers/{fingerprint}/test` does a signed ping round-trip and reports reachability, latency, clock skew, and fingerprint match.

A failed handshake or ping is fully diagnosable from logs + ledger + health alone.

### Testing
- New unit/integration tests across `internal/federation`, `internal/db`, and `internal/api` (identity, sign/verify, persistence, peer store, policy, invites, exchange recorder + health, signed-request middleware, pairing handler, and all admin endpoints incl. connection-test).
- **Full `go test ./...` passes with no regressions**; `go build ./...` and `gofmt` clean.
- Suggested during review: a live two-instance smoke (boot two servers, real invite→accept→test-connection round-trip) — the unit suite uses fakes for the outbound HTTP client.

### Deferred (follow-ups tracked in #1350)
SystemEvent integration for notable-event alerting (currently ledger + slog), the live WebSocket admin feed, the web admin UI, and ledger retention/pruning. Then Phases 1–4 (#1346–#1349).

Closes #1345
Part of #1343
