### PR TITLE
fix(player): controller-assignment polish — per-unit desktop persistence + design tokens (#1361)

### DIFF
--- a/player/CONTROLLER_ASSIGNMENT.md
+++ b/player/CONTROLLER_ASSIGNMENT.md
@@ -54,10 +54,11 @@ player_slot INTEGER NULL)`. Semantics:
 
 The stable key per platform:
 - **Android**: `InputDevice.descriptor` (stable per physical unit across reconnects).
-- **Desktop**: the SDL device **name** (consistent with `ControllerStyleOverride`'s
-  keying). Two *identical* desktop pads share a name and so can't hold distinct
-  persistent slots — a documented limitation; per-unit desktop persistence would
-  need SDL serial (a native/JNI change, deferred).
+- **Desktop**: the SDL **serial** (`SDL_GetGamepadSerial`, surfaced on
+  `GamepadState.serial` via the JNI bridge) when the pad exposes one, else the SDL
+  device **name** (#1361). Serial gives true per-unit identity so two *identical*
+  pads keep distinct slots; pads with no serial fall back to name (per-model, so
+  identical nameless pads still share — an inherent limit of those pads).
 
 **The repository is synchronous on purpose.** `GamepadPortManager` reads it from
 inside its `@Synchronized` critical sections on the input threads when a device

--- a/player/native/src/gamepad_sdl3.c
+++ b/player/native/src/gamepad_sdl3.c
@@ -186,7 +186,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_spela_player_libretro_LibretroJni_native
     jclass stateClass = (*env)->FindClass(env, "com/spela/player/libretro/GamepadState");
     if (!stateClass) return NULL;
 
-    jmethodID ctor = (*env)->GetMethodID(env, stateClass, "<init>", "(ILjava/lang/String;[Z[II)V");
+    jmethodID ctor = (*env)->GetMethodID(env, stateClass, "<init>", "(ILjava/lang/String;[Z[IILjava/lang/String;)V");
     if (!ctor) return NULL;
 
     int attached_count = 0;
@@ -206,6 +206,11 @@ JNIEXPORT jobjectArray JNICALL Java_com_spela_player_libretro_LibretroJni_native
 
         const char *name = SDL_GetGamepadName(gc);
         jstring jname = (*env)->NewStringUTF(env, name ? name : "Unknown Controller");
+
+        /* Per-unit serial when the pad exposes one (#1361). Often NULL — Kotlin
+         * falls back to the name as the persistence key in that case. */
+        const char *serial = SDL_GetGamepadSerial(gc);
+        jstring jserial = (*env)->NewStringUTF(env, serial ? serial : "");
 
         jbooleanArray buttons = (*env)->NewBooleanArray(env, NUM_BUTTONS);
         jboolean btnValues[NUM_BUTTONS];
@@ -230,11 +235,12 @@ JNIEXPORT jobjectArray JNICALL Java_com_spela_player_libretro_LibretroJni_native
         (*env)->SetIntArrayRegion(env, axes, 0, NUM_AXES, axisValues);
 
         jint gpType = (jint)SDL_GetRealGamepadType(gc);
-        jobject stateObj = (*env)->NewObject(env, stateClass, ctor, controllerId, jname, buttons, axes, gpType);
+        jobject stateObj = (*env)->NewObject(env, stateClass, ctor, controllerId, jname, buttons, axes, gpType, jserial);
         (*env)->SetObjectArrayElement(env, result, out_index, stateObj);
         out_index++;
 
         (*env)->DeleteLocalRef(env, jname);
+        (*env)->DeleteLocalRef(env, jserial);
         (*env)->DeleteLocalRef(env, buttons);
         (*env)->DeleteLocalRef(env, axes);
         (*env)->DeleteLocalRef(env, stateObj);

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/ControllerControls.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/ControllerControls.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
@@ -155,7 +154,8 @@ private fun ControllerListRow(
             .semantics {
                 role = Role.Button
                 contentDescription = "${controllerIdentity(controller)}, " +
-                    if (controller.slot != null) playerLabel(controller.slot) else "not assigned"
+                    (if (controller.slot != null) playerLabel(controller.slot) else "not assigned") +
+                    (if (controller.slot != null && controller.isActive) ", active" else "")
             },
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -238,7 +238,9 @@ private fun ControllerDetail(
             Text(
                 text = if (controller.slot != null) playerLabel(controller.slot) else "Not assigned",
                 style = SpTypography.BodyMedium,
-                color = if (controller.slot != null) SpColor.Primary else SpColor.OnBackgroundTertiary,
+                // PrimaryLight (not Primary) reads clearly on the dark card; the
+                // P-badge already carries the indigo accent (#1361).
+                color = if (controller.slot != null) SpColor.PrimaryLight else SpColor.OnBackgroundTertiary,
                 modifier = Modifier.weight(1f).testTag("controller_detail_player"),
             )
             SpButton(
@@ -413,7 +415,7 @@ private fun ActivityDot(isActive: Boolean) {
             .size(10.dp)
             .alpha(pulseAlpha)
             .clip(CircleShape)
-            .background(if (isActive) Color(0xFF4CAF50) else SpColor.OnBackgroundTertiary.copy(alpha = 0.3f))
+            .background(if (isActive) SpColor.Success else SpColor.OnBackgroundTertiary.copy(alpha = 0.3f))
             .semantics {
                 contentDescription = if (isActive) "Activity indicator active" else "Activity indicator inactive"
             },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadConfigScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
@@ -218,7 +217,7 @@ private fun ControllerRow(
 
 @Composable
 private fun ActivityIndicator(isActive: Boolean) {
-    val targetColor = if (isActive) Color(0xFF4CAF50) else SpColor.OnBackgroundTertiary.copy(alpha = 0.3f)
+    val targetColor = if (isActive) SpColor.Success else SpColor.OnBackgroundTertiary.copy(alpha = 0.3f)
     val color by animateColorAsState(
         targetValue = targetColor,
         animationSpec = tween(durationMillis = 150),

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
@@ -103,13 +103,16 @@ class DesktopGamepadPoller(
         for (state in states) {
             currentIds.add(state.controllerId)
 
-            // Connect new devices
+            // Connect new devices. Prefer the per-unit serial as the persistence
+            // stable key (#1361) so two identical pads keep distinct player slots;
+            // fall back to the name when the pad exposes no serial.
             if (state.controllerId !in knownControllers) {
                 knownControllers.add(state.controllerId)
                 gamepadPortManager.connectDevice(
                     state.controllerId,
                     state.name,
                     controllerStyleFromSdlType(state.type),
+                    stableKey = state.serial.ifBlank { state.name },
                 )
             }
 

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadState.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/GamepadState.kt
@@ -11,6 +11,10 @@ package com.spela.player.libretro
  *   Kotlin applies the configurable GamepadPosition→RetroPad mapping (#1334).
  * @param axes Axis values: [LX, LY, RX, RY, TriggerL, TriggerR] in SDL range (-32768..32767)
  * @param type SDL_GamepadType (SDL_GetRealGamepadType) integer for the connected pad; 0 = unknown
+ * @param serial Per-unit controller serial (SDL_GetGamepadSerial), or "" when the
+ *   pad exposes none. Used as the stable persistence key for player-slot
+ *   assignments so two identical pads can hold distinct slots (#1361); callers
+ *   fall back to [name] when blank.
  */
 data class GamepadState(
     val controllerId: Int,
@@ -18,6 +22,7 @@ data class GamepadState(
     val buttons: BooleanArray,
     val axes: IntArray,
     val type: Int,
+    val serial: String = "",
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -26,7 +31,8 @@ data class GamepadState(
             name == other.name &&
             buttons.contentEquals(other.buttons) &&
             axes.contentEquals(other.axes) &&
-            type == other.type
+            type == other.type &&
+            serial == other.serial
     }
 
     override fun hashCode(): Int {
@@ -35,6 +41,7 @@ data class GamepadState(
         result = 31 * result + buttons.contentHashCode()
         result = 31 * result + axes.contentHashCode()
         result = 31 * result + type
+        result = 31 * result + serial.hashCode()
         return result
     }
 }


### PR DESCRIPTION
Closes #1361. Follow-up polish from #1360.

## Changes
- **Desktop per-unit persistence:** surface `SDL_GetGamepadSerial` through the JNI bridge (`GamepadState.serial`) and use it as the player-slot **stable key** when present, falling back to the device name. Two *identical* pads that expose a serial now keep distinct slots. Android already keyed per-unit via `InputDevice.descriptor`. (Note: the **GUID is per-model**, so only the serial gives per-unit identity — pads without a serial still fall back to name.)
- **Tokenize the activity-dot green:** `SpColor.Success` replaces the raw `Color(0xFF4CAF50)` in `ControllerControls` and the original `GamepadConfigScreen` (drops the now-unused `Color` import in both).
- **"Player N" label readability:** uses `SpColor.PrimaryLight` (was `Primary`) on the dark detail card; the P-badge still carries the indigo accent.
- **A11y:** controller list-row `contentDescription` now announces ", active" (parity with the old `GamepadConfigScreen` row).
- Docs: `CONTROLLER_ASSIGNMENT.md` updated for the serial-or-name desktop key.

## Test
- `:shared:desktopTest` green (`GamepadState.serial` has a default so existing constructors are unaffected).
- `:desktop:desktopTest` `SettingsConsoleNavigationTest` green.
- **Native lib rebuilt** (`:desktop:buildNativeLibrary`) — `gamepad_sdl3.c` compiles + links with the new JNI ctor signature.
- These implement the ui-agent's own review nits from #1360 (token gap, label contrast, activity-in-row-desc); deploying to the AYN Thor for the label eyeball.