### PR TITLE
fix(player): Settings → Controls controller verify hub; gate keyboard to desktop (#1353)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
@@ -132,6 +132,26 @@ class SettingsConsoleNavigationTest {
         onAllNodesWithText("PER_CONSOLE").assertCountEquals(0)
     }
 
+    /**
+     * The Controls category is the controller "verify hub" (#1353): it renders
+     * the connected-controllers detection view (GamepadConfigScreen) so the user
+     * can verify which controller is detected and override its type. (The
+     * Android-only gating of the keyboard keycode section is platform-gated and
+     * verified on-device, not here.)
+     */
+    @Test
+    fun controlsCategoryShowsConnectedControllersVerifyHub() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToSettings(harness)
+        onNodeWithContentDescription("Controls").performClick()
+        advanceQuick(harness)
+
+        onNodeWithContentDescription("Controllers heading").assertExists()
+        onNodeWithContentDescription("Player 1: No controller").assertExists()
+    }
+
     @Test
     fun backFromConsoleSettingsReturnsToPerConsoleNotGeneral() = runComposeUiTest {
         val harness = createLoggedInHarness()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/ScreenRouter.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/ScreenRouter.kt
@@ -736,6 +736,7 @@ fun ScreenRouter(
                                 SettingsScreen(
                                     viewModel = settingsViewModel,
                                     keyMappingViewModel = keyMappingViewModel,
+                                    gamepadConfigViewModel = gamepadConfigViewModel,
                                     onBack = {
                                         navigationViewModel.onIntent(NavigationIntent.GoBack)
                                     },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
@@ -19,6 +19,8 @@ import androidx.compose.material.icons.filled.SportsEsports
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -49,6 +51,10 @@ import com.spela.player.presentation.viewmodel.SettingsViewModel
 import com.spela.player.presentation.viewmodel.SettingsState
 import com.spela.player.presentation.intent.KeyMappingIntent
 import com.spela.player.presentation.viewmodel.KeyMappingViewModel
+import com.spela.player.presentation.viewmodel.GamepadConfigIntent
+import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
+import com.spela.player.presentation.ui.components.gamepad.GamepadConfigScreen
+import com.spela.player.util.currentPlatform
 import com.spela.player.presentation.state.KeyMappingState
 import com.spela.player.data.remote.SyncState
 import com.spela.player.data.remote.ConnectionState
@@ -67,6 +73,7 @@ fun SettingsCategoryContent(
     connectionState: ConnectionState,
     keyMappingViewModel: KeyMappingViewModel?,
     keyMappingState: KeyMappingState?,
+    gamepadConfigViewModel: GamepadConfigViewModel?,
     onNavigateToConsoleSettings: (String) -> Unit,
     onNavigateToLicenses: () -> Unit,
     onLogout: () -> Unit,
@@ -96,7 +103,7 @@ fun SettingsCategoryContent(
             SettingsCategory.GENERAL -> generalContent(state, viewModel)
             SettingsCategory.EMULATION -> emulationContent(state, viewModel)
             SettingsCategory.CONTROLS -> controlsContent(
-                state, viewModel, keyMappingViewModel, keyMappingState,
+                state, viewModel, keyMappingViewModel, keyMappingState, gamepadConfigViewModel,
             )
             SettingsCategory.CONSOLES -> consolesContent(state, onNavigateToConsoleSettings)
             SettingsCategory.ACHIEVEMENTS -> achievementsContent(state, viewModel)
@@ -259,10 +266,54 @@ private fun androidx.compose.foundation.lazy.LazyListScope.controlsContent(
     viewModel: SettingsViewModel,
     keyMappingViewModel: KeyMappingViewModel?,
     keyMappingState: KeyMappingState?,
+    gamepadConfigViewModel: GamepadConfigViewModel?,
 ) {
-    // Controls presets
-    if (keyMappingViewModel != null && keyMappingState != null) {
-        item { SettingsSectionHeader(title = "Default Controls") }
+    // Connected controllers: detected type + per-controller "Type:" override.
+    // This is the one global place to verify "which controller do I have" and
+    // correct a mis-detection (#1334 / #1353). Shown on every platform.
+    if (gamepadConfigViewModel != null) {
+        // GamepadConfigScreen renders its own "Controllers" heading, so no extra
+        // SettingsSectionHeader here (avoids a doubled heading).
+        item {
+            val gamepadConfigState by gamepadConfigViewModel.state.collectAsState()
+            SpCard(onGradient = true) {
+                GamepadConfigScreen(
+                    state = gamepadConfigState,
+                    onConfigurePort = {},
+                    onSwapUp = { port ->
+                        gamepadConfigViewModel.onIntent(GamepadConfigIntent.SwapPorts(port - 1, port))
+                    },
+                    onSwapDown = { port ->
+                        gamepadConfigViewModel.onIntent(GamepadConfigIntent.SwapPorts(port, port + 1))
+                    },
+                    onSetStyleOverride = { port, style ->
+                        gamepadConfigViewModel.onIntent(GamepadConfigIntent.SetStyleOverride(port, style))
+                    },
+                    // Per-port keyboard key-mapping isn't a global concept; gamepad
+                    // button mappings are edited per console (see below).
+                    showConfigureButton = false,
+                )
+            }
+        }
+        item {
+            Text(
+                text = "Gamepad button mappings are configured per console — open a console " +
+                    "(Consoles tab) to view and change which physical button does what.",
+                style = SpTypography.BodySmall,
+                color = SpColor.OnBackgroundTertiary,
+                modifier = Modifier.padding(
+                    horizontal = SpSpacing.Default,
+                    vertical = SpSpacing.Small,
+                ),
+            )
+        }
+    }
+
+    // Keyboard key mapping (keycode presets). Desktop-only: there is no keyboard
+    // on Android, and Android gamepad input is positional — so the keycode preset
+    // UI would be empty/dead there (#1353).
+    if (keyMappingViewModel != null && keyMappingState != null && currentPlatform() != "android") {
+        item { SettingsSectionHeader(title = "Keyboard") }
         controlsDefaultScopeItems(
             presets = keyMappingState.availablePresets,
             activePresetId = keyMappingState.activePresetId,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
@@ -31,6 +31,7 @@ import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.intent.KeyMappingIntent
 import com.spela.player.presentation.viewmodel.KeyMappingViewModel
+import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
 import com.spela.player.presentation.viewmodel.SettingsIntent
 import com.spela.player.presentation.viewmodel.SettingsViewModel
 import androidx.compose.foundation.layout.Arrangement
@@ -43,6 +44,7 @@ private const val LIST_DETAIL_BREAKPOINT = 600
 fun SettingsScreen(
     viewModel: SettingsViewModel,
     keyMappingViewModel: KeyMappingViewModel? = null,
+    gamepadConfigViewModel: GamepadConfigViewModel? = null,
     onBack: () -> Unit = {},
     onLogout: () -> Unit,
     onNavigateToConsoleSettings: (String) -> Unit = {},
@@ -108,6 +110,7 @@ fun SettingsScreen(
                         connectionState = connectionState,
                         keyMappingViewModel = keyMappingViewModel,
                         keyMappingState = keyMappingState?.value,
+                        gamepadConfigViewModel = gamepadConfigViewModel,
                         onNavigateToConsoleSettings = onNavigateToConsoleSettings,
                         onNavigateToLicenses = onNavigateToLicenses,
                         onLogout = onLogout,
@@ -128,6 +131,7 @@ fun SettingsScreen(
                         connectionState = connectionState,
                         keyMappingViewModel = keyMappingViewModel,
                         keyMappingState = keyMappingState?.value,
+                        gamepadConfigViewModel = gamepadConfigViewModel,
                         onNavigateToConsoleSettings = onNavigateToConsoleSettings,
                         onNavigateToLicenses = onNavigateToLicenses,
                         onLogout = onLogout,


### PR DESCRIPTION
Fixes #1353 (found during AYN Thor testing of #1334).

## Problem
On Android, Settings → **Controls** showed an empty keycode preset picker — *"No presets available for this platform."* — because the Android per-brand presets were removed for the positional model, but the global Controls category's keycode UI wasn't gated to desktop (only per-console settings + the overlay were).

## Fix
Reworks the Controls category into a controller **verify hub**:
- **Connected Controllers** section (the `GamepadConfigScreen`) on every platform: detected controller type + the per-controller **"Type:"** override → one global place to verify/correct which controller is detected.
- A pointer to per-console settings for gamepad **button** mappings (the positional layer is per-console by design).
- The keyboard keycode preset section ("Keyboard") is gated to `currentPlatform() != "android"`, which removes the empty picker on Android.

## Test
Adds a desktop E2E (`SettingsConsoleNavigationTest.controlsCategoryShowsConnectedControllersVerifyHub`) asserting the Controls category renders the Connected Controllers view. The Android-only keyboard gating is platform-gated → verified on the AYN Thor.

ui-agent reviewed (APPROVE; doubled-heading + missing-test items addressed).