### PR TITLE
test(federation): web E2E for connected-server search + fix broken E2E runner

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -183,7 +183,6 @@ SPELA_CORS_ORIGINS="http://localhost:$VITE_PORT" \
 SPELA_ENCRYPTION_KEY="e2e-test-encryption-key-32bytes!" \
 SPELA_CHALLENGE_RATE_LIMIT_SEC=0 \
 SPELA_TEST_MODE=true \
-GIN_MODE=release \
 "$E2E_DIR/spela-server" &
 SERVER_PID=$!
 

--- a/server/internal/api/huma_test_federation.go
+++ b/server/internal/api/huma_test_federation.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/spela/server/internal/db"
+)
+
+// TestSeedCatalogInput seeds one connected-server catalog snapshot row.
+type TestSeedCatalogInput struct {
+	Body struct {
+		OriginFingerprint string `json:"originFingerprint" doc:"Origin server fingerprint (must differ from self to count as remote)."`
+		Key               string `json:"key" doc:"Cross-server game key, e.g. igdb:1022."`
+		Title             string `json:"title"`
+		Console           string `json:"console"`
+	}
+}
+
+type TestSeedCatalogResponse struct {
+	Seeded bool `json:"seeded"`
+}
+
+type TestSeedCatalogOutput struct {
+	Body TestSeedCatalogResponse
+}
+
+// RegisterTestFederationRoute wires POST /api/test/federation/seed-catalog,
+// which inserts a single connected-server catalog snapshot so E2E tests can
+// exercise federated discovery without standing up a second server. Test-mode
+// only — registered alongside /api/test/reset and never exposed in production.
+func RegisterTestFederationRoute(api huma.API, h *TestHandler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "testSeedFederationCatalog",
+		Method:      http.MethodPost,
+		Path:        "/api/test/federation/seed-catalog",
+		Summary:     "Seed a connected-server catalog entry (E2E test only)",
+		Description: "Inserts a FederationCatalogSnapshot row so federated discovery can be tested without a second server. Only registered with SPELA_TEST_MODE=true.",
+		Tags:        []string{"test"},
+	}, h.HumaSeedFederationCatalog)
+}
+
+func (h *TestHandler) HumaSeedFederationCatalog(_ context.Context, in *TestSeedCatalogInput) (*TestSeedCatalogOutput, error) {
+	// Idempotent: clear any rows from a prior seed so repeated runs stay clean
+	// (the reset endpoint intentionally leaves federation tables untouched).
+	if err := h.DB.Where("source_peer_fingerprint = ?", "e2e-test-peer").Delete(&db.FederationCatalogSnapshot{}).Error; err != nil {
+		return nil, huma.Error500InternalServerError("seed cleanup failed")
+	}
+	row := db.FederationCatalogSnapshot{
+		SourcePeerFingerprint: "e2e-test-peer",
+		OriginFingerprint:     in.Body.OriginFingerprint,
+		Hops:                  1,
+		Key:                   in.Body.Key,
+		Title:                 in.Body.Title,
+		Console:               in.Body.Console,
+		FetchedAt:             time.Now(),
+	}
+	if err := h.DB.Create(&row).Error; err != nil {
+		return nil, huma.Error500InternalServerError("seed failed")
+	}
+	return &TestSeedCatalogOutput{Body: TestSeedCatalogResponse{Seeded: true}}, nil
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -473,6 +473,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	if cfg.TestMode {
 		testHandler := &TestHandler{DB: cfg.DB}
 		RegisterTestRoute(humaAPI, testHandler)
+		RegisterTestFederationRoute(humaAPI, testHandler)
 	}
 
 	// Serve frontend static files when configured (unified single-container deployment)

--- a/web/e2e/federation-search.spec.ts
+++ b/web/e2e/federation-search.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect, resetServer } from "./fixtures";
+
+const SERVER_URL = "http://localhost:8080";
+
+// Seeds a connected-server catalog entry directly in the real backend (no second
+// server needed) via the test-only endpoint, then verifies the web ⌘K command
+// palette surfaces it in the read-only "On connected servers" section — i.e. the
+// federated search wiring works against a live backend end to end.
+test.describe("Federation — connected-server search", () => {
+  test.beforeEach(async () => {
+    await resetServer();
+  });
+
+  test("⌘K surfaces a game available on a connected server", async ({ page }) => {
+    const seed = await fetch(`${SERVER_URL}/api/test/federation/seed-catalog`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        originFingerprint: "e2e-remote-server-fingerprint",
+        key: "igdb:1022",
+        title: "Chrono Trigger",
+        console: "SNES",
+      }),
+    });
+    expect(seed.ok, "seed-catalog endpoint failed").toBe(true);
+
+    await page.goto("/");
+
+    // Open the command palette via the sidebar search button. Clicking it
+    // auto-waits for the app shell to mount, avoiding a race with the palette's
+    // event listener.
+    await page.getByRole("button", { name: "Open search" }).click();
+    await expect(page.getByTestId("search-palette")).toBeVisible();
+
+    await page.getByLabel("Search input").fill("Chrono");
+
+    // The connected-servers section and the seeded game appear — served by the
+    // real backend's federated catalog, rendered read-only in the palette.
+    await expect(page.getByTestId("federated-search-section")).toBeVisible();
+    const row = page.getByTestId("federated-result-igdb:1022");
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("Chrono Trigger");
+    await expect(row).toContainText("on 1 connected server");
+  });
+});

--- a/web/e2e/start-e2e.sh
+++ b/web/e2e/start-e2e.sh
@@ -111,7 +111,6 @@ SPELA_CORS_ORIGINS="http://localhost:$VITE_PORT" \
 SPELA_ENCRYPTION_KEY="e2e-test-encryption-key-32bytes!" \
 SPELA_CHALLENGE_RATE_LIMIT_SEC=0 \
 SPELA_TEST_MODE=true \
-GIN_MODE=release \
 "$E2E_DIR/spela-server" &
 SERVER_PID=$!
 


### PR DESCRIPTION
## What

Closes the last verification gap for federation cover-art/search: a Playwright E2E that proves the web ⌘K command palette surfaces a **connected-server** game against a **real backend** (previously the federated search section was only unit-tested against mocked API responses).

- **New test-only endpoint** `POST /api/test/federation/seed-catalog` — gated by `SPELA_TEST_MODE` and registered alongside the existing `/api/test/reset`, never in production. Inserts one `FederationCatalogSnapshot` row so federated discovery can be exercised **without standing up a second server**. Idempotent (clears prior seed rows first).
- **`web/e2e/federation-search.spec.ts`** — resets the DB, seeds a connected-server game, opens the palette via the sidebar search button, and asserts the "On connected servers" section + the seeded game render. Passes locally (`4 passed`).

## Also: fixes a pre-existing broken E2E runner

`run-e2e.sh` **and** `web/e2e/start-e2e.sh` both set `GIN_MODE=release` alongside `SPELA_TEST_MODE=true`, but the server's `#1330` guard FATALs on that combo ("test mode exposes /api/test/reset — must not run in release"). So **web E2E has been broken since that guard landed** — and since CI doesn't run E2E, nobody caught it. Removed `GIN_MODE=release` from both scripts (the encryption key is set explicitly, so debug mode is correct for the test server). I hit this first-hand: the server refused to start until I removed it.

## Testing

- **E2E**: `./run-e2e.sh federation-search` → `4 passed` (after the runner fix + provisioning test ROMs locally).
- **Go**: full `internal/api` package passes (`ok`); `go build`/`gofmt` clean. The new endpoint is exercised end-to-end by the E2E.
- Reviewed; applied both findings (fixed the same `GIN_MODE` bug in `start-e2e.sh`; the seed endpoint now checks its cleanup-delete error).

> Note: this is test-infra only — no production behavior changes (the seed endpoint exists only under `SPELA_TEST_MODE`). E2E doesn't run in CI, so CI green here reflects unit/build checks; the E2E was validated locally.

Part of #1350, part of #1343