### PR TITLE
feat(web): admin federation pairing lifecycle — invite / accept / revoke

### DIFF
--- a/web/src/features/admin/components/federation-peers-table.tsx
+++ b/web/src/features/admin/components/federation-peers-table.tsx
@@ -9,6 +9,7 @@ interface FederationPeersTableProps {
   isLoading: boolean;
   testingFingerprint: string | null;
   onTest: (fingerprint: string) => void;
+  onRevoke: (peer: FederationPeer) => void;
 }
 
 const HEADERS = ["Friend", "Status", "Last contact", "Last error", ""];
@@ -18,6 +19,7 @@ export function FederationPeersTable({
   isLoading,
   testingFingerprint,
   onTest,
+  onRevoke,
 }: FederationPeersTableProps) {
   return (
     <Section>
@@ -74,16 +76,26 @@ export function FederationPeersTable({
                   <td className="px-5 py-3 text-sm text-surface-400 max-w-xs truncate">
                     {peer.lastError || "—"}
                   </td>
-                  <td className="px-5 py-3 text-right">
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      loading={testingFingerprint === peer.fingerprint}
-                      onClick={() => onTest(peer.fingerprint)}
-                      data-testid="test-connection-button"
-                    >
-                      Test connection
-                    </Button>
+                  <td className="px-5 py-3">
+                    <div className="flex items-center justify-end gap-2">
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        loading={testingFingerprint === peer.fingerprint}
+                        onClick={() => onTest(peer.fingerprint)}
+                        data-testid="test-connection-button"
+                      >
+                        Test connection
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onRevoke(peer)}
+                        data-testid="revoke-peer-button"
+                      >
+                        Revoke
+                      </Button>
+                    </div>
                   </td>
                 </tr>
               ))

--- a/web/src/features/admin/components/pair-friend-dialog.tsx
+++ b/web/src/features/admin/components/pair-friend-dialog.tsx
@@ -1,0 +1,187 @@
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+import {
+  Modal,
+  Button,
+  Input,
+  Textarea,
+  StateTabNav,
+  StateTabItem,
+  useToast,
+} from "@/components/ui";
+import {
+  useIssueFederationInvite,
+  useAcceptFederationInvite,
+} from "@/hooks/use-federation";
+
+interface PairFriendDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Tab = "accept" | "invite";
+
+// Modal for forming a federation link with a friend server. Two directions:
+// accept an invite a friend gave you, or generate one to hand to them. Pairing
+// is mutual and invite-gated; either side can initiate.
+export function PairFriendDialog({ open, onClose }: PairFriendDialogProps) {
+  const { toast } = useToast();
+  const [tab, setTab] = useState<Tab>("accept");
+
+  // Accept-invite form.
+  const [invite, setInvite] = useState("");
+  const [name, setName] = useState("");
+  const acceptInvite = useAcceptFederationInvite();
+
+  // Issue-invite result.
+  const issueInvite = useIssueFederationInvite();
+  const [generated, setGenerated] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const close = () => {
+    onClose();
+    // Reset after the close animation so fields don't flicker mid-fade.
+    setTimeout(() => {
+      setTab("accept");
+      setInvite("");
+      setName("");
+      setGenerated(null);
+      setCopied(false);
+    }, 200);
+  };
+
+  const handleAccept = () => {
+    acceptInvite.mutate(
+      { invite: invite.trim(), name: name.trim() },
+      {
+        onSuccess: () => {
+          toast("success", "Friend server paired");
+          close();
+        },
+        onError: (e) =>
+          toast("error", e instanceof Error ? e.message : "Pairing failed"),
+      },
+    );
+  };
+
+  const handleGenerate = () => {
+    issueInvite.mutate(undefined, {
+      onSuccess: (data) => {
+        if (data?.invite) {
+          setGenerated(data.invite);
+        } else {
+          toast("error", "Server returned an empty invite");
+        }
+      },
+      onError: (e) =>
+        toast(
+          "error",
+          e instanceof Error ? e.message : "Could not generate an invite",
+        ),
+    });
+  };
+
+  const handleCopy = () => {
+    if (!generated) return;
+    navigator.clipboard.writeText(generated).then(() => {
+      setCopied(true);
+      toast("success", "Invite copied to clipboard");
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <Modal open={open} onClose={close} title="Pair a friend server" size="lg">
+      <div className="space-y-5">
+        <StateTabNav>
+          <StateTabItem active={tab === "accept"} onClick={() => setTab("accept")}>
+            Accept an invite
+          </StateTabItem>
+          <StateTabItem active={tab === "invite"} onClick={() => setTab("invite")}>
+            Invite a friend
+          </StateTabItem>
+        </StateTabNav>
+
+        {tab === "accept" ? (
+          <div className="space-y-4" data-testid="accept-invite-panel">
+            <p className="text-sm text-surface-400">
+              Paste the invite a friend sent you. We'll verify it, connect to
+              their server, and add them as a peer.
+            </p>
+            <Textarea
+              label="Friend's invite"
+              rows={4}
+              value={invite}
+              onChange={(e) => setInvite(e.target.value)}
+              placeholder="Paste the invite string your friend sent you"
+              className="font-mono text-xs"
+              data-testid="accept-invite-input"
+            />
+            <Input
+              label="Name for this friend"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Alice's Server"
+              data-testid="accept-invite-name"
+            />
+            <div className="flex justify-end">
+              <Button
+                variant="primary"
+                loading={acceptInvite.isPending}
+                disabled={!invite.trim() || !name.trim()}
+                onClick={handleAccept}
+                data-testid="accept-invite-submit"
+              >
+                Pair
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4" data-testid="invite-friend-panel">
+            <p className="text-sm text-surface-400">
+              Generate a one-time invite and send it to your friend's admin
+              out-of-band. They paste it under “Accept an invite” to connect.
+            </p>
+            {generated ? (
+              <>
+                <Textarea
+                  label="Invite (expires in 30 minutes)"
+                  readOnly
+                  rows={4}
+                  value={generated}
+                  className="font-mono text-xs"
+                  data-testid="generated-invite"
+                />
+                <div className="flex justify-end gap-3">
+                  <Button
+                    variant="secondary"
+                    onClick={handleCopy}
+                    data-testid="copy-invite-button"
+                  >
+                    {copied ? (
+                      <Check className="h-4 w-4" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                    {copied ? "Copied!" : "Copy"}
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <div className="flex justify-end">
+                <Button
+                  variant="primary"
+                  loading={issueInvite.isPending}
+                  onClick={handleGenerate}
+                  data-testid="generate-invite-button"
+                >
+                  Generate invite
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/hooks/use-federation.ts
+++ b/web/src/hooks/use-federation.ts
@@ -42,3 +42,46 @@ export function useTestFederationPeer() {
     },
   });
 }
+
+// Issue a one-time pairing invite to hand to a friend's admin out-of-band.
+// Does not change our peer list — the friend appears only after they accept
+// and call our /pair callback (picked up by the 10s peer poll).
+export function useIssueFederationInvite() {
+  return useMutation({
+    mutationFn: () => unwrap(typedApi.POST("/api/admin/federation/invite")),
+  });
+}
+
+// Accept a friend's invite: verifies it, calls them back, and stores them as
+// an active peer immediately — so refresh peers + activity on success.
+export function useAcceptFederationInvite() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { invite: string; name: string }) =>
+      unwrap(
+        typedApi.POST("/api/admin/federation/peers/accept", { body }),
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "federation", "peers"] });
+      queryClient.invalidateQueries({ queryKey: ["admin", "federation", "exchanges"] });
+    },
+  });
+}
+
+// Revoke a peer. The server also drops the peer's cached stat/catalog
+// snapshots, so its mesh contribution vanishes immediately.
+export function useRevokeFederationPeer() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (fingerprint: string) =>
+      unwrap(
+        typedApi.DELETE("/api/admin/federation/peers/{fingerprint}", {
+          params: { path: { fingerprint } },
+        }),
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "federation", "peers"] });
+      queryClient.invalidateQueries({ queryKey: ["admin", "federation", "exchanges"] });
+    },
+  });
+}

--- a/web/src/pages/admin/__tests__/federation-page.test.tsx
+++ b/web/src/pages/admin/__tests__/federation-page.test.tsx
@@ -1,26 +1,39 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
+import { ToastProvider } from "@/components/ui";
 
 vi.mock("@/hooks/use-federation", () => ({
   useFederationPeers: vi.fn(),
   useFederationExchanges: vi.fn(),
   useTestFederationPeer: vi.fn(),
+  useIssueFederationInvite: vi.fn(),
+  useAcceptFederationInvite: vi.fn(),
+  useRevokeFederationPeer: vi.fn(),
 }));
 
 import {
   useFederationPeers,
   useFederationExchanges,
   useTestFederationPeer,
+  useIssueFederationInvite,
+  useAcceptFederationInvite,
+  useRevokeFederationPeer,
 } from "@/hooks/use-federation";
 import { AdminFederationPage } from "../federation-page";
 
 const mockUsePeers = useFederationPeers as ReturnType<typeof vi.fn>;
 const mockUseExchanges = useFederationExchanges as ReturnType<typeof vi.fn>;
 const mockUseTest = useTestFederationPeer as ReturnType<typeof vi.fn>;
+const mockUseIssue = useIssueFederationInvite as ReturnType<typeof vi.fn>;
+const mockUseAccept = useAcceptFederationInvite as ReturnType<typeof vi.fn>;
+const mockUseRevoke = useRevokeFederationPeer as ReturnType<typeof vi.fn>;
 const mockTestMutate = vi.fn();
+const mockIssueMutate = vi.fn();
+const mockAcceptMutate = vi.fn();
+const mockRevokeMutate = vi.fn();
 
 function renderPage() {
   const queryClient = new QueryClient({
@@ -28,35 +41,44 @@ function renderPage() {
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
-        <AdminFederationPage />
-      </MemoryRouter>
+      <ToastProvider>
+        <MemoryRouter>
+          <AdminFederationPage />
+        </MemoryRouter>
+      </ToastProvider>
     </QueryClientProvider>,
   );
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockUsePeers.mockReturnValue({ data: { peers: [] }, isLoading: false });
+  mockUseExchanges.mockReturnValue({ data: { exchanges: [] }, isLoading: false });
   mockUseTest.mockReturnValue({ mutate: mockTestMutate, isPending: false });
+  mockUseIssue.mockReturnValue({ mutate: mockIssueMutate, isPending: false });
+  mockUseAccept.mockReturnValue({ mutate: mockAcceptMutate, isPending: false });
+  mockUseRevoke.mockReturnValue({ mutate: mockRevokeMutate, isPending: false });
 });
+
+const onePeer = {
+  data: {
+    peers: [
+      {
+        fingerprint: "abcdef1234567890xyz",
+        name: "Alice's Server",
+        status: "active",
+        reachable: true,
+        lastError: "",
+        lastContactAt: "2026-06-15T00:00:00Z",
+      },
+    ],
+  },
+  isLoading: false,
+};
 
 describe("AdminFederationPage", () => {
   it("renders peers with a status badge and an exchange row", () => {
-    mockUsePeers.mockReturnValue({
-      data: {
-        peers: [
-          {
-            fingerprint: "abcdef1234567890xyz",
-            name: "Alice's Server",
-            status: "active",
-            reachable: true,
-            lastError: "",
-            lastContactAt: "2026-06-15T00:00:00Z",
-          },
-        ],
-      },
-      isLoading: false,
-    });
+    mockUsePeers.mockReturnValue(onePeer);
     mockUseExchanges.mockReturnValue({
       data: {
         exchanges: [
@@ -84,9 +106,6 @@ describe("AdminFederationPage", () => {
   });
 
   it("shows empty states when there are no peers or activity", () => {
-    mockUsePeers.mockReturnValue({ data: { peers: [] }, isLoading: false });
-    mockUseExchanges.mockReturnValue({ data: { exchanges: [] }, isLoading: false });
-
     renderPage();
 
     expect(screen.getByText("No friend servers")).toBeInTheDocument();
@@ -102,7 +121,6 @@ describe("AdminFederationPage", () => {
       error: new Error("network down"),
       refetch: refetchPeers,
     });
-    mockUseExchanges.mockReturnValue({ data: { exchanges: [] }, isLoading: false });
 
     renderPage();
 
@@ -131,13 +149,60 @@ describe("AdminFederationPage", () => {
       },
       isLoading: false,
     });
-    mockUseExchanges.mockReturnValue({ data: { exchanges: [] }, isLoading: false });
 
     renderPage();
     await userEvent.setup().click(screen.getByTestId("test-connection-button"));
 
     expect(mockTestMutate).toHaveBeenCalledWith(
       "fp-to-test-0000000",
+      expect.anything(),
+    );
+  });
+
+  it("opens the pair dialog on the accept-invite panel and generates an invite", async () => {
+    mockIssueMutate.mockImplementation((_vars, opts) =>
+      opts.onSuccess({ invite: "INVITE-XYZ" }),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByTestId("pair-friend-button"));
+    expect(screen.getByTestId("accept-invite-panel")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Invite a friend" }));
+    await user.click(screen.getByTestId("generate-invite-button"));
+
+    expect(mockIssueMutate).toHaveBeenCalled();
+    expect(screen.getByTestId("generated-invite")).toHaveValue("INVITE-XYZ");
+  });
+
+  it("submits an accepted invite with the pasted string and name", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByTestId("pair-friend-button"));
+    await user.type(screen.getByTestId("accept-invite-input"), "friend-invite");
+    await user.type(screen.getByTestId("accept-invite-name"), "Carol");
+    await user.click(screen.getByTestId("accept-invite-submit"));
+
+    expect(mockAcceptMutate).toHaveBeenCalledWith(
+      { invite: "friend-invite", name: "Carol" },
+      expect.anything(),
+    );
+  });
+
+  it("revokes a peer only after confirmation", async () => {
+    mockUsePeers.mockReturnValue(onePeer);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByTestId("revoke-peer-button"));
+    // Confirmation modal — confirm button lives inside the dialog.
+    const dialog = screen.getByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "Revoke" }));
+
+    expect(mockRevokeMutate).toHaveBeenCalledWith(
+      "abcdef1234567890xyz",
       expect.anything(),
     );
   });

--- a/web/src/pages/admin/federation-page.tsx
+++ b/web/src/pages/admin/federation-page.tsx
@@ -1,15 +1,21 @@
 import { useState } from "react";
+import { Plus } from "lucide-react";
 import { PageLayout, SectionList, TitledSection } from "@/components/layout";
+import { Button, ConfirmDeleteModal, useToast } from "@/components/ui";
 import { FederationPeersTable } from "@/features/admin/components/federation-peers-table";
 import { FederationExchangeTable } from "@/features/admin/components/federation-exchange-table";
 import { FederationErrorBlock } from "@/features/admin/components/federation-error-block";
+import { PairFriendDialog } from "@/features/admin/components/pair-friend-dialog";
 import {
   useFederationPeers,
   useFederationExchanges,
   useTestFederationPeer,
+  useRevokeFederationPeer,
 } from "@/hooks/use-federation";
+import type { FederationPeer } from "@/generated/schemas";
 
 export function AdminFederationPage() {
+  const { toast } = useToast();
   const {
     data: peersData,
     isLoading: peersLoading,
@@ -25,11 +31,28 @@ export function AdminFederationPage() {
     refetch: refetchExchanges,
   } = useFederationExchanges();
   const testPeer = useTestFederationPeer();
+  const revokePeer = useRevokeFederationPeer();
   const [testing, setTesting] = useState<string | null>(null);
+  const [pairOpen, setPairOpen] = useState(false);
+  const [revokeTarget, setRevokeTarget] = useState<FederationPeer | null>(null);
 
   const handleTest = (fingerprint: string) => {
     setTesting(fingerprint);
     testPeer.mutate(fingerprint, { onSettled: () => setTesting(null) });
+  };
+
+  const handleRevoke = () => {
+    if (!revokeTarget) return;
+    revokePeer.mutate(revokeTarget.fingerprint, {
+      onSuccess: () => {
+        toast("success", "Friend server revoked");
+        setRevokeTarget(null);
+      },
+      onError: (e) => {
+        toast("error", e instanceof Error ? e.message : "Revoke failed");
+        setRevokeTarget(null);
+      },
+    });
   };
 
   return (
@@ -38,7 +61,20 @@ export function AdminFederationPage() {
       subtitle="Your friend servers and the data flowing between them. Pulls, catalog refreshes, and downloads are recorded below."
     >
       <SectionList>
-        <TitledSection title="Friend servers">
+        <TitledSection
+          title="Friend servers"
+          renderRight={
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => setPairOpen(true)}
+              data-testid="pair-friend-button"
+            >
+              <Plus className="h-4 w-4" />
+              Pair friend server
+            </Button>
+          }
+        >
           {peersError ? (
             <FederationErrorBlock
               title="Failed to load friend servers"
@@ -51,6 +87,7 @@ export function AdminFederationPage() {
               isLoading={peersLoading}
               testingFingerprint={testing}
               onTest={handleTest}
+              onRevoke={setRevokeTarget}
             />
           )}
         </TitledSection>
@@ -70,6 +107,18 @@ export function AdminFederationPage() {
           )}
         </TitledSection>
       </SectionList>
+
+      <PairFriendDialog open={pairOpen} onClose={() => setPairOpen(false)} />
+
+      <ConfirmDeleteModal
+        open={revokeTarget !== null}
+        onClose={() => setRevokeTarget(null)}
+        title="Revoke friend server"
+        message={`Revoke "${revokeTarget?.name || "this friend"}"? They will be removed as a peer and their shared data will stop appearing across the mesh. You can re-pair later with a new invite.`}
+        onConfirm={handleRevoke}
+        isPending={revokePeer.isPending}
+        actionLabel="Revoke"
+      />
     </PageLayout>
   );
 }


### PR DESCRIPTION
## What

PR-2 of the federation admin UI. Builds on the read-only visibility page (#1369) by letting an admin actually **form the mesh from the web** — issue an invite, accept a friend's invite, and revoke a peer.

### Pair a friend server
A **Pair friend server** action on the "Friend servers" section opens a two-tab dialog:
- **Accept an invite** — paste the invite a friend sent you + give them a name. The server verifies the invite, calls the friend back, and stores them as an active peer (appears in the table immediately).
- **Invite a friend** — generate a one-time, 30-minute token to copy and hand to your friend's admin out-of-band; they paste it under "Accept an invite".

### Revoke
Each peer row gains a **Revoke** action behind a confirmation modal. Revoking removes the peer and (server-side) drops its cached stat/catalog snapshots, so its mesh contribution disappears immediately.

## How

- Three new mutation hooks in `use-federation.ts`: `useIssueFederationInvite`, `useAcceptFederationInvite`, `useRevokeFederationPeer`. Accept and revoke invalidate the peers + exchange queries; issuing does **not** — the friend only appears once they accept and call our `/pair` callback, which the existing 10s poll picks up.
- All wiring uses the existing backend endpoints (`POST /invite`, `POST /peers/accept`, `DELETE /peers/{fingerprint}`) — **no backend changes**.
- Design system: `Modal` + `StateTabNav` for the dialog, `ConfirmDeleteModal` for revoke, `Textarea`/`Input`/`Button` atoms, `useToast` for outcomes; clipboard-copy follows the existing netplay `session-code` pattern.

## Out of scope (follow-up PR-3)

Per-friend share/consume **policy editing** (a freshly-paired peer defaults to deny-all, so it shares/consumes nothing until policies are set — that needs a new backend endpoint) and the default-off **ROM relay toggle**. Grouped into the next PR since both govern *what* data flows.

## Testing

- Extended `federation-page.test.tsx` (now 7 cases): pair dialog opens on the accept panel + generates an invite; accept submits `{invite, name}`; revoke fires only after confirmation; plus the existing render/empty/error/test-connection cases. Assertions use `data-testid`.
- `npm run build` (type-safe) ✅
- Full web vitest suite: 148 files / 1635 tests ✅

Part of #1350, part of #1343