### PR TITLE
fix(player): controller detail is a real page; gamepad B no-ops at tab root (#1372)

### DIFF
--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -1211,6 +1211,17 @@ internal fun ComposeRule.navigateBackToHome() {
             Thread.sleep(500)
         }
     }
+    // Back no longer crosses tab roots (#1372): B/back at a tab root is a no-op,
+    // so unwinding from a sibling tab (e.g. Settings) never reaches Home via back.
+    // Fall back to tapping the Home tab directly — same approach as
+    // navigateToGameAndPlay's reset.
+    if (!runCatching { isOnHomeScreen() }.getOrDefault(false)) {
+        runCatching {
+            onAllNodes(hasTestTag(TestTags.NAV_HOME))[0].performClick()
+            waitForIdle()
+            Thread.sleep(500)
+        }
+    }
 }
 
 /**

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionNavigationTest.kt
@@ -161,7 +161,7 @@ class SectionNavigationTest {
     }
 
     @Test
-    fun goBackFromConsolesReturnsToHome() = runComposeUiTest {
+    fun goBackAtConsolesTabRootIsNoOp() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
@@ -172,13 +172,14 @@ class SectionNavigationTest {
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
         assertEquals(SpScreen.Consoles, harness.navigationViewModel.state.value.currentScreen)
 
-        // GoBack with empty backstack from Consoles should go to Home
+        // GoBack at a tab root is a no-op (#1372): each tab owns its stack and the
+        // root is the floor — B never leaves the tab, so we stay on Consoles.
         harness.navigationViewModel.onIntent(NavigationIntent.GoBack)
-        assertEquals(SpScreen.Home, harness.navigationViewModel.state.value.currentScreen)
+        assertEquals(SpScreen.Consoles, harness.navigationViewModel.state.value.currentScreen)
     }
 
     @Test
-    fun goBackFromCollectionsReturnsToHome() = runComposeUiTest {
+    fun goBackAtCollectionsTabRootIsNoOp() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
@@ -190,8 +191,8 @@ class SectionNavigationTest {
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
         assertEquals(SpScreen.Collections, harness.navigationViewModel.state.value.currentScreen)
 
-        // GoBack with empty backstack from Collections should go to Home
+        // GoBack at a tab root is a no-op (#1372) — we stay on Collections.
         harness.navigationViewModel.onIntent(NavigationIntent.GoBack)
-        assertEquals(SpScreen.Home, harness.navigationViewModel.state.value.currentScreen)
+        assertEquals(SpScreen.Collections, harness.navigationViewModel.state.value.currentScreen)
     }
 }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
@@ -187,20 +187,23 @@ class SettingsConsoleNavigationTest {
         navigateToSettings(harness)
         openControlsCategory(harness)
 
-        // Drill into the controller's detail.
+        // Drill into the controller's detail — now a real navigation page (#1372).
         onNodeWithTag("controller_row_500").performClick()
         advanceQuick(harness)
+        assertEquals(
+            SpScreen.ControllerDetail(500),
+            harness.navigationViewModel.state.value.currentScreen,
+        )
         onNodeWithTag("controller_detail_title").assertExists()
 
         // On-device the tester captures when its element is focused; here we
         // activate it directly for the selected controller.
-        harness.gamepadConfigViewModel.onIntent(GamepadConfigIntent.SetInputTestActive(true))
+        harness.gamepadConfigViewModel.onIntent(GamepadConfigIntent.SetInputTestActive(500, true))
         harness.gamepadPortManager.reportPositionInput(500, GamepadPosition.SOUTH, pressed = true)
         advanceQuick(harness)
 
-        onNodeWithTag("settings_category_content_list")
-            .performScrollToNode(hasTestTag("tester_pos_SOUTH"))
         onNodeWithTag("tester_pos_SOUTH")
+            .performScrollTo()
             .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Pressed"))
         onNodeWithTag("tester_pos_EAST")
             .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Not pressed"))
@@ -220,10 +223,14 @@ class SettingsConsoleNavigationTest {
         navigateToSettings(harness)
         openControlsCategory(harness)
 
-        // In Pad B's detail, try to take P1 (held by Pad A).
+        // In Pad B's detail (a real navigation page, #1372), try to take P1 (held by Pad A).
         onNodeWithTag("controller_row_600").performClick()
         advanceQuick(harness)
-        onNodeWithTag("controller_detail_change_player").performClick()
+        assertEquals(
+            SpScreen.ControllerDetail(600),
+            harness.navigationViewModel.state.value.currentScreen,
+        )
+        onNodeWithTag("controller_detail_change_player").performScrollTo().performClick()
         advanceQuick(harness)
         onNodeWithTag("slot_chip_0").performClick()
         advanceQuick(harness)
@@ -250,7 +257,11 @@ class SettingsConsoleNavigationTest {
 
         onNodeWithTag("controller_row_500").performClick()
         advanceQuick(harness)
-        onNodeWithTag("controller_detail_clear_player").performClick()
+        assertEquals(
+            SpScreen.ControllerDetail(500),
+            harness.navigationViewModel.state.value.currentScreen,
+        )
+        onNodeWithTag("controller_detail_clear_player").performScrollTo().performClick()
         advanceQuick(harness)
 
         assertEquals(-1, harness.gamepadPortManager.getPort(500))

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
@@ -77,15 +77,10 @@ class NavigationViewModel(
                 isTabSwitch = false,
             )
         }
-        // Stack has only the root — go to Home tab if not already there
-        if (state.activeTab != BottomNavTab.HOME) {
-            return state.copy(
-                activeTab = BottomNavTab.HOME,
-                isGoingBack = true,
-                isTabSwitch = false,
-            )
-        }
-        return null // Home root — nothing to do (platform handles app exit)
+        // Stack has only the root — nothing to pop. Back does nothing at a tab
+        // root: it never leaves the current tab or jumps to Home (#1372). Each
+        // tab owns its own stack; that tab's root is the floor.
+        return null
     }
 
     fun onIntent(intent: NavigationIntent) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -21,6 +21,9 @@ sealed class SpScreen(val route: String) {
     data object Downloads : SpScreen("downloads")
     data object Settings : SpScreen("settings")
     data class ConsoleSettings(val consoleId: String) : SpScreen("console_settings/$consoleId")
+    /** Per-controller detail (#1377): profile/type, player assignment, input tester.
+     *  A real navigation page so gamepad B pops it like any screen (#1372). */
+    data class ControllerDetail(val deviceId: Int) : SpScreen("controller_detail/$deviceId")
     data class UserProfile(val userId: String) : SpScreen("user/$userId")
     data object SharedSessions : SpScreen("sharedSessions")
     data class SharedSessionDetail(val sharedSessionId: String) : SpScreen("sharedSession/$sharedSessionId")

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/ScreenRouter.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/ScreenRouter.kt
@@ -12,6 +12,7 @@ import com.spela.player.presentation.intent.NetplayIntent
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.NavigationState
 import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.ui.components.gamepad.ControllerDetailScreen
 import com.spela.player.presentation.ui.screen.ActivityScreen
 import com.spela.player.presentation.ui.screen.AllGamesScreen
 import com.spela.player.presentation.ui.screen.ChallengeDetailScreen
@@ -750,6 +751,11 @@ fun ScreenRouter(
                                             NavigationIntent.NavigateTo(SpScreen.ConsoleSettings(consoleId))
                                         )
                                     },
+                                    onNavigateToControllerDetail = { deviceId ->
+                                        navigationViewModel.onIntent(
+                                            NavigationIntent.NavigateTo(SpScreen.ControllerDetail(deviceId))
+                                        )
+                                    },
                                     onNavigateToLicenses = {
                                         navigationViewModel.onIntent(
                                             NavigationIntent.NavigateTo(SpScreen.Licenses)
@@ -769,6 +775,20 @@ fun ScreenRouter(
                                         navigationViewModel.onIntent(NavigationIntent.GoBack)
                                     },
                                 )
+                            }
+
+                            is SpScreen.ControllerDetail -> {
+                                if (gamepadConfigViewModel != null) {
+                                    val gamepadConfigState by gamepadConfigViewModel.state.collectAsState()
+                                    ControllerDetailScreen(
+                                        deviceId = screen.deviceId,
+                                        state = gamepadConfigState,
+                                        onIntent = gamepadConfigViewModel::onIntent,
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
                             }
 
                             is SpScreen.UserProfile -> {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/ControllerControls.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/ControllerControls.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,6 +44,9 @@ import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.ControllerStyle
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpScreen
+import com.spela.player.presentation.ui.components.SpScreenTopSpacer
+import com.spela.player.presentation.ui.components.SpScrollableContent
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.components.SpConfirmDialog
@@ -55,51 +59,74 @@ import com.spela.player.presentation.viewmodel.GamepadConfigIntent
 import com.spela.player.presentation.viewmodel.GamepadConfigState
 
 /**
- * Per-controller configuration for Settings → Controls (#1359): a list of every
- * connected controller, drilling into a detail subscreen where the user can edit
- * the controller's profile/type, assign or clear its player number, and test its
- * buttons live. The list ⇄ detail toggle is driven by [GamepadConfigState.selectedDeviceId];
- * the player-slot conflict prompt is driven by [GamepadConfigState.conflict].
+ * Per-controller list for Settings → Controls (#1359): every connected controller,
+ * each row drilling into [ControllerDetailScreen] (a real navigation page, #1372)
+ * to edit its profile/type, assign or clear its player number, and test its buttons
+ * live. Selecting a row calls [onSelectController] with the controller's device id.
  */
 @Composable
 fun ControllerControls(
     state: GamepadConfigState,
-    onIntent: (GamepadConfigIntent) -> Unit,
+    onSelectController: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val selected = state.selectedDeviceId?.let { id -> state.controllers.find { it.deviceId == id } }
-    if (selected != null) {
-        ControllerDetail(
-            controller = selected,
-            pressedPositions = state.pressedPositions,
-            onBack = { onIntent(GamepadConfigIntent.CloseDetail) },
-            onSelectStyle = { style ->
-                onIntent(GamepadConfigIntent.SetStyleOverrideForController(selected.deviceId, style))
-            },
-            onAssignSlot = { slot -> onIntent(GamepadConfigIntent.AssignPlayer(selected.deviceId, slot)) },
-            onClear = { onIntent(GamepadConfigIntent.ClearPlayer(selected.deviceId)) },
-            onTestActiveChange = { active -> onIntent(GamepadConfigIntent.SetInputTestActive(active)) },
-            modifier = modifier,
-        )
-    } else {
-        ControllerList(
-            controllers = state.controllers,
-            onSelect = { id -> onIntent(GamepadConfigIntent.SelectController(id)) },
-            modifier = modifier,
-        )
-    }
+    ControllerList(
+        controllers = state.controllers,
+        onSelect = onSelectController,
+        modifier = modifier,
+    )
+}
 
-    val conflict = state.conflict
-    if (conflict != null) {
-        SpConfirmDialog(
-            title = "Switch player?",
-            message = "${playerLabel(conflict.slot)} is currently ${conflict.currentDeviceName}. " +
-                "Switch ${playerLabel(conflict.slot)} to this controller? " +
-                "${conflict.currentDeviceName} will become unassigned.",
-            confirmText = "Switch",
-            onConfirm = { onIntent(GamepadConfigIntent.ConfirmConflict) },
-            onDismiss = { onIntent(GamepadConfigIntent.DismissConflict) },
-        )
+/**
+ * Per-controller detail PAGE (#1372): profile/type, player assignment, and the
+ * live input tester for one controller. A real navigation screen, so gamepad B
+ * pops it like any other screen (no in-screen back special-casing). Pops back
+ * automatically if the controller disconnects while open.
+ */
+@Composable
+fun ControllerDetailScreen(
+    deviceId: Int,
+    state: GamepadConfigState,
+    onIntent: (GamepadConfigIntent) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    PlatformBackHandler { onBack() }
+    val controller = state.controllers.find { it.deviceId == deviceId }
+    SpScreen {
+        if (controller == null) {
+            LaunchedEffect(Unit) { onBack() }
+        } else {
+            SpScrollableContent(modifier = modifier) {
+                // Clear the section-indicator pill in gamepad mode (no-op in touch),
+                // matching sibling detail screens like ConsoleSettingsScreen.
+                SpScreenTopSpacer()
+                ControllerDetail(
+                    controller = controller,
+                    pressedPositions = state.pressedPositions,
+                    onBack = onBack,
+                    onSelectStyle = { style ->
+                        onIntent(GamepadConfigIntent.SetStyleOverrideForController(deviceId, style))
+                    },
+                    onAssignSlot = { slot -> onIntent(GamepadConfigIntent.AssignPlayer(deviceId, slot)) },
+                    onClear = { onIntent(GamepadConfigIntent.ClearPlayer(deviceId)) },
+                    onTestActiveChange = { active -> onIntent(GamepadConfigIntent.SetInputTestActive(deviceId, active)) },
+                )
+            }
+
+            val conflict = state.conflict
+            if (conflict != null) {
+                SpConfirmDialog(
+                    title = "Switch player?",
+                    message = "${playerLabel(conflict.slot)} is currently ${conflict.currentDeviceName}. " +
+                        "Switch ${playerLabel(conflict.slot)} to this controller? " +
+                        "${conflict.currentDeviceName} will become unassigned.",
+                    confirmText = "Switch",
+                    onConfirm = { onIntent(GamepadConfigIntent.ConfirmConflict) },
+                    onDismiss = { onIntent(GamepadConfigIntent.DismissConflict) },
+                )
+            }
+        }
     }
 }
 
@@ -196,12 +223,9 @@ private fun ControllerDetail(
     var showStylePicker by remember { mutableStateOf(false) }
     var showSlotPicker by remember { mutableStateOf(false) }
 
-    // Hardware back / B closes the detail (returns to the list) rather than
-    // leaving Settings. Dialogs (style/slot pickers) intercept back themselves.
-    PlatformBackHandler(enabled = true) { onBack() }
-
     Column(modifier = modifier.fillMaxWidth().padding(SpSpacing.Default)) {
-        // Back affordance — first focusable, so the recovery moveFocus(Next) lands here.
+        // On-screen back affordance (touch). Gamepad B pops the page via the nav
+        // stack; it's also the first focusable, so moveFocus(Next) lands here.
         BackRow(onBack = onBack)
         Spacer(Modifier.height(SpSpacing.Small))
         Text(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
@@ -74,6 +74,7 @@ fun SettingsCategoryContent(
     keyMappingState: KeyMappingState?,
     gamepadConfigViewModel: GamepadConfigViewModel?,
     onNavigateToConsoleSettings: (String) -> Unit,
+    onNavigateToControllerDetail: (Int) -> Unit,
     onNavigateToLicenses: () -> Unit,
     onLogout: () -> Unit,
     modifier: Modifier = Modifier,
@@ -103,6 +104,7 @@ fun SettingsCategoryContent(
             SettingsCategory.EMULATION -> emulationContent(state, viewModel)
             SettingsCategory.CONTROLS -> controlsContent(
                 state, viewModel, keyMappingViewModel, keyMappingState, gamepadConfigViewModel,
+                onNavigateToControllerDetail,
             )
             SettingsCategory.CONSOLES -> consolesContent(state, onNavigateToConsoleSettings)
             SettingsCategory.ACHIEVEMENTS -> achievementsContent(state, viewModel)
@@ -266,6 +268,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.controlsContent(
     keyMappingViewModel: KeyMappingViewModel?,
     keyMappingState: KeyMappingState?,
     gamepadConfigViewModel: GamepadConfigViewModel?,
+    onNavigateToControllerDetail: (Int) -> Unit,
 ) {
     // Per-controller configuration (#1359): a list of connected controllers,
     // each drilling into a detail subscreen to edit its profile/type, assign or
@@ -278,7 +281,7 @@ private fun androidx.compose.foundation.lazy.LazyListScope.controlsContent(
             SpCard(onGradient = true) {
                 ControllerControls(
                     state = gamepadConfigState,
-                    onIntent = gamepadConfigViewModel::onIntent,
+                    onSelectController = onNavigateToControllerDetail,
                 )
             }
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
@@ -48,6 +48,7 @@ fun SettingsScreen(
     onBack: () -> Unit = {},
     onLogout: () -> Unit,
     onNavigateToConsoleSettings: (String) -> Unit = {},
+    onNavigateToControllerDetail: (Int) -> Unit = {},
     onNavigateToLicenses: () -> Unit = {},
 ) {
     val state by viewModel.state.collectAsState()
@@ -112,6 +113,7 @@ fun SettingsScreen(
                         keyMappingState = keyMappingState?.value,
                         gamepadConfigViewModel = gamepadConfigViewModel,
                         onNavigateToConsoleSettings = onNavigateToConsoleSettings,
+                        onNavigateToControllerDetail = onNavigateToControllerDetail,
                         onNavigateToLicenses = onNavigateToLicenses,
                         onLogout = onLogout,
                         modifier = Modifier.weight(1f).fillMaxHeight(),
@@ -133,6 +135,7 @@ fun SettingsScreen(
                         keyMappingState = keyMappingState?.value,
                         gamepadConfigViewModel = gamepadConfigViewModel,
                         onNavigateToConsoleSettings = onNavigateToConsoleSettings,
+                        onNavigateToControllerDetail = onNavigateToControllerDetail,
                         onNavigateToLicenses = onNavigateToLicenses,
                         onLogout = onLogout,
                         modifier = Modifier.fillMaxSize(),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadConfigViewModel.kt
@@ -24,8 +24,6 @@ data class GamepadConfigState(
     /** All connected controllers and their player-slot assignment (#1359) — the
      *  source for the per-controller list/detail UI in Settings → Controls. */
     val controllers: List<ControllerUi> = emptyList(),
-    /** The controller whose detail subscreen is open, or null for the list (#1359). */
-    val selectedDeviceId: Int? = null,
     /** A pending player-slot conflict awaiting the user's switch/cancel (#1359). */
     val conflict: SlotConflict? = null,
 )
@@ -85,13 +83,7 @@ sealed interface GamepadConfigIntent {
      */
     data class SetStyleOverride(val port: Int, val style: ControllerStyle?) : GamepadConfigIntent
 
-    // --- Per-controller list/detail (#1359) ---
-
-    /** Open the detail subscreen for [deviceId]. */
-    data class SelectController(val deviceId: Int) : GamepadConfigIntent
-
-    /** Close the detail subscreen back to the controller list. */
-    data object CloseDetail : GamepadConfigIntent
+    // --- Per-controller list/detail (#1359; detail is its own page #1372) ---
 
     /** Assign [deviceId] to player [slot] (0-based). Raises a [SlotConflict] when
      *  another controller holds the slot, instead of assigning immediately. */
@@ -110,8 +102,8 @@ sealed interface GamepadConfigIntent {
      *  identified by [deviceId] — works for unassigned controllers too. */
     data class SetStyleOverrideForController(val deviceId: Int, val style: ControllerStyle?) : GamepadConfigIntent
 
-    /** Toggle input-test capture for the open controller's detail (tester focus). */
-    data class SetInputTestActive(val active: Boolean) : GamepadConfigIntent
+    /** Toggle input-test capture for [deviceId]'s detail page (tester focus). */
+    data class SetInputTestActive(val deviceId: Int, val active: Boolean) : GamepadConfigIntent
 }
 
 class GamepadConfigViewModel(
@@ -179,13 +171,6 @@ class GamepadConfigViewModel(
                     ?: return
                 persistStyleOverride(deviceName, intent.style)
             }
-            is GamepadConfigIntent.SelectController -> {
-                _state.update { it.copy(selectedDeviceId = intent.deviceId) }
-            }
-            GamepadConfigIntent.CloseDetail -> {
-                gamepadPortManager.setTestCaptureDevice(null)
-                _state.update { it.copy(selectedDeviceId = null) }
-            }
             is GamepadConfigIntent.AssignPlayer -> {
                 val occupant = gamepadPortManager.deviceOnSlot(intent.slot)
                 if (occupant != null && occupant != intent.deviceId) {
@@ -228,9 +213,7 @@ class GamepadConfigViewModel(
                 persistStyleOverride(deviceName, intent.style)
             }
             is GamepadConfigIntent.SetInputTestActive -> {
-                gamepadPortManager.setTestCaptureDevice(
-                    if (intent.active) _state.value.selectedDeviceId else null,
-                )
+                gamepadPortManager.setTestCaptureDevice(if (intent.active) intent.deviceId else null)
             }
         }
     }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -344,7 +344,7 @@ class NavigationViewModelTest {
     }
 
     @Test
-    fun goBackFromConsolesTabReturnsToHome() = runTest(testDispatcher) {
+    fun goBackAtConsolesTabRootIsNoOp() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()
         simulateLoggedIn(vm)
@@ -354,14 +354,14 @@ class NavigationViewModelTest {
         assertEquals(BottomNavTab.CONSOLES, vm.state.value.activeTab)
         assertEquals(SpScreen.Consoles, vm.state.value.currentScreen)
 
-        // GoBack from tab root → Home
+        // GoBack at a tab root does nothing — stays on the tab, never jumps to Home (#1372).
         vm.onIntent(NavigationIntent.GoBack)
-        assertEquals(BottomNavTab.HOME, vm.state.value.activeTab)
-        assertEquals(SpScreen.Home, vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.CONSOLES, vm.state.value.activeTab)
+        assertEquals(SpScreen.Consoles, vm.state.value.currentScreen)
     }
 
     @Test
-    fun goBackFromCollectionsTabReturnsToHome() = runTest(testDispatcher) {
+    fun goBackAtCollectionsTabRootIsNoOp() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()
 
@@ -369,7 +369,7 @@ class NavigationViewModelTest {
         assertEquals(BottomNavTab.COLLECTIONS, vm.state.value.activeTab)
 
         vm.onIntent(NavigationIntent.GoBack)
-        assertEquals(BottomNavTab.HOME, vm.state.value.activeTab)
+        assertEquals(BottomNavTab.COLLECTIONS, vm.state.value.activeTab)
     }
 
     @Test


### PR DESCRIPTION
## Problem

On a gamepad-first handheld (AYN Thor), the per-controller detail in Settings → Controls (#1359/#1360) was an **in-screen toggle panel**. The hardware B button (`KEYCODE_BUTTON_B`) routed straight to `NavigationIntent.GoBack`, which bypassed the in-screen handler and popped the **whole Settings tab** instead of closing the detail. Separately, `GoBack` at a tab root switched to the Home tab.

The user's requirement: *"B should never leave the current tab — that should be its own navigation stack"* and *"B should do nothing on ALL tab root screens, if that is the only item left in the navigation stack."*

## Fix

- **Controller detail is now a real navigation screen** — `SpScreen.ControllerDetail(deviceId)`. Selecting a controller in the list navigates to it (`ScreenRouter` renders `ControllerDetailScreen`), so gamepad B pops it like any other screen. The on-screen `BackRow` stays for touch, and the page registers its own `PlatformBackHandler` exactly like sibling detail screens (`ConsoleSettingsScreen`, `GameDetailScreen`). Removed the in-screen list⇄detail toggle (`GamepadConfigState.selectedDeviceId`, the `SelectController`/`CloseDetail` intents); `SetInputTestActive` now carries the `deviceId` of the controller under test.
- **`NavigationViewModel.popScreen` is a no-op at a tab root** (stack == just the root): each tab owns its own stack and the root is the floor, so B never leaves the current tab and does nothing at a tab root.

The detail's visual content (controller type/profile, player-slot assignment, live input tester) is unchanged — it was rehosted into a full-screen page using the standard `SpScreen` + `SpScrollableContent` scaffold, with `SpScreenTopSpacer()` to clear the gamepad section-indicator pill (matching `ConsoleSettingsScreen`).

## Tests

- `SectionNavigationTest` + `NavigationViewModelTest`: assert the no-op-at-root behavior (back at a tab root stays on the tab, never jumps to Home).
- `SettingsConsoleNavigationTest`: drills into the controller detail via the new route; tester / conflict / clear flows updated for the new `SetInputTestActive(deviceId, active)` signature.
- `navigateBackToHome` (Android E2E helper): falls back to a Home-tab tap since back no longer crosses tab roots.
- Full `:shared:desktopTest` + `:desktop:desktopTest` green (848 tests, 0 failures); Android main + androidTest compile.

UI/UX reviewed by the design-system agent: APPROVE (gamepad pill clearance + `SpScrollableContent` convention applied).

Closes #1372
