### PR TITLE
feat(player): live controller input tester (input layer) (#1355)

### DIFF
--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.lifecycle.lifecycleScope
 import com.spela.player.domain.model.ControllerClassifier
 import com.spela.player.domain.repository.PreferencesRepository
+import com.spela.player.libretro.AndroidGamepadNormalizer
 import com.spela.player.libretro.AndroidLibretroController
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.presentation.App
@@ -228,6 +229,25 @@ class MainActivity : ComponentActivity() {
         return isGamepad || isJoystick
     }
 
+    /**
+     * Routes a test button to the live input tester (#1355) — but ONLY while the
+     * tester element is focused, and never the D-pad. Returns true when it
+     * captured the event so the caller consumes it (the button must not also
+     * navigate/select). When the tester isn't focused this is a no-op and input
+     * routing is unchanged, so navigation is never disrupted by the tester being
+     * on screen. The D-pad always falls through to navigation.
+     */
+    private fun captureTestInput(event: KeyEvent?, keyCode: Int, pressed: Boolean): Boolean {
+        if (!gamepadPortManager.testCaptureActive.value) return false
+        val deviceId = event?.deviceId ?: return false
+        val port = gamepadPortManager.getPort(deviceId)
+        if (port < 0) return false
+        val position = AndroidGamepadNormalizer.normalize(keyCode) ?: return false
+        if (position.isDpad) return false
+        gamepadPortManager.reportPositionInput(port, position, pressed)
+        return true
+    }
+
     /** Key codes that are gamepad-relevant and should be captured during key mapping. */
     private fun isGamepadCapturable(keyCode: Int): Boolean = when (keyCode) {
         KeyEvent.KEYCODE_BUTTON_A, KeyEvent.KEYCODE_BUTTON_B,
@@ -260,6 +280,11 @@ class MainActivity : ComponentActivity() {
         if (event != null) {
             ensureDeviceConnected(event.deviceId)
         }
+
+        // Live input tester (#1355): when its element is focused, capture test
+        // buttons (face/shoulder/trigger/stick — never the D-pad) and consume
+        // them so they don't navigate. No-op otherwise.
+        if (captureTestInput(event, keyCode, pressed = true)) return true
 
         // Key mapping capture: when in listening mode, intercept gamepad buttons
         if (keyMappingViewModel.state.value.currentMappingButton != null && isGamepadCapturable(keyCode)) {
@@ -362,6 +387,9 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+        // Live input tester (#1355): release the captured test button.
+        if (captureTestInput(event, keyCode, pressed = false)) return true
+
         // Key mapping capture: consume key-up for gamepad buttons when in listening mode
         if (keyMappingViewModel.state.value.currentMappingButton != null && isGamepadCapturable(keyCode)) {
             return true

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
@@ -1,6 +1,8 @@
 package com.spela.player.desktop.e2e
 
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.*
+import com.spela.player.domain.model.GamepadPosition
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.SpScreen
 import com.spela.player.presentation.viewmodel.SettingsIntent
@@ -150,6 +152,41 @@ class SettingsConsoleNavigationTest {
 
         onNodeWithContentDescription("Controllers heading").assertExists()
         onNodeWithContentDescription("Player 1: No controller").assertExists()
+    }
+
+    /**
+     * The live input tester (#1355): a simulated press of a canonical input
+     * position lights up its chip, so the user can verify the detected type by
+     * pressing physical buttons. Driven via GamepadPortManager (the same signal
+     * the desktop poller / Android key dispatch feed on-device).
+     */
+    @Test
+    fun inputTesterHighlightsPressedPosition() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToSettings(harness)
+        onNodeWithContentDescription("Controls").performClick()
+        advanceQuick(harness)
+
+        onNodeWithTag("settings_category_content_list")
+            .performScrollToNode(hasTestTag("tester_pos_SOUTH"))
+        onNodeWithTag("tester_pos_SOUTH")
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Not pressed"))
+
+        // Simulate pressing the bottom (SOUTH) physical button.
+        harness.gamepadPortManager.reportPositionInput(0, GamepadPosition.SOUTH, pressed = true)
+        advanceQuick(harness)
+        onNodeWithTag("tester_pos_SOUTH")
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Pressed"))
+        onNodeWithTag("tester_pos_EAST")
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Not pressed"))
+
+        // Release.
+        harness.gamepadPortManager.reportPositionInput(0, GamepadPosition.SOUTH, pressed = false)
+        advanceQuick(harness)
+        onNodeWithTag("tester_pos_SOUTH")
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Not pressed"))
     }
 
     @Test

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/GamepadPosition.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/GamepadPosition.kt
@@ -58,6 +58,11 @@ enum class GamepadPosition {
             START -> "Start"
             SELECT -> "Select"
         }
+
+    /** D-pad directions. They're positional-standard (don't vary by controller)
+     *  and drive navigation, so the input tester neither shows nor captures them. */
+    val isDpad: Boolean
+        get() = this == DPAD_UP || this == DPAD_DOWN || this == DPAD_LEFT || this == DPAD_RIGHT
 }
 
 /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
@@ -87,6 +87,33 @@ class GamepadPortManager(
     private val _assignments = MutableStateFlow<List<PortAssignment>>(emptyList())
     val assignments: StateFlow<List<PortAssignment>> = _assignments.asStateFlow()
 
+    /** Currently-pressed canonical input positions per port (the input layer).
+     *  Fed by the desktop poller and Android key dispatch; consumed by the live
+     *  input tester so a user can press a button and see which GamepadPosition it
+     *  normalizes to (#1355). */
+    private val pressedByPort = HashMap<Int, MutableSet<GamepadPosition>>()
+    private val _pressedPositions = MutableStateFlow<Set<GamepadPosition>>(emptySet())
+    /** Union of currently-pressed positions across all connected controllers. */
+    val pressedPositions: StateFlow<Set<GamepadPosition>> = _pressedPositions.asStateFlow()
+
+    /** True only while the input-tester element is focused. The input pipelines
+     *  (Android key dispatch, desktop poller) capture test buttons for the tester
+     *  ONLY when this is set, and the D-pad is never captured — so navigation is
+     *  never disrupted by the tester being on screen (#1355). */
+    private val _testCaptureActive = MutableStateFlow(false)
+    val testCaptureActive: StateFlow<Boolean> = _testCaptureActive.asStateFlow()
+
+    /** Set by the tester UI on focus gain/loss. Clears stale highlights on exit. */
+    @Synchronized
+    fun setTestCaptureActive(active: Boolean) {
+        if (_testCaptureActive.value == active) return
+        _testCaptureActive.value = active
+        if (!active && pressedByPort.isNotEmpty()) {
+            pressedByPort.clear()
+            _pressedPositions.value = emptySet()
+        }
+    }
+
     /** Current input mode: TOUCH when touch input was last used, GAMEPAD when D-pad/buttons were. */
     private val _inputMode = MutableStateFlow(InputMode.TOUCH)
     val inputMode: StateFlow<InputMode> = _inputMode.asStateFlow()
@@ -148,6 +175,7 @@ class GamepadPortManager(
         portKeyMappings[assignment.port] = null
         portGamepadMappings[assignment.port] = null
         lastActivityMs[assignment.port] = 0L
+        if (pressedByPort.remove(assignment.port) != null) recomputePressedPositions()
         _assignments.value = deviceToPort.values.toList()
         _portActivity.value = buildActivityMap()
         emitControllerStatus()
@@ -268,6 +296,40 @@ class GamepadPortManager(
     }
 
     /**
+     * Records that a single canonical [position] was pressed/released on [port]
+     * (incremental — used by the Android key dispatch). Feeds [pressedPositions]
+     * for the live input tester (#1355).
+     */
+    @Synchronized
+    fun reportPositionInput(port: Int, position: GamepadPosition, pressed: Boolean) {
+        if (port < 0 || port >= MAX_PORTS) return
+        val set = pressedByPort.getOrPut(port) { mutableSetOf() }
+        val changed = if (pressed) set.add(position) else set.remove(position)
+        if (changed) recomputePressedPositions()
+    }
+
+    /**
+     * Replaces the full set of currently-pressed positions for [port] (wholesale
+     * — used by the desktop poller, which has all positions each frame). Only
+     * emits when the union actually changes, so the 120 Hz poll loop doesn't
+     * churn [pressedPositions].
+     */
+    @Synchronized
+    fun reportPressedPositions(port: Int, positions: Set<GamepadPosition>) {
+        if (port < 0 || port >= MAX_PORTS) return
+        val set = pressedByPort.getOrPut(port) { mutableSetOf() }
+        if (set == positions) return
+        set.clear()
+        set.addAll(positions)
+        recomputePressedPositions()
+    }
+
+    /** Must be called while holding the monitor. */
+    private fun recomputePressedPositions() {
+        _pressedPositions.value = pressedByPort.values.flatMapTo(mutableSetOf()) { it }
+    }
+
+    /**
      * Loads per-game key mapping for a specific port, with fallback chain:
      * per-game -> per-console -> global default -> hardcoded defaults.
      */
@@ -385,6 +447,8 @@ class GamepadPortManager(
         fallbackKeyMapping = null
         fallbackGamepadMapping = null
         lastActivityMs.fill(0L)
+        pressedByPort.clear()
+        _pressedPositions.value = emptySet()
         _assignments.value = emptyList()
         _portActivity.value = emptyMap()
         emitControllerStatus()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadInputTester.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadInputTester.kt
@@ -1,0 +1,112 @@
+package com.spela.player.presentation.ui.components.gamepad
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import com.spela.player.domain.model.GamepadPosition
+import com.spela.player.presentation.ui.gamepad.gamepadFocusable
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Live input-layer tester (#1355). The whole panel is a SINGLE focusable
+ * element: the user D-pad-navigates onto it, then presses face/shoulder/trigger/
+ * stick buttons to see which canonical [GamepadPosition] each maps to — which
+ * verifies the detected controller type without launching a game.
+ *
+ * Capture is scoped to focus: while this element is focused ([onActiveChange]
+ * fires true), the input pipeline routes those buttons here and consumes them
+ * (so A/B don't navigate). The **D-pad is never captured** — it always
+ * navigates, so the user can move onto and off the panel. When unfocused,
+ * nothing is captured and A/B behave normally everywhere else.
+ *
+ * D-pad positions are intentionally not shown (they don't vary by controller).
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun GamepadInputTester(
+    pressedPositions: Set<GamepadPosition>,
+    onActiveChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val focused by interactionSource.collectIsFocusedAsState()
+
+    // Drive capture from this element's focus, and always release on exit.
+    LaunchedEffect(focused) { onActiveChange(focused) }
+    DisposableEffect(Unit) { onDispose { onActiveChange(false) } }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .gamepadFocusable(
+                shape = RoundedCornerShape(SpSpacing.RadiusMedium),
+                interactionSource = interactionSource,
+            )
+            .padding(SpSpacing.Default)
+            .testTag("input_tester"),
+    ) {
+        Text(
+            text = if (focused) {
+                "Press a button on your controller — the matching position lights up. " +
+                    "Use the D-pad to move away. If the wrong position lights up, change the Type above."
+            } else {
+                "Navigate here with the D-pad, then press your buttons to see which position " +
+                    "each maps to — to confirm the controller type is detected correctly."
+            },
+            style = SpTypography.BodySmall,
+            color = SpColor.OnBackgroundTertiary,
+        )
+        Spacer(Modifier.height(SpSpacing.Medium))
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            // D-pad excluded — it isn't tested (positional-standard, drives navigation).
+            GamepadPosition.entries.filterNot { it.isDpad }.forEach { position ->
+                val active = position in pressedPositions
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(SpSpacing.RadiusMedium))
+                        .background(if (active) SpColor.Primary else SpColor.SurfaceElevated)
+                        .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small)
+                        .testTag("tester_pos_${position.name}")
+                        .semantics {
+                            contentDescription = position.displayName
+                            stateDescription = if (active) "Pressed" else "Not pressed"
+                        },
+                ) {
+                    Text(
+                        text = position.displayName,
+                        style = SpTypography.BodyMedium,
+                        color = if (active) SpColor.OnPrimary else SpColor.OnCard,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
@@ -54,6 +54,7 @@ import com.spela.player.presentation.viewmodel.KeyMappingViewModel
 import com.spela.player.presentation.viewmodel.GamepadConfigIntent
 import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
 import com.spela.player.presentation.ui.components.gamepad.GamepadConfigScreen
+import com.spela.player.presentation.ui.components.gamepad.GamepadInputTester
 import com.spela.player.util.currentPlatform
 import com.spela.player.presentation.state.KeyMappingState
 import com.spela.player.data.remote.SyncState
@@ -295,6 +296,20 @@ private fun androidx.compose.foundation.lazy.LazyListScope.controlsContent(
                 )
             }
         }
+
+        // Live input tester (#1355): press a button, see which canonical input
+        // position lights up — verifies the detected type/normalization.
+        item { SettingsSectionHeader(title = "Test controller input") }
+        item {
+            val gamepadConfigState by gamepadConfigViewModel.state.collectAsState()
+            SpCard(onGradient = true) {
+                GamepadInputTester(
+                    pressedPositions = gamepadConfigState.pressedPositions,
+                    onActiveChange = { gamepadConfigViewModel.setInputTestActive(it) },
+                )
+            }
+        }
+
         item {
             Text(
                 text = "Gamepad button mappings are configured per console — open a console " +

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModel.kt
@@ -1,6 +1,7 @@
 package com.spela.player.presentation.viewmodel
 
 import com.spela.player.domain.model.ControllerStyle
+import com.spela.player.domain.model.GamepadPosition
 import com.spela.player.domain.repository.ControllerStyleOverrideRepository
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.util.DispatcherProvider
@@ -17,6 +18,9 @@ import kotlinx.coroutines.launch
 data class GamepadConfigState(
     val portAssignments: List<PortAssignmentUi> = emptyList(),
     val selectedPort: Int? = null,
+    /** Canonical input positions currently held down (any controller) — drives
+     *  the live input tester (#1355). */
+    val pressedPositions: Set<GamepadPosition> = emptySet(),
 )
 
 data class PortAssignmentUi(
@@ -81,6 +85,20 @@ class GamepadConfigViewModel(
 
     init {
         startRefreshing()
+        // Mirror the live pressed-positions signal into state (event-driven, not
+        // the 200 ms poll) so the input tester highlights feel immediate.
+        scope.launch(dispatchers.default) {
+            gamepadPortManager.pressedPositions.collect { positions ->
+                _state.update { it.copy(pressedPositions = positions) }
+            }
+        }
+    }
+
+    /** Toggle input-test capture (called by the tester element on focus change).
+     *  While active, the input pipelines route test buttons to [pressedPositions]
+     *  and consume them so they don't navigate; the D-pad is never captured. */
+    fun setInputTestActive(active: Boolean) {
+        gamepadPortManager.setTestCaptureActive(active)
     }
 
     fun onIntent(intent: GamepadConfigIntent) {

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
@@ -130,6 +130,17 @@ class DesktopGamepadPoller(
                 positionPressed[GamepadPosition.R2.ordinal] = state.axes[5] > TRIGGER_THRESHOLD
             }
 
+            // Live input tester (#1355): only while the tester element is focused,
+            // report pressed test positions (D-pad excluded — it always navigates).
+            if (gamepadPortManager.testCaptureActive.value) {
+                gamepadPortManager.reportPressedPositions(
+                    port,
+                    GamepadPosition.entries.filterTo(mutableSetOf()) {
+                        positionPressed[it.ordinal] && !it.isDpad
+                    },
+                )
+            }
+
             // Apply the configurable mapping layer (position -> RetroPad), with
             // fan-in handled so a released position can't clobber another's press.
             val mapping = gamepadPortManager.getGamepadMapping(port)
@@ -162,7 +173,22 @@ class DesktopGamepadPoller(
             }
         }
 
-        uiNavigator.handle(states)
+        // While the input tester is focused, mask the test buttons (everything
+        // except the D-pad) from UI navigation so e.g. the right face button
+        // doesn't trigger "back" while the user is testing it (#1355). The D-pad
+        // still navigates, so the user can move off the tester.
+        val navStates = if (gamepadPortManager.testCaptureActive.value) {
+            Array(states.size) { idx ->
+                val st = states[idx]
+                val masked = BooleanArray(st.buttons.size) { i ->
+                    st.buttons[i] && i in GamepadPosition.DPAD_UP.ordinal..GamepadPosition.DPAD_RIGHT.ordinal
+                }
+                st.copy(buttons = masked)
+            }
+        } else {
+            states
+        }
+        uiNavigator.handle(navStates)
 
         // Detect disconnections
         val disconnected = knownControllers - currentIds

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
@@ -1,6 +1,7 @@
 package com.spela.player.libretro
 
 import com.spela.player.domain.model.ControllerStyle
+import com.spela.player.domain.model.GamepadPosition
 import com.spela.player.domain.model.KeyMappingProfile
 import com.spela.player.domain.repository.KeyMappingRepository
 import kotlinx.coroutines.test.runTest
@@ -384,6 +385,53 @@ class GamepadPortManagerTest {
         // Both ports still connected after swap
         assertTrue(after.ports[0].connected)
         assertTrue(after.ports[1].connected)
+    }
+
+    // ── Live input tester: pressedPositions (#1355) ──────────────────────────
+
+    @Test
+    fun reportPositionInputTracksPressAndRelease() {
+        manager.reportPositionInput(0, GamepadPosition.SOUTH, pressed = true)
+        assertTrue(GamepadPosition.SOUTH in manager.pressedPositions.value)
+        manager.reportPositionInput(0, GamepadPosition.SOUTH, pressed = false)
+        assertFalse(GamepadPosition.SOUTH in manager.pressedPositions.value)
+    }
+
+    @Test
+    fun reportPressedPositionsReplacesPortSet() {
+        manager.reportPressedPositions(0, setOf(GamepadPosition.SOUTH, GamepadPosition.EAST))
+        assertEquals(setOf(GamepadPosition.SOUTH, GamepadPosition.EAST), manager.pressedPositions.value)
+        manager.reportPressedPositions(0, setOf(GamepadPosition.WEST))
+        assertEquals(setOf(GamepadPosition.WEST), manager.pressedPositions.value)
+    }
+
+    @Test
+    fun pressedPositionsUnionAcrossPortsAndReleaseIsIsolated() {
+        manager.reportPositionInput(0, GamepadPosition.SOUTH, pressed = true)
+        manager.reportPositionInput(1, GamepadPosition.NORTH, pressed = true)
+        assertEquals(setOf(GamepadPosition.SOUTH, GamepadPosition.NORTH), manager.pressedPositions.value)
+        // Releasing port 0's button doesn't clear port 1's.
+        manager.reportPositionInput(0, GamepadPosition.SOUTH, pressed = false)
+        assertEquals(setOf(GamepadPosition.NORTH), manager.pressedPositions.value)
+    }
+
+    @Test
+    fun deactivatingTestCaptureClearsHighlights() {
+        manager.setTestCaptureActive(true)
+        manager.reportPositionInput(0, GamepadPosition.SOUTH, pressed = true)
+        assertTrue(GamepadPosition.SOUTH in manager.pressedPositions.value)
+        // Leaving the tester (focus lost) clears stale highlights.
+        manager.setTestCaptureActive(false)
+        assertTrue(manager.pressedPositions.value.isEmpty())
+    }
+
+    @Test
+    fun disconnectClearsPressedPositionsForThatPort() {
+        manager.connectDevice(deviceId = 7, deviceName = "Pad")
+        manager.reportPositionInput(0, GamepadPosition.SOUTH, pressed = true)
+        assertTrue(GamepadPosition.SOUTH in manager.pressedPositions.value)
+        manager.disconnectDevice(7)
+        assertFalse(GamepadPosition.SOUTH in manager.pressedPositions.value)
     }
 
     private class FakeKeyMappingRepo : KeyMappingRepository {


### PR DESCRIPTION
Closes #1355.

## What
A live **input-layer tester** in Settings → Controls: press a physical controller button and the matching canonical **GamepadPosition** chip lights up — so you can verify the detected controller type/normalization is correct *without launching a game*. If the wrong position lights up, change the controller's **Type** in the Connected Controllers section right above.

Input layer only (physical → position). Per-console position→action testing is a later follow-up.

## How
- `GamepadPortManager` exposes a `pressedPositions` StateFlow (union across ports), fed by:
  - the desktop SDL poller (per-frame, before the mapping layer), and
  - Android `onKeyDown/onKeyUp` — reported additively at the top of dispatch (non-consuming), so it works in the settings UI, not just in-game.
- `GamepadConfigViewModel` mirrors it into state event-driven (not the 200ms poll) for immediate highlights.
- `GamepadInputTester` renders the positions brand-neutrally; pressed chip = Primary highlight, with a11y name + state.

## Test
- `GamepadPortManagerTest`: press/release, wholesale set, cross-port union + isolation, disconnect-clears.
- Desktop E2E `inputTesterHighlightsPressedPosition`: simulated press lights the chip.
- ui-agent reviewed (APPROVE; accessible-name fix applied).
- On-device (real button presses) verified on the AYN Thor.