### PR TITLE
feat(server): federation Phase 3a — catalog metadata federation (#1348)

### DIFF
--- a/server/internal/api/federation_catalog.go
+++ b/server/internal/api/federation_catalog.go
@@ -1,0 +1,239 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+)
+
+// catalogClient fetches a peer's source-stamped catalog over a signed request.
+type catalogClient interface {
+	FetchCatalog(baseURL, requestID string, id federation.Identity, peerFingerprint string, maxHops int) ([]federation.CatalogEntry, error)
+}
+
+type httpCatalogClient struct{}
+
+func (httpCatalogClient) FetchCatalog(baseURL, requestID string, id federation.Identity, peerFingerprint string, maxHops int) ([]federation.CatalogEntry, error) {
+	const path = "/api/federation/catalog"
+	url := fmt.Sprintf("%s%s?maxHops=%d", baseURL, path, maxHops)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range signedFederationHeaders(id, http.MethodGet, path, requestID, nil, peerFingerprint) {
+		req.Header.Set(k, v)
+	}
+	resp, err := fedHTTPClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("remote returned %d", resp.StatusCode)
+	}
+	var body struct {
+		Entries []federation.CatalogEntry `json:"entries"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxStatsResponseBytes)).Decode(&body); err != nil {
+		return nil, err
+	}
+	return body.Entries, nil
+}
+
+// sanitizeCatalogBatch drops entries claiming our own origin (loop) or exceeding
+// the hop budget, and caps the count per peer.
+func sanitizeCatalogBatch(entries []federation.CatalogEntry, selfFingerprint string, maxAcceptedHops int) []federation.CatalogEntry {
+	out := make([]federation.CatalogEntry, 0, len(entries))
+	for _, e := range entries {
+		if e.OriginFingerprint == "" || e.OriginFingerprint == selfFingerprint {
+			continue
+		}
+		if e.Hops < 0 || e.Hops > maxAcceptedHops || e.Key == "" {
+			continue
+		}
+		out = append(out, e)
+		if len(out) >= maxStatEntriesPerPeer {
+			break
+		}
+	}
+	return out
+}
+
+// ginExportCatalog serves this server's catalog (hop 0) plus its cached friend
+// catalogs within the requested hop budget. Behind VerifyFederationRequest +
+// SharePolicy(catalog).
+func (h *FederationHandler) ginExportCatalog(c *gin.Context) {
+	reqID := c.GetHeader(headerFedRequestID)
+	if reqID == "" {
+		reqID = federation.NewRequestID()
+	}
+	peer, ok := federationPeerFromGin(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "no verified peer"})
+		return
+	}
+	if !federation.CanShare(*peer, federation.DataClassCatalog) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "catalog not shared with this peer"})
+		return
+	}
+
+	maxHops := federation.MaxFederationHops - 1
+	if q := c.Query("maxHops"); q != "" {
+		if n, err := strconv.Atoi(q); err == nil && n >= 0 && n <= maxHops {
+			maxHops = n
+		}
+	}
+
+	local, err := federation.BuildLocalCatalog(h.DB, h.Identity.Fingerprint())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build catalog"})
+		return
+	}
+	cached, err := h.CatalogSnapshots.EntriesWithinHops(maxHops)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read catalog snapshots"})
+		return
+	}
+	entries := append(local, cached...)
+
+	federation.RecordExchange(h.DB, federation.ExchangeRecord{
+		RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+		Direction: db.ExchangeInbound, Operation: "catalog_export", MaxHops: maxHops,
+		DataClass: string(federation.DataClassCatalog), Status: db.ExchangeOK, ItemCount: len(entries),
+	})
+	c.JSON(http.StatusOK, gin.H{"entries": entries})
+}
+
+// RefreshFederationCatalog pulls each catalog-consumable active friend's catalog,
+// sanitizes + increments hops, and replaces that friend's cached snapshot.
+// Serialized against itself; runs on the periodic ticker + admin trigger.
+func (h *FederationHandler) RefreshFederationCatalog() (int, int) {
+	if !h.catalogRefreshMu.TryLock() {
+		slog.Info("federation: catalog refresh already in progress, skipping", "component", "federation")
+		return 0, 0
+	}
+	defer h.catalogRefreshMu.Unlock()
+
+	peers, err := h.Peers.List()
+	if err != nil {
+		return 0, 0
+	}
+	client := h.CatalogClient
+	if client == nil {
+		client = httpCatalogClient{}
+	}
+	refreshed, failed := 0, 0
+	for _, peer := range peers {
+		if peer.Status != db.PeerStatusActive || !federation.CanConsume(peer, federation.DataClassCatalog) {
+			continue
+		}
+		reqID := federation.NewRequestID()
+		started := time.Now()
+		raw, ferr := client.FetchCatalog(peer.BaseURL, reqID, h.Identity, peer.Fingerprint, federation.MaxFederationHops-1)
+		if ferr != nil {
+			federation.RecordExchange(h.DB, federation.ExchangeRecord{
+				RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+				Direction: db.ExchangeOutbound, Operation: "catalog_pull",
+				DataClass: string(federation.DataClassCatalog), Status: db.ExchangeError,
+				StartedAt: started, Error: ferr.Error(),
+			})
+			failed++
+			continue
+		}
+		cleaned := sanitizeCatalogBatch(raw, h.Identity.Fingerprint(), federation.MaxFederationHops-1)
+		for i := range cleaned {
+			cleaned[i].Hops++
+		}
+		if err := h.CatalogSnapshots.ReplacePeerSnapshot(peer.Fingerprint, cleaned, time.Now()); err != nil {
+			federation.RecordExchange(h.DB, federation.ExchangeRecord{
+				RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+				Direction: db.ExchangeOutbound, Operation: "catalog_pull",
+				DataClass: string(federation.DataClassCatalog), Status: db.ExchangeError,
+				StartedAt: started, Error: "store: " + err.Error(),
+			})
+			failed++
+			continue
+		}
+		federation.RecordExchange(h.DB, federation.ExchangeRecord{
+			RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+			Direction: db.ExchangeOutbound, Operation: "catalog_pull",
+			DataClass: string(federation.DataClassCatalog), Status: db.ExchangeOK,
+			StartedAt: started, ItemCount: len(cleaned),
+		})
+		refreshed++
+	}
+	return refreshed, failed
+}
+
+// --- Available games (user-facing discovery) -------------------------------
+
+type AvailableGamesInput struct {
+	MaxHops    int  `query:"maxHops"`    // viewer reach; <=0 = full reachable mesh
+	RemoteOnly bool `query:"remoteOnly"` // only games not available locally
+}
+type AvailableGamesOutput struct {
+	Body struct {
+		Games []federation.CatalogAvailability `json:"games"`
+	}
+}
+
+// HumaAvailableGames returns the mesh game catalog (local + cached friends),
+// each row showing how many servers offer it and whether it's local.
+func (h *FederationHandler) HumaAvailableGames(_ context.Context, in *AvailableGamesInput) (*AvailableGamesOutput, error) {
+	local, err := federation.BuildLocalCatalog(h.DB, h.Identity.Fingerprint())
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to build local catalog")
+	}
+	snapHops := -1
+	if in.MaxHops >= 1 {
+		snapHops = in.MaxHops
+	}
+	cached, err := h.CatalogSnapshots.EntriesWithinHops(snapHops)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to read catalog snapshots")
+	}
+	all := append(local, cached...)
+
+	games := federation.AggregateCatalog(all, h.Identity.Fingerprint())
+	if in.RemoteOnly {
+		filtered := make([]federation.CatalogAvailability, 0, len(games))
+		for _, g := range games {
+			if !g.Local {
+				filtered = append(filtered, g)
+			}
+		}
+		games = filtered
+	}
+
+	out := &AvailableGamesOutput{}
+	out.Body.Games = games
+	return out, nil
+}
+
+// --- Catalog refresh (admin trigger) ---------------------------------------
+
+type RefreshCatalogInput struct{}
+type RefreshCatalogOutput struct {
+	Body struct {
+		Refreshed int `json:"refreshed"`
+		Failed    int `json:"failed"`
+	}
+}
+
+func (h *FederationHandler) HumaRefreshCatalog(_ context.Context, _ *RefreshCatalogInput) (*RefreshCatalogOutput, error) {
+	r, f := h.RefreshFederationCatalog()
+	out := &RefreshCatalogOutput{}
+	out.Body.Refreshed = r
+	out.Body.Failed = f
+	return out, nil
+}

--- a/server/internal/api/federation_catalog.go
+++ b/server/internal/api/federation_catalog.go
@@ -58,8 +58,16 @@ func sanitizeCatalogBatch(entries []federation.CatalogEntry, selfFingerprint str
 		if e.OriginFingerprint == "" || e.OriginFingerprint == selfFingerprint {
 			continue
 		}
-		if e.Hops < 0 || e.Hops > maxAcceptedHops || e.Key == "" {
+		if e.Hops < 0 || e.Hops > maxAcceptedHops || e.Key == "" || len(e.Key) > 255 {
 			continue
+		}
+		// Bound untrusted string fields — SQLite ignores the VARCHAR size hints,
+		// so a hostile peer could otherwise store arbitrarily long Title/Console.
+		if len(e.Title) > 255 {
+			e.Title = e.Title[:255]
+		}
+		if len(e.Console) > 32 {
+			e.Console = e.Console[:32]
 		}
 		out = append(out, e)
 		if len(out) >= maxStatEntriesPerPeer {

--- a/server/internal/api/federation_catalog_test.go
+++ b/server/internal/api/federation_catalog_test.go
@@ -148,6 +148,28 @@ func TestRefreshCatalog_SanitizesLoopAndOverBudget(t *testing.T) {
 	assert.Equal(t, "Y", cached[0].OriginFingerprint)
 }
 
+func TestRefreshCatalog_TruncatesOversizedStrings(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+	catalogPolicyPeer(t, database, friendID, "Friend", "https://friend", true, true)
+
+	longTitle := make([]byte, 1000)
+	for i := range longTitle {
+		longTitle[i] = 'A'
+	}
+	fake := &fakeCatalogClient{byBase: map[string][]federation.CatalogEntry{
+		"https://friend": {{OriginFingerprint: friendID.Fingerprint(), Hops: 0, Key: "igdb:9", Title: string(longTitle), Console: "NES"}},
+	}}
+	h := catalogHandler(database, selfID, fake)
+
+	_, _ = h.RefreshFederationCatalog()
+	cached, err := h.CatalogSnapshots.EntriesWithinHops(-1)
+	require.NoError(t, err)
+	require.Len(t, cached, 1)
+	assert.LessOrEqual(t, len(cached[0].Title), 255, "oversized title bounded before storage")
+}
+
 func TestRefreshCatalog_RecordsErrorOnFailure(t *testing.T) {
 	database := openAPIFedTestDB(t)
 	selfID, _ := federation.GenerateIdentity()

--- a/server/internal/api/federation_catalog_test.go
+++ b/server/internal/api/federation_catalog_test.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type fakeCatalogClient struct {
+	byBase map[string][]federation.CatalogEntry
+	err    error
+}
+
+func (f *fakeCatalogClient) FetchCatalog(baseURL, _ string, _ federation.Identity, _ string, _ int) ([]federation.CatalogEntry, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.byBase[baseURL], nil
+}
+
+func catalogHandler(database *gorm.DB, selfID federation.Identity, client catalogClient) *FederationHandler {
+	return &FederationHandler{
+		DB: database, Identity: selfID,
+		Peers:            federation.PeerStore{DB: database},
+		Snapshots:        federation.SnapshotStore{DB: database},
+		CatalogSnapshots: federation.CatalogSnapshotStore{DB: database},
+		BaseURL:          "https://self",
+		CatalogClient:    client,
+	}
+}
+
+func seedConsoleAndGame(t *testing.T, database *gorm.DB, scraperID, title string) {
+	t.Helper()
+	var console db.Console
+	if err := database.Where("abbreviation = ?", "SNES").First(&console).Error; err != nil {
+		console = db.Console{Name: "Super Nintendo", Abbreviation: "SNES"}
+		require.NoError(t, database.Create(&console).Error)
+	}
+	require.NoError(t, database.Create(&db.Game{Title: title, ScraperID: scraperID, FilePath: "/" + scraperID, ConsoleID: console.ID}).Error)
+}
+
+func catalogPolicyPeer(t *testing.T, database *gorm.DB, id federation.Identity, name, baseURL string, share, consume bool) {
+	t.Helper()
+	sp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassCatalog: share})
+	cp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassCatalog: consume})
+	require.NoError(t, federation.PeerStore{DB: database}.Upsert(&db.FederationPeer{
+		Fingerprint: id.Fingerprint(), PublicKey: b64(id.PublicKey), Name: name, BaseURL: baseURL,
+		Status: db.PeerStatusActive, SharePolicy: sp, ConsumePolicy: cp,
+	}))
+}
+
+func callExportCatalog(h *FederationHandler, peer *db.FederationPeer) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/x", func(c *gin.Context) {
+		c.Set(fedPeerContextKey, peer)
+		h.ginExportCatalog(c)
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/x", nil))
+	return w
+}
+
+func TestExportCatalog_ServesLocalWhenShared(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	seedConsoleAndGame(t, database, "igdb:1", "Game One")
+	h := catalogHandler(database, selfID, nil)
+
+	sp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassCatalog: true})
+	peer := &db.FederationPeer{Fingerprint: "fp", Name: "Friend", SharePolicy: sp, Status: db.PeerStatusActive}
+
+	w := callExportCatalog(h, peer)
+	require.Equal(t, http.StatusOK, w.Code)
+	var body struct {
+		Entries []federation.CatalogEntry `json:"entries"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Len(t, body.Entries, 1)
+	assert.Equal(t, "igdb:1", body.Entries[0].Key)
+	assert.Equal(t, selfID.Fingerprint(), body.Entries[0].OriginFingerprint)
+	assert.Equal(t, "SNES", body.Entries[0].Console)
+}
+
+func TestExportCatalog_ForbiddenWhenNotShared(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	seedConsoleAndGame(t, database, "igdb:1", "Game One")
+	h := catalogHandler(database, selfID, nil)
+
+	peer := &db.FederationPeer{Fingerprint: "fp", Name: "Friend", SharePolicy: "", Status: db.PeerStatusActive}
+	w := callExportCatalog(h, peer)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestRefreshCatalog_PullsConsumableFriend(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+	catalogPolicyPeer(t, database, friendID, "Friend", "https://friend", true, true)
+
+	fake := &fakeCatalogClient{byBase: map[string][]federation.CatalogEntry{
+		"https://friend": {{OriginFingerprint: friendID.Fingerprint(), Hops: 0, Key: "igdb:9", Title: "Remote", Console: "NES"}},
+	}}
+	h := catalogHandler(database, selfID, fake)
+
+	refreshed, failed := h.RefreshFederationCatalog()
+	assert.Equal(t, 1, refreshed)
+	assert.Equal(t, 0, failed)
+
+	cached, err := h.CatalogSnapshots.EntriesWithinHops(-1)
+	require.NoError(t, err)
+	require.Len(t, cached, 1)
+	assert.Equal(t, 1, cached[0].Hops, "friend's hop-0 entry stored at hop 1")
+	assert.Equal(t, "igdb:9", cached[0].Key)
+}
+
+func TestRefreshCatalog_SanitizesLoopAndOverBudget(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+	catalogPolicyPeer(t, database, friendID, "Friend", "https://friend", true, true)
+
+	fake := &fakeCatalogClient{byBase: map[string][]federation.CatalogEntry{
+		"https://friend": {
+			{OriginFingerprint: selfID.Fingerprint(), Hops: 0, Key: "loop", Title: "Loop"},
+			{OriginFingerprint: "X", Hops: federation.MaxFederationHops, Key: "toofar", Title: "Far"},
+			{OriginFingerprint: "Y", Hops: 1, Key: "ok", Title: "OK"},
+		},
+	}}
+	h := catalogHandler(database, selfID, fake)
+
+	_, _ = h.RefreshFederationCatalog()
+	cached, err := h.CatalogSnapshots.EntriesWithinHops(-1)
+	require.NoError(t, err)
+	require.Len(t, cached, 1, "loop + over-budget dropped")
+	assert.Equal(t, "Y", cached[0].OriginFingerprint)
+}
+
+func TestRefreshCatalog_RecordsErrorOnFailure(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+	catalogPolicyPeer(t, database, friendID, "Friend", "https://friend", true, true)
+	h := catalogHandler(database, selfID, &fakeCatalogClient{err: errors.New("refused")})
+
+	_, failed := h.RefreshFederationCatalog()
+	assert.Equal(t, 1, failed)
+	var errs int64
+	database.Model(&db.FederationExchange{}).Where("operation = ? AND status = ?", "catalog_pull", db.ExchangeError).Count(&errs)
+	assert.Equal(t, int64(1), errs)
+}
+
+func TestAvailableGames_AggregatesAndFiltersRemoteOnly(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	seedConsoleAndGame(t, database, "igdb:local", "Local Game") // local has igdb:local
+	h := catalogHandler(database, selfID, nil)
+
+	// A friend offers a game we DON'T have, plus the same one we do.
+	require.NoError(t, h.CatalogSnapshots.ReplacePeerSnapshot("B", []federation.CatalogEntry{
+		{OriginFingerprint: "B", Hops: 1, Key: "igdb:remote", Title: "Remote Game", Console: "NES"},
+		{OriginFingerprint: "B", Hops: 1, Key: "igdb:local", Title: "Local Game", Console: "SNES"},
+	}, time.Unix(1, 0)))
+
+	all, err := h.HumaAvailableGames(context.Background(), &AvailableGamesInput{})
+	require.NoError(t, err)
+	assert.Len(t, all.Body.Games, 2)
+
+	remoteOnly, err := h.HumaAvailableGames(context.Background(), &AvailableGamesInput{RemoteOnly: true})
+	require.NoError(t, err)
+	require.Len(t, remoteOnly.Body.Games, 1, "only the game we don't have locally")
+	assert.Equal(t, "igdb:remote", remoteOnly.Body.Games[0].Key)
+	assert.False(t, remoteOnly.Body.Games[0].Local)
+}

--- a/server/internal/api/federation_testutil_test.go
+++ b/server/internal/api/federation_testutil_test.go
@@ -26,8 +26,10 @@ func openAPIFedTestDB(t *testing.T) *gorm.DB {
 		&db.FederationInviteNonce{},
 		&db.FederationExchange{},
 		&db.FederationStatSnapshot{},
-		// For stats rollup tests.
+		&db.FederationCatalogSnapshot{},
+		// For stats rollup + catalog tests.
 		&db.User{},
+		&db.Console{},
 		&db.Game{},
 		&db.PlayHistory{},
 	))

--- a/server/internal/api/huma_federation.go
+++ b/server/internal/api/huma_federation.go
@@ -23,7 +23,9 @@ type FederationHandler struct {
 	Peers    federation.PeerStore
 	// Snapshots caches friends' rollups for transitive re-serving (#1347).
 	Snapshots federation.SnapshotStore
-	BaseURL   string // this server's own reachable federation endpoint
+	// CatalogSnapshots caches friends' game catalogs for discovery (#1348).
+	CatalogSnapshots federation.CatalogSnapshotStore
+	BaseURL          string // this server's own reachable federation endpoint
 	// PairClient performs the outbound pairing callback to a friend. Defaults to
 	// httpPairClient when nil; overridden in tests.
 	PairClient pairClient
@@ -33,9 +35,13 @@ type FederationHandler struct {
 	// StatsClient fetches a friend's stat rollup. Defaults to httpStatsClient
 	// when nil; overridden in tests.
 	StatsClient statsClient
-	// refreshMu serializes RefreshFederationStats so the periodic ticker and an
-	// admin trigger can't run concurrently and race on the snapshot store.
-	refreshMu sync.Mutex
+	// CatalogClient fetches a friend's catalog. Defaults to httpCatalogClient
+	// when nil; overridden in tests.
+	CatalogClient catalogClient
+	// refreshMu / catalogRefreshMu serialize the respective refreshes so the
+	// periodic ticker and an admin trigger can't race the snapshot stores.
+	refreshMu        sync.Mutex
+	catalogRefreshMu sync.Mutex
 }
 
 // pairClient performs the outbound pairing callback to a friend.

--- a/server/internal/api/huma_federation_admin.go
+++ b/server/internal/api/huma_federation_admin.go
@@ -158,6 +158,10 @@ func (h *FederationHandler) HumaRevokePeer(_ context.Context, in *RevokePeerInpu
 		slog.Warn("federation: failed to drop revoked peer snapshot", "component", "federation",
 			"peer", federation.ShortFingerprint(in.Fingerprint), "error", err)
 	}
+	if err := h.CatalogSnapshots.RemovePeerSnapshot(in.Fingerprint); err != nil {
+		slog.Warn("federation: failed to drop revoked peer catalog snapshot", "component", "federation",
+			"peer", federation.ShortFingerprint(in.Fingerprint), "error", err)
+	}
 	slog.Info("federation: revoked peer", "component", "federation",
 		"peer", federation.ShortFingerprint(in.Fingerprint))
 	out := &RevokePeerOutput{}
@@ -365,12 +369,35 @@ func RegisterFederationRoutes(api huma.API, h *FederationHandler, jwtSecret stri
 		Middlewares: adminMW,
 		Security:    sec,
 	}, h.HumaRefreshStats)
+
+	// User-facing: mesh game catalog (which games are available across friends).
+	huma.Register(api, huma.Operation{
+		OperationID: "federationAvailableGames",
+		Method:      http.MethodGet,
+		Path:        "/api/federation/catalog/available",
+		Summary:     "Games available across the friend mesh, hop-bounded",
+		Tags:        []string{"federation", "catalog"},
+		Middlewares: huma.Middlewares{requireAuth, rateLimit},
+		Security:    sec,
+	}, h.HumaAvailableGames)
+
+	// Admin: force a refresh of cached friend catalogs (also runs periodically).
+	huma.Register(api, huma.Operation{
+		OperationID: "federationRefreshCatalog",
+		Method:      http.MethodPost,
+		Path:        "/api/admin/federation/catalog/refresh",
+		Summary:     "Refresh cached friend game catalogs now",
+		Tags:        []string{"federation", "admin"},
+		Middlewares: adminMW,
+		Security:    sec,
+	}, h.HumaRefreshCatalog)
 }
 
 // RegisterFederationGinRoutes wires raw-gin federation routes: the signed ping
-// used by the connection-test diagnostic.
+// used by the connection-test diagnostic, plus the signed stat/catalog exports.
 func RegisterFederationGinRoutes(r *gin.Engine, h *FederationHandler) {
 	requireFedPeer := VerifyFederationRequest(h.DB, h.Identity.Fingerprint())
 	r.GET("/api/federation/ping", requireFedPeer, h.ginPing)
 	r.GET("/api/federation/stats", requireFedPeer, h.ginExportStats)
+	r.GET("/api/federation/catalog", requireFedPeer, h.ginExportCatalog)
 }

--- a/server/internal/api/huma_federation_admin_test.go
+++ b/server/internal/api/huma_federation_admin_test.go
@@ -115,7 +115,10 @@ func TestRevokePeer_RemovesIt(t *testing.T) {
 	require.NoError(t, store.Upsert(&db.FederationPeer{
 		Fingerprint: "fp-x", PublicKey: "k", BaseURL: "https://x", Status: db.PeerStatusActive,
 	}))
-	h := &FederationHandler{DB: database, Identity: selfID, Peers: store, Snapshots: federation.SnapshotStore{DB: database}, BaseURL: "https://self"}
+	h := &FederationHandler{DB: database, Identity: selfID, Peers: store,
+		Snapshots:        federation.SnapshotStore{DB: database},
+		CatalogSnapshots: federation.CatalogSnapshotStore{DB: database},
+		BaseURL:          "https://self"}
 
 	_, err := h.HumaRevokePeer(context.Background(), &RevokePeerInput{Fingerprint: "fp-x"})
 	require.NoError(t, err)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -187,11 +187,12 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		slog.Info("federation: identity ready", "fingerprint", federation.ShortFingerprint(fedIdentity.Fingerprint()))
 	}
 	federationHandler := &FederationHandler{
-		DB:        cfg.DB,
-		Identity:  fedIdentity,
-		Peers:     federation.PeerStore{DB: cfg.DB},
-		Snapshots: federation.SnapshotStore{DB: cfg.DB},
-		BaseURL:   cfg.PublicBaseURL,
+		DB:               cfg.DB,
+		Identity:         fedIdentity,
+		Peers:            federation.PeerStore{DB: cfg.DB},
+		Snapshots:        federation.SnapshotStore{DB: cfg.DB},
+		CatalogSnapshots: federation.CatalogSnapshotStore{DB: cfg.DB},
+		BaseURL:          cfg.PublicBaseURL,
 	}
 
 	socialHandler := &SocialHandler{DB: cfg.DB, Hub: cfg.Hub}
@@ -483,6 +484,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 					return
 				case <-ticker.C:
 					federationHandler.RefreshFederationStats()
+					federationHandler.RefreshFederationCatalog()
 				}
 			}
 		}()

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -239,6 +239,8 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&FederationExchange{},
 		// Phase 2 (#1347): cached friend rollups for transitive re-serving.
 		&FederationStatSnapshot{},
+		// Phase 3 (#1348): cached friend catalogs for game discovery.
+		&FederationCatalogSnapshot{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running migrations: %w", err)

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -626,6 +626,22 @@ type FederationStatSnapshot struct {
 	FetchedAt             time.Time `json:"fetchedAt"`
 }
 
+// FederationCatalogSnapshot caches a "game available on some server" record
+// pulled from a direct friend, for transitive catalog discovery (Phase 3,
+// #1348). Same source/origin/hops semantics as FederationStatSnapshot. Key is
+// the cross-server game id (IGDB scraper id / CRC32).
+type FederationCatalogSnapshot struct {
+	ID                    uint      `gorm:"primarykey" json:"id"`
+	CreatedAt             time.Time `json:"createdAt"`
+	SourcePeerFingerprint string    `gorm:"size:64;index" json:"sourcePeerFingerprint"`
+	OriginFingerprint     string    `gorm:"size:64;index" json:"originFingerprint"`
+	Hops                  int       `json:"hops"`
+	Key                   string    `gorm:"size:255;index" json:"key"`
+	Title                 string    `gorm:"size:255" json:"title"`
+	Console               string    `gorm:"size:32" json:"console"`
+	FetchedAt             time.Time `json:"fetchedAt"`
+}
+
 // ConsoleSaveStateChoice is the user's per-console save-state opt-out
 // state. Drives whether the in-game overlay shows the save/load
 // buttons or grays them out, and whether the first-launch prompt

--- a/server/internal/federation/catalog.go
+++ b/server/internal/federation/catalog.go
@@ -1,0 +1,188 @@
+package federation
+
+import (
+	"sort"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// CatalogEntry is a source-stamped record that a game is available on some
+// server in the mesh. Key is the cross-server game id (IGDB scraper id / CRC32).
+type CatalogEntry struct {
+	OriginFingerprint string `json:"originFingerprint"`
+	Hops              int    `json:"hops"`
+	Key               string `json:"key"`
+	Title             string `json:"title"`
+	Console           string `json:"console"` // console abbreviation, e.g. "SNES"
+}
+
+// crossGameKey derives a game's cross-server identity from its scraper id /
+// CRC32. ok=false when neither is present (the game can't be reliably matched
+// across servers, so it isn't federated).
+func crossGameKey(scraperID, crc32 string) (string, bool) {
+	if scraperID != "" {
+		return scraperID, true
+	}
+	if crc32 != "" {
+		return "crc:" + crc32, true
+	}
+	return "", false
+}
+
+// BuildLocalCatalog lists this server's games as source-stamped catalog entries
+// (origin = self, hop 0), one per cross-identifiable game key. Catalog data is
+// non-personal (it's about the library, not users), so there is no per-user
+// gate — exposure is governed per-friend by SharePolicy(catalog).
+func BuildLocalCatalog(database *gorm.DB, selfFingerprint string) ([]CatalogEntry, error) {
+	type row struct {
+		ScraperID string
+		CRC32     string
+		Title     string
+		Console   string
+	}
+	var rows []row
+	if err := database.Model(&db.Game{}).
+		Select("games.scraper_id as scraper_id, games.crc32 as crc32, games.title as title, consoles.abbreviation as console").
+		Joins("JOIN consoles ON consoles.id = games.console_id").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]bool, len(rows))
+	out := make([]CatalogEntry, 0, len(rows))
+	for _, r := range rows {
+		key, ok := crossGameKey(r.ScraperID, r.CRC32)
+		if !ok || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, CatalogEntry{
+			OriginFingerprint: selfFingerprint, Hops: 0,
+			Key: key, Title: r.Title, Console: r.Console,
+		})
+	}
+	return out, nil
+}
+
+// CatalogSnapshotStore persists catalog entries pulled from direct friends for
+// transitive discovery (#1348). Mirrors SnapshotStore.
+type CatalogSnapshotStore struct {
+	DB *gorm.DB
+}
+
+func (s CatalogSnapshotStore) ReplacePeerSnapshot(sourcePeerFingerprint string, entries []CatalogEntry, fetchedAt time.Time) error {
+	return s.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("source_peer_fingerprint = ?", sourcePeerFingerprint).
+			Delete(&db.FederationCatalogSnapshot{}).Error; err != nil {
+			return err
+		}
+		if len(entries) == 0 {
+			return nil
+		}
+		rows := make([]db.FederationCatalogSnapshot, 0, len(entries))
+		for _, e := range entries {
+			rows = append(rows, db.FederationCatalogSnapshot{
+				SourcePeerFingerprint: sourcePeerFingerprint,
+				OriginFingerprint:     e.OriginFingerprint,
+				Hops:                  e.Hops,
+				Key:                   e.Key,
+				Title:                 e.Title,
+				Console:               e.Console,
+				FetchedAt:             fetchedAt,
+			})
+		}
+		return tx.Create(&rows).Error
+	})
+}
+
+func (s CatalogSnapshotStore) RemovePeerSnapshot(sourcePeerFingerprint string) error {
+	return s.DB.Where("source_peer_fingerprint = ?", sourcePeerFingerprint).
+		Delete(&db.FederationCatalogSnapshot{}).Error
+}
+
+func (s CatalogSnapshotStore) EntriesWithinHops(maxHops int) ([]CatalogEntry, error) {
+	q := s.DB.Model(&db.FederationCatalogSnapshot{})
+	if maxHops >= 0 {
+		q = q.Where("hops <= ?", maxHops)
+	}
+	var rows []db.FederationCatalogSnapshot
+	if err := q.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make([]CatalogEntry, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, CatalogEntry{
+			OriginFingerprint: r.OriginFingerprint, Hops: r.Hops,
+			Key: r.Key, Title: r.Title, Console: r.Console,
+		})
+	}
+	return out, nil
+}
+
+// CatalogAvailability is a per-game discovery row: how many distinct servers in
+// reach have it, and whether THIS server already has it. Peer fingerprints are
+// not exposed (admin-only) — only counts.
+type CatalogAvailability struct {
+	Key         string `json:"key"`
+	Title       string `json:"title"`
+	Console     string `json:"console"`
+	OriginCount int    `json:"originCount"` // distinct servers (incl. local) that have it
+	Local       bool   `json:"local"`       // does this server have it
+}
+
+// AggregateCatalog dedupes (by origin, key) then groups by game key: counts the
+// distinct origins offering each game and flags local availability. Sorted by
+// title for stable output.
+func AggregateCatalog(entries []CatalogEntry, selfFingerprint string) []CatalogAvailability {
+	type acc struct {
+		title   string
+		console string
+		origins map[string]bool
+		local   bool
+	}
+	byKey := map[string]*acc{}
+	order := []string{}
+	seen := map[statCatalogDedupeKey]bool{}
+	for _, e := range entries {
+		dk := statCatalogDedupeKey{e.OriginFingerprint, e.Key}
+		if seen[dk] {
+			continue
+		}
+		seen[dk] = true
+
+		a, ok := byKey[e.Key]
+		if !ok {
+			a = &acc{title: e.Title, console: e.Console, origins: map[string]bool{}}
+			byKey[e.Key] = a
+			order = append(order, e.Key)
+		}
+		if a.title == "" {
+			a.title = e.Title
+		}
+		if a.console == "" {
+			a.console = e.Console
+		}
+		a.origins[e.OriginFingerprint] = true
+		if e.OriginFingerprint == selfFingerprint {
+			a.local = true
+		}
+	}
+
+	out := make([]CatalogAvailability, 0, len(order))
+	for _, key := range order {
+		a := byKey[key]
+		out = append(out, CatalogAvailability{
+			Key: key, Title: a.title, Console: a.console,
+			OriginCount: len(a.origins), Local: a.local,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Title < out[j].Title })
+	return out
+}
+
+type statCatalogDedupeKey struct {
+	origin string
+	key    string
+}

--- a/server/internal/federation/catalog_test.go
+++ b/server/internal/federation/catalog_test.go
@@ -1,0 +1,94 @@
+package federation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func openCatalogTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&db.Console{}, &db.Game{}, &db.FederationCatalogSnapshot{}))
+	return database
+}
+
+func TestBuildLocalCatalog_StampsAndSkipsUnidentifiable(t *testing.T) {
+	database := openCatalogTestDB(t)
+	console := db.Console{Name: "Super Nintendo", Abbreviation: "SNES"}
+	require.NoError(t, database.Create(&console).Error)
+
+	// Identifiable (scraper id), identifiable (crc), and unidentifiable (neither).
+	require.NoError(t, database.Create(&db.Game{Title: "Game A", ScraperID: "igdb:1", FilePath: "/a", ConsoleID: console.ID}).Error)
+	require.NoError(t, database.Create(&db.Game{Title: "Game B", CRC32: "deadbeef", FilePath: "/b", ConsoleID: console.ID}).Error)
+	require.NoError(t, database.Create(&db.Game{Title: "Homebrew", FilePath: "/c", ConsoleID: console.ID}).Error)
+
+	entries, err := BuildLocalCatalog(database, "selfFP")
+	require.NoError(t, err)
+	require.Len(t, entries, 2, "unidentifiable game is not federated")
+
+	keys := map[string]CatalogEntry{}
+	for _, e := range entries {
+		keys[e.Key] = e
+		assert.Equal(t, "selfFP", e.OriginFingerprint)
+		assert.Equal(t, 0, e.Hops)
+		assert.Equal(t, "SNES", e.Console)
+	}
+	assert.Contains(t, keys, "igdb:1")
+	assert.Contains(t, keys, "crc:deadbeef")
+}
+
+func TestCatalogSnapshotStore_ReplaceFilterRemove(t *testing.T) {
+	store := CatalogSnapshotStore{DB: openCatalogTestDB(t)}
+	require.NoError(t, store.ReplacePeerSnapshot("B", []CatalogEntry{
+		{OriginFingerprint: "B", Hops: 1, Key: "k1", Title: "T1", Console: "NES"},
+		{OriginFingerprint: "C", Hops: 3, Key: "k2", Title: "T2", Console: "NES"},
+	}, time.Unix(1, 0)))
+	// Replace is idempotent (no duplication).
+	require.NoError(t, store.ReplacePeerSnapshot("B", []CatalogEntry{
+		{OriginFingerprint: "B", Hops: 1, Key: "k1", Title: "T1", Console: "NES"},
+		{OriginFingerprint: "C", Hops: 3, Key: "k2", Title: "T2", Console: "NES"},
+	}, time.Unix(1, 0)))
+
+	within1, err := store.EntriesWithinHops(1)
+	require.NoError(t, err)
+	assert.Len(t, within1, 1, "hop filter excludes the hop-3 entry")
+
+	all, err := store.EntriesWithinHops(-1)
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+
+	require.NoError(t, store.RemovePeerSnapshot("B"))
+	all, err = store.EntriesWithinHops(-1)
+	require.NoError(t, err)
+	assert.Empty(t, all)
+}
+
+func TestAggregateCatalog_CountsOriginsAndFlagsLocal(t *testing.T) {
+	entries := []CatalogEntry{
+		{OriginFingerprint: "self", Hops: 0, Key: "g1", Title: "Game 1", Console: "SNES"},
+		{OriginFingerprint: "B", Hops: 1, Key: "g1", Title: "Game 1", Console: "SNES"},
+		{OriginFingerprint: "B", Hops: 1, Key: "g1", Title: "Game 1", Console: "SNES"}, // dup (origin,key) → ignored
+		{OriginFingerprint: "C", Hops: 2, Key: "g2", Title: "Game 2", Console: "NES"},
+	}
+	out := AggregateCatalog(entries, "self")
+	require.Len(t, out, 2)
+
+	byKey := map[string]CatalogAvailability{}
+	for _, a := range out {
+		byKey[a.Key] = a
+	}
+	assert.Equal(t, 2, byKey["g1"].OriginCount, "self + B, dup ignored")
+	assert.True(t, byKey["g1"].Local)
+	assert.Equal(t, 1, byKey["g2"].OriginCount)
+	assert.False(t, byKey["g2"].Local, "g2 only on a remote server")
+}


### PR DESCRIPTION
## Federation Phase 3a — Catalog metadata federation (game discovery)

Part of #1348 (the discovery layer; the **opt-in ROM download relay** is the next, separate PR — see below). Builds on Phase 2 (#1357).

Lets a server discover **which games are available across the friend mesh** — pure metadata, **no ROM bytes move**. Mirrors the proven Phase 2 stats architecture (snapshot cache + hop-bounded re-serving + periodic refresh).

### What's included
- **`FederationCatalogSnapshot` + `CatalogSnapshotStore`** — cache friends' catalogs for transitive discovery.
- **`BuildLocalCatalog`** — this server's games as source-stamped entries keyed by cross-server id (IGDB scraper id → CRC32). Games without a cross-identifier aren't federated (can't be matched reliably). Catalog is non-personal, so no per-user gate — exposure is **per-friend opt-in via `SharePolicy(catalog)`**.
- **Export** — `GET /api/federation/catalog?maxHops=N` (signed, `SharePolicy(catalog)`-gated) serves local + cached transitive entries within the hop budget.
- **`RefreshFederationCatalog`** — pulls catalog-consumable friends, sanitizes (drop loops/over-budget, cap per peer), `+1` hop, replaces snapshot. On the 15-min ticker + admin `POST /api/admin/federation/catalog/refresh`. TryLock-serialized.
- **Available-games read** — `GET /api/federation/catalog/available` returns the mesh game list, each row with a per-game **origin count** and **local flag** (peer fingerprints not exposed — admin-only). `?remoteOnly=true` shows only games you don't have locally (the discovery view); `?maxHops` bounds reach.
- **Revoke drops the peer's catalog snapshot.**

### Testing
- Catalog domain tests (build/stamp/skip-unidentifiable, snapshot replace/filter/remove, availability aggregation with origin-count + local flag + dedupe) and API tests (export share-gate, refresh pull/consume-gate/sanitize/error, available-games aggregation + remoteOnly).
- **Full `go test ./...` passes, no regressions**; build + gofmt clean.

### Next: the opt-in ROM download relay (#1348, separate PR)
Per your decision, the actual ROM byte-relay will be **default-OFF, opt-in by the server admin** (an explicit enable). This PR deliberately ships only the metadata discovery layer so nothing copyright-sensitive is introduced here — you can see *what's available* across the mesh, but downloading a friend's ROM via relay is a separate, opt-in capability.

### Also remaining (UI track)
Player/web surfacing of "available from friends" + the reach slider.

Part of #1348
