### PR TITLE
feat(player): RetroArch-style hold-to-bind controller-buttons editor (#1377)

### DIFF
--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -266,6 +266,20 @@ class MainActivity : ComponentActivity() {
         return true
     }
 
+    /**
+     * Hold-to-bind capture (#1377): while the per-console mapping editor has a
+     * binding session open, capture EVERY gamepad button — including the D-pad —
+     * from ANY controller and feed it to the binder, consuming the event so a
+     * press only binds (never navigates). No-op when no session is active.
+     */
+    private fun captureBindInput(event: KeyEvent?, keyCode: Int, pressed: Boolean): Boolean {
+        if (!gamepadPortManager.bindCaptureActive.value) return false
+        val deviceId = event?.deviceId ?: return false
+        val position = AndroidGamepadNormalizer.normalize(keyCode) ?: return false
+        gamepadPortManager.reportBindPosition(deviceId, position, pressed)
+        return true
+    }
+
     /** Key codes that are gamepad-relevant and should be captured during key mapping. */
     private fun isGamepadCapturable(keyCode: Int): Boolean = when (keyCode) {
         KeyEvent.KEYCODE_BUTTON_A, KeyEvent.KEYCODE_BUTTON_B,
@@ -298,6 +312,10 @@ class MainActivity : ComponentActivity() {
         if (event != null) {
             ensureDeviceConnected(event.deviceId)
         }
+
+        // Hold-to-bind capture (#1377): when the mapping editor is awaiting a
+        // press, capture every button (incl. D-pad) from any pad and consume it.
+        if (captureBindInput(event, keyCode, pressed = true)) return true
 
         // Live input tester (#1355): when its element is focused, capture test
         // buttons (face/shoulder/trigger/stick — never the D-pad) and consume
@@ -405,6 +423,9 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+        // Hold-to-bind capture (#1377): release feeds the binder (resets the hold).
+        if (captureBindInput(event, keyCode, pressed = false)) return true
+
         // Live input tester (#1355): release the captured test button.
         if (captureTestInput(event, keyCode, pressed = false)) return true
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadMappingTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadMappingTest.kt
@@ -1,5 +1,6 @@
 package com.spela.player.desktop.e2e
 
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.*
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.SpScreen
@@ -8,15 +9,21 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlin.test.Test
 
 /**
- * E2E tests for the desktop positional gamepad mapping editor (#1334, Phase 3c).
+ * E2E tests for the desktop gamepad mapping editor (#1334; RetroArch-style
+ * redesign #1377).
  *
- * Verifies the brand-neutral position→action editor: it opens from console
- * settings, shows the default mapping, lets the user reassign a position to a
- * different console action, and resets to defaults — all positional, no brand
- * glyphs.
+ * Verifies the console-button-oriented editor: it opens from console settings,
+ * lists the console's buttons with the physical position that triggers each
+ * (brand-neutral positional names), and opening a button starts a hold-to-bind
+ * capture prompt that can be cancelled. The hold/abort *timing* is covered by
+ * GamepadMappingViewModelTest; this suite covers the rendering and interaction.
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
 class GamepadMappingTest {
+
+    // RetroPad ids on the NES layout.
+    private val NES_B = 0
+    private val NES_A = 8
 
     private fun createLoggedInHarness(): SpelaTestHarness {
         val harness = SpelaTestHarness(StandardTestDispatcher())
@@ -39,53 +46,75 @@ class GamepadMappingTest {
     }
 
     @Test
-    fun editorShowsDefaultMappingPositionally() = runComposeUiTest {
+    fun editorListsConsoleButtonsWithBoundPositions() = runComposeUiTest {
         val harness = createLoggedInHarness()
         setContent { harness.App() }
         openGamepadEditor(harness, "nes")
 
-        // NES default: bottom button = B, right button = A. Brand-neutral labels.
-        // Rows are clickable (semantics merged), so query the value Text unmerged.
-        onNodeWithTag("gamepad_action_SOUTH", useUnmergedTree = true).assertTextEquals("B")
-        onNodeWithTag("gamepad_action_EAST", useUnmergedTree = true).assertTextEquals("A")
-        // West has no NES action by default.
-        onNodeWithTag("gamepad_action_WEST", useUnmergedTree = true).assertTextEquals("—")
+        // The editor lists the CONSOLE's buttons (not the gamepad's positions).
+        onNodeWithTag("mapping_output_$NES_B").assertExists()
+        onNodeWithTag("mapping_output_$NES_A").assertExists()
+
+        // Each shows which physical position triggers it, by canonical name.
+        // NES default: B ← bottom face, A ← right face. Rows merge semantics, so
+        // query the value Text unmerged.
+        onNodeWithTag("mapping_bound_$NES_B", useUnmergedTree = true).assertTextEquals("Bottom button")
+        onNodeWithTag("mapping_bound_$NES_A", useUnmergedTree = true).assertTextEquals("Right button")
     }
 
     @Test
-    fun reassigningAPositionPersistsInTheRow() = runComposeUiTest {
+    fun openingAConsoleButtonStartsHoldToBindPrompt() = runComposeUiTest {
         val harness = createLoggedInHarness()
         setContent { harness.App() }
         openGamepadEditor(harness, "nes")
 
-        // Guiding example: make the bottom button act as NES A.
-        onNodeWithTag("gamepad_pos_SOUTH").performScrollTo().performClick()
-        advance(harness)
-        onNodeWithTag("gamepad_action_picker").assertExists()
-        // The picker's "A" option sets a contentDescription; the row value
-        // Texts don't, so this targets the option unambiguously.
-        onNodeWithContentDescription("A").performClick()
-        advance(harness)
+        onNodeWithTag("mapping_output_$NES_A").performScrollTo().performClick()
+        advanceQuick(harness) // stay under the 5s abort window
 
-        onNodeWithTag("gamepad_action_picker").assertDoesNotExist()
-        onNodeWithTag("gamepad_action_SOUTH", useUnmergedTree = true).assertTextEquals("A")
+        onNodeWithTag("binding_prompt").assertExists()
+        onNodeWithText("Assign A").assertExists()
+        // Capture is now active so a held button would feed the binder.
+        assert(harness.gamepadPortManager.bindCaptureActive.value)
     }
 
     @Test
-    fun resetToDefaultsRestoresMapping() = runComposeUiTest {
+    fun pressingAButtonInThePromptCapturesItWithoutClosing() = runComposeUiTest {
         val harness = createLoggedInHarness()
         setContent { harness.App() }
         openGamepadEditor(harness, "nes")
 
-        // Reassign, then reset.
-        onNodeWithTag("gamepad_pos_SOUTH").performScrollTo().performClick()
-        advance(harness)
-        onNodeWithContentDescription("A").performClick()
-        advance(harness)
-        onNodeWithTag("gamepad_action_SOUTH", useUnmergedTree = true).assertTextEquals("A")
+        onNodeWithTag("mapping_output_$NES_A").performScrollTo().performClick()
+        advanceQuick(harness)
+        onNodeWithTag("binding_prompt").assertExists()
 
-        onNodeWithTag("gamepad_mapping_reset").performClick()
-        advance(harness)
-        onNodeWithTag("gamepad_action_SOUTH", useUnmergedTree = true).assertTextEquals("B")
+        // Press (hold) the bottom face button. This used to just activate the
+        // focused Cancel button and close the prompt (the #1377 bug the dialog's
+        // onPreviewKeyEvent fixes). runCurrent (no virtual-time advance) processes
+        // the capture without elapsing the 2s commit hold.
+        onNodeWithTag("binding_prompt").performKeyInput { keyDown(Key.ButtonA) }
+        harness.testDispatcher.scheduler.runCurrent()
+        waitForIdle()
+
+        onNodeWithTag("binding_prompt").assertExists() // did NOT close
+        onNodeWithTag("binding_held", useUnmergedTree = true).assertTextEquals("Bottom button")
+    }
+
+    @Test
+    fun cancellingBindingReturnsToTheButtonList() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        openGamepadEditor(harness, "nes")
+
+        onNodeWithTag("mapping_output_$NES_A").performScrollTo().performClick()
+        advanceQuick(harness)
+        onNodeWithTag("binding_prompt").assertExists()
+
+        onNodeWithTag("binding_cancel").performClick()
+        advanceQuick(harness)
+
+        // Back to the list; capture released.
+        onNodeWithTag("binding_prompt").assertDoesNotExist()
+        onNodeWithTag("mapping_output_$NES_A").assertExists()
+        assert(!harness.gamepadPortManager.bindCaptureActive.value)
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GamepadMappingRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GamepadMappingRepositoryImpl.kt
@@ -43,6 +43,27 @@ class GamepadMappingRepositoryImpl(
         )
     }
 
+    override suspend fun bindPositionExclusive(
+        consoleId: String,
+        port: Int,
+        position: GamepadPosition,
+        retroButtonId: Int,
+    ) {
+        // 1:1 (#1377): clear any OTHER position currently mapping to this button
+        // (it becomes UNMAPPED → does nothing), then bind this position. Setting
+        // this position also steals it from whatever button it used to trigger,
+        // since each position maps to exactly one button.
+        if (retroButtonId != GamepadMappingRepository.UNMAPPED) {
+            val effective = getEffectiveMapping(consoleId, port)
+            for ((p, id) in effective) {
+                if (id == retroButtonId && p != position) {
+                    setBinding(consoleId, port, p, GamepadMappingRepository.UNMAPPED)
+                }
+            }
+        }
+        setBinding(consoleId, port, position, retroButtonId)
+    }
+
     override suspend fun resetToDefault(consoleId: String, port: Int) {
         queries.deleteGamepadMappingsForConsole(consoleId, port.toLong())
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/GamepadMappingRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/GamepadMappingRepository.kt
@@ -20,9 +20,25 @@ interface GamepadMappingRepository {
     /** Persist one position→RetroPad binding (idempotent). */
     suspend fun setBinding(consoleId: String, port: Int, position: GamepadPosition, retroButtonId: Int)
 
+    /**
+     * Bind [position] to [retroButtonId] **1:1** (#1377): the console button ends
+     * up triggered by exactly this position. Any OTHER position currently mapping
+     * to [retroButtonId] is cleared to [UNMAPPED] (it then does nothing), and the
+     * binding steals [position] from whatever button it used to trigger.
+     * Idempotent.
+     */
+    suspend fun bindPositionExclusive(consoleId: String, port: Int, position: GamepadPosition, retroButtonId: Int)
+
     /** Clear all stored overrides for a console/port (revert to defaults). */
     suspend fun resetToDefault(consoleId: String, port: Int)
 
     /** The default position→RetroPad mapping, with no overrides. */
     fun getDefaultMapping(): Map<GamepadPosition, Int>
+
+    companion object {
+        /** Sentinel RetroPad id meaning "this position does nothing" — out of the
+         *  resolver's valid 0..15 range, so it's skipped. Used to free a position
+         *  during a 1:1 rebind (#1377). */
+        const val UNMAPPED = -1
+    }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
@@ -157,6 +157,32 @@ class GamepadPortManager(
         _pressedPositions.value = emptySet()
     }
 
+    /** Positions held during a hold-to-bind session, merged across ALL devices
+     *  and INCLUDING the D-pad (#1377). Distinct from the input tester, which is
+     *  per-device and excludes the D-pad: the binding editor lets the user assign
+     *  any physical button — including D-pad directions — using any controller. */
+    private val bindPressedByDevice = HashMap<Int, MutableSet<GamepadPosition>>()
+    private val _bindPressedPositions = MutableStateFlow<Set<GamepadPosition>>(emptySet())
+    val bindPressedPositions: StateFlow<Set<GamepadPosition>> = _bindPressedPositions.asStateFlow()
+
+    /** True while the per-console mapping editor is capturing a hold-to-bind press
+     *  (#1377). The input pipelines route every position (incl. D-pad) from any
+     *  device into [bindPressedPositions] and suppress navigation, so a press only
+     *  feeds the binder. Mutually exclusive with the input tester in practice (they
+     *  live on different screens). */
+    private val _bindCaptureActive = MutableStateFlow(false)
+    val bindCaptureActive: StateFlow<Boolean> = _bindCaptureActive.asStateFlow()
+
+    /** Set by the mapping editor when a hold-to-bind session starts/ends. Clears
+     *  any stale held positions on each transition. */
+    @Synchronized
+    fun setBindCaptureActive(active: Boolean) {
+        if (_bindCaptureActive.value == active) return
+        _bindCaptureActive.value = active
+        bindPressedByDevice.clear()
+        _bindPressedPositions.value = emptySet()
+    }
+
     /** Current input mode: TOUCH when touch input was last used, GAMEPAD when D-pad/buttons were. */
     private val _inputMode = MutableStateFlow(InputMode.TOUCH)
     val inputMode: StateFlow<InputMode> = _inputMode.asStateFlow()
@@ -339,6 +365,9 @@ class GamepadPortManager(
         if (pressedByDevice.remove(deviceId) != null && _testCaptureDeviceId.value == deviceId) {
             recomputePressedPositions()
         }
+        if (bindPressedByDevice.remove(deviceId) != null && _bindCaptureActive.value) {
+            recomputeBindPressed()
+        }
         if (!wasConnected) return
         _portActivity.value = buildActivityMap()
         emitConnectedControllers()
@@ -494,6 +523,42 @@ class GamepadPortManager(
     }
 
     /**
+     * Records a hold-to-bind press/release for [deviceId] during a binding session
+     * (#1377). Captures from ANY device and INCLUDES the D-pad — fed by the desktop
+     * poller and (on Android) the mapping dialog's key handler. No-op unless
+     * [bindCaptureActive] is set, so stray presses outside a session are ignored.
+     */
+    @Synchronized
+    fun reportBindPosition(deviceId: Int, position: GamepadPosition, pressed: Boolean) {
+        if (!_bindCaptureActive.value) return
+        val set = bindPressedByDevice.getOrPut(deviceId) { mutableSetOf() }
+        val changed = if (pressed) set.add(position) else set.remove(position)
+        if (changed) recomputeBindPressed()
+    }
+
+    /**
+     * Replaces the full set of held bind positions for [deviceId] (wholesale —
+     * used by the desktop poller, which has all positions each frame). Includes
+     * the D-pad. No-op unless [bindCaptureActive] is set.
+     */
+    @Synchronized
+    fun reportBindPressedPositions(deviceId: Int, positions: Set<GamepadPosition>) {
+        if (!_bindCaptureActive.value) return
+        val set = bindPressedByDevice.getOrPut(deviceId) { mutableSetOf() }
+        if (set == positions) return
+        set.clear()
+        set.addAll(positions)
+        recomputeBindPressed()
+    }
+
+    /** Must be called while holding the monitor. */
+    private fun recomputeBindPressed() {
+        val merged = mutableSetOf<GamepadPosition>()
+        for (positions in bindPressedByDevice.values) merged.addAll(positions)
+        _bindPressedPositions.value = merged
+    }
+
+    /**
      * Loads per-game key mapping for a specific port, with fallback chain:
      * per-game -> per-console -> global default -> hardcoded defaults.
      */
@@ -616,6 +681,9 @@ class GamepadPortManager(
         pressedByDevice.clear()
         _pressedPositions.value = emptySet()
         _testCaptureDeviceId.value = null
+        bindPressedByDevice.clear()
+        _bindPressedPositions.value = emptySet()
+        _bindCaptureActive.value = false
         _assignments.value = emptyList()
         _connectedControllers.value = emptyList()
         _portActivity.value = emptyMap()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadMappingDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadMappingDialog.kt
@@ -1,8 +1,13 @@
 package com.spela.player.presentation.ui.components.gamepad
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -18,52 +23,65 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import kotlin.math.ceil
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.spela.player.domain.model.ButtonInfo
 import com.spela.player.domain.model.GamepadPosition
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
-import com.spela.player.presentation.ui.components.SpDialog
-import com.spela.player.presentation.ui.components.SpRadioOption
 import com.spela.player.presentation.ui.feature.settings.SettingsDivider
 import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.viewmodel.GamepadMappingState
+import com.spela.player.presentation.viewmodel.GamepadMappingViewModel
 
 /**
- * Desktop gamepad mapping editor (#1334, component C — gamepad mode). For the
- * current console it lists each physical [GamepadPosition] and the console
- * action it triggers, and lets the user reassign by position. Brand-neutral:
- * positions are physical ("Bottom button"), actions are the console's own
- * labels — no Xbox/Nintendo glyphs.
+ * Desktop/Android gamepad mapping editor (#1334 component C; redesigned RetroArch-
+ * style in #1377). Lists this **console's** buttons (NES = D-pad/Select/Start/B/A)
+ * and which physical position currently triggers each. To rebind, the user picks a
+ * console button and *holds* the physical button they want — held [HOLD_MS] it's
+ * assigned 1:1; releasing resets; [ABORT_MS] idle aborts. Brand-neutral throughout:
+ * the prompt names the held button by canonical position ("Bottom button"), never a
+ * Xbox/Nintendo glyph.
  *
- * @param state the effective position→action mapping + console outputs
- * @param onSetBinding assign a console action (RetroPad id) to a position
+ * @param state effective position→action mapping, console outputs, + binding session
+ * @param onStartBinding begin hold-to-bind for a console button
+ * @param onBindKey report a captured gamepad press/release during a binding session
+ *   (Android: the editor is a Dialog window, so its content captures keys itself)
+ * @param onCancelBinding cancel the active hold-to-bind session
  * @param onResetToDefaults clear all overrides for this console
  * @param onDismiss close the editor
  */
 @Composable
 fun GamepadMappingDialog(
     state: GamepadMappingState,
-    onSetBinding: (GamepadPosition, Int) -> Unit,
+    onStartBinding: (ButtonInfo) -> Unit,
+    onBindKey: (GamepadPosition, Boolean) -> Unit,
+    onCancelBinding: () -> Unit,
     onResetToDefaults: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var editingPosition by remember { mutableStateOf<GamepadPosition?>(null) }
-
     Dialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = { if (state.bindingOutput != null) onCancelBinding() else onDismiss() },
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         Box(
@@ -77,7 +95,7 @@ fun GamepadMappingDialog(
                     .fillMaxWidth(0.9f)
                     // Cap to the available screen height so the action buttons are
                     // never clipped on short landscape screens like the AYN Thor
-                    // (#1371). The position list below scrolls to fit.
+                    // (#1371). The button list below scrolls to fit.
                     .fillMaxHeight(0.9f)
                     .heightIn(max = 600.dp)
                     .clip(RoundedCornerShape(SpSpacing.RadiusPill))
@@ -85,78 +103,92 @@ fun GamepadMappingDialog(
                     .padding(SpSpacing.XLarge)
                     .testTag("gamepad_mapping_dialog"),
             ) {
-                Text(
-                    text = "Controller buttons — ${state.displayName}",
-                    style = SpTypography.HeadlineMedium,
-                    color = SpColor.OnBackground,
-                )
-                Text(
-                    text = "Choose what each physical button does on this console.",
-                    style = SpTypography.BodySmall,
-                    color = SpColor.OnBackgroundTertiary,
-                )
-
-                Spacer(Modifier.height(SpSpacing.Medium))
-
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        // Take the remaining space (between header and the pinned
-                        // action buttons) and scroll within it (#1371).
-                        .weight(1f)
-                        .verticalScroll(rememberScrollState()),
-                ) {
-                    GamepadPosition.entries.forEachIndexed { index, position ->
-                        PositionRow(
-                            position = position,
-                            actionLabel = actionLabelFor(state, position),
-                            onClick = { editingPosition = position },
-                        )
-                        if (index < GamepadPosition.entries.size - 1) {
-                            SettingsDivider()
-                        }
-                    }
+                val binding = state.bindingOutput
+                if (binding != null) {
+                    BindingPrompt(
+                        output = binding,
+                        heldPosition = state.bindingHeldPosition,
+                        tick = state.bindingTick,
+                        onBindKey = onBindKey,
+                        onCancel = onCancelBinding,
+                    )
+                } else {
+                    MappingList(
+                        state = state,
+                        onStartBinding = onStartBinding,
+                        onResetToDefaults = onResetToDefaults,
+                        onDismiss = onDismiss,
+                    )
                 }
+            }
+        }
+    }
+}
 
-                Spacer(Modifier.height(SpSpacing.Default))
+/** The default view: header + scrollable console-button list + pinned actions. */
+@Composable
+private fun androidx.compose.foundation.layout.ColumnScope.MappingList(
+    state: GamepadMappingState,
+    onStartBinding: (ButtonInfo) -> Unit,
+    onResetToDefaults: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Text(
+        text = "Controller buttons — ${state.displayName}",
+        style = SpTypography.HeadlineMedium,
+        color = SpColor.OnBackground,
+    )
+    Text(
+        text = "Pick a console button, then hold the controller button you want it to use.",
+        style = SpTypography.BodySmall,
+        color = SpColor.OnBackgroundTertiary,
+    )
 
-                SpButton(
-                    text = "Reset to defaults",
-                    onClick = onResetToDefaults,
-                    style = SpButtonStyle.Secondary,
-                    modifier = Modifier.fillMaxWidth().testTag("gamepad_mapping_reset"),
-                )
-                Spacer(Modifier.height(SpSpacing.Small))
-                SpButton(
-                    text = "Done",
-                    onClick = onDismiss,
-                    style = SpButtonStyle.Primary,
-                    modifier = Modifier.fillMaxWidth().testTag("gamepad_mapping_done"),
-                )
+    Spacer(Modifier.height(SpSpacing.Medium))
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            // Take the remaining space (between header and the pinned action
+            // buttons) and scroll within it (#1371).
+            .weight(1f)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        state.outputs.forEachIndexed { index, output ->
+            OutputRow(
+                output = output,
+                positionLabel = boundPositionLabel(state, output.retroButtonId),
+                onClick = { onStartBinding(output) },
+            )
+            if (index < state.outputs.size - 1) {
+                SettingsDivider()
             }
         }
     }
 
-    val editing = editingPosition
-    if (editing != null) {
-        GamepadActionPickerDialog(
-            position = editing,
-            state = state,
-            onSelect = { retroButtonId ->
-                onSetBinding(editing, retroButtonId)
-                editingPosition = null
-            },
-            onDismiss = { editingPosition = null },
-        )
-    }
+    Spacer(Modifier.height(SpSpacing.Default))
+
+    SpButton(
+        text = "Reset to defaults",
+        onClick = onResetToDefaults,
+        style = SpButtonStyle.Secondary,
+        modifier = Modifier.fillMaxWidth().testTag("gamepad_mapping_reset"),
+    )
+    Spacer(Modifier.height(SpSpacing.Small))
+    SpButton(
+        text = "Done",
+        onClick = onDismiss,
+        style = SpButtonStyle.Primary,
+        modifier = Modifier.fillMaxWidth().testTag("gamepad_mapping_done"),
+    )
 }
 
-/** A settings-style row: physical position on the left, its console action on
- *  the right. Tapping opens the action picker. */
+/** A settings-style row: console button on the left, the physical position that
+ *  triggers it on the right. Tapping starts a hold-to-bind session. */
 @Composable
-private fun PositionRow(
-    position: GamepadPosition,
-    actionLabel: String,
+private fun OutputRow(
+    output: ButtonInfo,
+    positionLabel: String,
     onClick: () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -174,57 +206,198 @@ private fun PositionRow(
                 addFocusable = false,
             )
             .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Medium)
-            .testTag("gamepad_pos_${position.name}"),
+            .testTag("mapping_output_${output.retroButtonId}"),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = position.displayName,
+            text = output.label,
             style = SpTypography.BodyMedium,
             color = SpColor.OnCard,
             modifier = Modifier.weight(1f),
         )
         Text(
-            text = actionLabel,
+            text = positionLabel,
             style = SpTypography.TitleMedium,
-            color = if (actionLabel == "—") SpColor.OnBackgroundTertiary else SpColor.Primary,
-            modifier = Modifier.testTag("gamepad_action_${position.name}"),
+            color = if (positionLabel == UNBOUND_LABEL) SpColor.OnBackgroundTertiary else SpColor.Primary,
+            modifier = Modifier.testTag("mapping_bound_${output.retroButtonId}"),
         )
     }
 }
 
-/** Picker of the console's actions to assign to a single physical position. */
+/** The hold-to-bind capture prompt shown while a session is active. */
 @Composable
-private fun GamepadActionPickerDialog(
-    position: GamepadPosition,
-    state: GamepadMappingState,
-    onSelect: (Int) -> Unit,
-    onDismiss: () -> Unit,
+private fun androidx.compose.foundation.layout.ColumnScope.BindingPrompt(
+    output: ButtonInfo,
+    heldPosition: GamepadPosition?,
+    tick: Int,
+    onBindKey: (GamepadPosition, Boolean) -> Unit,
+    onCancel: () -> Unit,
 ) {
-    val current = state.mapping[position]
-    SpDialog(
-        title = position.displayName,
-        onDismiss = onDismiss,
-        confirmText = "Done",
-        onConfirm = onDismiss,
-        modifier = Modifier.testTag("gamepad_action_picker"),
-    ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            state.outputs.forEachIndexed { index, output ->
-                SpRadioOption(
-                    title = output.label,
-                    description = "Make the ${position.displayName.lowercase()} act as ${output.label}",
-                    isSelected = current == output.retroButtonId,
-                    onClick = { onSelect(output.retroButtonId) },
-                )
-                if (index < state.outputs.size - 1) {
-                    SettingsDivider()
+    val focusRequester = remember { FocusRequester() }
+    // On Android the editor is a Dialog window, so MainActivity.onKeyDown never
+    // sees these presses — without capturing here, a press just activates the
+    // focused Cancel button and the prompt closes. onPreviewKeyEvent runs before
+    // the focus system: it maps the key to a canonical position, feeds the binder,
+    // and consumes it so it can't double as a click or navigation. The desktop
+    // poller feeds the same binder signal directly. (#1377)
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .weight(1f)
+            .focusRequester(focusRequester)
+            .focusable()
+            .onPreviewKeyEvent { event ->
+                val position = keyToGamepadPosition(event.key) ?: return@onPreviewKeyEvent false
+                when (event.type) {
+                    KeyEventType.KeyDown -> { onBindKey(position, true); true }
+                    KeyEventType.KeyUp -> { onBindKey(position, false); true }
+                    else -> false
                 }
             }
+            .testTag("binding_prompt"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "Assign ${output.label}",
+            style = SpTypography.HeadlineMedium,
+            color = SpColor.OnBackground,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(SpSpacing.Large))
+
+        if (heldPosition == null) {
+            Text(
+                text = "Hold the controller button you want to use for ${output.label}.",
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackgroundTertiary,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(SpSpacing.Default))
+            CountdownLabel(
+                tick = tick,
+                durationMs = GamepadMappingViewModel.ABORT_MS,
+                prefix = "Aborting in ",
+                testTag = "binding_abort_countdown",
+            )
+        } else {
+            Text(
+                text = heldPosition.displayName,
+                style = SpTypography.HeadlineSmall,
+                color = SpColor.Primary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.testTag("binding_held"),
+            )
+            Spacer(Modifier.height(SpSpacing.Default))
+            HoldProgressBar(tick = tick)
+            Spacer(Modifier.height(SpSpacing.Small))
+            CountdownLabel(
+                tick = tick,
+                durationMs = GamepadMappingViewModel.HOLD_MS,
+                prefix = "Keep holding… ",
+                testTag = "binding_hold_countdown",
+            )
+        }
+    }
+
+    Spacer(Modifier.height(SpSpacing.Default))
+    SpButton(
+        text = "Cancel",
+        onClick = onCancel,
+        style = SpButtonStyle.Secondary,
+        modifier = Modifier.fillMaxWidth().testTag("binding_cancel"),
+    )
+}
+
+/** A linear fill over [GamepadMappingViewModel.HOLD_MS] that restarts on each
+ *  [tick] change, visually tracking the hold the ViewModel is timing. */
+@Composable
+private fun HoldProgressBar(tick: Int) {
+    androidx.compose.runtime.key(tick) {
+        val progress = remember { Animatable(0f) }
+        LaunchedEffect(Unit) {
+            progress.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(
+                    durationMillis = GamepadMappingViewModel.HOLD_MS.toInt(),
+                    easing = LinearEasing,
+                ),
+            )
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(SpSpacing.Small)
+                .clip(RoundedCornerShape(SpSpacing.RadiusPill))
+                .background(SpColor.SurfaceBright),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(progress.value)
+                    .height(SpSpacing.Small)
+                    .clip(RoundedCornerShape(SpSpacing.RadiusPill))
+                    .background(SpColor.Primary),
+            )
         }
     }
 }
 
-private fun actionLabelFor(state: GamepadMappingState, position: GamepadPosition): String {
-    val retroId = state.mapping[position] ?: return "—"
-    return state.outputs.firstOrNull { it.retroButtonId == retroId }?.label ?: "—"
+/** A whole-second countdown ("…3s, 2s, 1s") over [durationMs], restarting on each
+ *  [tick] change so it stays in lock-step with the ViewModel's timer. */
+@Composable
+private fun CountdownLabel(tick: Int, durationMs: Long, prefix: String, testTag: String) {
+    androidx.compose.runtime.key(tick) {
+        val progress = remember { Animatable(0f) }
+        LaunchedEffect(Unit) {
+            progress.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(durationMillis = durationMs.toInt(), easing = LinearEasing),
+            )
+        }
+        val secondsLeft = ceil((1f - progress.value) * (durationMs / 1000f)).toInt().coerceAtLeast(0)
+        Text(
+            text = "$prefix${secondsLeft}s",
+            style = SpTypography.BodySmall,
+            color = SpColor.OnBackgroundTertiary,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.testTag(testTag),
+        )
+    }
+}
+
+/** Maps a Compose [Key] to its canonical [GamepadPosition], mirroring
+ *  AndroidGamepadNormalizer's positional keycode mapping. Returns null for keys
+ *  that aren't gamepad buttons. */
+private fun keyToGamepadPosition(key: Key): GamepadPosition? = when (key) {
+    Key.ButtonA -> GamepadPosition.SOUTH
+    Key.ButtonB -> GamepadPosition.EAST
+    Key.ButtonX -> GamepadPosition.WEST
+    Key.ButtonY -> GamepadPosition.NORTH
+    Key.DirectionUp -> GamepadPosition.DPAD_UP
+    Key.DirectionDown -> GamepadPosition.DPAD_DOWN
+    Key.DirectionLeft -> GamepadPosition.DPAD_LEFT
+    Key.DirectionRight -> GamepadPosition.DPAD_RIGHT
+    Key.ButtonL1 -> GamepadPosition.L1
+    Key.ButtonR1 -> GamepadPosition.R1
+    Key.ButtonL2 -> GamepadPosition.L2
+    Key.ButtonR2 -> GamepadPosition.R2
+    Key.ButtonThumbLeft -> GamepadPosition.L3
+    Key.ButtonThumbRight -> GamepadPosition.R3
+    Key.ButtonStart -> GamepadPosition.START
+    Key.ButtonSelect -> GamepadPosition.SELECT
+    else -> null
+}
+
+private const val UNBOUND_LABEL = "Unbound"
+
+/** The positional name (e.g. "Bottom button") of the position currently bound to
+ *  [retroButtonId], or [UNBOUND_LABEL] when nothing triggers this console button. */
+private fun boundPositionLabel(state: GamepadMappingState, retroButtonId: Int): String {
+    val position = state.mapping.entries
+        .filter { it.value == retroButtonId }
+        .minByOrNull { it.key.ordinal }
+        ?.key
+        ?: return UNBOUND_LABEL
+    return position.displayName
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleSettingsScreen.kt
@@ -322,15 +322,27 @@ fun ConsoleSettingsScreen(
                     if (showGamepadMapping) {
                         GamepadMappingDialog(
                             state = gamepadMappingState,
-                            onSetBinding = { position, retroButtonId ->
+                            onStartBinding = { output ->
                                 gamepadMappingViewModel.onIntent(
-                                    GamepadMappingIntent.SetBinding(position, retroButtonId)
+                                    GamepadMappingIntent.StartBinding(output)
                                 )
+                            },
+                            onBindKey = { position, pressed ->
+                                gamepadMappingViewModel.onIntent(
+                                    GamepadMappingIntent.ReportBindInput(position, pressed)
+                                )
+                            },
+                            onCancelBinding = {
+                                gamepadMappingViewModel.onIntent(GamepadMappingIntent.CancelBinding)
                             },
                             onResetToDefaults = {
                                 gamepadMappingViewModel.onIntent(GamepadMappingIntent.ResetAll)
                             },
-                            onDismiss = { showGamepadMapping = false },
+                            onDismiss = {
+                                // End any in-flight hold-to-bind before closing.
+                                gamepadMappingViewModel.onIntent(GamepadMappingIntent.CancelBinding)
+                                showGamepadMapping = false
+                            },
                         )
                     }
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadMappingViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GamepadMappingViewModel.kt
@@ -9,6 +9,8 @@ import com.spela.player.libretro.GamepadButtonResolver
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,14 +23,40 @@ data class GamepadMappingState(
     val displayName: String = "",
     /** Effective position → RetroPad id (defaults + stored overrides). */
     val mapping: Map<GamepadPosition, Int> = emptyMap(),
-    /** The console's RetroPad outputs (digital only), for the action picker. */
+    /** The console's RetroPad outputs (digital only) — the buttons the editor lists. */
     val outputs: List<ButtonInfo> = emptyList(),
     val isLoading: Boolean = true,
+    /** The console button currently being (re)bound via hold-to-bind (#1377), or
+     *  null when no binding session is active. Non-null shows the capture prompt. */
+    val bindingOutput: ButtonInfo? = null,
+    /** The canonical position currently held during the active binding session, or
+     *  null while waiting for a press. Drives the 2s hold countdown in the prompt;
+     *  shown by its positional name (e.g. "Bottom button"), never a brand glyph. */
+    val bindingHeldPosition: GamepadPosition? = null,
+    /** Increments on each binding phase change (start, press, release) so the UI's
+     *  countdown animations restart in lock-step with the ViewModel's hold/abort
+     *  timers (#1377). */
+    val bindingTick: Int = 0,
 )
 
 sealed interface GamepadMappingIntent {
     data class Load(val consoleId: String, val port: Int = 0) : GamepadMappingIntent
-    data class SetBinding(val position: GamepadPosition, val retroButtonId: Int) : GamepadMappingIntent
+
+    /** Begin a RetroArch-style hold-to-bind session for [output] (#1377): the next
+     *  physical button held for 2s becomes its 1:1 binding; 5s idle aborts. */
+    data class StartBinding(val output: ButtonInfo) : GamepadMappingIntent
+
+    /**
+     * Feed a captured gamepad press/release into the active binding session
+     * (#1377). On Android the editor is a Dialog window, so its content captures
+     * keys via Compose `onPreviewKeyEvent` and routes them here (the desktop poller
+     * feeds the same signal directly). No-op when no session is active.
+     */
+    data class ReportBindInput(val position: GamepadPosition, val pressed: Boolean) : GamepadMappingIntent
+
+    /** Cancel the active hold-to-bind session without changing the mapping. */
+    data object CancelBinding : GamepadMappingIntent
+
     data object ResetAll : GamepadMappingIntent
 }
 
@@ -51,17 +79,20 @@ class GamepadMappingViewModel(
     private val _state = MutableStateFlow(GamepadMappingState())
     val state: StateFlow<GamepadMappingState> = _state.asStateFlow()
 
+    /** Collects [GamepadPortManager.bindPressedPositions] for the active session. */
+    private var bindCollectJob: Job? = null
+    /** Fires after [HOLD_MS] of holding [GamepadMappingState.bindingHeldPosition]. */
+    private var holdJob: Job? = null
+    /** Fires after [ABORT_MS] to give up an unproductive session. */
+    private var abortJob: Job? = null
+
     fun onIntent(intent: GamepadMappingIntent) {
         when (intent) {
             is GamepadMappingIntent.Load -> load(intent.consoleId, intent.port)
-            is GamepadMappingIntent.SetBinding -> {
-                val s = _state.value
-                if (s.consoleId.isEmpty()) return
-                scope.launch(dispatchers.io) {
-                    gamepadMappingRepository.setBinding(s.consoleId, s.port, intent.position, intent.retroButtonId)
-                    applyAndRefresh(s.consoleId, s.port)
-                }
-            }
+            is GamepadMappingIntent.StartBinding -> startBinding(intent.output)
+            is GamepadMappingIntent.ReportBindInput ->
+                gamepadPortManager.reportBindPosition(BIND_INPUT_DEVICE, intent.position, intent.pressed)
+            GamepadMappingIntent.CancelBinding -> endBindingSession()
             GamepadMappingIntent.ResetAll -> {
                 val s = _state.value
                 if (s.consoleId.isEmpty()) return
@@ -74,6 +105,7 @@ class GamepadMappingViewModel(
     }
 
     private fun load(consoleId: String, port: Int) {
+        endBindingSession()
         _state.update { it.copy(consoleId = consoleId, port = port, isLoading = true) }
         scope.launch(dispatchers.io) {
             val layout = DefaultKeyMappings.getLayoutForConsole(consoleId)
@@ -90,6 +122,81 @@ class GamepadMappingViewModel(
         }
     }
 
+    /**
+     * RetroArch-style hold-to-bind (#1377): open capture for [output], then watch
+     * [GamepadPortManager.bindPressedPositions]. Holding one position for [HOLD_MS]
+     * commits it 1:1 to [output]; releasing resets the hold; [ABORT_MS] of *idle*
+     * (no button held) ends the session unchanged.
+     */
+    private fun startBinding(output: ButtonInfo) {
+        if (_state.value.consoleId.isEmpty()) return
+        endBindingSession()
+        _state.update { it.copy(bindingOutput = output, bindingHeldPosition = null, bindingTick = it.bindingTick + 1) }
+        gamepadPortManager.setBindCaptureActive(true)
+        bindCollectJob = scope.launch(dispatchers.default) {
+            gamepadPortManager.bindPressedPositions.collect { positions ->
+                onBindPositionsChanged(positions)
+            }
+        }
+        restartAbortTimer()
+    }
+
+    /** (Re)arm the idle-abort timer — runs only while no button is being held. */
+    private fun restartAbortTimer() {
+        abortJob?.cancel()
+        abortJob = scope.launch(dispatchers.default) {
+            delay(ABORT_MS)
+            endBindingSession()
+        }
+    }
+
+    /** Reacts to the held-positions set changing during a binding session. */
+    private fun onBindPositionsChanged(positions: Set<GamepadPosition>) {
+        if (_state.value.bindingOutput == null) return
+        // Deterministically pick one held position (lowest ordinal) so multi-press
+        // is stable; the common case is exactly one held button.
+        val held = positions.minByOrNull { it.ordinal }
+        if (held == _state.value.bindingHeldPosition) return
+        // The held position changed (new press, swap, or release) — reset the hold
+        // and bump the tick so the prompt's countdown animation restarts in sync.
+        holdJob?.cancel()
+        _state.update { it.copy(bindingHeldPosition = held, bindingTick = it.bindingTick + 1) }
+        if (held != null) {
+            // A button is down: pause the idle-abort and run the 2s commit hold.
+            abortJob?.cancel()
+            holdJob = scope.launch(dispatchers.default) {
+                delay(HOLD_MS)
+                commitBinding(held)
+            }
+        } else {
+            // Back to idle (released before committing): re-arm the idle-abort.
+            restartAbortTimer()
+        }
+    }
+
+    /** Persists [position] as [GamepadMappingState.bindingOutput]'s 1:1 binding. */
+    private fun commitBinding(position: GamepadPosition) {
+        val s = _state.value
+        val output = s.bindingOutput ?: return
+        scope.launch(dispatchers.io) {
+            gamepadMappingRepository.bindPositionExclusive(s.consoleId, s.port, position, output.retroButtonId)
+            applyAndRefresh(s.consoleId, s.port)
+        }
+        endBindingSession()
+    }
+
+    /** Tears down the active session: stop capture, cancel timers, clear prompt. */
+    private fun endBindingSession() {
+        abortJob?.cancel()
+        bindCollectJob?.cancel()
+        holdJob?.cancel()
+        abortJob = null
+        bindCollectJob = null
+        holdJob = null
+        gamepadPortManager.setBindCaptureActive(false)
+        _state.update { it.copy(bindingOutput = null, bindingHeldPosition = null) }
+    }
+
     /** Reload the live port mapping, refresh the displayed mapping, and sync the
      *  positional layer to the server (best-effort) so it follows the user. */
     private suspend fun applyAndRefresh(consoleId: String, port: Int) {
@@ -97,5 +204,16 @@ class GamepadMappingViewModel(
         val mapping = gamepadMappingRepository.getEffectiveMapping(consoleId, port)
         _state.update { it.copy(mapping = mapping) }
         preferencesRepository.pushKeyMappingsToServer()
+    }
+
+    companion object {
+        /** Synthetic device id for presses captured via Compose key events (the
+         *  Android dialog path); real Android device ids are non-negative. */
+        private const val BIND_INPUT_DEVICE = -7777
+
+        /** Continuous hold required to commit a binding (RetroArch-style). */
+        const val HOLD_MS = 2000L
+        /** Idle timeout after which an unproductive binding session gives up. */
+        const val ABORT_MS = 5000L
     }
 }

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
@@ -141,6 +141,18 @@ class DesktopGamepadPoller(
                 )
             }
 
+            // Hold-to-bind capture (#1377): any controller, INCLUDING the D-pad, so
+            // the user can rebind D-pad directions. Reported for every controller —
+            // the editor binds with whichever pad the user holds a button on.
+            if (gamepadPortManager.bindCaptureActive.value) {
+                gamepadPortManager.reportBindPressedPositions(
+                    state.controllerId,
+                    GamepadPosition.entries.filterTo(mutableSetOf()) {
+                        positionPressed[it.ordinal]
+                    },
+                )
+            }
+
             // Emulation routing requires an assigned player port; unassigned
             // controllers stop here (they only feed the tester above).
             val port = gamepadPortManager.getPort(state.controllerId)
@@ -187,8 +199,15 @@ class DesktopGamepadPoller(
         // normally — and the D-pad always navigates, so the user can move off the
         // tester.
         val testTarget = gamepadPortManager.testCaptureDeviceId.value
-        val navStates = if (testTarget != null) {
-            Array(states.size) { idx ->
+        val navStates = when {
+            // During a hold-to-bind session every press (incl. D-pad) feeds the
+            // binder, so mask ALL buttons on ALL controllers from navigation — a
+            // press must never also move focus or trigger back (#1377).
+            gamepadPortManager.bindCaptureActive.value -> Array(states.size) { idx ->
+                val st = states[idx]
+                st.copy(buttons = BooleanArray(st.buttons.size))
+            }
+            testTarget != null -> Array(states.size) { idx ->
                 val st = states[idx]
                 if (st.controllerId != testTarget) {
                     st
@@ -199,8 +218,7 @@ class DesktopGamepadPoller(
                     st.copy(buttons = masked)
                 }
             }
-        } else {
-            states
+            else -> states
         }
         uiNavigator.handle(navStates)
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/AndroidGamepadNormalizerTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/AndroidGamepadNormalizerTest.kt
@@ -77,6 +77,7 @@ class AndroidGamepadNormalizerTest {
     ) : GamepadMappingRepository {
         override suspend fun getEffectiveMapping(consoleId: String, port: Int) = mapping
         override suspend fun setBinding(consoleId: String, port: Int, position: GamepadPosition, retroButtonId: Int) {}
+        override suspend fun bindPositionExclusive(consoleId: String, port: Int, position: GamepadPosition, retroButtonId: Int) {}
         override suspend fun resetToDefault(consoleId: String, port: Int) {}
         override fun getDefaultMapping() = DefaultGamepadMapping.POSITION_TO_RETRO
     }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
@@ -450,6 +450,66 @@ class GamepadPortManagerTest {
         assertFalse(GamepadPosition.SOUTH in manager.pressedPositions.value)
     }
 
+    // ── Hold-to-bind capture: any-device + D-pad (#1377) ─────────────────────
+
+    @Test
+    fun bindCaptureTracksPressAndReleaseIncludingDpad() {
+        manager.setBindCaptureActive(true)
+        manager.reportBindPosition(10, GamepadPosition.DPAD_UP, pressed = true)
+        assertTrue(GamepadPosition.DPAD_UP in manager.bindPressedPositions.value)
+        manager.reportBindPosition(10, GamepadPosition.DPAD_UP, pressed = false)
+        assertFalse(GamepadPosition.DPAD_UP in manager.bindPressedPositions.value)
+    }
+
+    @Test
+    fun bindCaptureMergesAcrossDevices() {
+        manager.setBindCaptureActive(true)
+        manager.reportBindPosition(10, GamepadPosition.SOUTH, pressed = true)
+        // Unlike the tester, binding captures any controller — both presses show.
+        manager.reportBindPosition(20, GamepadPosition.NORTH, pressed = true)
+        assertEquals(
+            setOf(GamepadPosition.SOUTH, GamepadPosition.NORTH),
+            manager.bindPressedPositions.value,
+        )
+    }
+
+    @Test
+    fun bindCaptureIgnoresPressesWhenInactive() {
+        manager.reportBindPosition(10, GamepadPosition.SOUTH, pressed = true)
+        assertTrue(manager.bindPressedPositions.value.isEmpty())
+    }
+
+    @Test
+    fun deactivatingBindCaptureClearsHeldPositions() {
+        manager.setBindCaptureActive(true)
+        manager.reportBindPosition(10, GamepadPosition.SOUTH, pressed = true)
+        assertTrue(GamepadPosition.SOUTH in manager.bindPressedPositions.value)
+        manager.setBindCaptureActive(false)
+        assertTrue(manager.bindPressedPositions.value.isEmpty())
+    }
+
+    @Test
+    fun bindCaptureIsIndependentFromInputTester() {
+        // The tester (per-device, no D-pad) and the binder (any-device, incl D-pad)
+        // use separate signals and must not bleed into each other.
+        manager.setTestCaptureDevice(10)
+        manager.setBindCaptureActive(true)
+        manager.reportPositionInput(10, GamepadPosition.SOUTH, pressed = true)
+        manager.reportBindPosition(20, GamepadPosition.DPAD_LEFT, pressed = true)
+        assertEquals(setOf(GamepadPosition.SOUTH), manager.pressedPositions.value)
+        assertEquals(setOf(GamepadPosition.DPAD_LEFT), manager.bindPressedPositions.value)
+    }
+
+    @Test
+    fun disconnectClearsBindHeldPositions() {
+        manager.connectDevice(deviceId = 7, deviceName = "Pad")
+        manager.setBindCaptureActive(true)
+        manager.reportBindPosition(7, GamepadPosition.SOUTH, pressed = true)
+        assertTrue(GamepadPosition.SOUTH in manager.bindPressedPositions.value)
+        manager.disconnectDevice(7)
+        assertFalse(GamepadPosition.SOUTH in manager.bindPressedPositions.value)
+    }
+
     // ── Player-slot assignment (#1359) ───────────────────────────────────────
 
     @Test

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GamepadMappingViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GamepadMappingViewModelTest.kt
@@ -1,0 +1,314 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.domain.model.ButtonInfo
+import com.spela.player.domain.model.DefaultGamepadMapping
+import com.spela.player.domain.model.GamepadPosition
+import com.spela.player.domain.model.KeyMappingPreset
+import com.spela.player.domain.model.KeyMappingProfile
+import com.spela.player.domain.repository.GamepadMappingRepository
+import com.spela.player.domain.repository.KeyMappingRepository
+import com.spela.player.libretro.GamepadPortManager
+import com.spela.player.presentation.viewmodel.emulation.StubPreferencesRepository
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GamepadMappingViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val dispatchers = object : DispatcherProvider {
+        override val main = testDispatcher
+        override val io = testDispatcher
+        override val default = testDispatcher
+    }
+
+    private val mappingRepo = FakeGamepadMappingRepo()
+    private val portManager = GamepadPortManager(
+        keyMappingRepository = NoOpKeyMappingRepo(),
+        gamepadMappingRepository = mappingRepo,
+    )
+
+    /** RetroPad A on the NES layout (id 8) — an arbitrary console output to bind. */
+    private val outputA = ButtonInfo(retroButtonId = 8, label = "A")
+    private val DEVICE = 1
+
+    private fun createViewModel(scope: CoroutineScope) = GamepadMappingViewModel(
+        gamepadMappingRepository = mappingRepo,
+        gamepadPortManager = portManager,
+        preferencesRepository = StubPreferencesRepository(),
+        dispatchers = dispatchers,
+        scope = scope,
+    )
+
+    private fun ready(scope: CoroutineScope): GamepadMappingViewModel {
+        val vm = createViewModel(scope)
+        vm.onIntent(GamepadMappingIntent.Load("nes", 0))
+        return vm
+    }
+
+    @Test
+    fun startBindingActivatesCaptureAndSetsBindingOutput() = runTest(testDispatcher) {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = ready(scope)
+        advanceUntilIdle()
+
+        vm.onIntent(GamepadMappingIntent.StartBinding(outputA))
+        runCurrent()
+
+        assertEquals(outputA, vm.state.value.bindingOutput)
+        assertTrue(portManager.bindCaptureActive.value)
+        scope.cancel()
+    }
+
+    @Test
+    fun heldPositionSurfacesInStateWhilePressed() = runTest(testDispatcher) {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = ready(scope)
+        advanceUntilIdle()
+        vm.onIntent(GamepadMappingIntent.StartBinding(outputA))
+        runCurrent()
+
+        portManager.reportBindPosition(DEVICE, GamepadPosition.SOUTH, pressed = true)
+        advanceTimeBy(500)
+        runCurrent()
+
+        assertEquals(GamepadPosition.SOUTH, vm.state.value.bindingHeldPosition)
+        scope.cancel()
+    }
+
+    @Test
+    fun holdingPositionForHoldMsCommitsBindingExclusively() = runTest(testDispatcher) {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = ready(scope)
+        advanceUntilIdle()
+        vm.onIntent(GamepadMappingIntent.StartBinding(outputA))
+        runCurrent()
+
+        portManager.reportBindPosition(DEVICE, GamepadPosition.SOUTH, pressed = true)
+        runCurrent()
+        // Hold past the 2s threshold (but under the 5s abort).
+        advanceTimeBy(GamepadMappingViewModel.HOLD_MS + 100)
+        advanceUntilIdle()
+
+        assertEquals(
+            GamepadPosition.SOUTH to outputA.retroButtonId,
+            mappingRepo.lastExclusiveBind,
+        )
+        // Session ended: capture off, prompt cleared.
+        assertNull(vm.state.value.bindingOutput)
+        assertFalse(portManager.bindCaptureActive.value)
+        scope.cancel()
+    }
+
+    @Test
+    fun releasingBeforeHoldMsDoesNotCommitAndResetsHold() = runTest(testDispatcher) {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = ready(scope)
+        advanceUntilIdle()
+        vm.onIntent(GamepadMappingIntent.StartBinding(outputA))
+        runCurrent()
+
+        portManager.reportBindPosition(DEVICE, GamepadPosition.SOUTH, pressed = true)
+        runCurrent()
+        advanceTimeBy(1000) // not yet 2s
+        portManager.reportBindPosition(DEVICE, GamepadPosition.SOUTH, pressed = false)
+        runCurrent()
+        advanceTimeBy(1500) // would have crossed 2s had we kept holding
+
+        assertNull(mappingRepo.lastExclusiveBind)
+        assertNull(vm.state.value.bindingHeldPosition)
+        // Still in the session, awaiting another press.
+        assertEquals(outputA, vm.state.value.bindingOutput)
+        scope.cancel()
+    }
+
+    @Test
+    fun idleForAbortMsEndsSessionWithoutCommitting() = runTest(testDispatcher) {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = ready(scope)
+        advanceUntilIdle()
+        vm.onIntent(GamepadMappingIntent.StartBinding(outputA))
+        runCurrent()
+
+        advanceTimeBy(GamepadMappingViewModel.ABORT_MS + 100)
+        advanceUntilIdle()
+
+        assertNull(mappingRepo.lastExclusiveBind)
+        assertNull(vm.state.value.bindingOutput)
+        assertFalse(portManager.bindCaptureActive.value)
+        scope.cancel()
+    }
+
+    @Test
+    fun cancelBindingEndsSessionImmediately() = runTest(testDispatcher) {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = ready(scope)
+        advanceUntilIdle()
+        vm.onIntent(GamepadMappingIntent.StartBinding(outputA))
+        runCurrent()
+
+        vm.onIntent(GamepadMappingIntent.CancelBinding)
+        runCurrent()
+
+        assertNull(vm.state.value.bindingOutput)
+        assertFalse(portManager.bindCaptureActive.value)
+        assertNull(mappingRepo.lastExclusiveBind)
+        scope.cancel()
+    }
+
+    @Test
+    fun swappingHeldPositionRestartsHoldAndCommitsTheLater() = runTest(testDispatcher) {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = ready(scope)
+        advanceUntilIdle()
+        vm.onIntent(GamepadMappingIntent.StartBinding(outputA))
+        runCurrent()
+
+        // Hold SOUTH for 1.5s, then swap to WEST and hold the full 2s.
+        portManager.reportBindPosition(DEVICE, GamepadPosition.SOUTH, pressed = true)
+        runCurrent()
+        advanceTimeBy(1500)
+        portManager.reportBindPosition(DEVICE, GamepadPosition.SOUTH, pressed = false)
+        portManager.reportBindPosition(DEVICE, GamepadPosition.WEST, pressed = true)
+        runCurrent()
+        advanceTimeBy(GamepadMappingViewModel.HOLD_MS + 100)
+        advanceUntilIdle()
+
+        assertEquals(
+            GamepadPosition.WEST to outputA.retroButtonId,
+            mappingRepo.lastExclusiveBind,
+        )
+        scope.cancel()
+    }
+
+    @Test
+    fun reportBindInputIntentFeedsTheBinderAndCommits() = runTest(testDispatcher) {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = ready(scope)
+        advanceUntilIdle()
+        vm.onIntent(GamepadMappingIntent.StartBinding(outputA))
+        runCurrent()
+
+        // Drive the press through the intent (the path the Android dialog uses),
+        // not the port manager directly.
+        vm.onIntent(GamepadMappingIntent.ReportBindInput(GamepadPosition.SOUTH, pressed = true))
+        runCurrent()
+        advanceTimeBy(GamepadMappingViewModel.HOLD_MS + 100)
+        advanceUntilIdle()
+
+        assertEquals(GamepadPosition.SOUTH to outputA.retroButtonId, mappingRepo.lastExclusiveBind)
+        scope.cancel()
+    }
+
+    @Test
+    fun abortIsIdleOnlySoALateHoldStillCommits() = runTest(testDispatcher) {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = ready(scope)
+        advanceUntilIdle()
+        vm.onIntent(GamepadMappingIntent.StartBinding(outputA))
+        runCurrent()
+
+        // Idle almost the full abort window, THEN start holding. The idle-abort
+        // must pause while held, so the 2s hold still commits (it would not if the
+        // abort were a fixed 5s from session start).
+        advanceTimeBy(GamepadMappingViewModel.ABORT_MS - 500)
+        portManager.reportBindPosition(DEVICE, GamepadPosition.SOUTH, pressed = true)
+        runCurrent()
+        advanceTimeBy(GamepadMappingViewModel.HOLD_MS + 100)
+        advanceUntilIdle()
+
+        assertEquals(GamepadPosition.SOUTH to outputA.retroButtonId, mappingRepo.lastExclusiveBind)
+        scope.cancel()
+    }
+
+    @Test
+    fun bindingTickAdvancesOnEachPhaseChange() = runTest(testDispatcher) {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val vm = ready(scope)
+        advanceUntilIdle()
+
+        vm.onIntent(GamepadMappingIntent.StartBinding(outputA))
+        runCurrent()
+        val atStart = vm.state.value.bindingTick
+
+        portManager.reportBindPosition(DEVICE, GamepadPosition.SOUTH, pressed = true)
+        runCurrent()
+        val afterPress = vm.state.value.bindingTick
+
+        portManager.reportBindPosition(DEVICE, GamepadPosition.SOUTH, pressed = false)
+        runCurrent()
+        val afterRelease = vm.state.value.bindingTick
+
+        assertTrue(afterPress > atStart, "tick should bump on press")
+        assertTrue(afterRelease > afterPress, "tick should bump on release")
+        scope.cancel()
+    }
+
+    // ── Fakes ────────────────────────────────────────────────────────────────
+
+    /** In-memory mapping repo recording the last 1:1 bind, with real exclusive logic. */
+    private class FakeGamepadMappingRepo : GamepadMappingRepository {
+        private val overrides = HashMap<Pair<String, Int>, MutableMap<GamepadPosition, Int>>()
+        var lastExclusiveBind: Pair<GamepadPosition, Int>? = null
+            private set
+
+        override suspend fun getEffectiveMapping(consoleId: String, port: Int): Map<GamepadPosition, Int> =
+            DefaultGamepadMapping.POSITION_TO_RETRO + (overrides[consoleId to port] ?: emptyMap())
+
+        override suspend fun setBinding(consoleId: String, port: Int, position: GamepadPosition, retroButtonId: Int) {
+            overrides.getOrPut(consoleId to port) { mutableMapOf() }[position] = retroButtonId
+        }
+
+        override suspend fun bindPositionExclusive(
+            consoleId: String,
+            port: Int,
+            position: GamepadPosition,
+            retroButtonId: Int,
+        ) {
+            lastExclusiveBind = position to retroButtonId
+            if (retroButtonId != GamepadMappingRepository.UNMAPPED) {
+                for ((p, id) in getEffectiveMapping(consoleId, port)) {
+                    if (id == retroButtonId && p != position) {
+                        setBinding(consoleId, port, p, GamepadMappingRepository.UNMAPPED)
+                    }
+                }
+            }
+            setBinding(consoleId, port, position, retroButtonId)
+        }
+
+        override suspend fun resetToDefault(consoleId: String, port: Int) {
+            overrides.remove(consoleId to port)
+        }
+
+        override fun getDefaultMapping(): Map<GamepadPosition, Int> = DefaultGamepadMapping.POSITION_TO_RETRO
+    }
+
+    private class NoOpKeyMappingRepo : KeyMappingRepository {
+        override suspend fun getMappingForConsole(consoleId: String, port: Int): KeyMappingProfile? = null
+        override suspend fun setBinding(consoleId: String, port: Int, retroButtonId: Int, platformKeyCode: Int) {}
+        override suspend fun resetToDefault(consoleId: String, port: Int) {}
+        override suspend fun clearBinding(consoleId: String, port: Int, retroButtonId: Int) {}
+        override suspend fun getEffectiveMapping(consoleId: String, port: Int): Map<Int, Int> = emptyMap()
+        override fun getDefaultMapping(): Map<Int, Int> = emptyMap()
+        override fun getAvailablePresets(): List<KeyMappingPreset> = emptyList()
+        override suspend fun applyPreset(presetId: String) {}
+        override suspend fun ensureDefaultsApplied() {}
+        override suspend fun getEffectiveMappingForGame(gameId: String, consoleId: String, port: Int): Map<Int, Int> = emptyMap()
+        override suspend fun setGameMapping(gameId: String, bindings: Map<Int, Int>) {}
+        override suspend fun clearGameMapping(gameId: String) {}
+        override suspend fun hasGameMapping(gameId: String): Boolean = false
+    }
+}


### PR DESCRIPTION
## Summary

Redesigns the per-console "Controller buttons" editor (Console Settings → "Configure controller buttons") from position-oriented to **console-button-oriented**, RetroArch-style.

- Lists the **console's** buttons (NES = D-pad / Select / Start / B / A) and, for each, the physical position that triggers it — by canonical positional name ("Bottom button"), never a brand glyph.
- Picking a console button starts a **hold-to-bind** capture: *"Hold the controller button you want to use for A."* While held, the prompt shows the button's positional name, a 2-second progress bar, and a **"Keep holding… Ns" countdown**; holding the full 2s commits the binding **1:1** (steals the position, clears any other position driving this button → `UNMAPPED=-1`). Releasing resets the hold; **5s idle aborts** (with a visible "Aborting in Ns" countdown).
- The **D-pad is bindable** too.

## Capture plumbing

Unified bind-capture signal on `GamepadPortManager` (`setBindCaptureActive` / `reportBindPosition` / `reportBindPressedPositions` / `bindPressedPositions`) — captures from **any** device and **includes** the D-pad, distinct from the input tester.

- **Desktop**: `DesktopGamepadPoller` feeds every held position (incl. D-pad) and masks all buttons from navigation.
- **Android**: the editor is a `Dialog` (separate window), so `MainActivity.onKeyDown` never sees the keys — a press would just activate the focused Cancel button and close the prompt. Fixed by capturing in the dialog's Compose layer via **`onPreviewKeyEvent`** (runs before the focus system), mapping the key to a canonical position, feeding the binder, and consuming it. Routed through `GamepadMappingViewModel.ReportBindInput`.
- `GamepadMappingViewModel` runs the hold(2s)/idle-abort(5s) state machine off that signal; the idle-abort pauses while a button is held so a late hold still commits.

## Tests

- `GamepadPortManagerTest` (+6): bind capture incl. D-pad, any-device merge, tester independence, disconnect cleanup.
- `GamepadMappingViewModelTest` (new, 10, virtual-time): hold commits exclusively, release resets, swap re-times, idle-abort, late-hold-still-commits, `ReportBindInput`, tick bumps, cancel.
- `GamepadMappingTest` desktop E2E (4): lists console buttons with bound positions, opens the prompt, **a key press is captured (shows the position) without closing the prompt** (the exact regression), cancel.
- Full `:shared:desktopTest` + `:desktop:desktopTest` green; Android main + androidTest compile. ui-agent: APPROVE.

Verified on the AYN Thor: editor renders correctly; the press-closes-prompt bug is fixed by the `onPreviewKeyEvent` path (also covered by the new E2E).

Closes #1377
