### PR TITLE
feat(server): federation Phase 3b-1 — direct-friend ROM download (#1348)

### DIFF
--- a/server/internal/api/federation_download.go
+++ b/server/internal/api/federation_download.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+	"github.com/spela/server/internal/storage"
+	"gorm.io/gorm"
+)
+
+// downloadClient fetches a ROM from a friend over a signed request, returning
+// the raw response so the caller can stream the body. Faked in tests.
+type downloadClient interface {
+	FetchDownload(baseURL, requestID string, id federation.Identity, peerFingerprint, key string) (*http.Response, error)
+}
+
+type httpDownloadClient struct{}
+
+func (httpDownloadClient) FetchDownload(baseURL, requestID string, id federation.Identity, peerFingerprint, key string) (*http.Response, error) {
+	const path = "/api/federation/download"
+	u := baseURL + path + "?key=" + url.QueryEscape(key)
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	// Sign the path (query is excluded from the signature, matching the verifier).
+	for k, v := range signedFederationHeaders(id, http.MethodGet, path, requestID, nil, peerFingerprint) {
+		req.Header.Set(k, v)
+	}
+	// No client timeout: ROM transfers can be large and slow.
+	return (&http.Client{}).Do(req)
+}
+
+// resolveLocalGameByKey finds a local game by its cross-server key (IGDB scraper
+// id, or "crc:"+CRC32) and returns its on-disk path. ok=false if not found or
+// the path is unsafe/missing.
+func (h *FederationHandler) resolveLocalGameByKey(key string) (db.Game, string, bool) {
+	var game db.Game
+	var q *gorm.DB
+	if strings.HasPrefix(key, "crc:") {
+		q = h.DB.Where("crc32 = ? AND crc32 != ''", strings.TrimPrefix(key, "crc:"))
+	} else {
+		q = h.DB.Where("scraper_id = ? AND scraper_id != ''", key)
+	}
+	if err := q.First(&game).Error; err != nil {
+		return db.Game{}, "", false
+	}
+	abs, err := storage.ResolveGamePath(game.FilePath, h.GameDirs)
+	if err != nil || !storage.ValidateROMPath(abs, h.GameDirs) {
+		return db.Game{}, "", false
+	}
+	return game, abs, true
+}
+
+// ginServeDownload streams a LOCAL ROM to a friend that we share downloads with.
+// Behind VerifyFederationRequest + SharePolicy(download). Phase 3b-1 does NOT
+// forward (relay) games we don't have — that's the opt-in multi-hop relay.
+func (h *FederationHandler) ginServeDownload(c *gin.Context) {
+	reqID := c.GetHeader(headerFedRequestID)
+	if reqID == "" {
+		reqID = federation.NewRequestID()
+	}
+	peer, ok := federationPeerFromGin(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "no verified peer"})
+		return
+	}
+	if !federation.CanShare(*peer, federation.DataClassDownload) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "downloads not shared with this peer"})
+		return
+	}
+	key := c.Query("key")
+	if key == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing key"})
+		return
+	}
+
+	game, absPath, found := h.resolveLocalGameByKey(key)
+	if !found {
+		federation.RecordExchange(h.DB, federation.ExchangeRecord{
+			RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+			Direction: db.ExchangeInbound, Operation: "download_serve",
+			DataClass: string(federation.DataClassDownload), Status: db.ExchangeError,
+			Error: "not available locally (no forwarding in 3b-1)",
+		})
+		c.JSON(http.StatusNotFound, gin.H{"error": "game not available here"})
+		return
+	}
+
+	federation.RecordExchange(h.DB, federation.ExchangeRecord{
+		RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+		Direction: db.ExchangeInbound, Operation: "download_serve",
+		DataClass: string(federation.DataClassDownload), Status: db.ExchangeOK, ItemCount: 1,
+	})
+	c.FileAttachment(absPath, filepath.Base(game.FilePath))
+}
+
+// ginUserDownload lets a local user download a game that a DIRECT friend offers.
+// Finds a hop-1 friend with the key whose ConsumePolicy(download) is set, fetches
+// from them, and streams the bytes through. Behind user auth.
+func (h *FederationHandler) ginUserDownload(c *gin.Context) {
+	key := c.Query("key")
+	if key == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing key"})
+		return
+	}
+	sources, err := h.CatalogSnapshots.DirectSourcesForKey(key)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to look up sources"})
+		return
+	}
+	client := h.DownloadClient
+	if client == nil {
+		client = httpDownloadClient{}
+	}
+
+	for _, fp := range sources {
+		peer, err := h.Peers.GetByFingerprint(fp)
+		if err != nil || peer.Status != db.PeerStatusActive || !federation.CanConsume(*peer, federation.DataClassDownload) {
+			continue
+		}
+		reqID := federation.NewRequestID()
+		started := time.Now()
+		resp, ferr := client.FetchDownload(peer.BaseURL, reqID, h.Identity, peer.Fingerprint, key)
+		if ferr != nil || resp.StatusCode != http.StatusOK {
+			if resp != nil {
+				resp.Body.Close()
+			}
+			errMsg := "download fetch failed"
+			if ferr != nil {
+				errMsg = ferr.Error()
+			}
+			federation.RecordExchange(h.DB, federation.ExchangeRecord{
+				RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+				Direction: db.ExchangeOutbound, Operation: "download_fetch",
+				DataClass: string(federation.DataClassDownload), Status: db.ExchangeError,
+				StartedAt: started, Error: errMsg,
+			})
+			continue
+		}
+		// Proxy the stream through to the user.
+		for _, hdr := range []string{"Content-Type", "Content-Disposition", "Content-Length"} {
+			if v := resp.Header.Get(hdr); v != "" {
+				c.Header(hdr, v)
+			}
+		}
+		c.Status(http.StatusOK)
+		n, _ := io.Copy(c.Writer, resp.Body)
+		resp.Body.Close()
+		federation.RecordExchange(h.DB, federation.ExchangeRecord{
+			RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+			Direction: db.ExchangeOutbound, Operation: "download_fetch",
+			DataClass: string(federation.DataClassDownload), Status: db.ExchangeOK,
+			StartedAt: started, Bytes: n,
+		})
+		return
+	}
+	c.JSON(http.StatusNotFound, gin.H{"error": "not available from any direct friend"})
+}

--- a/server/internal/api/federation_download.go
+++ b/server/internal/api/federation_download.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,6 +15,25 @@ import (
 	"github.com/spela/server/internal/storage"
 	"gorm.io/gorm"
 )
+
+// safeDownloadName turns a cross-server game key into a filesystem-safe download
+// filename (the peer's filename is untrusted and never used).
+func safeDownloadName(key string) string {
+	b := make([]byte, 0, len(key))
+	for i := 0; i < len(key); i++ {
+		c := key[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '.', c == '-', c == '_':
+			b = append(b, c)
+		default:
+			b = append(b, '_')
+		}
+	}
+	if len(b) == 0 {
+		return "download.bin"
+	}
+	return string(b) + ".bin"
+}
 
 // downloadClient fetches a ROM from a friend over a signed request, returning
 // the raw response so the caller can stream the body. Faked in tests.
@@ -145,10 +165,17 @@ func (h *FederationHandler) ginUserDownload(c *gin.Context) {
 			})
 			continue
 		}
-		// Proxy the stream through to the user.
-		for _, hdr := range []string{"Content-Type", "Content-Disposition", "Content-Length"} {
-			if v := resp.Header.Get(hdr); v != "" {
-				c.Header(hdr, v)
+		// SECURITY: never echo the peer's Content-Type / Content-Disposition. A
+		// malicious friend could send text/html and have it rendered on OUR
+		// origin (stored XSS). Force a safe binary attachment; the client names
+		// the file from the catalog metadata it already has. Only Content-Length
+		// is forwarded, and only if it's a valid number.
+		c.Header("Content-Type", "application/octet-stream")
+		c.Header("Content-Disposition", `attachment; filename="`+safeDownloadName(key)+`"`)
+		c.Header("X-Content-Type-Options", "nosniff")
+		if cl := resp.Header.Get("Content-Length"); cl != "" {
+			if _, perr := strconv.ParseInt(cl, 10, 64); perr == nil {
+				c.Header("Content-Length", cl)
 			}
 		}
 		c.Status(http.StatusOK)

--- a/server/internal/api/federation_download.go
+++ b/server/internal/api/federation_download.go
@@ -43,6 +43,15 @@ type downloadClient interface {
 
 type httpDownloadClient struct{}
 
+// fedDownloadHTTPClient bounds the dial/TLS/response-header phase (so a dead or
+// stalling friend can't hold a goroutine + connection forever) but sets no
+// overall timeout — the body stream is large and legitimately slow.
+var fedDownloadHTTPClient = func() *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.ResponseHeaderTimeout = 30 * time.Second
+	return &http.Client{Transport: tr}
+}()
+
 func (httpDownloadClient) FetchDownload(baseURL, requestID string, id federation.Identity, peerFingerprint, key string) (*http.Response, error) {
 	const path = "/api/federation/download"
 	u := baseURL + path + "?key=" + url.QueryEscape(key)
@@ -54,8 +63,7 @@ func (httpDownloadClient) FetchDownload(baseURL, requestID string, id federation
 	for k, v := range signedFederationHeaders(id, http.MethodGet, path, requestID, nil, peerFingerprint) {
 		req.Header.Set(k, v)
 	}
-	// No client timeout: ROM transfers can be large and slow.
-	return (&http.Client{}).Do(req)
+	return fedDownloadHTTPClient.Do(req)
 }
 
 // resolveLocalGameByKey finds a local game by its cross-server key (IGDB scraper

--- a/server/internal/api/federation_download_test.go
+++ b/server/internal/api/federation_download_test.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type fakeDownloadClient struct {
+	body   string
+	status int
+	err    error
+}
+
+func (f *fakeDownloadClient) FetchDownload(_, _ string, _ federation.Identity, _, _ string) (*http.Response, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	st := f.status
+	if st == 0 {
+		st = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: st,
+		Body:       io.NopCloser(strings.NewReader(f.body)),
+		Header:     http.Header{},
+	}, nil
+}
+
+func downloadHandler(database *gorm.DB, selfID federation.Identity, gameDirs []string, client downloadClient) *FederationHandler {
+	return &FederationHandler{
+		DB: database, Identity: selfID,
+		Peers:            federation.PeerStore{DB: database},
+		CatalogSnapshots: federation.CatalogSnapshotStore{DB: database},
+		GameDirs:         gameDirs,
+		BaseURL:          "https://self",
+		DownloadClient:   client,
+	}
+}
+
+// seedLocalROM writes a fake ROM file into a temp game dir and registers a game.
+func seedLocalROM(t *testing.T, database *gorm.DB, scraperID, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "rom.bin"), []byte(contents), 0o644))
+	var console db.Console
+	if err := database.Where("abbreviation = ?", "SNES").First(&console).Error; err != nil {
+		console = db.Console{Name: "Super Nintendo", Abbreviation: "SNES"}
+		require.NoError(t, database.Create(&console).Error)
+	}
+	require.NoError(t, database.Create(&db.Game{Title: "Local", ScraperID: scraperID, FilePath: "rom.bin", ConsoleID: console.ID}).Error)
+	return dir
+}
+
+func callServeDownload(h *FederationHandler, peer *db.FederationPeer, key string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/x", func(c *gin.Context) {
+		c.Set(fedPeerContextKey, peer)
+		h.ginServeDownload(c)
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/x?key="+key, nil))
+	return w
+}
+
+func TestServeDownload_StreamsLocalWhenShared(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	dir := seedLocalROM(t, database, "igdb:1", "ROM-BYTES-HERE")
+	h := downloadHandler(database, selfID, []string{dir}, nil)
+
+	sp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassDownload: true})
+	peer := &db.FederationPeer{Fingerprint: "fp", Name: "Friend", SharePolicy: sp, Status: db.PeerStatusActive}
+
+	w := callServeDownload(h, peer, "igdb:1")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "ROM-BYTES-HERE", w.Body.String())
+}
+
+func TestServeDownload_ForbiddenWhenNotShared(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	dir := seedLocalROM(t, database, "igdb:1", "X")
+	h := downloadHandler(database, selfID, []string{dir}, nil)
+
+	peer := &db.FederationPeer{Fingerprint: "fp", Name: "Friend", SharePolicy: "", Status: db.PeerStatusActive}
+	w := callServeDownload(h, peer, "igdb:1")
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestServeDownload_NotFoundWhenNotLocal(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	h := downloadHandler(database, selfID, []string{t.TempDir()}, nil)
+
+	sp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassDownload: true})
+	peer := &db.FederationPeer{Fingerprint: "fp", Name: "Friend", SharePolicy: sp, Status: db.PeerStatusActive}
+	w := callServeDownload(h, peer, "igdb:nope")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func callUserDownload(h *FederationHandler, key string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/x", h.ginUserDownload)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/x?key="+key, nil))
+	return w
+}
+
+func TestUserDownload_ProxiesFromDirectFriend(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+
+	// Friend is active and we consume downloads from them.
+	dp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassDownload: true})
+	require.NoError(t, federation.PeerStore{DB: database}.Upsert(&db.FederationPeer{
+		Fingerprint: friendID.Fingerprint(), PublicKey: b64(friendID.PublicKey), Name: "Friend",
+		BaseURL: "https://friend", Status: db.PeerStatusActive, ConsumePolicy: dp,
+	}))
+	// Catalog says the friend (hop 1) has the game.
+	cs := federation.CatalogSnapshotStore{DB: database}
+	require.NoError(t, cs.ReplacePeerSnapshot(friendID.Fingerprint(), []federation.CatalogEntry{
+		{OriginFingerprint: friendID.Fingerprint(), Hops: 1, Key: "igdb:7", Title: "Friend Game", Console: "NES"},
+	}, time.Unix(1, 0)))
+
+	h := downloadHandler(database, selfID, nil, &fakeDownloadClient{body: "FRIEND-ROM"})
+
+	w := callUserDownload(h, "igdb:7")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "FRIEND-ROM", w.Body.String())
+}
+
+func TestUserDownload_NotFoundWhenNoConsumableSource(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+
+	// Friend has the game but we do NOT consume downloads from them.
+	require.NoError(t, federation.PeerStore{DB: database}.Upsert(&db.FederationPeer{
+		Fingerprint: friendID.Fingerprint(), PublicKey: b64(friendID.PublicKey), Name: "Friend",
+		BaseURL: "https://friend", Status: db.PeerStatusActive, ConsumePolicy: "",
+	}))
+	cs := federation.CatalogSnapshotStore{DB: database}
+	require.NoError(t, cs.ReplacePeerSnapshot(friendID.Fingerprint(), []federation.CatalogEntry{
+		{OriginFingerprint: friendID.Fingerprint(), Hops: 1, Key: "igdb:7", Title: "Friend Game", Console: "NES"},
+	}, time.Unix(1, 0)))
+
+	called := false
+	h := downloadHandler(database, selfID, nil, downloadClientFunc(func() { called = true }))
+
+	w := callUserDownload(h, "igdb:7")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.False(t, called, "must not fetch from a peer we don't consume downloads from")
+}
+
+type downloadClientFunc func()
+
+func (f downloadClientFunc) FetchDownload(_, _ string, _ federation.Identity, _, _ string) (*http.Response, error) {
+	f()
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("")), Header: http.Header{}}, nil
+}

--- a/server/internal/api/federation_download_test.go
+++ b/server/internal/api/federation_download_test.go
@@ -32,10 +32,11 @@ func (f *fakeDownloadClient) FetchDownload(_, _ string, _ federation.Identity, _
 	if st == 0 {
 		st = http.StatusOK
 	}
+	// Simulate a HOSTILE peer trying to get HTML rendered on our origin.
 	return &http.Response{
 		StatusCode: st,
 		Body:       io.NopCloser(strings.NewReader(f.body)),
-		Header:     http.Header{},
+		Header:     http.Header{"Content-Type": {"text/html"}, "Content-Disposition": {"inline"}},
 	}, nil
 }
 
@@ -143,6 +144,10 @@ func TestUserDownload_ProxiesFromDirectFriend(t *testing.T) {
 	w := callUserDownload(h, "igdb:7")
 	require.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "FRIEND-ROM", w.Body.String())
+	// SECURITY: the peer's malicious text/html content typing must NOT be echoed.
+	assert.Equal(t, "application/octet-stream", w.Header().Get("Content-Type"))
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
 }
 
 func TestUserDownload_NotFoundWhenNoConsumableSource(t *testing.T) {

--- a/server/internal/api/huma_federation.go
+++ b/server/internal/api/huma_federation.go
@@ -38,6 +38,14 @@ type FederationHandler struct {
 	// CatalogClient fetches a friend's catalog. Defaults to httpCatalogClient
 	// when nil; overridden in tests.
 	CatalogClient catalogClient
+	// GameDirs / JWTSecret support direct-friend ROM download (#1348 Phase 3b):
+	// GameDirs resolves a local game file to serve; JWTSecret authenticates the
+	// user-facing download route.
+	GameDirs  []string
+	JWTSecret string
+	// DownloadClient fetches a ROM from a friend. Defaults to httpDownloadClient
+	// when nil; overridden in tests.
+	DownloadClient downloadClient
 	// refreshMu / catalogRefreshMu serialize the respective refreshes so the
 	// periodic ticker and an admin trigger can't race the snapshot stores.
 	refreshMu        sync.Mutex

--- a/server/internal/api/huma_federation_admin.go
+++ b/server/internal/api/huma_federation_admin.go
@@ -395,13 +395,15 @@ func RegisterFederationRoutes(api huma.API, h *FederationHandler, jwtSecret stri
 
 // RegisterFederationGinRoutes wires raw-gin federation routes: the signed ping
 // used by the connection-test diagnostic, plus the signed stat/catalog exports.
-func RegisterFederationGinRoutes(r *gin.Engine, h *FederationHandler) {
+func RegisterFederationGinRoutes(r *gin.Engine, h *FederationHandler, downloadLimiter *RateLimiter) {
 	requireFedPeer := VerifyFederationRequest(h.DB, h.Identity.Fingerprint())
 	r.GET("/api/federation/ping", requireFedPeer, h.ginPing)
 	r.GET("/api/federation/stats", requireFedPeer, h.ginExportStats)
 	r.GET("/api/federation/catalog", requireFedPeer, h.ginExportCatalog)
+	// Binary ROM transfer routes are bandwidth-sensitive — rate-limit them like
+	// the other download endpoints (#1348 Phase 3b-1).
 	// Serve a local ROM to a friend (peer-to-peer, SharePolicy(download)-gated).
-	r.GET("/api/federation/download", requireFedPeer, h.ginServeDownload)
-	// User-facing: download a game a direct friend offers (#1348 Phase 3b-1).
-	r.GET("/api/federation/games/download", AuthMiddleware(h.JWTSecret, h.DB), h.ginUserDownload)
+	r.GET("/api/federation/download", downloadLimiter.RateLimit(), requireFedPeer, h.ginServeDownload)
+	// User-facing: download a game a direct friend offers.
+	r.GET("/api/federation/games/download", downloadLimiter.RateLimit(), AuthMiddleware(h.JWTSecret, h.DB), h.ginUserDownload)
 }

--- a/server/internal/api/huma_federation_admin.go
+++ b/server/internal/api/huma_federation_admin.go
@@ -400,4 +400,8 @@ func RegisterFederationGinRoutes(r *gin.Engine, h *FederationHandler) {
 	r.GET("/api/federation/ping", requireFedPeer, h.ginPing)
 	r.GET("/api/federation/stats", requireFedPeer, h.ginExportStats)
 	r.GET("/api/federation/catalog", requireFedPeer, h.ginExportCatalog)
+	// Serve a local ROM to a friend (peer-to-peer, SharePolicy(download)-gated).
+	r.GET("/api/federation/download", requireFedPeer, h.ginServeDownload)
+	// User-facing: download a game a direct friend offers (#1348 Phase 3b-1).
+	r.GET("/api/federation/games/download", AuthMiddleware(h.JWTSecret, h.DB), h.ginUserDownload)
 }

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -258,7 +258,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterCoreRoutes(humaAPI, coreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterStatsRoutes(humaAPI, statsHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterFederationRoutes(humaAPI, federationHandler, cfg.JWTSecret, cfg.DB, userLimiter)
-	RegisterFederationGinRoutes(r, federationHandler)
+	RegisterFederationGinRoutes(r, federationHandler, downloadLimiter)
 	RegisterConsoleRoutes(humaAPI, consoleHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterUserRoutes(humaAPI, userHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterUserMutationRoutes(humaAPI, userHandler, cfg.JWTSecret, cfg.DB, userLimiter, authLimiter)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -192,6 +192,8 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		Peers:            federation.PeerStore{DB: cfg.DB},
 		Snapshots:        federation.SnapshotStore{DB: cfg.DB},
 		CatalogSnapshots: federation.CatalogSnapshotStore{DB: cfg.DB},
+		GameDirs:         cfg.GameDirs,
+		JWTSecret:        cfg.JWTSecret,
 		BaseURL:          cfg.PublicBaseURL,
 	}
 

--- a/server/internal/federation/catalog.go
+++ b/server/internal/federation/catalog.go
@@ -102,6 +102,20 @@ func (s CatalogSnapshotStore) RemovePeerSnapshot(sourcePeerFingerprint string) e
 		Delete(&db.FederationCatalogSnapshot{}).Error
 }
 
+// DirectSourcesForKey returns the fingerprints of DIRECT friends (hop 1) whose
+// catalog offers the given game key — i.e. friends we can download it from
+// directly, without forwarding. Used by Phase 3b-1 direct-friend download.
+func (s CatalogSnapshotStore) DirectSourcesForKey(key string) ([]string, error) {
+	var fps []string
+	if err := s.DB.Model(&db.FederationCatalogSnapshot{}).
+		Where("key = ? AND hops = ?", key, 1).
+		Distinct("source_peer_fingerprint").
+		Pluck("source_peer_fingerprint", &fps).Error; err != nil {
+		return nil, err
+	}
+	return fps, nil
+}
+
 func (s CatalogSnapshotStore) EntriesWithinHops(maxHops int) ([]CatalogEntry, error) {
 	q := s.DB.Model(&db.FederationCatalogSnapshot{})
 	if maxHops >= 0 {

--- a/server/internal/federation/catalog_sources_test.go
+++ b/server/internal/federation/catalog_sources_test.go
@@ -1,0 +1,27 @@
+package federation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirectSourcesForKey_OnlyHop1(t *testing.T) {
+	store := CatalogSnapshotStore{DB: openCatalogTestDB(t)}
+	require.NoError(t, store.ReplacePeerSnapshot("B", []CatalogEntry{
+		{OriginFingerprint: "B", Hops: 1, Key: "g1", Title: "T"},        // direct friend has it
+		{OriginFingerprint: "C", Hops: 2, Key: "g1", Title: "T"},        // friend-of-friend (not direct)
+		{OriginFingerprint: "B", Hops: 1, Key: "other", Title: "Other"}, // different game
+	}, time.Unix(1, 0)))
+
+	sources, err := store.DirectSourcesForKey("g1")
+	require.NoError(t, err)
+	require.Len(t, sources, 1, "only the hop-1 source qualifies for direct download")
+	assert.Equal(t, "B", sources[0])
+
+	none, err := store.DirectSourcesForKey("missing")
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}


### PR DESCRIPTION
## Federation Phase 3b-1 — Direct-friend ROM download

Part of #1348. The safe core of ROM federation: **download a game a *direct* friend has**, with **no forwarding** (the opt-in multi-hop relay is the next, separate PR — see below). Builds on Phase 3a catalog discovery (#1358).

### What's included
- **Serve a local ROM to a friend** — `GET /api/federation/download?key=` (signed, behind `VerifyFederationRequest` + `SharePolicy(download)`). Resolves the local game by cross-server key (IGDB scraper id / CRC32) to its on-disk path (`storage.ResolveGamePath` + `ValidateROMPath`) and streams it via gin's file serving (HTTP ranges handled). Returns **404 for games we don't have locally — no forwarding** in this PR.
- **User downloads from a direct friend** — `GET /api/federation/games/download?key=` (user auth). Finds a hop-1 friend offering the game (`CatalogSnapshotStore.DirectSourcesForKey`) whose `ConsumePolicy(download)` is set, fetches from them, and streams the bytes through.
- Both sides are **per-friend opt-in** via the download policy (default-deny). **No global relay flag needed** — that gates the multi-hop forwarding in 3b-2.
- All exchanges recorded to the observability ledger.

### Security
The user-facing proxy **forces a safe download disposition** — it never echoes the peer's `Content-Type`/`Content-Disposition` (a malicious friend returning `text/html` would otherwise render on our origin → stored XSS). It sets `application/octet-stream` + `attachment` (filename derived from the key, not the peer) + `X-Content-Type-Options: nosniff`, and forwards only a numeric `Content-Length`. (Flagged by automated review, fixed + regression-tested.)

### Testing
- Serve: streams local when shared; 403 when not shared; 404 when not local.
- User download: proxies from a direct friend; respects `ConsumePolicy(download)` (won't fetch from a non-consented peer); 404 when no source; **asserts a hostile peer's `text/html` is not echoed**.
- `DirectSourcesForKey` returns only hop-1 sources.
- Full `go test ./...` green; build + gofmt clean.

### Heads-up: test-suite timing
The `internal/api` package now runs ~400s alone (under Go's 600s per-package default). Under a parallel `go test ./...` it can tip over the per-package timeout on a busy machine — a pre-existing scaling watch-item (the package is large), not introduced here. CI runs it green. Worth a future split/parallelization pass if it keeps growing.

### Next: 3b-2 (the opt-in multi-hop relay)
Per your decision, the forwarding relay (B forwards C's file to A when A can't reach C) is **default-OFF behind an explicit `federation_relay_enabled` admin setting**. That's the legally-sensitive part and the next PR — I'll confirm scope with you before building it.

Part of #1348
