### PR TITLE
feat(federation): surface connected-server games in the web search palette

### DIFF
--- a/server/internal/api/federation_catalog.go
+++ b/server/internal/api/federation_catalog.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -186,8 +187,9 @@ func (h *FederationHandler) RefreshFederationCatalog() (int, int) {
 // --- Available games (user-facing discovery) -------------------------------
 
 type AvailableGamesInput struct {
-	MaxHops    int  `query:"maxHops"`    // viewer reach; <=0 = full reachable mesh
-	RemoteOnly bool `query:"remoteOnly"` // only games not available locally
+	MaxHops    int    `query:"maxHops"`    // viewer reach; <=0 = full reachable mesh
+	RemoteOnly bool   `query:"remoteOnly"` // only games not available locally
+	Q          string `query:"q"`          // case-insensitive title filter; empty = all
 }
 type AvailableGamesOutput struct {
 	Body struct {
@@ -217,6 +219,15 @@ func (h *FederationHandler) HumaAvailableGames(_ context.Context, in *AvailableG
 		filtered := make([]federation.CatalogAvailability, 0, len(games))
 		for _, g := range games {
 			if !g.Local {
+				filtered = append(filtered, g)
+			}
+		}
+		games = filtered
+	}
+	if q := strings.TrimSpace(strings.ToLower(in.Q)); q != "" {
+		filtered := make([]federation.CatalogAvailability, 0, len(games))
+		for _, g := range games {
+			if strings.Contains(strings.ToLower(g.Title), q) {
 				filtered = append(filtered, g)
 			}
 		}

--- a/server/internal/api/federation_catalog_test.go
+++ b/server/internal/api/federation_catalog_test.go
@@ -206,3 +206,25 @@ func TestAvailableGames_AggregatesAndFiltersRemoteOnly(t *testing.T) {
 	assert.Equal(t, "igdb:remote", remoteOnly.Body.Games[0].Key)
 	assert.False(t, remoteOnly.Body.Games[0].Local)
 }
+
+func TestAvailableGames_FiltersByQuery(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	h := catalogHandler(database, selfID, nil)
+
+	require.NoError(t, h.CatalogSnapshots.ReplacePeerSnapshot("B", []federation.CatalogEntry{
+		{OriginFingerprint: "B", Hops: 1, Key: "igdb:1", Title: "Super Mario Bros", Console: "NES"},
+		{OriginFingerprint: "B", Hops: 1, Key: "igdb:2", Title: "Sonic the Hedgehog", Console: "MD"},
+	}, time.Unix(1, 0)))
+
+	// Case-insensitive substring match on title.
+	res, err := h.HumaAvailableGames(context.Background(), &AvailableGamesInput{Q: "mario"})
+	require.NoError(t, err)
+	require.Len(t, res.Body.Games, 1)
+	assert.Equal(t, "Super Mario Bros", res.Body.Games[0].Title)
+
+	// Blank query returns everything (no filter).
+	none, err := h.HumaAvailableGames(context.Background(), &AvailableGamesInput{Q: "   "})
+	require.NoError(t, err)
+	assert.Len(t, none.Body.Games, 2)
+}

--- a/web/src/features/search/components/__tests__/search-palette.test.tsx
+++ b/web/src/features/search/components/__tests__/search-palette.test.tsx
@@ -226,6 +226,46 @@ describe("SearchPalette", () => {
       });
     });
 
+    it("shows connected-server games in a read-only section, even while local search is still loading", async () => {
+      // Path-aware: local search never resolves (stays loading), federated
+      // catalog resolves with a match — the federated section must still show.
+      mockGet.mockImplementation((path: string) => {
+        if (
+          typeof path === "string" &&
+          path.includes("/api/federation/catalog/available")
+        ) {
+          return Promise.resolve({
+            games: [
+              {
+                key: "igdb:9",
+                title: "Chrono Trigger",
+                console: "SNES",
+                originCount: 2,
+                local: false,
+              },
+            ],
+          });
+        }
+        return new Promise(() => {}); // local search hangs
+      });
+
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+      await userEvent.type(screen.getByLabelText("Search input"), "chrono");
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("federated-search-section"),
+        ).toBeInTheDocument();
+      });
+
+      const row = screen.getByTestId("federated-result-igdb:9");
+      expect(row).toHaveTextContent("Chrono Trigger");
+      expect(row).toHaveTextContent("on 2 connected servers");
+      // Read-only: no "No results" message despite empty local results.
+      expect(screen.queryByText(/No results for/)).not.toBeInTheDocument();
+    });
+
     it("navigates and closes when clicking a result", async () => {
       mockGet.mockResolvedValue(resultsWithGames());
 

--- a/web/src/features/search/components/search-palette.tsx
+++ b/web/src/features/search/components/search-palette.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { Search, Loader2, Clock, X } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { useSearch } from "@/hooks/use-search";
+import { useFederatedGameSearch } from "@/hooks/use-federation-search";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { useHotkey } from "@/hooks/use-hotkey";
 import { useRecentSearches } from "@/hooks/use-recent-searches";
@@ -17,6 +18,10 @@ export function SearchPalette() {
     useRecentSearches();
 
   const { data: results, isLoading, isFetching } = useSearch(debouncedQuery);
+  const { data: fedData, isFetching: fedFetching } =
+    useFederatedGameSearch(debouncedQuery);
+  const fedGames = fedData?.games ?? [];
+  const hasFedResults = fedGames.length > 0;
 
   const openPalette = useCallback(() => setOpen(true), []);
   const closePalette = useCallback(() => {
@@ -128,7 +133,7 @@ export function SearchPalette() {
             className="flex-1 bg-transparent py-4 text-base text-surface-100 placeholder:text-surface-500 focus:outline-none"
             aria-label="Search input"
           />
-          {isFetching && (
+          {(isFetching || fedFetching) && (
             <Loader2 className="h-4 w-4 text-surface-500 animate-spin flex-shrink-0" data-testid="search-loading" />
           )}
           <kbd className="hidden sm:inline-flex items-center gap-0.5 rounded border border-surface-700 bg-surface-800 px-1.5 py-0.5 text-xs text-surface-500">
@@ -203,8 +208,10 @@ export function SearchPalette() {
           {/* No results */}
           {debouncedQuery.length >= 2 &&
             !isLoading &&
+            !fedFetching &&
             results &&
-            !hasResults && (
+            !hasResults &&
+            !hasFedResults && (
               <div className="flex flex-col items-center py-8">
                 <Search className="h-8 w-8 text-surface-600 mb-2" />
                 <p className="text-sm text-surface-500">
@@ -213,11 +220,14 @@ export function SearchPalette() {
               </div>
             )}
 
-          {/* Results */}
-          {results && hasResults && (
+          {/* Results — federated games render independently of the local
+              query, so connected-server hits show even while the local
+              search is still loading or returns nothing. */}
+          {(hasResults || hasFedResults) && (
             <SearchResultsDisplay
               results={results}
               onNavigate={handleNavigate}
+              federatedGames={fedGames}
             />
           )}
         </div>

--- a/web/src/features/search/components/search-results.tsx
+++ b/web/src/features/search/components/search-results.tsx
@@ -19,10 +19,18 @@ import type {
   SeriesSearchResult,
   FranchiseSearchResult,
 } from "@/hooks/use-search";
+import type { CatalogAvailability } from "@/generated/schemas";
+
+// Cap the connected-servers teaser so it never crowds out local results.
+const FEDERATED_LIMIT = 6;
 
 interface SearchResultsDisplayProps {
-  results: SearchResults;
+  // Optional: federated results can render before the local search resolves.
+  results?: SearchResults;
   onNavigate: (path: string) => void;
+  // Games found on connected servers (not in the local library). Read-only —
+  // listed for discovery; not navigable or downloadable yet.
+  federatedGames?: CatalogAvailability[];
 }
 
 interface ResultSection {
@@ -127,8 +135,10 @@ function buildSections(results: SearchResults): ResultSection[] {
 export function SearchResultsDisplay({
   results,
   onNavigate,
+  federatedGames,
 }: SearchResultsDisplayProps) {
-  const sections = buildSections(results);
+  const sections = results ? buildSections(results) : [];
+  const fedGames = federatedGames ?? [];
   const allItems = sections.flatMap((s) => s.items);
   const [highlightIndex, setHighlightIndex] = useState(-1);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -181,7 +191,7 @@ export function SearchResultsDisplay({
     }
   }, [highlightIndex]);
 
-  if (sections.length === 0) return null;
+  if (sections.length === 0 && fedGames.length === 0) return null;
 
   let globalIndex = 0;
 
@@ -219,6 +229,31 @@ export function SearchResultsDisplay({
           })}
         </div>
       ))}
+
+      {fedGames.length > 0 && (
+        <div className="py-2" data-testid="federated-search-section">
+          <div className="px-4 py-1.5 flex items-center justify-between">
+            <span className="text-xs font-semibold uppercase tracking-wider text-surface-500">
+              On connected servers
+            </span>
+            {fedGames.length > FEDERATED_LIMIT && (
+              <span className="text-xs text-surface-500">
+                {fedGames.length} total
+              </span>
+            )}
+          </div>
+          {fedGames.slice(0, FEDERATED_LIMIT).map((game) => (
+            // Read-only: discovery only — not navigable or downloadable yet.
+            <div
+              key={game.key}
+              data-testid={`federated-result-${game.key}`}
+              className="px-4 py-1.5"
+            >
+              <FederatedGameRow game={game} />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -332,6 +367,25 @@ function GameRow({
         </span>
       }
       highlighted={highlighted}
+    />
+  );
+}
+
+// Connected-server game: discovery row. No cover art is carried in the
+// federated catalog (metadata only), so the cover slot is a placeholder.
+function FederatedGameRow({ game }: { game: CatalogAvailability }) {
+  const servers = game.originCount;
+  return (
+    <SearchResultRow
+      icon={<div className="h-10 w-8 rounded bg-surface-700 flex-shrink-0" />}
+      title={game.title}
+      subtitle={`on ${servers} connected ${servers === 1 ? "server" : "servers"}`}
+      rightContent={
+        <span className="text-xs font-medium px-2 py-0.5 rounded bg-surface-800 text-surface-400 uppercase flex-shrink-0">
+          {game.console}
+        </span>
+      }
+      highlighted={false}
     />
   );
 }

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -14148,6 +14148,7 @@ export interface operations {
             query?: {
                 maxHops?: number;
                 remoteOnly?: boolean;
+                q?: string;
             };
             header?: never;
             path?: never;

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -19015,6 +19015,14 @@
             "schema": {
               "type": "boolean"
             }
+          },
+          {
+            "explode": false,
+            "in": "query",
+            "name": "q",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/web/src/hooks/use-federation-search.ts
+++ b/web/src/hooks/use-federation-search.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { typedApi, unwrap } from "@/lib/api-client";
+
+// Searches the federated catalog (games on connected servers) by title.
+// remoteOnly=true so results don't duplicate games already in the local
+// library — those already show in the main search results.
+export function useFederatedGameSearch(query: string) {
+  return useQuery({
+    queryKey: ["federation", "catalog", "search", query],
+    queryFn: () =>
+      unwrap(
+        typedApi.GET("/api/federation/catalog/available", {
+          params: { query: { q: query, remoteOnly: true } },
+        }),
+      ),
+    enabled: query.length >= 2,
+    staleTime: 30 * 1000,
+  });
+}


### PR DESCRIPTION
## What

The first slice of federation **discovery** in a client: the web ⌘K command palette now lists games available on **connected servers** alongside local library results, in a read-only **"On connected servers"** section.

This deliberately starts as small as possible to prove the federated catalog reaches a client and renders — building toward the broader "parallel worlds" design (a dedicated connected-servers browse area + import-on-download), but with none of that complexity yet.

## Scope (intentionally minimal)

- **Read-only.** Results are listed for discovery — **not navigable, not downloadable**. (Download = import-into-your-library is a later phase; it's what gives a game a local `Game` row so sessions/saves/etc. have a home.)
- **No "friend" terminology** — this is a server-to-server relation, so the UI says "connected servers."
- **Box art is a placeholder** for now: the federated catalog is metadata-only (key/title/console), so there are no covers in the data. Resolving real covers from the cross-id (IGDB scraper id) is the clear follow-up.

## Backend

- Added a `q` case-insensitive title filter to the existing `GET /api/admin/federation/catalog/available`… (user-facing `/api/federation/catalog/available`) handler, so the palette can search the federated catalog directly. The web call uses `remoteOnly=true` so federated results don't duplicate games already in the local library.

## Web

- `useFederatedGameSearch(query)` hook (TanStack Query, debounced via the palette's existing debounce, `enabled` at ≥2 chars).
- A trailing **"On connected servers"** section in the search results: each row shows a cover placeholder, title, "on N connected servers", and the console badge. Capped at 6 with an "N total" overflow hint, matching the local sections.
- Federated results render **independently of the local query**, so connected-server hits show even while the local search is still loading or returns nothing.

## Testing

- **Go**: `TestAvailableGames_FiltersByQuery` (case-insensitive match + blank-query passthrough). Full `internal/api` package passes locally (`ok`, 505s); `gofmt`/`vet` clean.
- **Web**: new palette test asserting the federated section renders (with a path-aware mock) **even while the local query hangs** — directly covering the independent-render fix. Full web suite: 148 files / 1638 tests ✅; type-safe build ✅.
- Reviewed; one real bug found and fixed (federated results were gated behind the local query resolving).

Part of #1350, part of #1343