### PR TITLE
feat(server): federation Phase 2 — hop-bounded transitive aggregates (#1347)

### DIFF
--- a/server/internal/api/federation_stats.go
+++ b/server/internal/api/federation_stats.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -18,16 +19,24 @@ import (
 // hostile/misconfigured peer returning an unbounded body).
 const maxStatsResponseBytes = 4 << 20 // 4 MiB
 
-// statsClient fetches a peer's source-stamped stat rollup over a signed request.
+// maxStatEntriesPerPeer caps how many entries we accept from one friend per
+// refresh, bounding a friend's influence (a single friend can't flood the mesh).
+const maxStatEntriesPerPeer = 5000
+
+// statsClient fetches a peer's source-stamped rollup over a signed request,
+// asking for entries up to maxHops hops from that peer.
 type statsClient interface {
-	FetchStats(baseURL, requestID string, id federation.Identity, peerFingerprint string) ([]federation.StatEntry, error)
+	FetchStats(baseURL, requestID string, id federation.Identity, peerFingerprint string, maxHops int) ([]federation.StatEntry, error)
 }
 
 type httpStatsClient struct{}
 
-func (httpStatsClient) FetchStats(baseURL, requestID string, id federation.Identity, peerFingerprint string) ([]federation.StatEntry, error) {
+func (httpStatsClient) FetchStats(baseURL, requestID string, id federation.Identity, peerFingerprint string, maxHops int) ([]federation.StatEntry, error) {
 	const path = "/api/federation/stats"
-	req, err := http.NewRequest(http.MethodGet, baseURL+path, nil)
+	// maxHops rides in the query (not signed — it only bounds how much data comes
+	// back). The signature covers the path, which is identical on both ends.
+	url := fmt.Sprintf("%s%s?maxHops=%d", baseURL, path, maxHops)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -51,22 +60,36 @@ func (httpStatsClient) FetchStats(baseURL, requestID string, id federation.Ident
 	return body.Entries, nil
 }
 
-// validPeerStatBatch enforces the 1-hop invariant on a friend's rollup: every
-// entry must originate from that friend (no claiming a third server's or our own
-// identity), be hop 0 on their side, and carry non-negative values. A friend
-// that violates this is misbehaving, so the whole batch is rejected rather than
-// cherry-picked.
-func validPeerStatBatch(entries []federation.StatEntry, peerFingerprint string) bool {
+// sanitizeFriendBatch cleans a friend's transitive rollup before we ingest it:
+// drop entries that claim OUR origin (a loop — our local data is authoritative),
+// exceed the hop budget, carry negative values, or are missing an origin. Caps
+// the count per peer. (Phase 2 trusts a direct friend to have honestly
+// aggregated its own friends — a friend can still invent unknown origins; that
+// residual risk is bounded by this cap, dedupe-by-origin, and the per-friend
+// consume toggle. Cryptographic per-origin provenance is a later hardening.)
+func sanitizeFriendBatch(entries []federation.StatEntry, selfFingerprint string, maxAcceptedHops int) []federation.StatEntry {
+	out := make([]federation.StatEntry, 0, len(entries))
 	for _, e := range entries {
-		if e.OriginFingerprint != peerFingerprint || e.Hops != 0 || e.PlayTimeSeconds < 0 || e.Players < 0 {
-			return false
+		if e.OriginFingerprint == "" || e.OriginFingerprint == selfFingerprint {
+			continue
+		}
+		if e.Hops < 0 || e.Hops > maxAcceptedHops {
+			continue
+		}
+		if e.PlayTimeSeconds < 0 || e.Players < 0 {
+			continue
+		}
+		out = append(out, e)
+		if len(out) >= maxStatEntriesPerPeer {
+			break
 		}
 	}
-	return true
+	return out
 }
 
-// ginExportStats serves this server's source-stamped rollup (hop 0) to an
-// authenticated peer we share stats with. Behind VerifyFederationRequest.
+// ginExportStats serves this server's rollup (hop 0) PLUS its cached friend
+// rollups up to the requested hop distance, so a friend can re-aggregate
+// transitively. Behind VerifyFederationRequest + SharePolicy(stats).
 func (h *FederationHandler) ginExportStats(c *gin.Context) {
 	reqID := c.GetHeader(headerFedRequestID)
 	if reqID == "" {
@@ -81,56 +104,57 @@ func (h *FederationHandler) ginExportStats(c *gin.Context) {
 		c.JSON(http.StatusForbidden, gin.H{"error": "stats not shared with this peer"})
 		return
 	}
-	entries, err := federation.BuildLocalRollup(h.DB, h.Identity.Fingerprint())
+
+	maxHops := federation.MaxFederationHops - 1
+	if q := c.Query("maxHops"); q != "" {
+		if n, err := strconv.Atoi(q); err == nil && n >= 0 && n < maxHops {
+			maxHops = n
+		}
+	}
+
+	local, err := federation.BuildLocalRollup(h.DB, h.Identity.Fingerprint())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build rollup"})
 		return
 	}
+	// Re-serve cached friend data within the hop budget (maxHops counts the
+	// distance from THIS server; the requester adds 1 on ingest).
+	cached, err := h.Snapshots.EntriesWithinHops(maxHops)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read snapshots"})
+		return
+	}
+	entries := append(local, cached...)
+
 	federation.RecordExchange(h.DB, federation.ExchangeRecord{
 		RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
-		Direction: db.ExchangeInbound, Operation: "stats_export",
+		Direction: db.ExchangeInbound, Operation: "stats_export", MaxHops: maxHops,
 		DataClass: string(federation.DataClassStats), Status: db.ExchangeOK, ItemCount: len(entries),
 	})
 	c.JSON(http.StatusOK, gin.H{"entries": entries})
 }
 
-// --- Aggregated read (user-facing) -----------------------------------------
-
-type AggregatedStatsInput struct {
-	Metric string `query:"metric" enum:"game_play,player_play"`
-	Limit  int    `query:"limit"`
-}
-type AggregatedStatsOutput struct {
-	Body struct {
-		Stats []federation.AggregatedStat `json:"stats"`
-	}
-}
-
-// HumaAggregatedStats merges this server's rollup (hop 0) with each stats-
-// consumable active friend's rollup (hop 1) and returns the aggregated
-// leaderboard with per-source breakdown. Phase 1: direct friends only. A friend
-// that fails to respond is recorded and skipped (graceful degradation).
-func (h *FederationHandler) HumaAggregatedStats(_ context.Context, in *AggregatedStatsInput) (*AggregatedStatsOutput, error) {
-	all, err := federation.BuildLocalRollup(h.DB, h.Identity.Fingerprint())
-	if err != nil {
-		return nil, huma.Error500InternalServerError("failed to build local rollup")
-	}
-
+// RefreshFederationStats pulls each stats-consumable active friend's rollup
+// (bounded by the hop budget), sanitizes + increments hops, and replaces that
+// friend's cached snapshot. This is the periodic sync that powers transitive
+// re-serving. Returns (refreshed, failed) peer counts.
+func (h *FederationHandler) RefreshFederationStats() (int, int) {
 	peers, err := h.Peers.List()
 	if err != nil {
-		return nil, huma.Error500InternalServerError("failed to list peers")
+		return 0, 0
 	}
 	client := h.StatsClient
 	if client == nil {
 		client = httpStatsClient{}
 	}
+	refreshed, failed := 0, 0
 	for _, peer := range peers {
 		if peer.Status != db.PeerStatusActive || !federation.CanConsume(peer, federation.DataClassStats) {
 			continue
 		}
 		reqID := federation.NewRequestID()
 		started := time.Now()
-		entries, ferr := client.FetchStats(peer.BaseURL, reqID, h.Identity, peer.Fingerprint)
+		raw, ferr := client.FetchStats(peer.BaseURL, reqID, h.Identity, peer.Fingerprint, federation.MaxFederationHops-1)
 		if ferr != nil {
 			federation.RecordExchange(h.DB, federation.ExchangeRecord{
 				RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
@@ -138,31 +162,84 @@ func (h *FederationHandler) HumaAggregatedStats(_ context.Context, in *Aggregate
 				DataClass: string(federation.DataClassStats), Status: db.ExchangeError,
 				StartedAt: started, Error: ferr.Error(),
 			})
+			failed++
 			continue
 		}
-		// Reject a misbehaving friend's batch wholesale (spoofed origin, wrong
-		// hop, or negative values would poison the aggregate).
-		if !validPeerStatBatch(entries, peer.Fingerprint) {
+		cleaned := sanitizeFriendBatch(raw, h.Identity.Fingerprint(), federation.MaxFederationHops-1)
+		for i := range cleaned {
+			cleaned[i].Hops++ // distance from us = distance from the friend + 1
+		}
+		if err := h.Snapshots.ReplacePeerSnapshot(peer.Fingerprint, cleaned, time.Now()); err != nil {
 			federation.RecordExchange(h.DB, federation.ExchangeRecord{
 				RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
 				Direction: db.ExchangeOutbound, Operation: "stats_pull",
-				DataClass: string(federation.DataClassStats), Status: db.ExchangeRejected,
-				StartedAt: started, ItemCount: len(entries), Error: "invalid stat batch (origin/hop/value)",
+				DataClass: string(federation.DataClassStats), Status: db.ExchangeError,
+				StartedAt: started, Error: "store: " + err.Error(),
 			})
+			failed++
 			continue
 		}
-		// Ingest: a friend's hop-0 datum is hop 1 from us.
-		for i := range entries {
-			entries[i].Hops++
-		}
-		all = append(all, entries...)
 		federation.RecordExchange(h.DB, federation.ExchangeRecord{
 			RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
 			Direction: db.ExchangeOutbound, Operation: "stats_pull",
 			DataClass: string(federation.DataClassStats), Status: db.ExchangeOK,
-			StartedAt: started, ItemCount: len(entries),
+			StartedAt: started, ItemCount: len(cleaned),
 		})
+		refreshed++
 	}
+	return refreshed, failed
+}
+
+// --- Refresh (admin trigger) -----------------------------------------------
+
+type RefreshStatsInput struct{}
+type RefreshStatsOutput struct {
+	Body struct {
+		Refreshed int `json:"refreshed"`
+		Failed    int `json:"failed"`
+	}
+}
+
+func (h *FederationHandler) HumaRefreshStats(_ context.Context, _ *RefreshStatsInput) (*RefreshStatsOutput, error) {
+	r, f := h.RefreshFederationStats()
+	out := &RefreshStatsOutput{}
+	out.Body.Refreshed = r
+	out.Body.Failed = f
+	return out, nil
+}
+
+// --- Aggregated read (user-facing) -----------------------------------------
+
+type AggregatedStatsInput struct {
+	Metric  string `query:"metric" enum:"game_play,player_play"`
+	Limit   int    `query:"limit"`
+	MaxHops int    `query:"maxHops"` // viewer reach: >=1 limits to that distance; <=0 = full reachable mesh
+}
+type AggregatedStatsOutput struct {
+	Body struct {
+		Stats []federation.AggregatedStat `json:"stats"`
+	}
+}
+
+// HumaAggregatedStats merges this server's rollup (hop 0) with its cached friend
+// snapshots (hop >= 1) and returns the aggregated mesh leaderboard. Reads from
+// the snapshot store (populated by RefreshFederationStats) — no live pulls — so
+// reach is unbounded in depth yet cheap. MaxHops bounds the viewer's reach.
+func (h *FederationHandler) HumaAggregatedStats(_ context.Context, in *AggregatedStatsInput) (*AggregatedStatsOutput, error) {
+	all, err := federation.BuildLocalRollup(h.DB, h.Identity.Fingerprint())
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to build local rollup")
+	}
+
+	snapHops := -1 // full reachable mesh
+	if in.MaxHops >= 1 {
+		snapHops = in.MaxHops
+	}
+	cached, err := h.Snapshots.EntriesWithinHops(snapHops)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to read snapshots")
+	}
+	all = append(all, cached...)
 
 	aggregated := federation.AggregateStatEntries(all)
 	if in.Metric != "" {
@@ -180,7 +257,6 @@ func (h *FederationHandler) HumaAggregatedStats(_ context.Context, in *Aggregate
 
 	// Strip the per-source breakdown: it carries peer fingerprints, and the peer
 	// roster is admin-only elsewhere. Regular users get totals + labels only.
-	// (A future admin-only detailed view can expose Sources for anti-inflation.)
 	for i := range aggregated {
 		aggregated[i].Sources = nil
 	}

--- a/server/internal/api/federation_stats.go
+++ b/server/internal/api/federation_stats.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -107,7 +108,7 @@ func (h *FederationHandler) ginExportStats(c *gin.Context) {
 
 	maxHops := federation.MaxFederationHops - 1
 	if q := c.Query("maxHops"); q != "" {
-		if n, err := strconv.Atoi(q); err == nil && n >= 0 && n < maxHops {
+		if n, err := strconv.Atoi(q); err == nil && n >= 0 && n <= maxHops {
 			maxHops = n
 		}
 	}
@@ -139,6 +140,15 @@ func (h *FederationHandler) ginExportStats(c *gin.Context) {
 // friend's cached snapshot. This is the periodic sync that powers transitive
 // re-serving. Returns (refreshed, failed) peer counts.
 func (h *FederationHandler) RefreshFederationStats() (int, int) {
+	// Serialize refreshes: the periodic ticker and an admin trigger must not run
+	// concurrently (WAL allows overlapping write txns, which would race the
+	// per-peer delete-then-insert). If one is already running, skip.
+	if !h.refreshMu.TryLock() {
+		slog.Info("federation: stats refresh already in progress, skipping", "component", "federation")
+		return 0, 0
+	}
+	defer h.refreshMu.Unlock()
+
 	peers, err := h.Peers.List()
 	if err != nil {
 		return 0, 0

--- a/server/internal/api/federation_stats_test.go
+++ b/server/internal/api/federation_stats_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/db"
@@ -18,11 +19,13 @@ import (
 
 // fakeStatsClient returns canned friend entries keyed by base URL.
 type fakeStatsClient struct {
-	byBase map[string][]federation.StatEntry
-	err    error
+	byBase      map[string][]federation.StatEntry
+	err         error
+	lastMaxHops int
 }
 
-func (f fakeStatsClient) FetchStats(baseURL, _ string, _ federation.Identity, _ string) ([]federation.StatEntry, error) {
+func (f *fakeStatsClient) FetchStats(baseURL, _ string, _ federation.Identity, _ string, maxHops int) ([]federation.StatEntry, error) {
+	f.lastMaxHops = maxHops
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -38,6 +41,18 @@ func seedLocalPlay(t *testing.T, database *gorm.DB, scraperID string, playTime i
 	require.NoError(t, database.Create(&db.PlayHistory{UserID: u.ID, GameID: g.ID, PlayTime: playTime}).Error)
 }
 
+func statsHandler(database *gorm.DB, selfID federation.Identity, client statsClient) *FederationHandler {
+	return &FederationHandler{
+		DB: database, Identity: selfID,
+		Peers:       federation.PeerStore{DB: database},
+		Snapshots:   federation.SnapshotStore{DB: database},
+		BaseURL:     "https://self",
+		StatsClient: client,
+	}
+}
+
+// --- Export ---------------------------------------------------------------
+
 func callExport(h *FederationHandler, peer *db.FederationPeer) *httptest.ResponseRecorder {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -50,11 +65,16 @@ func callExport(h *FederationHandler, peer *db.FederationPeer) *httptest.Respons
 	return w
 }
 
-func TestExportStats_SharesStampedRollupWhenPolicyAllows(t *testing.T) {
+func TestExportStats_ServesLocalPlusCachedWithinHops(t *testing.T) {
 	database := openAPIFedTestDB(t)
 	selfID, _ := federation.GenerateIdentity()
 	seedLocalPlay(t, database, "igdb:1", 100)
-	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self"}
+	h := statsHandler(database, selfID, nil)
+
+	// Cache a friend-of-friend entry (hop 2) so the export should re-serve it.
+	require.NoError(t, h.Snapshots.ReplacePeerSnapshot("B", []federation.StatEntry{
+		{OriginFingerprint: "C", Hops: 2, Metric: federation.MetricGamePlay, Key: "igdb:9", Label: "Far Game", PlayTimeSeconds: 40},
+	}, time.Unix(1, 0)))
 
 	sp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassStats: true})
 	peer := &db.FederationPeer{Fingerprint: "fp-friend", Name: "Friend", SharePolicy: sp, Status: db.PeerStatusActive}
@@ -66,127 +86,153 @@ func TestExportStats_SharesStampedRollupWhenPolicyAllows(t *testing.T) {
 		Entries []federation.StatEntry `json:"entries"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-	require.NotEmpty(t, body.Entries)
+
+	var sawLocal, sawCached bool
 	for _, e := range body.Entries {
-		assert.Equal(t, selfID.Fingerprint(), e.OriginFingerprint)
-		assert.Equal(t, 0, e.Hops)
+		if e.OriginFingerprint == selfID.Fingerprint() && e.Hops == 0 {
+			sawLocal = true
+		}
+		if e.OriginFingerprint == "C" && e.Hops == 2 {
+			sawCached = true
+		}
 	}
+	assert.True(t, sawLocal, "export includes local hop-0 data")
+	assert.True(t, sawCached, "export re-serves cached transitive data within the hop budget")
 }
 
 func TestExportStats_ForbiddenWhenNotShared(t *testing.T) {
 	database := openAPIFedTestDB(t)
 	selfID, _ := federation.GenerateIdentity()
 	seedLocalPlay(t, database, "igdb:1", 100)
-	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self"}
+	h := statsHandler(database, selfID, nil)
 
-	// SharePolicy does not include stats.
 	peer := &db.FederationPeer{Fingerprint: "fp-friend", Name: "Friend", SharePolicy: "", Status: db.PeerStatusActive}
-
 	w := callExport(h, peer)
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
-func TestAggregatedStats_MergesLocalAndFriend(t *testing.T) {
+// --- Refresh (pull into snapshot store) -----------------------------------
+
+func TestRefresh_PullsConsumableFriendIntoSnapshot(t *testing.T) {
 	database := openAPIFedTestDB(t)
 	selfID, _ := federation.GenerateIdentity()
 	friendID, _ := federation.GenerateIdentity()
-	seedLocalPlay(t, database, "igdb:1", 100) // local: game igdb:1 = 100
-
-	// An active friend we consume stats from.
 	policyPeer(t, database, friendID, "Friend", "https://friend", true, true)
 
-	// Friend reports the same game igdb:1 with 250 (hop 0 on their side).
-	fake := fakeStatsClient{byBase: map[string][]federation.StatEntry{
+	fake := &fakeStatsClient{byBase: map[string][]federation.StatEntry{
 		"https://friend": {{
 			OriginFingerprint: friendID.Fingerprint(), Hops: 0,
-			Metric: federation.MetricGamePlay, Key: "igdb:1", Label: "Local Game", PlayTimeSeconds: 250, Players: 5,
+			Metric: federation.MetricGamePlay, Key: "igdb:1", PlayTimeSeconds: 250, Players: 5,
 		}},
 	}}
-	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self", StatsClient: fake}
+	h := statsHandler(database, selfID, fake)
 
-	out, err := h.HumaAggregatedStats(context.Background(), &AggregatedStatsInput{Metric: "game_play"})
+	refreshed, failed := h.RefreshFederationStats()
+	assert.Equal(t, 1, refreshed)
+	assert.Equal(t, 0, failed)
+	assert.Equal(t, federation.MaxFederationHops-1, fake.lastMaxHops, "asks for the hop budget minus one")
+
+	cached, err := h.Snapshots.EntriesWithinHops(-1)
 	require.NoError(t, err)
-	require.Len(t, out.Body.Stats, 1)
-	assert.Equal(t, "igdb:1", out.Body.Stats[0].Key)
-	assert.Equal(t, int64(350), out.Body.Stats[0].TotalPlayTime, "local 100 + friend 250")
-	assert.Empty(t, out.Body.Stats[0].Sources, "per-source breakdown stripped from the user-facing response")
-
-	// A successful pull was recorded in the ledger.
-	var pulls int64
-	database.Model(&db.FederationExchange{}).Where("operation = ? AND status = ?", "stats_pull", db.ExchangeOK).Count(&pulls)
-	assert.Equal(t, int64(1), pulls)
+	require.Len(t, cached, 1)
+	assert.Equal(t, 1, cached[0].Hops, "friend's hop-0 datum is stored at hop 1")
+	assert.Equal(t, friendID.Fingerprint(), cached[0].OriginFingerprint)
 }
 
-func TestAggregatedStats_RejectsSpoofedFriendBatch(t *testing.T) {
+func TestRefresh_SkipsNonConsumablePeer(t *testing.T) {
 	database := openAPIFedTestDB(t)
 	selfID, _ := federation.GenerateIdentity()
 	friendID, _ := federation.GenerateIdentity()
-	seedLocalPlay(t, database, "igdb:1", 100)
-	policyPeer(t, database, friendID, "Friend", "https://friend", true, true)
+	policyPeer(t, database, friendID, "Friend", "https://friend", true, false) // consume=false
 
-	// The friend claims an entry that originates from a THIRD fingerprint (spoof)
-	// with an absurd play time — the whole batch must be rejected.
-	fake := fakeStatsClient{byBase: map[string][]federation.StatEntry{
-		"https://friend": {{
-			OriginFingerprint: "someoneelse", Hops: 0,
-			Metric: federation.MetricGamePlay, Key: "igdb:1", PlayTimeSeconds: 999999,
-		}},
+	fake := &fakeStatsClient{byBase: map[string][]federation.StatEntry{
+		"https://friend": {{OriginFingerprint: friendID.Fingerprint(), Hops: 0, Metric: federation.MetricGamePlay, Key: "igdb:1", PlayTimeSeconds: 1}},
 	}}
-	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self", StatsClient: fake}
+	h := statsHandler(database, selfID, fake)
 
-	out, err := h.HumaAggregatedStats(context.Background(), &AggregatedStatsInput{Metric: "game_play"})
-	require.NoError(t, err)
-	require.Len(t, out.Body.Stats, 1)
-	assert.Equal(t, int64(100), out.Body.Stats[0].TotalPlayTime, "spoofed batch rejected; local-only result")
-
-	var rejected int64
-	database.Model(&db.FederationExchange{}).Where("operation = ? AND status = ?", "stats_pull", db.ExchangeRejected).Count(&rejected)
-	assert.Equal(t, int64(1), rejected)
+	refreshed, _ := h.RefreshFederationStats()
+	assert.Equal(t, 0, refreshed)
+	cached, _ := h.Snapshots.EntriesWithinHops(-1)
+	assert.Empty(t, cached)
 }
 
-func TestAggregatedStats_SkipsFriendOnErrorButReturnsLocal(t *testing.T) {
+func TestRefresh_SanitizesLoopAndOverBudgetEntries(t *testing.T) {
 	database := openAPIFedTestDB(t)
 	selfID, _ := federation.GenerateIdentity()
 	friendID, _ := federation.GenerateIdentity()
-	seedLocalPlay(t, database, "igdb:1", 100)
 	policyPeer(t, database, friendID, "Friend", "https://friend", true, true)
 
-	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self",
-		StatsClient: fakeStatsClient{err: errors.New("connection refused")}}
+	fake := &fakeStatsClient{byBase: map[string][]federation.StatEntry{
+		"https://friend": {
+			{OriginFingerprint: selfID.Fingerprint(), Hops: 0, Metric: federation.MetricGamePlay, Key: "loop", PlayTimeSeconds: 100},             // our own data looping back
+			{OriginFingerprint: "X", Hops: federation.MaxFederationHops, Metric: federation.MetricGamePlay, Key: "toofar", PlayTimeSeconds: 100}, // over budget
+			{OriginFingerprint: "Y", Hops: 1, Metric: federation.MetricGamePlay, Key: "ok", PlayTimeSeconds: 100},                                // good
+		},
+	}}
+	h := statsHandler(database, selfID, fake)
 
-	out, err := h.HumaAggregatedStats(context.Background(), &AggregatedStatsInput{Metric: "game_play"})
-	require.NoError(t, err, "an unreachable friend must not fail the whole read")
-	require.Len(t, out.Body.Stats, 1)
-	assert.Equal(t, int64(100), out.Body.Stats[0].TotalPlayTime, "local-only when friend is down")
+	_, _ = h.RefreshFederationStats()
+	cached, err := h.Snapshots.EntriesWithinHops(-1)
+	require.NoError(t, err)
+	require.Len(t, cached, 1, "loop + over-budget entries dropped")
+	assert.Equal(t, "Y", cached[0].OriginFingerprint)
+	assert.Equal(t, 2, cached[0].Hops)
+}
+
+func TestRefresh_RecordsErrorOnFetchFailure(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+	policyPeer(t, database, friendID, "Friend", "https://friend", true, true)
+	h := statsHandler(database, selfID, &fakeStatsClient{err: errors.New("connection refused")})
+
+	refreshed, failed := h.RefreshFederationStats()
+	assert.Equal(t, 0, refreshed)
+	assert.Equal(t, 1, failed)
 
 	var errs int64
 	database.Model(&db.FederationExchange{}).Where("operation = ? AND status = ?", "stats_pull", db.ExchangeError).Count(&errs)
 	assert.Equal(t, int64(1), errs)
 }
 
-func TestAggregatedStats_DoesNotPullWhenConsumeDisabled(t *testing.T) {
+// --- Aggregated read (from snapshot store) --------------------------------
+
+func TestAggregatedStats_MergesLocalAndSnapshots(t *testing.T) {
 	database := openAPIFedTestDB(t)
 	selfID, _ := federation.GenerateIdentity()
-	friendID, _ := federation.GenerateIdentity()
-	seedLocalPlay(t, database, "igdb:1", 100)
-	// share=true but consume=false → we must NOT pull stats from this peer.
-	policyPeer(t, database, friendID, "Friend", "https://friend", true, false)
+	seedLocalPlay(t, database, "igdb:1", 100) // local: igdb:1 = 100
+	h := statsHandler(database, selfID, nil)
 
-	called := false
-	h := &FederationHandler{DB: database, Identity: selfID, Peers: federation.PeerStore{DB: database}, BaseURL: "https://self",
-		StatsClient: fakeStatsClientFunc(func() { called = true })}
+	// A previously-refreshed friend snapshot for the same game (hop 1).
+	require.NoError(t, h.Snapshots.ReplacePeerSnapshot("B", []federation.StatEntry{
+		{OriginFingerprint: "B", Hops: 1, Metric: federation.MetricGamePlay, Key: "igdb:1", Label: "Local Game", PlayTimeSeconds: 250, Players: 5},
+	}, time.Unix(1, 0)))
 
 	out, err := h.HumaAggregatedStats(context.Background(), &AggregatedStatsInput{Metric: "game_play"})
 	require.NoError(t, err)
-	assert.False(t, called, "must not fetch from a peer we don't consume stats from")
 	require.Len(t, out.Body.Stats, 1)
-	assert.Equal(t, int64(100), out.Body.Stats[0].TotalPlayTime)
+	assert.Equal(t, int64(350), out.Body.Stats[0].TotalPlayTime, "local 100 + snapshot 250")
+	assert.Empty(t, out.Body.Stats[0].Sources, "per-source breakdown stripped from the user-facing response")
 }
 
-// fakeStatsClientFunc records whether FetchStats was invoked.
-type fakeStatsClientFunc func()
+func TestAggregatedStats_RespectsViewerMaxHops(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	seedLocalPlay(t, database, "igdb:local", 10)
+	h := statsHandler(database, selfID, nil)
 
-func (f fakeStatsClientFunc) FetchStats(_, _ string, _ federation.Identity, _ string) ([]federation.StatEntry, error) {
-	f()
-	return nil, nil
+	require.NoError(t, h.Snapshots.ReplacePeerSnapshot("B", []federation.StatEntry{
+		{OriginFingerprint: "B", Hops: 1, Metric: federation.MetricGamePlay, Key: "near", Label: "Near", PlayTimeSeconds: 1},
+		{OriginFingerprint: "D", Hops: 3, Metric: federation.MetricGamePlay, Key: "far", Label: "Far", PlayTimeSeconds: 1},
+	}, time.Unix(1, 0)))
+
+	out, err := h.HumaAggregatedStats(context.Background(), &AggregatedStatsInput{Metric: "game_play", MaxHops: 1})
+	require.NoError(t, err)
+	keys := map[string]bool{}
+	for _, s := range out.Body.Stats {
+		keys[s.Key] = true
+	}
+	assert.True(t, keys["igdb:local"], "local always included")
+	assert.True(t, keys["near"], "hop-1 included at maxHops=1")
+	assert.False(t, keys["far"], "hop-3 excluded at maxHops=1")
 }

--- a/server/internal/api/federation_testutil_test.go
+++ b/server/internal/api/federation_testutil_test.go
@@ -25,6 +25,7 @@ func openAPIFedTestDB(t *testing.T) *gorm.DB {
 		&db.FederationPeer{},
 		&db.FederationInviteNonce{},
 		&db.FederationExchange{},
+		&db.FederationStatSnapshot{},
 		// For stats rollup tests.
 		&db.User{},
 		&db.Game{},

--- a/server/internal/api/huma_federation.go
+++ b/server/internal/api/huma_federation.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -32,6 +33,9 @@ type FederationHandler struct {
 	// StatsClient fetches a friend's stat rollup. Defaults to httpStatsClient
 	// when nil; overridden in tests.
 	StatsClient statsClient
+	// refreshMu serializes RefreshFederationStats so the periodic ticker and an
+	// admin trigger can't run concurrently and race on the snapshot store.
+	refreshMu sync.Mutex
 }
 
 // pairClient performs the outbound pairing callback to a friend.

--- a/server/internal/api/huma_federation.go
+++ b/server/internal/api/huma_federation.go
@@ -20,7 +20,9 @@ type FederationHandler struct {
 	DB       *gorm.DB
 	Identity federation.Identity
 	Peers    federation.PeerStore
-	BaseURL  string // this server's own reachable federation endpoint
+	// Snapshots caches friends' rollups for transitive re-serving (#1347).
+	Snapshots federation.SnapshotStore
+	BaseURL   string // this server's own reachable federation endpoint
 	// PairClient performs the outbound pairing callback to a friend. Defaults to
 	// httpPairClient when nil; overridden in tests.
 	PairClient pairClient

--- a/server/internal/api/huma_federation_admin.go
+++ b/server/internal/api/huma_federation_admin.go
@@ -152,6 +152,12 @@ func (h *FederationHandler) HumaRevokePeer(_ context.Context, in *RevokePeerInpu
 	if err := h.Peers.Remove(in.Fingerprint); err != nil {
 		return nil, huma.Error500InternalServerError("failed to revoke peer")
 	}
+	// Drop the revoked friend's cached rollup so its contribution vanishes
+	// immediately (clean blast radius).
+	if err := h.Snapshots.RemovePeerSnapshot(in.Fingerprint); err != nil {
+		slog.Warn("federation: failed to drop revoked peer snapshot", "component", "federation",
+			"peer", federation.ShortFingerprint(in.Fingerprint), "error", err)
+	}
 	slog.Info("federation: revoked peer", "component", "federation",
 		"peer", federation.ShortFingerprint(in.Fingerprint))
 	out := &RevokePeerOutput{}
@@ -343,11 +349,22 @@ func RegisterFederationRoutes(api huma.API, h *FederationHandler, jwtSecret stri
 		OperationID: "federationAggregatedStats",
 		Method:      http.MethodGet,
 		Path:        "/api/federation/stats/aggregated",
-		Summary:     "Federated (mesh) aggregate stats across direct friends",
+		Summary:     "Federated (mesh) aggregate stats, hop-bounded",
 		Tags:        []string{"federation", "stats"},
 		Middlewares: huma.Middlewares{requireAuth, rateLimit},
 		Security:    sec,
 	}, h.HumaAggregatedStats)
+
+	// Admin: force a refresh of cached friend rollups (also runs periodically).
+	huma.Register(api, huma.Operation{
+		OperationID: "federationRefreshStats",
+		Method:      http.MethodPost,
+		Path:        "/api/admin/federation/stats/refresh",
+		Summary:     "Refresh cached friend stat rollups now",
+		Tags:        []string{"federation", "admin"},
+		Middlewares: adminMW,
+		Security:    sec,
+	}, h.HumaRefreshStats)
 }
 
 // RegisterFederationGinRoutes wires raw-gin federation routes: the signed ping

--- a/server/internal/api/huma_federation_admin_test.go
+++ b/server/internal/api/huma_federation_admin_test.go
@@ -115,7 +115,7 @@ func TestRevokePeer_RemovesIt(t *testing.T) {
 	require.NoError(t, store.Upsert(&db.FederationPeer{
 		Fingerprint: "fp-x", PublicKey: "k", BaseURL: "https://x", Status: db.PeerStatusActive,
 	}))
-	h := &FederationHandler{DB: database, Identity: selfID, Peers: store, BaseURL: "https://self"}
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: store, Snapshots: federation.SnapshotStore{DB: database}, BaseURL: "https://self"}
 
 	_, err := h.HumaRevokePeer(context.Background(), &RevokePeerInput{Fingerprint: "fp-x"})
 	require.NoError(t, err)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -26,17 +26,17 @@ import (
 
 // Config holds configuration for the API router.
 type Config struct {
-	DB            *gorm.DB
-	JWTSecret     string
-	EncryptionKey []byte // separate AES key; falls back to DeriveEncryptionKey(JWTSecret) if nil
-	GameDirs      []string
-	Storage       *storage.Storage
-	Scanner       *scanner.Scanner
-	Scraper       *scraper.Scraper
-	Hub           *ws.Hub
-	NetplayHub    *ws.NetplayHub
-	CoreDir       string
-	FrontendDir   string // path to Vite dist/ output; empty = disabled
+	DB                           *gorm.DB
+	JWTSecret                    string
+	EncryptionKey                []byte // separate AES key; falls back to DeriveEncryptionKey(JWTSecret) if nil
+	GameDirs                     []string
+	Storage                      *storage.Storage
+	Scanner                      *scanner.Scanner
+	Scraper                      *scraper.Scraper
+	Hub                          *ws.Hub
+	NetplayHub                   *ws.NetplayHub
+	CoreDir                      string
+	FrontendDir                  string // path to Vite dist/ output; empty = disabled
 	CORSOrigins                  []string
 	RAClient                     *retroachievements.RAClient // optional; defaults to production RA client
 	ChallengeAttemptRateLimitSec int                         // 0 = disabled; default 30 in production
@@ -186,10 +186,11 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		slog.Info("federation: identity ready", "fingerprint", federation.ShortFingerprint(fedIdentity.Fingerprint()))
 	}
 	federationHandler := &FederationHandler{
-		DB:       cfg.DB,
-		Identity: fedIdentity,
-		Peers:    federation.PeerStore{DB: cfg.DB},
-		BaseURL:  cfg.PublicBaseURL,
+		DB:        cfg.DB,
+		Identity:  fedIdentity,
+		Peers:     federation.PeerStore{DB: cfg.DB},
+		Snapshots: federation.SnapshotStore{DB: cfg.DB},
+		BaseURL:   cfg.PublicBaseURL,
 	}
 
 	socialHandler := &SocialHandler{DB: cfg.DB, Hub: cfg.Hub}
@@ -464,6 +465,25 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		r.NoRoute(serveFrontend(cfg.FrontendDir))
 	}
 
+	// Periodic federation stats refresh (#1347): pull friends' rollups into the
+	// local snapshot cache so the mesh leaderboard stays current. Disable with
+	// SPELA_DISABLE_FEDERATION_REFRESH=1; force one anytime via the admin endpoint.
+	stopFedRefresh := make(chan struct{})
+	if fedErr == nil && os.Getenv("SPELA_DISABLE_FEDERATION_REFRESH") == "" {
+		go func() {
+			ticker := time.NewTicker(15 * time.Minute)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stopFedRefresh:
+					return
+				case <-ticker.C:
+					federationHandler.RefreshFederationStats()
+				}
+			}
+		}()
+	}
+
 	cleanup := func() {
 		authLimiter.Close()
 		refreshLimiter.Close()
@@ -471,6 +491,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		uploadLimiter.Close()
 		userLimiter.Close()
 		imageLimiter.Close()
+		close(stopFedRefresh)
 	}
 
 	return r, cleanup

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-contrib/cors"
@@ -469,7 +470,10 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	// local snapshot cache so the mesh leaderboard stays current. Disable with
 	// SPELA_DISABLE_FEDERATION_REFRESH=1; force one anytime via the admin endpoint.
 	stopFedRefresh := make(chan struct{})
+	fedRefreshStarted := false
+	var stopFedRefreshOnce sync.Once
 	if fedErr == nil && os.Getenv("SPELA_DISABLE_FEDERATION_REFRESH") == "" {
+		fedRefreshStarted = true
 		go func() {
 			ticker := time.NewTicker(15 * time.Minute)
 			defer ticker.Stop()
@@ -491,7 +495,11 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		uploadLimiter.Close()
 		userLimiter.Close()
 		imageLimiter.Close()
-		close(stopFedRefresh)
+		// sync.Once so a second cleanup() call (e.g. in tests) can't panic on a
+		// double close; only close if the goroutine was actually started.
+		if fedRefreshStarted {
+			stopFedRefreshOnce.Do(func() { close(stopFedRefresh) })
+		}
 	}
 
 	return r, cleanup

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -237,6 +237,8 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&FederationPeer{},
 		&FederationInviteNonce{},
 		&FederationExchange{},
+		// Phase 2 (#1347): cached friend rollups for transitive re-serving.
+		&FederationStatSnapshot{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running migrations: %w", err)

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -606,6 +606,26 @@ type FederationExchange struct {
 	Error           string    `gorm:"size:512" json:"error"`
 }
 
+// FederationStatSnapshot caches a stat datum pulled from a direct friend so this
+// server can re-serve it transitively (Phase 2, #1347) without re-pulling on
+// every request. SourcePeerFingerprint is the direct friend we got it from (used
+// to replace that peer's rows on refresh); OriginFingerprint is where the datum
+// actually originated, which may be several hops away. Hops is the distance from
+// THIS server to the origin.
+type FederationStatSnapshot struct {
+	ID                    uint      `gorm:"primarykey" json:"id"`
+	CreatedAt             time.Time `json:"createdAt"`
+	SourcePeerFingerprint string    `gorm:"size:64;index" json:"sourcePeerFingerprint"`
+	OriginFingerprint     string    `gorm:"size:64;index" json:"originFingerprint"`
+	Hops                  int       `json:"hops"`
+	Metric                string    `gorm:"size:32;index" json:"metric"`
+	Key                   string    `gorm:"size:255" json:"key"`
+	Label                 string    `gorm:"size:255" json:"label"`
+	PlayTimeSeconds       int64     `json:"playTimeSeconds"`
+	Players               int64     `json:"players"`
+	FetchedAt             time.Time `json:"fetchedAt"`
+}
+
 // ConsoleSaveStateChoice is the user's per-console save-state opt-out
 // state. Drives whether the in-game overlay shows the save/load
 // buttons or grays them out, and whether the first-launch prompt

--- a/server/internal/federation/snapshot.go
+++ b/server/internal/federation/snapshot.go
@@ -1,0 +1,82 @@
+package federation
+
+import (
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// MaxFederationHops bounds how far stats propagate across the mesh: a datum more
+// than this many hops from a server is dropped on ingest. This caps storage
+// growth and prevents runaway loops — combined with dedupe-by-origin, a datum
+// circulating the mesh can never be counted twice or grow without bound.
+const MaxFederationHops = 4
+
+// SnapshotStore persists stat entries pulled from direct friends so this server
+// can re-serve them transitively without re-pulling on every request (#1347).
+type SnapshotStore struct {
+	DB *gorm.DB
+}
+
+// ReplacePeerSnapshot atomically replaces all cached entries from one direct
+// friend with a fresh set. Idempotent per peer: refreshing with the same data
+// yields the same rows.
+func (s SnapshotStore) ReplacePeerSnapshot(sourcePeerFingerprint string, entries []StatEntry, fetchedAt time.Time) error {
+	return s.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("source_peer_fingerprint = ?", sourcePeerFingerprint).
+			Delete(&db.FederationStatSnapshot{}).Error; err != nil {
+			return err
+		}
+		if len(entries) == 0 {
+			return nil
+		}
+		rows := make([]db.FederationStatSnapshot, 0, len(entries))
+		for _, e := range entries {
+			rows = append(rows, db.FederationStatSnapshot{
+				SourcePeerFingerprint: sourcePeerFingerprint,
+				OriginFingerprint:     e.OriginFingerprint,
+				Hops:                  e.Hops,
+				Metric:                string(e.Metric),
+				Key:                   e.Key,
+				Label:                 e.Label,
+				PlayTimeSeconds:       e.PlayTimeSeconds,
+				Players:               e.Players,
+				FetchedAt:             fetchedAt,
+			})
+		}
+		return tx.Create(&rows).Error
+	})
+}
+
+// RemovePeerSnapshot drops a direct friend's cached entries (e.g. on revocation).
+func (s SnapshotStore) RemovePeerSnapshot(sourcePeerFingerprint string) error {
+	return s.DB.Where("source_peer_fingerprint = ?", sourcePeerFingerprint).
+		Delete(&db.FederationStatSnapshot{}).Error
+}
+
+// EntriesWithinHops returns cached entries whose hop count is <= maxHops, as
+// StatEntry values. A negative maxHops means no limit.
+func (s SnapshotStore) EntriesWithinHops(maxHops int) ([]StatEntry, error) {
+	q := s.DB.Model(&db.FederationStatSnapshot{})
+	if maxHops >= 0 {
+		q = q.Where("hops <= ?", maxHops)
+	}
+	var rows []db.FederationStatSnapshot
+	if err := q.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make([]StatEntry, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, StatEntry{
+			OriginFingerprint: r.OriginFingerprint,
+			Hops:              r.Hops,
+			Metric:            StatMetric(r.Metric),
+			Key:               r.Key,
+			Label:             r.Label,
+			PlayTimeSeconds:   r.PlayTimeSeconds,
+			Players:           r.Players,
+		})
+	}
+	return out, nil
+}

--- a/server/internal/federation/snapshot_test.go
+++ b/server/internal/federation/snapshot_test.go
@@ -1,0 +1,68 @@
+package federation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func openSnapshotTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&db.FederationStatSnapshot{}))
+	return database
+}
+
+func TestSnapshotStore_ReplaceIsIdempotentPerPeer(t *testing.T) {
+	store := SnapshotStore{DB: openSnapshotTestDB(t)}
+	now := time.Unix(1000, 0)
+
+	entries := []StatEntry{
+		{OriginFingerprint: "C", Hops: 1, Metric: MetricGamePlay, Key: "g1", PlayTimeSeconds: 50},
+		{OriginFingerprint: "D", Hops: 2, Metric: MetricGamePlay, Key: "g2", PlayTimeSeconds: 70},
+	}
+	require.NoError(t, store.ReplacePeerSnapshot("B", entries, now))
+	require.NoError(t, store.ReplacePeerSnapshot("B", entries, now)) // replace, not append
+
+	got, err := store.EntriesWithinHops(-1)
+	require.NoError(t, err)
+	assert.Len(t, got, 2, "replace must not duplicate rows")
+}
+
+func TestSnapshotStore_FiltersByHops(t *testing.T) {
+	store := SnapshotStore{DB: openSnapshotTestDB(t)}
+	require.NoError(t, store.ReplacePeerSnapshot("B", []StatEntry{
+		{OriginFingerprint: "B", Hops: 1, Metric: MetricGamePlay, Key: "g1"},
+		{OriginFingerprint: "C", Hops: 2, Metric: MetricGamePlay, Key: "g2"},
+		{OriginFingerprint: "D", Hops: 3, Metric: MetricGamePlay, Key: "g3"},
+	}, time.Unix(1, 0)))
+
+	within2, err := store.EntriesWithinHops(2)
+	require.NoError(t, err)
+	assert.Len(t, within2, 2, "hop <= 2 excludes the hop-3 entry")
+
+	all, err := store.EntriesWithinHops(-1)
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+}
+
+func TestSnapshotStore_RemovePeer(t *testing.T) {
+	store := SnapshotStore{DB: openSnapshotTestDB(t)}
+	require.NoError(t, store.ReplacePeerSnapshot("B", []StatEntry{{OriginFingerprint: "B", Hops: 1, Key: "g1", Metric: MetricGamePlay}}, time.Unix(1, 0)))
+	require.NoError(t, store.ReplacePeerSnapshot("D", []StatEntry{{OriginFingerprint: "D", Hops: 1, Key: "g2", Metric: MetricGamePlay}}, time.Unix(1, 0)))
+
+	require.NoError(t, store.RemovePeerSnapshot("B"))
+	got, err := store.EntriesWithinHops(-1)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "D", got[0].OriginFingerprint)
+}

--- a/server/internal/federation/stats.go
+++ b/server/internal/federation/stats.go
@@ -37,27 +37,29 @@ type statDedupeKey struct {
 }
 
 // DedupeStatEntries removes duplicate (origin, metric, key) entries, keeping the
-// copy with the smallest hop count. This is what makes mesh aggregation correct
-// when one source is reachable via more than one friend (the diamond case): a
-// source must not be counted twice. Idempotent —
-// DedupeStatEntries(DedupeStatEntries(x)) == DedupeStatEntries(x).
+// FIRST occurrence. This is what makes mesh aggregation correct when one source
+// is reachable via more than one friend (the diamond case): a source must not be
+// counted twice. Idempotent — DedupeStatEntries(DedupeStatEntries(x)) ==
+// DedupeStatEntries(x).
+//
+// We deliberately do NOT prefer the lowest-hop copy: that would let a *near*
+// (possibly malicious) friend's claimed copy of an origin override that origin's
+// legitimate data arriving via a longer path (proximity-as-authority). The kept
+// copy's hop value isn't used downstream — reach filtering happens at the
+// snapshot-store level before aggregation — so first-seen is both safe and
+// sufficient. Honest copies of one origin are identical, so the choice only
+// matters under a misbehaving relay, where first-seen removes the reliable
+// overwrite vector. (Full mitigation = per-origin cryptographic provenance.)
 func DedupeStatEntries(entries []StatEntry) []StatEntry {
-	best := make(map[statDedupeKey]StatEntry, len(entries))
-	order := make([]statDedupeKey, 0, len(entries))
+	seen := make(map[statDedupeKey]bool, len(entries))
+	out := make([]StatEntry, 0, len(entries))
 	for _, e := range entries {
 		k := statDedupeKey{e.OriginFingerprint, e.Metric, e.Key}
-		if existing, ok := best[k]; ok {
-			if e.Hops < existing.Hops {
-				best[k] = e
-			}
+		if seen[k] {
 			continue
 		}
-		best[k] = e
-		order = append(order, k)
-	}
-	out := make([]StatEntry, 0, len(order))
-	for _, k := range order {
-		out = append(out, best[k])
+		seen[k] = true
+		out = append(out, e)
 	}
 	return out
 }

--- a/server/internal/federation/stats_test.go
+++ b/server/internal/federation/stats_test.go
@@ -6,16 +6,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDedupeStatEntries_SameSourceCountedOnce_KeepsMinHop(t *testing.T) {
-	// Same origin/metric/key arriving via two paths (e.g. a diamond in Phase 2):
-	// hop 3 via one friend, hop 1 via another. Must collapse to one, min hop.
+func TestDedupeStatEntries_SameSourceCountedOnce_KeepsFirstSeen(t *testing.T) {
+	// Same origin/metric/key arriving via two paths (a diamond): must collapse to
+	// ONE. We keep the first occurrence (NOT the nearest) so a near malicious
+	// relay can't override a distant origin's legitimate copy via a hop tiebreak.
 	entries := []StatEntry{
 		{OriginFingerprint: "C", Hops: 3, Metric: MetricGamePlay, Key: "g1", PlayTimeSeconds: 500, Players: 2},
 		{OriginFingerprint: "C", Hops: 1, Metric: MetricGamePlay, Key: "g1", PlayTimeSeconds: 500, Players: 2},
 	}
 	out := DedupeStatEntries(entries)
 	assert.Len(t, out, 1)
-	assert.Equal(t, 1, out[0].Hops)
+	assert.Equal(t, 3, out[0].Hops, "first occurrence kept, not the nearest")
 	assert.Equal(t, int64(500), out[0].PlayTimeSeconds)
 }
 


### PR DESCRIPTION
## Federation Phase 2 — Hop-bounded transitive aggregates

Part of #1347 (server-side; the player/web reach-slider UI remains — see below). Builds on Phase 1 (#1352).

Turns Phase 1's 1-hop stats into the full "aggregate of aggregates": each server **caches its friends' rollups and re-serves the merged set** up to a requested hop limit, so reach extends mesh-wide through stored re-serving — without ever connecting beyond direct friends and without read-time recursion.

### How it works
- **`FederationStatSnapshot` + `SnapshotStore`** — a per-direct-friend cache of contributed entries (replace-on-refresh, hop-filtered reads).
- **Export is now transitive** — `GET /api/federation/stats?maxHops=N` returns local hop-0 data **plus** cached friend data within the requested hop budget. The requester adds 1 on ingest.
- **`RefreshFederationStats`** — pulls each stats-`ConsumePolicy` active friend (asking for `MaxFederationHops-1`), **sanitizes** the batch (drops entries that loop our own origin back, exceed the hop budget, or carry negative values; caps entries per peer), `+1`-hops, and atomically replaces that friend's snapshot. Runs on a **15-min ticker** (`SPELA_DISABLE_FEDERATION_REFRESH` to disable) and via admin `POST /api/admin/federation/stats/refresh`.
- **Aggregated read serves from the cache** — `GET /api/federation/stats/aggregated?maxHops=N` merges local + cached snapshots (no live pulls), deduping by origin so the **diamond case never double-counts**, with `maxHops` powering the reach slider.
- **Revocation drops the friend's snapshot** — its contribution vanishes immediately.
- **Loop/growth bound** — `MaxFederationHops` (4) caps propagation depth; combined with dedupe-by-origin and dropping our-own-origin on ingest, a datum circulating the mesh can never be counted twice or grow without bound.

### Trust model (delegated, as designed)
Phase 2 trusts a direct friend to have honestly aggregated *its* friends — a friend can still invent unknown origins. That residual risk is bounded by: the per-peer entry cap, dedupe-by-origin (can't inflate by repeating an origin), the hop cap, and the per-friend **consume toggle** (an admin can stop consuming from a misbehaving friend while keeping it as, e.g., a game relay). Cryptographic per-origin provenance (each origin signs its own datum) is noted as a future hardening.

### On k-anonymity
The exploration doc listed k-anonymity as a Phase 2 item, but it's **unnecessary given Phase 1's public-only gate**: `BuildLocalRollup` already excludes private/disabled/pending users from *both* metrics, so no private user's play data ever enters the mesh. (If game totals were ever extended to include private users, k-anonymity would be needed then; documented in code.)

### Testing
- New unit tests: snapshot store (idempotent replace, hop filter, remove), export (local+cached within hops, share-gate), refresh (pull→store with +1 hop, consume-gate, loop/over-budget sanitization, fetch-error recording), aggregated read (merge-from-store, viewer maxHops).
- **Full `go test ./...` passes, no regressions**; build clean.

### Remaining (follow-up)
- **Reach-slider UI** (player/web) — "my server / my friends / 2 hops / all reachable", wired to the `maxHops` param. Part of the same UI track as #1346.
- Cryptographic per-origin provenance (hardening of the delegated-trust model).

Part of #1347
