### PR TITLE
feat(server): federation Phase 3b-2 — opt-in multi-hop ROM relay (#1348)

### DIFF
--- a/server/internal/api/admin_handler_settings.go
+++ b/server/internal/api/admin_handler_settings.go
@@ -58,4 +58,7 @@ var allowedSettingKeys = map[string]bool{
 	"default_region":           true,
 	"hide_pre_release_default": true,
 	"ra_api_key":               true,
+	// Federation ROM relay (#1348 Phase 3b-2): forwards friends-of-friends'
+	// game files. Default-off; an admin must explicitly enable it.
+	"federation_relay_enabled": true,
 }

--- a/server/internal/api/federation_download.go
+++ b/server/internal/api/federation_download.go
@@ -158,9 +158,12 @@ func (h *FederationHandler) ginServeDownload(c *gin.Context) {
 	}
 
 	// 2. Relay (forward) from a friend, if enabled and within the hop budget.
-	hops := federation.MaxFederationHops
+	// A missing ?hops defaults to 0 (NO relay): in-mesh requests always carry the
+	// budget, so a peer that omits it gets local-or-404 rather than a budget reset
+	// to max — keeping the hop cap authoritative from the origin.
+	hops := 0
 	if q := c.Query("hops"); q != "" {
-		if n, err := strconv.Atoi(q); err == nil && n >= 0 && n <= hops {
+		if n, err := strconv.Atoi(q); err == nil && n >= 0 && n <= federation.MaxFederationHops {
 			hops = n
 		}
 	}

--- a/server/internal/api/federation_download.go
+++ b/server/internal/api/federation_download.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -15,6 +16,21 @@ import (
 	"github.com/spela/server/internal/storage"
 	"gorm.io/gorm"
 )
+
+// relayEnabledSettingKey gates the multi-hop ROM relay (#1348 Phase 3b-2). The
+// relay forwards a friend-of-friend's game file through us — copyright-sensitive,
+// so it is OFF unless an admin explicitly enables it.
+const relayEnabledSettingKey = "federation_relay_enabled"
+
+// relayEnabled reports whether this server will forward (relay) ROMs it doesn't
+// have locally. Default false.
+func (h *FederationHandler) relayEnabled() bool {
+	var s db.ServerSetting
+	if err := h.DB.Where("key = ?", relayEnabledSettingKey).First(&s).Error; err != nil {
+		return false
+	}
+	return s.Value == "true"
+}
 
 // safeDownloadName turns a cross-server game key into a filesystem-safe download
 // filename (the peer's filename is untrusted and never used).
@@ -35,10 +51,28 @@ func safeDownloadName(key string) string {
 	return string(b) + ".bin"
 }
 
-// downloadClient fetches a ROM from a friend over a signed request, returning
-// the raw response so the caller can stream the body. Faked in tests.
+// streamSafeDownload proxies a fetched ROM response to c with a FORCED safe
+// disposition — never trusting the upstream's Content-Type/Disposition (a
+// malicious peer could send text/html → XSS on our origin). Returns bytes sent.
+func streamSafeDownload(c *gin.Context, resp *http.Response, key string) int64 {
+	c.Header("Content-Type", "application/octet-stream")
+	c.Header("Content-Disposition", `attachment; filename="`+safeDownloadName(key)+`"`)
+	c.Header("X-Content-Type-Options", "nosniff")
+	if cl := resp.Header.Get("Content-Length"); cl != "" {
+		if _, err := strconv.ParseInt(cl, 10, 64); err == nil {
+			c.Header("Content-Length", cl)
+		}
+	}
+	c.Status(http.StatusOK)
+	n, _ := io.Copy(c.Writer, resp.Body)
+	return n
+}
+
+// downloadClient fetches a ROM from a friend over a signed request, returning the
+// raw response so the caller can stream the body. hops is the remaining forward
+// budget the friend may use. Faked in tests.
 type downloadClient interface {
-	FetchDownload(baseURL, requestID string, id federation.Identity, peerFingerprint, key string) (*http.Response, error)
+	FetchDownload(baseURL, requestID string, id federation.Identity, peerFingerprint, key string, hops int) (*http.Response, error)
 }
 
 type httpDownloadClient struct{}
@@ -52,14 +86,14 @@ var fedDownloadHTTPClient = func() *http.Client {
 	return &http.Client{Transport: tr}
 }()
 
-func (httpDownloadClient) FetchDownload(baseURL, requestID string, id federation.Identity, peerFingerprint, key string) (*http.Response, error) {
+func (httpDownloadClient) FetchDownload(baseURL, requestID string, id federation.Identity, peerFingerprint, key string, hops int) (*http.Response, error) {
 	const path = "/api/federation/download"
-	u := baseURL + path + "?key=" + url.QueryEscape(key)
+	u := fmt.Sprintf("%s%s?key=%s&hops=%d", baseURL, path, url.QueryEscape(key), hops)
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
 	}
-	// Sign the path (query is excluded from the signature, matching the verifier).
+	// Sign the path only (query is excluded from the signature, matching the verifier).
 	for k, v := range signedFederationHeaders(id, http.MethodGet, path, requestID, nil, peerFingerprint) {
 		req.Header.Set(k, v)
 	}
@@ -87,9 +121,11 @@ func (h *FederationHandler) resolveLocalGameByKey(key string) (db.Game, string, 
 	return game, abs, true
 }
 
-// ginServeDownload streams a LOCAL ROM to a friend that we share downloads with.
-// Behind VerifyFederationRequest + SharePolicy(download). Phase 3b-1 does NOT
-// forward (relay) games we don't have — that's the opt-in multi-hop relay.
+// ginServeDownload serves a ROM to a requesting friend (signed +
+// SharePolicy(download)). If we have it locally, stream it. Otherwise, IF the
+// relay is enabled and there's hop budget, forward it from a friend that offers
+// it (multi-hop relay, #1348 Phase 3b-2). Default-off: with relay disabled this
+// is the direct-only behaviour from 3b-1.
 func (h *FederationHandler) ginServeDownload(c *gin.Context) {
 	reqID := c.GetHeader(headerFedRequestID)
 	if reqID == "" {
@@ -110,36 +146,105 @@ func (h *FederationHandler) ginServeDownload(c *gin.Context) {
 		return
 	}
 
-	game, absPath, found := h.resolveLocalGameByKey(key)
-	if !found {
+	// 1. Serve a local game directly.
+	if game, absPath, found := h.resolveLocalGameByKey(key); found {
 		federation.RecordExchange(h.DB, federation.ExchangeRecord{
 			RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
 			Direction: db.ExchangeInbound, Operation: "download_serve",
-			DataClass: string(federation.DataClassDownload), Status: db.ExchangeError,
-			Error: "not available locally (no forwarding in 3b-1)",
+			DataClass: string(federation.DataClassDownload), Status: db.ExchangeOK, ItemCount: 1,
 		})
-		c.JSON(http.StatusNotFound, gin.H{"error": "game not available here"})
+		c.FileAttachment(absPath, filepath.Base(game.FilePath))
+		return
+	}
+
+	// 2. Relay (forward) from a friend, if enabled and within the hop budget.
+	hops := federation.MaxFederationHops
+	if q := c.Query("hops"); q != "" {
+		if n, err := strconv.Atoi(q); err == nil && n >= 0 && n <= hops {
+			hops = n
+		}
+	}
+	if h.relayEnabled() && hops > 0 && h.relayForward(c, reqID, peer, key, hops) {
+		federation.RecordExchange(h.DB, federation.ExchangeRecord{
+			RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+			Direction: db.ExchangeInbound, Operation: "download_serve",
+			DataClass: string(federation.DataClassDownload), Status: db.ExchangeOK,
+			MaxHops: hops, ItemCount: 1,
+		})
 		return
 	}
 
 	federation.RecordExchange(h.DB, federation.ExchangeRecord{
 		RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
 		Direction: db.ExchangeInbound, Operation: "download_serve",
-		DataClass: string(federation.DataClassDownload), Status: db.ExchangeOK, ItemCount: 1,
+		DataClass: string(federation.DataClassDownload), Status: db.ExchangeError,
+		Error: "not available locally and no relay path (relay off, no budget, or no source)",
 	})
-	c.FileAttachment(absPath, filepath.Base(game.FilePath))
+	c.JSON(http.StatusNotFound, gin.H{"error": "game not available here"})
 }
 
-// ginUserDownload lets a local user download a game that a DIRECT friend offers.
-// Finds a hop-1 friend with the key whose ConsumePolicy(download) is set, fetches
-// from them, and streams the bytes through. Behind user auth.
+// relayForward fetches the key from a friend that offers it (excluding the
+// requester, to avoid a loop) and streams it through. Returns true if it served
+// the response. hops is the budget; the onward request gets hops-1.
+func (h *FederationHandler) relayForward(c *gin.Context, reqID string, requester *db.FederationPeer, key string, hops int) bool {
+	sources, err := h.CatalogSnapshots.SourcePeersForKey(key)
+	if err != nil {
+		return false
+	}
+	client := h.DownloadClient
+	if client == nil {
+		client = httpDownloadClient{}
+	}
+	for _, fp := range sources {
+		if fp == requester.Fingerprint {
+			continue // loop guard: never forward back to the requester
+		}
+		src, err := h.Peers.GetByFingerprint(fp)
+		if err != nil || src.Status != db.PeerStatusActive || !federation.CanConsume(*src, federation.DataClassDownload) {
+			continue
+		}
+		started := time.Now()
+		resp, ferr := client.FetchDownload(src.BaseURL, reqID, h.Identity, src.Fingerprint, key, hops-1)
+		if ferr != nil || resp.StatusCode != http.StatusOK {
+			if resp != nil {
+				resp.Body.Close()
+			}
+			errMsg := "relay fetch failed"
+			if ferr != nil {
+				errMsg = ferr.Error()
+			}
+			federation.RecordExchange(h.DB, federation.ExchangeRecord{
+				RequestID: reqID, PeerFingerprint: src.Fingerprint, PeerName: src.Name,
+				Direction: db.ExchangeOutbound, Operation: "download_relay",
+				DataClass: string(federation.DataClassDownload), Status: db.ExchangeError,
+				StartedAt: started, MaxHops: hops - 1, Error: errMsg,
+			})
+			continue
+		}
+		n := streamSafeDownload(c, resp, key)
+		resp.Body.Close()
+		federation.RecordExchange(h.DB, federation.ExchangeRecord{
+			RequestID: reqID, PeerFingerprint: src.Fingerprint, PeerName: src.Name,
+			Direction: db.ExchangeOutbound, Operation: "download_relay",
+			DataClass: string(federation.DataClassDownload), Status: db.ExchangeOK,
+			StartedAt: started, MaxHops: hops - 1, Bytes: n,
+		})
+		return true
+	}
+	return false
+}
+
+// ginUserDownload lets a local user download a game a friend offers — directly
+// from a friend that has it, or via that friend's relay for a friend-of-friend's
+// game. Picks a friend whose catalog offers the key and whose ConsumePolicy
+// allows downloads, then proxies the (safely re-typed) stream. Behind user auth.
 func (h *FederationHandler) ginUserDownload(c *gin.Context) {
 	key := c.Query("key")
 	if key == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "missing key"})
 		return
 	}
-	sources, err := h.CatalogSnapshots.DirectSourcesForKey(key)
+	sources, err := h.CatalogSnapshots.SourcePeersForKey(key)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to look up sources"})
 		return
@@ -156,7 +261,7 @@ func (h *FederationHandler) ginUserDownload(c *gin.Context) {
 		}
 		reqID := federation.NewRequestID()
 		started := time.Now()
-		resp, ferr := client.FetchDownload(peer.BaseURL, reqID, h.Identity, peer.Fingerprint, key)
+		resp, ferr := client.FetchDownload(peer.BaseURL, reqID, h.Identity, peer.Fingerprint, key, federation.MaxFederationHops-1)
 		if ferr != nil || resp.StatusCode != http.StatusOK {
 			if resp != nil {
 				resp.Body.Close()
@@ -173,21 +278,7 @@ func (h *FederationHandler) ginUserDownload(c *gin.Context) {
 			})
 			continue
 		}
-		// SECURITY: never echo the peer's Content-Type / Content-Disposition. A
-		// malicious friend could send text/html and have it rendered on OUR
-		// origin (stored XSS). Force a safe binary attachment; the client names
-		// the file from the catalog metadata it already has. Only Content-Length
-		// is forwarded, and only if it's a valid number.
-		c.Header("Content-Type", "application/octet-stream")
-		c.Header("Content-Disposition", `attachment; filename="`+safeDownloadName(key)+`"`)
-		c.Header("X-Content-Type-Options", "nosniff")
-		if cl := resp.Header.Get("Content-Length"); cl != "" {
-			if _, perr := strconv.ParseInt(cl, 10, 64); perr == nil {
-				c.Header("Content-Length", cl)
-			}
-		}
-		c.Status(http.StatusOK)
-		n, _ := io.Copy(c.Writer, resp.Body)
+		n := streamSafeDownload(c, resp, key)
 		resp.Body.Close()
 		federation.RecordExchange(h.DB, federation.ExchangeRecord{
 			RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
@@ -197,5 +288,5 @@ func (h *FederationHandler) ginUserDownload(c *gin.Context) {
 		})
 		return
 	}
-	c.JSON(http.StatusNotFound, gin.H{"error": "not available from any direct friend"})
+	c.JSON(http.StatusNotFound, gin.H{"error": "not available from any friend"})
 }

--- a/server/internal/api/federation_download_test.go
+++ b/server/internal/api/federation_download_test.go
@@ -24,7 +24,7 @@ type fakeDownloadClient struct {
 	err    error
 }
 
-func (f *fakeDownloadClient) FetchDownload(_, _ string, _ federation.Identity, _, _ string) (*http.Response, error) {
+func (f *fakeDownloadClient) FetchDownload(_, _ string, _ federation.Identity, _, _ string, _ int) (*http.Response, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -175,7 +175,120 @@ func TestUserDownload_NotFoundWhenNoConsumableSource(t *testing.T) {
 
 type downloadClientFunc func()
 
-func (f downloadClientFunc) FetchDownload(_, _ string, _ federation.Identity, _, _ string) (*http.Response, error) {
+func (f downloadClientFunc) FetchDownload(_, _ string, _ federation.Identity, _, _ string, _ int) (*http.Response, error) {
 	f()
 	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("")), Header: http.Header{}}, nil
+}
+
+// --- Multi-hop relay (#1348 Phase 3b-2) ------------------------------------
+
+func setRelayEnabled(t *testing.T, database *gorm.DB, on bool) {
+	t.Helper()
+	v := "false"
+	if on {
+		v = "true"
+	}
+	require.NoError(t, database.Save(&db.ServerSetting{Key: "federation_relay_enabled", Value: v}).Error)
+}
+
+// relaySetup wires: a requester peer (shares nothing back, just asks us) and a
+// source friend that offers the key (we consume downloads from them). Returns
+// the requester peer to pass into the serve handler.
+func relaySetup(t *testing.T, database *gorm.DB, key string) (*db.FederationPeer, federation.Identity) {
+	t.Helper()
+	requesterID, _ := federation.GenerateIdentity()
+	sourceID, _ := federation.GenerateIdentity()
+
+	// We must share downloads with the requester (so CanShare passes).
+	sp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassDownload: true})
+	requester := &db.FederationPeer{Fingerprint: requesterID.Fingerprint(), Name: "Requester", SharePolicy: sp, Status: db.PeerStatusActive}
+
+	// The source friend offers the key and we consume downloads from them.
+	dp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassDownload: true})
+	require.NoError(t, federation.PeerStore{DB: database}.Upsert(&db.FederationPeer{
+		Fingerprint: sourceID.Fingerprint(), PublicKey: b64(sourceID.PublicKey), Name: "Source",
+		BaseURL: "https://source", Status: db.PeerStatusActive, ConsumePolicy: dp,
+	}))
+	require.NoError(t, federation.CatalogSnapshotStore{DB: database}.ReplacePeerSnapshot(sourceID.Fingerprint(), []federation.CatalogEntry{
+		{OriginFingerprint: sourceID.Fingerprint(), Hops: 1, Key: key, Title: "Relayed", Console: "NES"},
+	}, time.Unix(1, 0)))
+	return requester, sourceID
+}
+
+func TestServeDownload_RelayForwardsWhenEnabled(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	setRelayEnabled(t, database, true)
+	requester, _ := relaySetup(t, database, "igdb:far")
+
+	// We don't have igdb:far locally (no GameDirs/game), so we must relay it.
+	h := downloadHandler(database, selfID, []string{t.TempDir()}, &fakeDownloadClient{body: "RELAYED-ROM"})
+
+	w := callServeDownload(h, requester, "igdb:far")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "RELAYED-ROM", w.Body.String())
+	assert.Equal(t, "application/octet-stream", w.Header().Get("Content-Type"))
+
+	var relays int64
+	database.Model(&db.FederationExchange{}).Where("operation = ? AND status = ?", "download_relay", db.ExchangeOK).Count(&relays)
+	assert.Equal(t, int64(1), relays)
+}
+
+func TestServeDownload_NoForwardWhenRelayDisabled(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	// relay NOT enabled (default)
+	requester, _ := relaySetup(t, database, "igdb:far")
+	called := false
+	h := downloadHandler(database, selfID, []string{t.TempDir()}, downloadClientFunc(func() { called = true }))
+
+	w := callServeDownload(h, requester, "igdb:far")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.False(t, called, "relay disabled → never forwards")
+}
+
+func TestServeDownload_RelayLoopGuard(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	setRelayEnabled(t, database, true)
+
+	// The ONLY catalog source for the key is the requester itself → must not
+	// forward back to them (loop guard) → 404.
+	requesterID, _ := federation.GenerateIdentity()
+	sp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassDownload: true})
+	dp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassDownload: true})
+	require.NoError(t, federation.PeerStore{DB: database}.Upsert(&db.FederationPeer{
+		Fingerprint: requesterID.Fingerprint(), PublicKey: b64(requesterID.PublicKey), Name: "Requester",
+		BaseURL: "https://req", Status: db.PeerStatusActive, SharePolicy: sp, ConsumePolicy: dp,
+	}))
+	require.NoError(t, federation.CatalogSnapshotStore{DB: database}.ReplacePeerSnapshot(requesterID.Fingerprint(), []federation.CatalogEntry{
+		{OriginFingerprint: requesterID.Fingerprint(), Hops: 1, Key: "igdb:loop", Title: "Loop", Console: "NES"},
+	}, time.Unix(1, 0)))
+	requester, _ := federation.PeerStore{DB: database}.GetByFingerprint(requesterID.Fingerprint())
+
+	called := false
+	h := downloadHandler(database, selfID, []string{t.TempDir()}, downloadClientFunc(func() { called = true }))
+
+	w := callServeDownload(h, requester, "igdb:loop")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.False(t, called, "must not forward back to the requester")
+}
+
+func TestServeDownload_NoForwardWhenBudgetExhausted(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	setRelayEnabled(t, database, true)
+	requester, _ := relaySetup(t, database, "igdb:far")
+	called := false
+	h := downloadHandler(database, selfID, []string{t.TempDir()}, downloadClientFunc(func() { called = true }))
+
+	// hops=0 → no budget to forward.
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/x", func(c *gin.Context) { c.Set(fedPeerContextKey, requester); h.ginServeDownload(c) })
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/x?key=igdb:far&hops=0", nil))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.False(t, called, "hops=0 → no forwarding")
 }

--- a/server/internal/api/federation_download_test.go
+++ b/server/internal/api/federation_download_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -73,7 +74,10 @@ func callServeDownload(h *FederationHandler, peer *db.FederationPeer, key string
 		h.ginServeDownload(c)
 	})
 	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/x?key="+key, nil))
+	// In-mesh requests always carry the hop budget; mirror that here so relay
+	// paths are exercised (budget-exhaustion is tested separately with hops=0).
+	url := fmt.Sprintf("/x?key=%s&hops=%d", key, federation.MaxFederationHops)
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, url, nil))
 	return w
 }
 

--- a/server/internal/federation/catalog.go
+++ b/server/internal/federation/catalog.go
@@ -102,13 +102,14 @@ func (s CatalogSnapshotStore) RemovePeerSnapshot(sourcePeerFingerprint string) e
 		Delete(&db.FederationCatalogSnapshot{}).Error
 }
 
-// DirectSourcesForKey returns the fingerprints of DIRECT friends (hop 1) whose
-// catalog offers the given game key — i.e. friends we can download it from
-// directly, without forwarding. Used by Phase 3b-1 direct-friend download.
-func (s CatalogSnapshotStore) DirectSourcesForKey(key string) ([]string, error) {
+// SourcePeersForKey returns the distinct DIRECT friends (source peers) whose
+// catalog offers the given game key, at ANY depth — the friends we can request a
+// download from (they either have it locally or relay it onward). Used by the
+// Phase 3b download paths.
+func (s CatalogSnapshotStore) SourcePeersForKey(key string) ([]string, error) {
 	var fps []string
 	if err := s.DB.Model(&db.FederationCatalogSnapshot{}).
-		Where("key = ? AND hops = ?", key, 1).
+		Where("key = ?", key).
 		Distinct("source_peer_fingerprint").
 		Pluck("source_peer_fingerprint", &fps).Error; err != nil {
 		return nil, err

--- a/server/internal/federation/catalog_sources_test.go
+++ b/server/internal/federation/catalog_sources_test.go
@@ -8,20 +8,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDirectSourcesForKey_OnlyHop1(t *testing.T) {
+func TestSourcePeersForKey_AnyHop(t *testing.T) {
 	store := CatalogSnapshotStore{DB: openCatalogTestDB(t)}
+	// B relays a friend-of-friend's game (hop 2); D has it directly (hop 1).
 	require.NoError(t, store.ReplacePeerSnapshot("B", []CatalogEntry{
-		{OriginFingerprint: "B", Hops: 1, Key: "g1", Title: "T"},        // direct friend has it
-		{OriginFingerprint: "C", Hops: 2, Key: "g1", Title: "T"},        // friend-of-friend (not direct)
-		{OriginFingerprint: "B", Hops: 1, Key: "other", Title: "Other"}, // different game
+		{OriginFingerprint: "C", Hops: 2, Key: "deep", Title: "Deep"},
+	}, time.Unix(1, 0)))
+	require.NoError(t, store.ReplacePeerSnapshot("D", []CatalogEntry{
+		{OriginFingerprint: "D", Hops: 1, Key: "deep", Title: "Deep"},
 	}, time.Unix(1, 0)))
 
-	sources, err := store.DirectSourcesForKey("g1")
+	sources, err := store.SourcePeersForKey("deep")
 	require.NoError(t, err)
-	require.Len(t, sources, 1, "only the hop-1 source qualifies for direct download")
-	assert.Equal(t, "B", sources[0])
+	// Both direct friends are askable, regardless of how deep the origin is.
+	assert.ElementsMatch(t, []string{"B", "D"}, sources)
 
-	none, err := store.DirectSourcesForKey("missing")
+	none, err := store.SourcePeersForKey("missing")
 	require.NoError(t, err)
 	assert.Empty(t, none)
 }


### PR DESCRIPTION
## Federation Phase 3b-2 — Opt-in multi-hop ROM relay

Part of #1348 — the final piece of Phase 3. Lets a server **forward a friend-of-a-friend's ROM** through a direct friend (B relays C's file to A when A can't reach C). Builds on 3b-1 direct download (#1364). **Default-OFF, explicit admin opt-in** per the agreed legal posture.

### What it adds
- **`federation_relay_enabled` server setting, default false** — toggled via the existing admin settings API (added to the allowlist). With it off, behaviour is exactly the direct-only 3b-1: a server only ever serves its *own* games.
- **Forwarding in the serve endpoint** — when enabled, for a game it doesn't have locally, it fetches from a friend that offers it (`CatalogSnapshotStore.SourcePeersForKey`, now any-hop) and streams it through:
  - **hop-capped** — `MaxFederationHops`, with a `?hops` budget decremented on each forward; `hops=0` → no forward.
  - **loop-guarded** — never forwards back to the requester; the hop cap bounds longer cycles.
  - **per-friend gated** — the relaying friend must be active with `ConsumePolicy(download)` set; the requester is still `SharePolicy(download)`-gated.
- **User download reaches friend-of-friend games** — `ginUserDownload` now picks any direct friend whose catalog offers the key; if it's a deeper origin, that friend relays it (if *their* relay is enabled).
- **Shared `streamSafeDownload`** — forces `application/octet-stream` + `attachment` + `nosniff` on **both** the relay and user-download paths, so the XSS protection from 3b-1 covers relayed bytes too. Never echoes a peer's content typing.
- Relay legs recorded as `download_relay` exchanges in the observability ledger.

### Three layers of gating (nothing forwards by accident)
1. Global `federation_relay_enabled` (default off).
2. Per-friend `SharePolicy(download)` (requester side) + `ConsumePolicy(download)` (source side).
3. Hop cap + loop guard.

### Testing
- Relay: forwards when enabled; **never forwards when disabled** (default); loop guard (won't forward back to the requester); budget exhaustion (`hops=0`); `download_relay` ledger row on success.
- Direct + user-download tests from 3b-1 still pass; `SourcePeersForKey` returns sources at any hop.
- Full local `go test ./...` green (see timing note); build + gofmt clean.

### Pass-through only
No caching / library-ingest of relayed ROMs in this PR (lowest legal footprint) — those would be further explicit opt-ins.

### Timing note
The `internal/api` package runs ~400–600s and occasionally tips its 600s per-package timeout on a *loaded* dev machine (I have several worktrees + background test runs going); it's green in CI's clean environment (~400s, as every prior phase). Pre-existing scaling watch-item — a future `-timeout` bump or package split, not introduced here. No test hangs (the timeout dump shows only a 5s test mid-run, never a stuck one).

Part of #1348
