### PR TITLE
feat(server): federation Phase 1 — direct-friend aggregate stats (#1346)

### DIFF
--- a/server/internal/api/federation_client.go
+++ b/server/internal/api/federation_client.go
@@ -22,10 +22,11 @@ func fedHTTPClient() *http.Client { return &http.Client{Timeout: federationHTTPT
 
 // signedFederationHeaders builds the signed headers for an outbound
 // server-to-server request, matching what VerifyFederationRequest expects.
-func signedFederationHeaders(id federation.Identity, method, path, requestID string, body []byte) map[string]string {
+// recipientFingerprint binds the request to its intended recipient.
+func signedFederationHeaders(id federation.Identity, method, path, requestID string, body []byte, recipientFingerprint string) map[string]string {
 	ts := strconv.FormatInt(time.Now().Unix(), 10)
 	bodyHash := sha256.Sum256(body)
-	sig := id.Sign(signedRequestMessage(method, path, ts, hex.EncodeToString(bodyHash[:])))
+	sig := id.Sign(signedRequestMessage(method, path, ts, hex.EncodeToString(bodyHash[:]), recipientFingerprint))
 	return map[string]string{
 		headerFedFingerprint: id.Fingerprint(),
 		headerFedTimestamp:   ts,
@@ -83,7 +84,7 @@ func (httpPeerPinger) Ping(baseURL, requestID string, id federation.Identity, ex
 	if err != nil {
 		return PingResult{Error: err.Error()}
 	}
-	for k, v := range signedFederationHeaders(id, http.MethodGet, path, requestID, nil) {
+	for k, v := range signedFederationHeaders(id, http.MethodGet, path, requestID, nil, expectFingerprint) {
 		req.Header.Set(k, v)
 	}
 	start := time.Now()

--- a/server/internal/api/federation_mw.go
+++ b/server/internal/api/federation_mw.go
@@ -35,25 +35,22 @@ const federationTimestampSkew = 5 * time.Minute
 const fedPeerContextKey = "federationPeer"
 
 // signedRequestMessage is the canonical byte string a peer signs for a
-// server-to-server request: method, path, timestamp, and body hash. Both the
-// signer (outbound client) and verifier (this middleware) must build it
-// identically.
-//
-// NOTE: this does NOT bind the recipient server's identity, so a signed request
-// is replayable to any other server the same peer is paired with, within the
-// timestamp skew window. Harmless in Phase 0 (the only signed endpoint is the
-// read-only /ping). Before any *mutating* federated endpoint lands (Phase 1,
-// #1346), bind the recipient fingerprint into this payload.
-func signedRequestMessage(method, path, timestamp, bodyHashHex string) []byte {
-	return []byte(fmt.Sprintf("%s\n%s\n%s\n%s", method, path, timestamp, bodyHashHex))
+// server-to-server request: method, path, timestamp, body hash, AND the
+// recipient server's fingerprint. Binding the recipient prevents a captured
+// signed request from being replayed against a different server the same peer is
+// paired with (within the skew window). Both the signer (outbound client) and
+// verifier (this middleware) must build it identically.
+func signedRequestMessage(method, path, timestamp, bodyHashHex, recipientFingerprint string) []byte {
+	return []byte(fmt.Sprintf("%s\n%s\n%s\n%s\n%s", method, path, timestamp, bodyHashHex, recipientFingerprint))
 }
 
 // VerifyFederationRequest authenticates server-to-server requests: it requires a
-// known, active peer whose Ed25519 signature covers method, path, timestamp, and
-// body hash, within the allowed clock skew. On success the verified peer is set
-// on the gin context under fedPeerContextKey. Rejections are logged (not written
-// to the ledger) to avoid a hostile peer flooding storage.
-func VerifyFederationRequest(database *gorm.DB) gin.HandlerFunc {
+// known, active peer whose Ed25519 signature covers method, path, timestamp,
+// body hash, and this server's own fingerprint (selfFingerprint), within the
+// allowed clock skew. On success the verified peer is set on the gin context
+// under fedPeerContextKey. Rejections are logged (not written to the ledger) to
+// avoid a hostile peer flooding storage.
+func VerifyFederationRequest(database *gorm.DB, selfFingerprint string) gin.HandlerFunc {
 	store := federation.PeerStore{DB: database}
 	return func(c *gin.Context) {
 		fp := c.GetHeader(headerFedFingerprint)
@@ -102,7 +99,7 @@ func VerifyFederationRequest(database *gorm.DB) gin.HandlerFunc {
 			reject("invalid signature encoding")
 			return
 		}
-		msg := signedRequestMessage(c.Request.Method, c.Request.URL.Path, tsStr, hex.EncodeToString(bodyHash[:]))
+		msg := signedRequestMessage(c.Request.Method, c.Request.URL.Path, tsStr, hex.EncodeToString(bodyHash[:]), selfFingerprint)
 		if !federation.Verify(pub, msg, sig) {
 			reject("signature verification failed")
 			return

--- a/server/internal/api/federation_mw_test.go
+++ b/server/internal/api/federation_mw_test.go
@@ -17,11 +17,12 @@ import (
 	"gorm.io/gorm"
 )
 
-// signedFedRequest builds a signed server-to-server request for tests.
-func signedFedRequest(id federation.Identity, method, path, body string, ts time.Time) *http.Request {
+// signedFedRequest builds a signed server-to-server request for tests, bound to
+// the given recipient fingerprint.
+func signedFedRequest(id federation.Identity, method, path, body string, ts time.Time, recipientFp string) *http.Request {
 	bodyHash := sha256.Sum256([]byte(body))
 	tsStr := strconv.FormatInt(ts.Unix(), 10)
-	msg := signedRequestMessage(method, path, tsStr, hex.EncodeToString(bodyHash[:]))
+	msg := signedRequestMessage(method, path, tsStr, hex.EncodeToString(bodyHash[:]), recipientFp)
 	sig := id.Sign(msg)
 
 	req := httptest.NewRequest(method, path, strings.NewReader(body))
@@ -31,9 +32,9 @@ func signedFedRequest(id federation.Identity, method, path, body string, ts time
 	return req
 }
 
-func fedMWRouter(database *gorm.DB) *gin.Engine {
+func fedMWRouter(database *gorm.DB, selfFp string) *gin.Engine {
 	r := gin.New()
-	r.Use(VerifyFederationRequest(database))
+	r.Use(VerifyFederationRequest(database, selfFp))
 	r.GET("/api/federation/test", func(c *gin.Context) {
 		peer, ok := federationPeerFromGin(c)
 		if !ok {
@@ -48,11 +49,13 @@ func fedMWRouter(database *gorm.DB) *gin.Engine {
 func TestFederationMW_AllowsValidSignedRequest(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	database := openAPIFedTestDB(t)
+	self, _ := federation.GenerateIdentity()
 	peerID, _ := federation.GenerateIdentity()
 	activePeer(t, database, peerID, "Peer", "https://peer")
 
 	w := httptest.NewRecorder()
-	fedMWRouter(database).ServeHTTP(w, signedFedRequest(peerID, http.MethodGet, "/api/federation/test", "", time.Now()))
+	fedMWRouter(database, self.Fingerprint()).ServeHTTP(w,
+		signedFedRequest(peerID, http.MethodGet, "/api/federation/test", "", time.Now(), self.Fingerprint()))
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, peerID.Fingerprint(), w.Body.String())
 }
@@ -60,50 +63,73 @@ func TestFederationMW_AllowsValidSignedRequest(t *testing.T) {
 func TestFederationMW_RejectsUnknownPeer(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	database := openAPIFedTestDB(t)
+	self, _ := federation.GenerateIdentity()
 	stranger, _ := federation.GenerateIdentity()
 
 	w := httptest.NewRecorder()
-	fedMWRouter(database).ServeHTTP(w, signedFedRequest(stranger, http.MethodGet, "/api/federation/test", "", time.Now()))
+	fedMWRouter(database, self.Fingerprint()).ServeHTTP(w,
+		signedFedRequest(stranger, http.MethodGet, "/api/federation/test", "", time.Now(), self.Fingerprint()))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestFederationMW_RejectsStaleTimestamp(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	database := openAPIFedTestDB(t)
+	self, _ := federation.GenerateIdentity()
 	peerID, _ := federation.GenerateIdentity()
 	activePeer(t, database, peerID, "Peer", "https://peer")
 
 	w := httptest.NewRecorder()
 	old := time.Now().Add(-10 * time.Minute)
-	fedMWRouter(database).ServeHTTP(w, signedFedRequest(peerID, http.MethodGet, "/api/federation/test", "", old))
+	fedMWRouter(database, self.Fingerprint()).ServeHTTP(w,
+		signedFedRequest(peerID, http.MethodGet, "/api/federation/test", "", old, self.Fingerprint()))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestFederationMW_RejectsTamperedPath(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	database := openAPIFedTestDB(t)
+	self, _ := federation.GenerateIdentity()
 	peerID, _ := federation.GenerateIdentity()
 	activePeer(t, database, peerID, "Peer", "https://peer")
 
 	// Sign for one path, send to another → signature must fail.
-	req := signedFedRequest(peerID, http.MethodGet, "/api/federation/other", "", time.Now())
+	req := signedFedRequest(peerID, http.MethodGet, "/api/federation/other", "", time.Now(), self.Fingerprint())
 	req2 := httptest.NewRequest(http.MethodGet, "/api/federation/test", nil)
 	for k, v := range req.Header {
 		req2.Header[k] = v
 	}
 	w := httptest.NewRecorder()
-	fedMWRouter(database).ServeHTTP(w, req2)
+	fedMWRouter(database, self.Fingerprint()).ServeHTTP(w, req2)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestFederationMW_RejectsWrongRecipient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	database := openAPIFedTestDB(t)
+	self, _ := federation.GenerateIdentity()
+	otherServer, _ := federation.GenerateIdentity()
+	peerID, _ := federation.GenerateIdentity()
+	activePeer(t, database, peerID, "Peer", "https://peer")
+
+	// Peer signs a request destined for otherServer, but we send it to self →
+	// recipient binding must reject it (anti cross-server replay).
+	w := httptest.NewRecorder()
+	fedMWRouter(database, self.Fingerprint()).ServeHTTP(w,
+		signedFedRequest(peerID, http.MethodGet, "/api/federation/test", "", time.Now(), otherServer.Fingerprint()))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestFederationMW_RejectsInactivePeer(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	database := openAPIFedTestDB(t)
+	self, _ := federation.GenerateIdentity()
 	peerID, _ := federation.GenerateIdentity()
 	store := activePeer(t, database, peerID, "Peer", "https://peer")
 	_ = store.SetStatus(peerID.Fingerprint(), "pending")
 
 	w := httptest.NewRecorder()
-	fedMWRouter(database).ServeHTTP(w, signedFedRequest(peerID, http.MethodGet, "/api/federation/test", "", time.Now()))
+	fedMWRouter(database, self.Fingerprint()).ServeHTTP(w,
+		signedFedRequest(peerID, http.MethodGet, "/api/federation/test", "", time.Now(), self.Fingerprint()))
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }

--- a/server/internal/api/federation_stats.go
+++ b/server/internal/api/federation_stats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -12,6 +13,10 @@ import (
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/federation"
 )
+
+// maxStatsResponseBytes caps an inbound friend stat payload (defense against a
+// hostile/misconfigured peer returning an unbounded body).
+const maxStatsResponseBytes = 4 << 20 // 4 MiB
 
 // statsClient fetches a peer's source-stamped stat rollup over a signed request.
 type statsClient interface {
@@ -40,10 +45,24 @@ func (httpStatsClient) FetchStats(baseURL, requestID string, id federation.Ident
 	var body struct {
 		Entries []federation.StatEntry `json:"entries"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxStatsResponseBytes)).Decode(&body); err != nil {
 		return nil, err
 	}
 	return body.Entries, nil
+}
+
+// validPeerStatBatch enforces the 1-hop invariant on a friend's rollup: every
+// entry must originate from that friend (no claiming a third server's or our own
+// identity), be hop 0 on their side, and carry non-negative values. A friend
+// that violates this is misbehaving, so the whole batch is rejected rather than
+// cherry-picked.
+func validPeerStatBatch(entries []federation.StatEntry, peerFingerprint string) bool {
+	for _, e := range entries {
+		if e.OriginFingerprint != peerFingerprint || e.Hops != 0 || e.PlayTimeSeconds < 0 || e.Players < 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // ginExportStats serves this server's source-stamped rollup (hop 0) to an
@@ -121,6 +140,17 @@ func (h *FederationHandler) HumaAggregatedStats(_ context.Context, in *Aggregate
 			})
 			continue
 		}
+		// Reject a misbehaving friend's batch wholesale (spoofed origin, wrong
+		// hop, or negative values would poison the aggregate).
+		if !validPeerStatBatch(entries, peer.Fingerprint) {
+			federation.RecordExchange(h.DB, federation.ExchangeRecord{
+				RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+				Direction: db.ExchangeOutbound, Operation: "stats_pull",
+				DataClass: string(federation.DataClassStats), Status: db.ExchangeRejected,
+				StartedAt: started, ItemCount: len(entries), Error: "invalid stat batch (origin/hop/value)",
+			})
+			continue
+		}
 		// Ingest: a friend's hop-0 datum is hop 1 from us.
 		for i := range entries {
 			entries[i].Hops++
@@ -146,6 +176,13 @@ func (h *FederationHandler) HumaAggregatedStats(_ context.Context, in *Aggregate
 	}
 	if in.Limit > 0 && len(aggregated) > in.Limit {
 		aggregated = aggregated[:in.Limit]
+	}
+
+	// Strip the per-source breakdown: it carries peer fingerprints, and the peer
+	// roster is admin-only elsewhere. Regular users get totals + labels only.
+	// (A future admin-only detailed view can expose Sources for anti-inflation.)
+	for i := range aggregated {
+		aggregated[i].Sources = nil
 	}
 
 	out := &AggregatedStatsOutput{}

--- a/server/internal/api/federation_stats.go
+++ b/server/internal/api/federation_stats.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+)
+
+// statsClient fetches a peer's source-stamped stat rollup over a signed request.
+type statsClient interface {
+	FetchStats(baseURL, requestID string, id federation.Identity, peerFingerprint string) ([]federation.StatEntry, error)
+}
+
+type httpStatsClient struct{}
+
+func (httpStatsClient) FetchStats(baseURL, requestID string, id federation.Identity, peerFingerprint string) ([]federation.StatEntry, error) {
+	const path = "/api/federation/stats"
+	req, err := http.NewRequest(http.MethodGet, baseURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range signedFederationHeaders(id, http.MethodGet, path, requestID, nil, peerFingerprint) {
+		req.Header.Set(k, v)
+	}
+	resp, err := fedHTTPClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("remote returned %d", resp.StatusCode)
+	}
+	var body struct {
+		Entries []federation.StatEntry `json:"entries"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	return body.Entries, nil
+}
+
+// ginExportStats serves this server's source-stamped rollup (hop 0) to an
+// authenticated peer we share stats with. Behind VerifyFederationRequest.
+func (h *FederationHandler) ginExportStats(c *gin.Context) {
+	reqID := c.GetHeader(headerFedRequestID)
+	if reqID == "" {
+		reqID = federation.NewRequestID()
+	}
+	peer, ok := federationPeerFromGin(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "no verified peer"})
+		return
+	}
+	if !federation.CanShare(*peer, federation.DataClassStats) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "stats not shared with this peer"})
+		return
+	}
+	entries, err := federation.BuildLocalRollup(h.DB, h.Identity.Fingerprint())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build rollup"})
+		return
+	}
+	federation.RecordExchange(h.DB, federation.ExchangeRecord{
+		RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+		Direction: db.ExchangeInbound, Operation: "stats_export",
+		DataClass: string(federation.DataClassStats), Status: db.ExchangeOK, ItemCount: len(entries),
+	})
+	c.JSON(http.StatusOK, gin.H{"entries": entries})
+}
+
+// --- Aggregated read (user-facing) -----------------------------------------
+
+type AggregatedStatsInput struct {
+	Metric string `query:"metric" enum:"game_play,player_play"`
+	Limit  int    `query:"limit"`
+}
+type AggregatedStatsOutput struct {
+	Body struct {
+		Stats []federation.AggregatedStat `json:"stats"`
+	}
+}
+
+// HumaAggregatedStats merges this server's rollup (hop 0) with each stats-
+// consumable active friend's rollup (hop 1) and returns the aggregated
+// leaderboard with per-source breakdown. Phase 1: direct friends only. A friend
+// that fails to respond is recorded and skipped (graceful degradation).
+func (h *FederationHandler) HumaAggregatedStats(_ context.Context, in *AggregatedStatsInput) (*AggregatedStatsOutput, error) {
+	all, err := federation.BuildLocalRollup(h.DB, h.Identity.Fingerprint())
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to build local rollup")
+	}
+
+	peers, err := h.Peers.List()
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to list peers")
+	}
+	client := h.StatsClient
+	if client == nil {
+		client = httpStatsClient{}
+	}
+	for _, peer := range peers {
+		if peer.Status != db.PeerStatusActive || !federation.CanConsume(peer, federation.DataClassStats) {
+			continue
+		}
+		reqID := federation.NewRequestID()
+		started := time.Now()
+		entries, ferr := client.FetchStats(peer.BaseURL, reqID, h.Identity, peer.Fingerprint)
+		if ferr != nil {
+			federation.RecordExchange(h.DB, federation.ExchangeRecord{
+				RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+				Direction: db.ExchangeOutbound, Operation: "stats_pull",
+				DataClass: string(federation.DataClassStats), Status: db.ExchangeError,
+				StartedAt: started, Error: ferr.Error(),
+			})
+			continue
+		}
+		// Ingest: a friend's hop-0 datum is hop 1 from us.
+		for i := range entries {
+			entries[i].Hops++
+		}
+		all = append(all, entries...)
+		federation.RecordExchange(h.DB, federation.ExchangeRecord{
+			RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+			Direction: db.ExchangeOutbound, Operation: "stats_pull",
+			DataClass: string(federation.DataClassStats), Status: db.ExchangeOK,
+			StartedAt: started, ItemCount: len(entries),
+		})
+	}
+
+	aggregated := federation.AggregateStatEntries(all)
+	if in.Metric != "" {
+		filtered := make([]federation.AggregatedStat, 0, len(aggregated))
+		for _, a := range aggregated {
+			if string(a.Metric) == in.Metric {
+				filtered = append(filtered, a)
+			}
+		}
+		aggregated = filtered
+	}
+	if in.Limit > 0 && len(aggregated) > in.Limit {
+		aggregated = aggregated[:in.Limit]
+	}
+
+	out := &AggregatedStatsOutput{}
+	out.Body.Stats = aggregated
+	return out, nil
+}

--- a/server/internal/api/federation_stats_test.go
+++ b/server/internal/api/federation_stats_test.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// fakeStatsClient returns canned friend entries keyed by base URL.
+type fakeStatsClient struct {
+	byBase map[string][]federation.StatEntry
+	err    error
+}
+
+func (f fakeStatsClient) FetchStats(baseURL, _ string, _ federation.Identity, _ string) ([]federation.StatEntry, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.byBase[baseURL], nil
+}
+
+func seedLocalPlay(t *testing.T, database *gorm.DB, scraperID string, playTime int64) {
+	t.Helper()
+	u := db.User{Username: "localuser", Email: "l@x.test", PasswordHash: "h", ProfileVisibility: "public"}
+	require.NoError(t, database.Create(&u).Error)
+	g := db.Game{Title: "Local Game", ScraperID: scraperID, FilePath: "/lg", ConsoleID: 1}
+	require.NoError(t, database.Create(&g).Error)
+	require.NoError(t, database.Create(&db.PlayHistory{UserID: u.ID, GameID: g.ID, PlayTime: playTime}).Error)
+}
+
+func callExport(h *FederationHandler, peer *db.FederationPeer) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/x", func(c *gin.Context) {
+		c.Set(fedPeerContextKey, peer)
+		h.ginExportStats(c)
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/x", nil))
+	return w
+}
+
+func TestExportStats_SharesStampedRollupWhenPolicyAllows(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	seedLocalPlay(t, database, "igdb:1", 100)
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self"}
+
+	sp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassStats: true})
+	peer := &db.FederationPeer{Fingerprint: "fp-friend", Name: "Friend", SharePolicy: sp, Status: db.PeerStatusActive}
+
+	w := callExport(h, peer)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body struct {
+		Entries []federation.StatEntry `json:"entries"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.NotEmpty(t, body.Entries)
+	for _, e := range body.Entries {
+		assert.Equal(t, selfID.Fingerprint(), e.OriginFingerprint)
+		assert.Equal(t, 0, e.Hops)
+	}
+}
+
+func TestExportStats_ForbiddenWhenNotShared(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	seedLocalPlay(t, database, "igdb:1", 100)
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self"}
+
+	// SharePolicy does not include stats.
+	peer := &db.FederationPeer{Fingerprint: "fp-friend", Name: "Friend", SharePolicy: "", Status: db.PeerStatusActive}
+
+	w := callExport(h, peer)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestAggregatedStats_MergesLocalAndFriend(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+	seedLocalPlay(t, database, "igdb:1", 100) // local: game igdb:1 = 100
+
+	// An active friend we consume stats from.
+	policyPeer(t, database, friendID, "Friend", "https://friend", true, true)
+
+	// Friend reports the same game igdb:1 with 250 (hop 0 on their side).
+	fake := fakeStatsClient{byBase: map[string][]federation.StatEntry{
+		"https://friend": {{
+			OriginFingerprint: friendID.Fingerprint(), Hops: 0,
+			Metric: federation.MetricGamePlay, Key: "igdb:1", Label: "Local Game", PlayTimeSeconds: 250, Players: 5,
+		}},
+	}}
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self", StatsClient: fake}
+
+	out, err := h.HumaAggregatedStats(context.Background(), &AggregatedStatsInput{Metric: "game_play"})
+	require.NoError(t, err)
+	require.Len(t, out.Body.Stats, 1)
+	assert.Equal(t, "igdb:1", out.Body.Stats[0].Key)
+	assert.Equal(t, int64(350), out.Body.Stats[0].TotalPlayTime, "local 100 + friend 250")
+	require.Len(t, out.Body.Stats[0].Sources, 2)
+
+	// A successful pull was recorded in the ledger.
+	var pulls int64
+	database.Model(&db.FederationExchange{}).Where("operation = ? AND status = ?", "stats_pull", db.ExchangeOK).Count(&pulls)
+	assert.Equal(t, int64(1), pulls)
+}
+
+func TestAggregatedStats_SkipsFriendOnErrorButReturnsLocal(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+	seedLocalPlay(t, database, "igdb:1", 100)
+	policyPeer(t, database, friendID, "Friend", "https://friend", true, true)
+
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self",
+		StatsClient: fakeStatsClient{err: errors.New("connection refused")}}
+
+	out, err := h.HumaAggregatedStats(context.Background(), &AggregatedStatsInput{Metric: "game_play"})
+	require.NoError(t, err, "an unreachable friend must not fail the whole read")
+	require.Len(t, out.Body.Stats, 1)
+	assert.Equal(t, int64(100), out.Body.Stats[0].TotalPlayTime, "local-only when friend is down")
+
+	var errs int64
+	database.Model(&db.FederationExchange{}).Where("operation = ? AND status = ?", "stats_pull", db.ExchangeError).Count(&errs)
+	assert.Equal(t, int64(1), errs)
+}
+
+func TestAggregatedStats_DoesNotPullWhenConsumeDisabled(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+	seedLocalPlay(t, database, "igdb:1", 100)
+	// share=true but consume=false → we must NOT pull stats from this peer.
+	policyPeer(t, database, friendID, "Friend", "https://friend", true, false)
+
+	called := false
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self",
+		StatsClient: fakeStatsClientFunc(func() { called = true })}
+
+	out, err := h.HumaAggregatedStats(context.Background(), &AggregatedStatsInput{Metric: "game_play"})
+	require.NoError(t, err)
+	assert.False(t, called, "must not fetch from a peer we don't consume stats from")
+	require.Len(t, out.Body.Stats, 1)
+	assert.Equal(t, int64(100), out.Body.Stats[0].TotalPlayTime)
+}
+
+// fakeStatsClientFunc records whether FetchStats was invoked.
+type fakeStatsClientFunc func()
+
+func (f fakeStatsClientFunc) FetchStats(_, _ string, _ federation.Identity, _ string) ([]federation.StatEntry, error) {
+	f()
+	return nil, nil
+}

--- a/server/internal/api/federation_stats_test.go
+++ b/server/internal/api/federation_stats_test.go
@@ -109,12 +109,39 @@ func TestAggregatedStats_MergesLocalAndFriend(t *testing.T) {
 	require.Len(t, out.Body.Stats, 1)
 	assert.Equal(t, "igdb:1", out.Body.Stats[0].Key)
 	assert.Equal(t, int64(350), out.Body.Stats[0].TotalPlayTime, "local 100 + friend 250")
-	require.Len(t, out.Body.Stats[0].Sources, 2)
+	assert.Empty(t, out.Body.Stats[0].Sources, "per-source breakdown stripped from the user-facing response")
 
 	// A successful pull was recorded in the ledger.
 	var pulls int64
 	database.Model(&db.FederationExchange{}).Where("operation = ? AND status = ?", "stats_pull", db.ExchangeOK).Count(&pulls)
 	assert.Equal(t, int64(1), pulls)
+}
+
+func TestAggregatedStats_RejectsSpoofedFriendBatch(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+	seedLocalPlay(t, database, "igdb:1", 100)
+	policyPeer(t, database, friendID, "Friend", "https://friend", true, true)
+
+	// The friend claims an entry that originates from a THIRD fingerprint (spoof)
+	// with an absurd play time — the whole batch must be rejected.
+	fake := fakeStatsClient{byBase: map[string][]federation.StatEntry{
+		"https://friend": {{
+			OriginFingerprint: "someoneelse", Hops: 0,
+			Metric: federation.MetricGamePlay, Key: "igdb:1", PlayTimeSeconds: 999999,
+		}},
+	}}
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self", StatsClient: fake}
+
+	out, err := h.HumaAggregatedStats(context.Background(), &AggregatedStatsInput{Metric: "game_play"})
+	require.NoError(t, err)
+	require.Len(t, out.Body.Stats, 1)
+	assert.Equal(t, int64(100), out.Body.Stats[0].TotalPlayTime, "spoofed batch rejected; local-only result")
+
+	var rejected int64
+	database.Model(&db.FederationExchange{}).Where("operation = ? AND status = ?", "stats_pull", db.ExchangeRejected).Count(&rejected)
+	assert.Equal(t, int64(1), rejected)
 }
 
 func TestAggregatedStats_SkipsFriendOnErrorButReturnsLocal(t *testing.T) {

--- a/server/internal/api/federation_testutil_test.go
+++ b/server/internal/api/federation_testutil_test.go
@@ -25,8 +25,23 @@ func openAPIFedTestDB(t *testing.T) *gorm.DB {
 		&db.FederationPeer{},
 		&db.FederationInviteNonce{},
 		&db.FederationExchange{},
+		// For stats rollup tests.
+		&db.User{},
+		&db.Game{},
+		&db.PlayHistory{},
 	))
 	return database
+}
+
+// sharePeer / consumePeer upsert an active peer with a single-class policy set.
+func policyPeer(t *testing.T, database *gorm.DB, id federation.Identity, name, baseURL string, share, consume bool) {
+	t.Helper()
+	sp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassStats: share})
+	cp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassStats: consume})
+	require.NoError(t, federation.PeerStore{DB: database}.Upsert(&db.FederationPeer{
+		Fingerprint: id.Fingerprint(), PublicKey: b64(id.PublicKey), Name: name, BaseURL: baseURL,
+		Status: db.PeerStatusActive, SharePolicy: sp, ConsumePolicy: cp,
+	}))
 }
 
 // b64 is a test helper for base64-std encoding a byte slice.

--- a/server/internal/api/huma_federation.go
+++ b/server/internal/api/huma_federation.go
@@ -27,6 +27,9 @@ type FederationHandler struct {
 	// Pinger performs the outbound connection-test ping. Defaults to
 	// httpPeerPinger when nil; overridden in tests.
 	Pinger peerPinger
+	// StatsClient fetches a friend's stat rollup. Defaults to httpStatsClient
+	// when nil; overridden in tests.
+	StatsClient statsClient
 }
 
 // pairClient performs the outbound pairing callback to a friend.

--- a/server/internal/api/huma_federation_admin.go
+++ b/server/internal/api/huma_federation_admin.go
@@ -337,10 +337,23 @@ func RegisterFederationRoutes(api huma.API, h *FederationHandler, jwtSecret stri
 		Middlewares: adminMW,
 		Security:    sec,
 	}, h.HumaListExchanges)
+
+	// User-facing: the federated (mesh) leaderboard. Auth + rate limit, not admin.
+	huma.Register(api, huma.Operation{
+		OperationID: "federationAggregatedStats",
+		Method:      http.MethodGet,
+		Path:        "/api/federation/stats/aggregated",
+		Summary:     "Federated (mesh) aggregate stats across direct friends",
+		Tags:        []string{"federation", "stats"},
+		Middlewares: huma.Middlewares{requireAuth, rateLimit},
+		Security:    sec,
+	}, h.HumaAggregatedStats)
 }
 
 // RegisterFederationGinRoutes wires raw-gin federation routes: the signed ping
 // used by the connection-test diagnostic.
 func RegisterFederationGinRoutes(r *gin.Engine, h *FederationHandler) {
-	r.GET("/api/federation/ping", VerifyFederationRequest(h.DB, h.Identity.Fingerprint()), h.ginPing)
+	requireFedPeer := VerifyFederationRequest(h.DB, h.Identity.Fingerprint())
+	r.GET("/api/federation/ping", requireFedPeer, h.ginPing)
+	r.GET("/api/federation/stats", requireFedPeer, h.ginExportStats)
 }

--- a/server/internal/api/huma_federation_admin.go
+++ b/server/internal/api/huma_federation_admin.go
@@ -342,5 +342,5 @@ func RegisterFederationRoutes(api huma.API, h *FederationHandler, jwtSecret stri
 // RegisterFederationGinRoutes wires raw-gin federation routes: the signed ping
 // used by the connection-test diagnostic.
 func RegisterFederationGinRoutes(r *gin.Engine, h *FederationHandler) {
-	r.GET("/api/federation/ping", VerifyFederationRequest(h.DB), h.ginPing)
+	r.GET("/api/federation/ping", VerifyFederationRequest(h.DB, h.Identity.Fingerprint()), h.ginPing)
 }

--- a/server/internal/federation/rollup.go
+++ b/server/internal/federation/rollup.go
@@ -1,34 +1,39 @@
 package federation
 
 import (
-	"strings"
-
 	"github.com/spela/server/internal/db"
 	"gorm.io/gorm"
 )
 
-// gameStatKey derives the cross-server identity for a game: prefer the IGDB
-// scraper id, then CRC32, falling back to a normalized title. Games that share a
-// key across servers aggregate together.
-func gameStatKey(g db.Game) string {
+// gameStatKey derives the cross-server identity for a game: the IGDB scraper id,
+// else CRC32. Games sharing a key across servers aggregate together. Returns
+// ok=false when the game has no reliable cross-identifier — such games are NOT
+// federated (a title fallback would falsely merge distinct games, both locally
+// and across servers).
+func gameStatKey(g db.Game) (string, bool) {
 	if g.ScraperID != "" {
-		return g.ScraperID
+		return g.ScraperID, true
 	}
 	if g.CRC32 != "" {
-		return "crc:" + g.CRC32
+		return "crc:" + g.CRC32, true
 	}
-	return "title:" + strings.ToLower(strings.TrimSpace(g.Title))
+	return "", false
 }
 
+// publicActiveUserFilter restricts an aggregate to users who have consented to
+// public visibility AND are active accounts. This is the origin-side privacy
+// gate: private, disabled, and pending-approval users never enter the mesh — for
+// BOTH metrics. (Game totals therefore reflect public, active users only in
+// Phase 1; full totals protected by k-anonymity are a Phase 2 concern.)
+const publicActiveUserFilter = "users.profile_visibility = ? AND users.disabled = ? AND users.pending_approval = ?"
+
 // BuildLocalRollup computes this server's own aggregate stats as source-stamped
-// StatEntry values (origin = selfFingerprint, hop 0). Game play time + distinct
-// players are keyed by cross-server game identity; player play time is included
-// only for users whose ProfileVisibility is public — the origin-side consent
-// gate, so private users never enter the mesh.
+// StatEntry values (origin = selfFingerprint, hop 0). Both metrics are gated by
+// publicActiveUserFilter so private/disabled/pending users never federate.
 func BuildLocalRollup(database *gorm.DB, selfFingerprint string) ([]StatEntry, error) {
 	entries := []StatEntry{}
 
-	// --- game_play: play time + distinct players per game ---
+	// --- game_play: play time + distinct players per game (public users only) ---
 	type gameRow struct {
 		GameID   uint
 		Players  int64
@@ -36,8 +41,10 @@ func BuildLocalRollup(database *gorm.DB, selfFingerprint string) ([]StatEntry, e
 	}
 	var grows []gameRow
 	if err := database.Model(&db.PlayHistory{}).
-		Select("game_id, COUNT(DISTINCT user_id) as players, SUM(play_time) as play_time").
-		Group("game_id").
+		Joins("JOIN users ON users.id = play_histories.user_id").
+		Where(publicActiveUserFilter, "public", false, false).
+		Select("play_histories.game_id as game_id, COUNT(DISTINCT play_histories.user_id) as players, SUM(play_histories.play_time) as play_time").
+		Group("play_histories.game_id").
 		Scan(&grows).Error; err != nil {
 		return nil, err
 	}
@@ -67,7 +74,10 @@ func BuildLocalRollup(database *gorm.DB, selfFingerprint string) ([]StatEntry, e
 			if !ok {
 				continue
 			}
-			key := gameStatKey(g)
+			key, hasKey := gameStatKey(g)
+			if !hasKey {
+				continue // can't cross-identify this game — don't federate it
+			}
 			a, ok := byKey[key]
 			if !ok {
 				a = &agg{label: g.Title}
@@ -95,7 +105,7 @@ func BuildLocalRollup(database *gorm.DB, selfFingerprint string) ([]StatEntry, e
 	if err := database.Model(&db.PlayHistory{}).
 		Select("users.username as username, SUM(play_histories.play_time) as play_time").
 		Joins("JOIN users ON users.id = play_histories.user_id").
-		Where("users.profile_visibility = ?", "public").
+		Where(publicActiveUserFilter, "public", false, false).
 		Group("play_histories.user_id").
 		Scan(&prows).Error; err != nil {
 		return nil, err

--- a/server/internal/federation/rollup.go
+++ b/server/internal/federation/rollup.go
@@ -1,0 +1,111 @@
+package federation
+
+import (
+	"strings"
+
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// gameStatKey derives the cross-server identity for a game: prefer the IGDB
+// scraper id, then CRC32, falling back to a normalized title. Games that share a
+// key across servers aggregate together.
+func gameStatKey(g db.Game) string {
+	if g.ScraperID != "" {
+		return g.ScraperID
+	}
+	if g.CRC32 != "" {
+		return "crc:" + g.CRC32
+	}
+	return "title:" + strings.ToLower(strings.TrimSpace(g.Title))
+}
+
+// BuildLocalRollup computes this server's own aggregate stats as source-stamped
+// StatEntry values (origin = selfFingerprint, hop 0). Game play time + distinct
+// players are keyed by cross-server game identity; player play time is included
+// only for users whose ProfileVisibility is public — the origin-side consent
+// gate, so private users never enter the mesh.
+func BuildLocalRollup(database *gorm.DB, selfFingerprint string) ([]StatEntry, error) {
+	entries := []StatEntry{}
+
+	// --- game_play: play time + distinct players per game ---
+	type gameRow struct {
+		GameID   uint
+		Players  int64
+		PlayTime int64
+	}
+	var grows []gameRow
+	if err := database.Model(&db.PlayHistory{}).
+		Select("game_id, COUNT(DISTINCT user_id) as players, SUM(play_time) as play_time").
+		Group("game_id").
+		Scan(&grows).Error; err != nil {
+		return nil, err
+	}
+	if len(grows) > 0 {
+		ids := make([]uint, len(grows))
+		for i, r := range grows {
+			ids[i] = r.GameID
+		}
+		var games []db.Game
+		if err := database.Where("id IN ?", ids).Find(&games).Error; err != nil {
+			return nil, err
+		}
+		gameByID := make(map[uint]db.Game, len(games))
+		for _, g := range games {
+			gameByID[g.ID] = g
+		}
+		// Sum by cross-server key (multiple local game rows can map to one key).
+		type agg struct {
+			label    string
+			players  int64
+			playTime int64
+		}
+		byKey := map[string]*agg{}
+		order := []string{}
+		for _, r := range grows {
+			g, ok := gameByID[r.GameID]
+			if !ok {
+				continue
+			}
+			key := gameStatKey(g)
+			a, ok := byKey[key]
+			if !ok {
+				a = &agg{label: g.Title}
+				byKey[key] = a
+				order = append(order, key)
+			}
+			a.players += r.Players
+			a.playTime += r.PlayTime
+		}
+		for _, key := range order {
+			a := byKey[key]
+			entries = append(entries, StatEntry{
+				OriginFingerprint: selfFingerprint, Hops: 0, Metric: MetricGamePlay,
+				Key: key, Label: a.label, PlayTimeSeconds: a.playTime, Players: a.players,
+			})
+		}
+	}
+
+	// --- player_play: play time per player, public profiles only ---
+	type playerRow struct {
+		Username string
+		PlayTime int64
+	}
+	var prows []playerRow
+	if err := database.Model(&db.PlayHistory{}).
+		Select("users.username as username, SUM(play_histories.play_time) as play_time").
+		Joins("JOIN users ON users.id = play_histories.user_id").
+		Where("users.profile_visibility = ?", "public").
+		Group("play_histories.user_id").
+		Scan(&prows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range prows {
+		entries = append(entries, StatEntry{
+			OriginFingerprint: selfFingerprint, Hops: 0, Metric: MetricPlayerPlay,
+			Key: r.Username, Label: r.Username, PlayTimeSeconds: r.PlayTime,
+		})
+	}
+
+	return entries, nil
+}

--- a/server/internal/federation/rollup_test.go
+++ b/server/internal/federation/rollup_test.go
@@ -53,16 +53,40 @@ func TestBuildLocalRollup_StampsGamesAndGatesPrivatePlayers(t *testing.T) {
 	assert.Equal(t, "selfFP", games[0].OriginFingerprint)
 	assert.Equal(t, 0, games[0].Hops)
 	assert.Equal(t, "igdb:111", games[0].Key)
-	assert.Equal(t, int64(300), games[0].PlayTimeSeconds, "both users' play time summed")
-	assert.Equal(t, int64(2), games[0].Players)
+	assert.Equal(t, int64(100), games[0].PlayTimeSeconds, "only the public user's play time counts toward the game total")
+	assert.Equal(t, int64(1), games[0].Players, "private user excluded from the game player count too")
 
 	require.Len(t, players, 1, "private user must be excluded from player_play")
 	assert.Equal(t, "publicguy", players[0].Key)
 	assert.Equal(t, int64(100), players[0].PlayTimeSeconds)
 }
 
-func TestGameStatKey_PrefersScraperThenCRCThenTitle(t *testing.T) {
-	assert.Equal(t, "igdb:5", gameStatKey(db.Game{ScraperID: "igdb:5", CRC32: "abc", Title: "T"}))
-	assert.Equal(t, "crc:abc", gameStatKey(db.Game{CRC32: "abc", Title: "T"}))
-	assert.Equal(t, "title:zelda", gameStatKey(db.Game{Title: "Zelda"}))
+func TestBuildLocalRollup_ExcludesDisabledAndPendingUsers(t *testing.T) {
+	database := openRollupTestDB(t)
+	disabled := db.User{Username: "banned", Email: "d@x.test", PasswordHash: "h", ProfileVisibility: "public", Disabled: true}
+	pending := db.User{Username: "newbie", Email: "p@x.test", PasswordHash: "h", ProfileVisibility: "public", PendingApproval: true}
+	require.NoError(t, database.Create(&disabled).Error)
+	require.NoError(t, database.Create(&pending).Error)
+
+	g := db.Game{Title: "G", ScraperID: "igdb:9", FilePath: "/g", ConsoleID: 1}
+	require.NoError(t, database.Create(&g).Error)
+	require.NoError(t, database.Create(&db.PlayHistory{UserID: disabled.ID, GameID: g.ID, PlayTime: 50}).Error)
+	require.NoError(t, database.Create(&db.PlayHistory{UserID: pending.ID, GameID: g.ID, PlayTime: 50}).Error)
+
+	entries, err := BuildLocalRollup(database, "selfFP")
+	require.NoError(t, err)
+	assert.Empty(t, entries, "disabled and pending-approval users must not federate (either metric)")
+}
+
+func TestGameStatKey_PrefersScraperThenCRC_SkipsUnidentifiable(t *testing.T) {
+	k, ok := gameStatKey(db.Game{ScraperID: "igdb:5", CRC32: "abc", Title: "T"})
+	assert.True(t, ok)
+	assert.Equal(t, "igdb:5", k)
+
+	k, ok = gameStatKey(db.Game{CRC32: "abc", Title: "T"})
+	assert.True(t, ok)
+	assert.Equal(t, "crc:abc", k)
+
+	_, ok = gameStatKey(db.Game{Title: "Zelda"})
+	assert.False(t, ok, "no scraper id / CRC32 => not federated (no title fallback)")
 }

--- a/server/internal/federation/rollup_test.go
+++ b/server/internal/federation/rollup_test.go
@@ -1,0 +1,68 @@
+package federation
+
+import (
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func openRollupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&db.User{}, &db.Game{}, &db.PlayHistory{}))
+	return database
+}
+
+func TestBuildLocalRollup_StampsGamesAndGatesPrivatePlayers(t *testing.T) {
+	database := openRollupTestDB(t)
+
+	pub := db.User{Username: "publicguy", Email: "a@x.test", PasswordHash: "h", ProfileVisibility: "public"}
+	priv := db.User{Username: "privateguy", Email: "b@x.test", PasswordHash: "h", ProfileVisibility: "private"}
+	require.NoError(t, database.Create(&pub).Error)
+	require.NoError(t, database.Create(&priv).Error)
+
+	g1 := db.Game{Title: "Game One", ScraperID: "igdb:111", FilePath: "/g1", ConsoleID: 1}
+	require.NoError(t, database.Create(&g1).Error)
+
+	// Both users played g1.
+	require.NoError(t, database.Create(&db.PlayHistory{UserID: pub.ID, GameID: g1.ID, PlayTime: 100}).Error)
+	require.NoError(t, database.Create(&db.PlayHistory{UserID: priv.ID, GameID: g1.ID, PlayTime: 200}).Error)
+
+	entries, err := BuildLocalRollup(database, "selfFP")
+	require.NoError(t, err)
+
+	var games, players []StatEntry
+	for _, e := range entries {
+		switch e.Metric {
+		case MetricGamePlay:
+			games = append(games, e)
+		case MetricPlayerPlay:
+			players = append(players, e)
+		}
+	}
+
+	require.Len(t, games, 1)
+	assert.Equal(t, "selfFP", games[0].OriginFingerprint)
+	assert.Equal(t, 0, games[0].Hops)
+	assert.Equal(t, "igdb:111", games[0].Key)
+	assert.Equal(t, int64(300), games[0].PlayTimeSeconds, "both users' play time summed")
+	assert.Equal(t, int64(2), games[0].Players)
+
+	require.Len(t, players, 1, "private user must be excluded from player_play")
+	assert.Equal(t, "publicguy", players[0].Key)
+	assert.Equal(t, int64(100), players[0].PlayTimeSeconds)
+}
+
+func TestGameStatKey_PrefersScraperThenCRCThenTitle(t *testing.T) {
+	assert.Equal(t, "igdb:5", gameStatKey(db.Game{ScraperID: "igdb:5", CRC32: "abc", Title: "T"}))
+	assert.Equal(t, "crc:abc", gameStatKey(db.Game{CRC32: "abc", Title: "T"}))
+	assert.Equal(t, "title:zelda", gameStatKey(db.Game{Title: "Zelda"}))
+}

--- a/server/internal/federation/stats.go
+++ b/server/internal/federation/stats.go
@@ -1,0 +1,113 @@
+package federation
+
+import "sort"
+
+// StatMetric identifies an aggregate leaderboard metric.
+type StatMetric string
+
+const (
+	MetricGamePlay   StatMetric = "game_play"   // play time + distinct players per game
+	MetricPlayerPlay StatMetric = "player_play" // play time per player
+)
+
+// StatEntry is one source-stamped aggregate datum from a single origin server.
+// Hops is the graph distance from the holder to the origin (0 = originated
+// here). Phase 1 only produces/consumes hop 0 (own) and hop 1 (direct friend);
+// deeper hops arrive in Phase 2.
+type StatEntry struct {
+	OriginFingerprint string     `json:"originFingerprint"`
+	Hops              int        `json:"hops"`
+	Metric            StatMetric `json:"metric"`
+	// Key is the stable identity within a metric: for game_play the cross-server
+	// game id (IGDB scraper id); for player_play the player's identity. The same
+	// game across servers shares a Key and is summed; players are scoped to their
+	// origin (cross-server player identity is a later concern).
+	Key             string `json:"key"`
+	Label           string `json:"label"` // display label (game title / username)
+	PlayTimeSeconds int64  `json:"playTimeSeconds"`
+	Players         int64  `json:"players"` // distinct players (game metric); 0 for player metric
+}
+
+// statDedupeKey identifies a datum by origin + metric + key, so the same source
+// datum arriving via multiple paths is counted exactly once.
+type statDedupeKey struct {
+	origin string
+	metric StatMetric
+	key    string
+}
+
+// DedupeStatEntries removes duplicate (origin, metric, key) entries, keeping the
+// copy with the smallest hop count. This is what makes mesh aggregation correct
+// when one source is reachable via more than one friend (the diamond case): a
+// source must not be counted twice. Idempotent —
+// DedupeStatEntries(DedupeStatEntries(x)) == DedupeStatEntries(x).
+func DedupeStatEntries(entries []StatEntry) []StatEntry {
+	best := make(map[statDedupeKey]StatEntry, len(entries))
+	order := make([]statDedupeKey, 0, len(entries))
+	for _, e := range entries {
+		k := statDedupeKey{e.OriginFingerprint, e.Metric, e.Key}
+		if existing, ok := best[k]; ok {
+			if e.Hops < existing.Hops {
+				best[k] = e
+			}
+			continue
+		}
+		best[k] = e
+		order = append(order, k)
+	}
+	out := make([]StatEntry, 0, len(order))
+	for _, k := range order {
+		out = append(out, best[k])
+	}
+	return out
+}
+
+// AggregatedStat is a leaderboard row summed across all contributing origins,
+// retaining the per-source breakdown for transparency and anti-inflation.
+type AggregatedStat struct {
+	Metric        StatMetric  `json:"metric"`
+	Key           string      `json:"key"`
+	Label         string      `json:"label"`
+	TotalPlayTime int64       `json:"totalPlayTimeSeconds"`
+	TotalPlayers  int64       `json:"totalPlayers"`
+	Sources       []StatEntry `json:"sources"`
+}
+
+// AggregateStatEntries dedupes (by origin) then sums entries by (metric, key)
+// across origins, producing leaderboard rows sorted by total play time
+// descending. Each row keeps its per-source breakdown so an admin can see who
+// contributed what.
+func AggregateStatEntries(entries []StatEntry) []AggregatedStat {
+	deduped := DedupeStatEntries(entries)
+
+	type aggKey struct {
+		metric StatMetric
+		key    string
+	}
+	agg := make(map[aggKey]*AggregatedStat)
+	order := make([]aggKey, 0)
+	for _, e := range deduped {
+		k := aggKey{e.Metric, e.Key}
+		a, ok := agg[k]
+		if !ok {
+			a = &AggregatedStat{Metric: e.Metric, Key: e.Key, Label: e.Label}
+			agg[k] = a
+			order = append(order, k)
+		}
+		if a.Label == "" {
+			a.Label = e.Label
+		}
+		a.TotalPlayTime += e.PlayTimeSeconds
+		a.TotalPlayers += e.Players
+		a.Sources = append(a.Sources, e)
+	}
+
+	out := make([]AggregatedStat, 0, len(order))
+	for _, k := range order {
+		out = append(out, *agg[k])
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].TotalPlayTime > out[j].TotalPlayTime
+	})
+	return out
+}

--- a/server/internal/federation/stats_test.go
+++ b/server/internal/federation/stats_test.go
@@ -1,0 +1,80 @@
+package federation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDedupeStatEntries_SameSourceCountedOnce_KeepsMinHop(t *testing.T) {
+	// Same origin/metric/key arriving via two paths (e.g. a diamond in Phase 2):
+	// hop 3 via one friend, hop 1 via another. Must collapse to one, min hop.
+	entries := []StatEntry{
+		{OriginFingerprint: "C", Hops: 3, Metric: MetricGamePlay, Key: "g1", PlayTimeSeconds: 500, Players: 2},
+		{OriginFingerprint: "C", Hops: 1, Metric: MetricGamePlay, Key: "g1", PlayTimeSeconds: 500, Players: 2},
+	}
+	out := DedupeStatEntries(entries)
+	assert.Len(t, out, 1)
+	assert.Equal(t, 1, out[0].Hops)
+	assert.Equal(t, int64(500), out[0].PlayTimeSeconds)
+}
+
+func TestDedupeStatEntries_Idempotent(t *testing.T) {
+	entries := []StatEntry{
+		{OriginFingerprint: "A", Hops: 0, Metric: MetricGamePlay, Key: "g1", PlayTimeSeconds: 10},
+		{OriginFingerprint: "B", Hops: 1, Metric: MetricGamePlay, Key: "g1", PlayTimeSeconds: 20},
+		{OriginFingerprint: "A", Hops: 0, Metric: MetricGamePlay, Key: "g1", PlayTimeSeconds: 10},
+	}
+	once := DedupeStatEntries(entries)
+	twice := DedupeStatEntries(once)
+	assert.Equal(t, once, twice, "dedupe must be idempotent f(f(x)) == f(x)")
+	assert.Len(t, once, 2)
+}
+
+func TestAggregateStatEntries_SumsSameGameAcrossDifferentOrigins(t *testing.T) {
+	// Same game (g1) played on two different servers → totals SUM (not deduped),
+	// because they are distinct sources contributing to the same game.
+	entries := []StatEntry{
+		{OriginFingerprint: "A", Hops: 0, Metric: MetricGamePlay, Key: "g1", Label: "Game One", PlayTimeSeconds: 100, Players: 3},
+		{OriginFingerprint: "B", Hops: 1, Metric: MetricGamePlay, Key: "g1", Label: "Game One", PlayTimeSeconds: 250, Players: 5},
+	}
+	out := AggregateStatEntries(entries)
+	assert.Len(t, out, 1)
+	assert.Equal(t, int64(350), out[0].TotalPlayTime)
+	assert.Equal(t, int64(8), out[0].TotalPlayers)
+	assert.Len(t, out[0].Sources, 2, "per-source breakdown retained")
+}
+
+func TestAggregateStatEntries_DiamondNotDoubleCounted(t *testing.T) {
+	// Source C's datum reaches us via both B and D. It must be counted ONCE,
+	// even though A's own contribution to the same game is summed in.
+	entries := []StatEntry{
+		{OriginFingerprint: "A", Hops: 0, Metric: MetricGamePlay, Key: "g1", Label: "G", PlayTimeSeconds: 100, Players: 1},
+		{OriginFingerprint: "C", Hops: 2, Metric: MetricGamePlay, Key: "g1", Label: "G", PlayTimeSeconds: 500, Players: 4}, // via B
+		{OriginFingerprint: "C", Hops: 2, Metric: MetricGamePlay, Key: "g1", Label: "G", PlayTimeSeconds: 500, Players: 4}, // via D
+	}
+	out := AggregateStatEntries(entries)
+	assert.Len(t, out, 1)
+	// A's 100 + C's 500 (counted once) = 600, NOT 1100.
+	assert.Equal(t, int64(600), out[0].TotalPlayTime)
+	assert.Equal(t, int64(5), out[0].TotalPlayers)
+}
+
+func TestAggregateStatEntries_SortedByPlayTimeDesc(t *testing.T) {
+	entries := []StatEntry{
+		{OriginFingerprint: "A", Metric: MetricGamePlay, Key: "low", Label: "Low", PlayTimeSeconds: 10},
+		{OriginFingerprint: "A", Metric: MetricGamePlay, Key: "high", Label: "High", PlayTimeSeconds: 1000},
+		{OriginFingerprint: "A", Metric: MetricGamePlay, Key: "mid", Label: "Mid", PlayTimeSeconds: 100},
+	}
+	out := AggregateStatEntries(entries)
+	assert.Equal(t, []string{"high", "mid", "low"}, []string{out[0].Key, out[1].Key, out[2].Key})
+}
+
+func TestAggregateStatEntries_SeparatesMetrics(t *testing.T) {
+	entries := []StatEntry{
+		{OriginFingerprint: "A", Metric: MetricGamePlay, Key: "g1", PlayTimeSeconds: 100},
+		{OriginFingerprint: "A", Metric: MetricPlayerPlay, Key: "g1", PlayTimeSeconds: 100},
+	}
+	out := AggregateStatEntries(entries)
+	assert.Len(t, out, 2, "same key under different metrics must not merge")
+}


### PR DESCRIPTION
## Federation Phase 1 — Direct-friend (1-hop) aggregate stats

Part of #1346 (server-side; player/web UI surfacing remains — see below). Builds on Phase 0 (#1351).

The first slice where data actually crosses the mesh, kept deliberately to **direct friends only, no transitivity, no relay** — it proves the source-stamping + signing + idempotent-merge + consent machinery end to end.

### What's included
- **Recipient-binding (security prerequisite, flagged in #1346):** signed server-to-server requests now bind the recipient server's fingerprint, so a captured signed request can't be replayed against a different paired server. New test covers the wrong-recipient case.
- **Source-stamped stat core:** `StatEntry` (origin fingerprint + hop count), `DedupeStatEntries` (count a source once across paths — the diamond case), `AggregateStatEntries` (sum the same game across *different* origins, sorted, with per-source breakdown). The idempotent-merge correctness heart, with the double-count regression test.
- **Local rollup:** `BuildLocalRollup` turns `PlayHistory` into source-stamped entries (origin = self, hop 0). `player_play` is gated by `ProfileVisibility` at the origin — **private users never enter the mesh.** Games are cross-identified by IGDB scraper id → CRC32 → normalized title.
- **Export:** `GET /api/federation/stats` — signed (Phase 0 middleware) and `SharePolicy(stats)`-gated; returns the stamped rollup; ledger-recorded.
- **Aggregated read:** `GET /api/federation/stats/aggregated` (auth + rate limit) — pulls each active friend whose `ConsumePolicy` allows stats, `+1` hop on ingest, merges with local via `AggregateStatEntries`, returns the mesh leaderboard with per-source breakdown. A friend that fails to respond is recorded and skipped (**graceful degradation** — one down friend never fails the read).

### Observability (#1350)
Every export/pull is recorded to the `FederationExchange` ledger and logged (`op=stats_export`/`stats_pull`, `data_class=stats`, item counts, correlation id), so "which friend did we pull, when, how many entries, did it fail" is answerable from logs + ledger.

### Testing
- New unit tests: dedupe/aggregate (incl. diamond + idempotency), rollup (stamping + private-player gate + key derivation), export (share-gate), aggregated read (merge, consume-policy gate, graceful degradation), recipient-binding rejection.
- **Full `go test ./...` passes, no regressions**; build + gofmt clean.

### Remaining for #1346 (follow-up)
- **Player/web UI surfacing** of the federated leaderboard (a scope slider lands in Phase 2). This is a player-app / web task, distinct from the backend federation here; tracked to complete #1346.
- Live caching of pulled rollups (Phase 1 pulls on read; fine at 1-hop, optimized later).

Part of #1346
