### PR TITLE
feat(player): right analog stick scrolls viewports in gamepad mode (#1362)

### DIFF
--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -561,22 +561,13 @@ class MainActivity : ComponentActivity() {
         analogDpadUp = nowUp
         analogDpadDown = nowDown
 
-        if (Math.abs(rY) > 0.15f) {
-            val props = MotionEvent.PointerProperties().apply {
-                id = 0
-                toolType = MotionEvent.TOOL_TYPE_MOUSE
-            }
-            val coords = MotionEvent.PointerCoords().apply {
-                setAxisValue(MotionEvent.AXIS_VSCROLL, -rY * 0.5f)
-            }
-            val scrollEvent = MotionEvent.obtain(
-                event.downTime, event.eventTime, MotionEvent.ACTION_SCROLL,
-                1, arrayOf(props), arrayOf(coords),
-                0, 0, 1f, 1f, event.deviceId, 0, InputDevice.SOURCE_MOUSE, 0
-            )
-            super.dispatchGenericMotionEvent(scrollEvent)
-            scrollEvent.recycle()
-        }
+        // Right-stick viewport scrolling (#1362): publish the deadzoned stick
+        // position to the shared signal that the UI's RightStickScroll effect
+        // consumes and applies directly to the active scroll container. Report 0 at
+        // rest so releasing the stick stops the scroll. (Replaces an earlier
+        // synthesized ACTION_SCROLL approach that routed by pointer position and so
+        // missed the focused pane on multi-pane screens like Settings.)
+        gamepadPortManager.setRightStickScroll(if (Math.abs(rY) > 0.15f) rY else 0f)
 
         return true
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
@@ -187,6 +187,18 @@ class GamepadPortManager(
     private val _inputMode = MutableStateFlow(InputMode.TOUCH)
     val inputMode: StateFlow<InputMode> = _inputMode.asStateFlow()
 
+    /** Normalized right-stick vertical position (-1 fully up .. +1 fully down, 0 at
+     *  rest after deadzone), published by the platform input layers for continuous
+     *  viewport scrolling (#1362). The UI reads the latest value each frame. */
+    private val _rightStickScroll = MutableStateFlow(0f)
+    val rightStickScroll: StateFlow<Float> = _rightStickScroll.asStateFlow()
+
+    /** Report the right-stick vertical position (already deadzoned by the caller). */
+    fun setRightStickScroll(normalizedY: Float) {
+        if (_rightStickScroll.value == normalizedY) return
+        _rightStickScroll.value = normalizedY
+    }
+
     /** Observable controller status for UI indicators. */
     private val _controllerStatus = MutableStateFlow(ControllerStatusState.Empty)
     val controllerStatus: StateFlow<ControllerStatusState> = _controllerStatus.asStateFlow()
@@ -684,6 +696,7 @@ class GamepadPortManager(
         bindPressedByDevice.clear()
         _bindPressedPositions.value = emptySet()
         _bindCaptureActive.value = false
+        _rightStickScroll.value = 0f
         _assignments.value = emptyList()
         _connectedControllers.value = emptyList()
         _portActivity.value = emptyMap()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -78,6 +78,7 @@ import com.spela.player.presentation.ui.gamepad.LocalIsForwardNavigation
 import com.spela.player.presentation.ui.gamepad.LocalIsTabSwitch
 import com.spela.player.presentation.ui.gamepad.InputModeClassifier
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
+import com.spela.player.presentation.ui.gamepad.LocalRightStickScroll
 import com.spela.player.presentation.ui.gamepad.resolveGamepadNavStyle
 import com.spela.player.presentation.ui.components.LocalScrapeService
 import com.spela.player.presentation.ui.theme.SpelaTheme
@@ -95,6 +96,7 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
     CompositionLocalProvider(
         LocalScrapeService provides scrapeService,
         LocalInputMode provides inputMode,
+        LocalRightStickScroll provides gamepadPortManager?.rightStickScroll,
     ) {
         val navState by navigationViewModel.state.collectAsState()
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import com.spela.player.presentation.ui.gamepad.RightStickScroll
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.spScreenBackground
 
@@ -109,6 +110,8 @@ fun SpScrollableContent(
 ) {
     val scrollState = rememberScrollState()
     CompositionLocalProvider(LocalScrollState provides scrollState) {
+        // Right analog stick scrolls this viewport in gamepad mode (#1362).
+        RightStickScroll(scrollState)
         Column(
             modifier = modifier
                 .fillMaxSize()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadMappingDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadMappingDialog.kt
@@ -47,6 +47,7 @@ import com.spela.player.domain.model.GamepadPosition
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.feature.settings.SettingsDivider
+import com.spela.player.presentation.ui.gamepad.RightStickScroll
 import com.spela.player.presentation.ui.gamepad.gamepadFocusable
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -146,13 +147,16 @@ private fun androidx.compose.foundation.layout.ColumnScope.MappingList(
 
     Spacer(Modifier.height(SpSpacing.Medium))
 
+    val listScroll = rememberScrollState()
+    // Right analog stick scrolls the button list in gamepad mode (#1362).
+    RightStickScroll(listScroll)
     Column(
         modifier = Modifier
             .fillMaxWidth()
             // Take the remaining space (between header and the pinned action
             // buttons) and scroll within it (#1371).
             .weight(1f)
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(listScroll),
     ) {
         state.outputs.forEachIndexed { index, output ->
             OutputRow(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/RightStickScroll.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/RightStickScroll.kt
@@ -1,0 +1,61 @@
+package com.spela.player.presentation.ui.gamepad
+
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlin.math.abs
+
+/**
+ * The right analog stick's normalized vertical position (-1 fully up .. +1 fully
+ * down, 0 at rest after deadzone), published by the platform input layers
+ * (#1362). Continuous viewport scrolling reads this; null when no gamepad source
+ * is wired (e.g. previews/tests).
+ */
+val LocalRightStickScroll = staticCompositionLocalOf<StateFlow<Float>?> { null }
+
+/** Pixels scrolled per second at full stick deflection. */
+private const val SCROLL_PX_PER_SECOND = 2600f
+
+/** Below this magnitude the stick is treated as at-rest (belt-and-suspenders; the
+ *  input layer already applies its own deadzone before publishing). */
+private const val DEADZONE = 0.02f
+
+/**
+ * Continuously scrolls [scrollable] from the right analog stick while in gamepad
+ * mode (#1362) — like a scroll wheel, independent of D-pad focus traversal. Reads
+ * the latest stick value each frame and applies a frame-rate-independent delta, so
+ * holding the stick scrolls smoothly and releasing it stops.
+ *
+ * [scrollable] is the common supertype of both `ScrollState` (verticalScroll) and
+ * `LazyListState` (LazyColumn), so this drives either. Place it inside the
+ * scrollable container's composition. No-op in touch mode or without a source.
+ */
+@Composable
+fun RightStickScroll(scrollable: ScrollableState) {
+    val flow = LocalRightStickScroll.current ?: return
+    val gamepadMode = LocalInputMode.current == InputMode.GAMEPAD
+    LaunchedEffect(scrollable, flow, gamepadMode) {
+        if (!gamepadMode) return@LaunchedEffect
+        // collectLatest cancels the per-deflection frame loop when the stick value
+        // changes. At rest (|v| <= deadzone, the common case) we return immediately
+        // and stay suspended on the flow — requesting NO frames, so Compose can go
+        // idle (otherwise an always-on withFrameNanos loop hangs waitForIdle in
+        // tests and renders forever on-device).
+        flow.collectLatest { v ->
+            if (abs(v) <= DEADZONE) return@collectLatest
+            var lastFrame = 0L
+            while (true) {
+                val now = withFrameNanos { it }
+                val dt = if (lastFrame == 0L) 0f else (now - lastFrame) / 1_000_000_000f
+                lastFrame = now
+                // +v (stick down) scrolls toward the end of the content (down).
+                if (dt > 0f) scrollable.scrollBy(v * SCROLL_PX_PER_SECOND * dt)
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -53,6 +54,7 @@ import com.spela.player.presentation.intent.KeyMappingIntent
 import com.spela.player.presentation.viewmodel.KeyMappingViewModel
 import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
 import com.spela.player.presentation.ui.components.gamepad.ControllerControls
+import com.spela.player.presentation.ui.gamepad.RightStickScroll
 import com.spela.player.util.currentPlatform
 import com.spela.player.presentation.state.KeyMappingState
 import com.spela.player.data.remote.SyncState
@@ -80,7 +82,11 @@ fun SettingsCategoryContent(
     modifier: Modifier = Modifier,
     topPadding: Dp = 0.dp,
 ) {
+    val listState = rememberLazyListState()
+    // Right analog stick scrolls the settings content in gamepad mode (#1362).
+    RightStickScroll(listState)
     LazyColumn(
+        state = listState,
         modifier = modifier.fillMaxSize().testTag("settings_category_content_list"),
         contentPadding = PaddingValues(
             start = SpSpacing.ScreenHorizontal,

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopGamepadPoller.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlin.math.abs
 
 /**
  * Polls connected gamepads via SDL2 (JNI) and routes their input
@@ -34,6 +35,9 @@ class DesktopGamepadPoller(
 
         /** Axis dead zone (SDL range is -32768..32767, ~15% dead zone). */
         private const val AXIS_DEADZONE = 4800
+
+        /** SDL axis magnitude, for normalizing to -1..1 (#1362 right-stick scroll). */
+        private const val AXIS_RANGE = 32768f
 
         /** Number of axes: LX, LY, RX, RY, TriggerL, TriggerR. */
         private const val NUM_AXES = 6
@@ -100,6 +104,10 @@ class DesktopGamepadPoller(
         // Track which controllers are present this frame
         val currentIds = mutableSetOf<Int>()
 
+        // Largest right-stick Y deflection across all pads, for UI viewport
+        // scrolling (#1362) — works for assigned and unassigned controllers alike.
+        var uiScrollY = 0f
+
         for (state in states) {
             currentIds.add(state.controllerId)
 
@@ -153,6 +161,14 @@ class DesktopGamepadPoller(
                 )
             }
 
+            // Right-stick viewport scroll (#1362): track the largest right-stick Y
+            // deflection across pads (before the port check, so an unassigned pad
+            // still scrolls the UI). The UI's RightStickScroll effect consumes it.
+            if (state.axes.size >= NUM_AXES) {
+                val ry = applyDeadzone(state.axes[3]) / AXIS_RANGE
+                if (abs(ry) > abs(uiScrollY)) uiScrollY = ry
+            }
+
             // Emulation routing requires an assigned player port; unassigned
             // controllers stop here (they only feed the tester above).
             val port = gamepadPortManager.getPort(state.controllerId)
@@ -191,6 +207,9 @@ class DesktopGamepadPoller(
                 gamepadPortManager.reportActivity(port)
             }
         }
+
+        // Publish the frame's right-stick deflection for UI viewport scroll (#1362).
+        gamepadPortManager.setRightStickScroll(uiScrollY)
 
         // While a controller is under test, mask its test buttons (everything
         // except the D-pad) from UI navigation so e.g. the right face button

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
@@ -510,6 +510,17 @@ class GamepadPortManagerTest {
         assertFalse(GamepadPosition.SOUTH in manager.bindPressedPositions.value)
     }
 
+    // ── Right-stick viewport scroll signal (#1362) ───────────────────────────
+
+    @Test
+    fun rightStickScrollDefaultsToZeroAndReportsValue() {
+        assertEquals(0f, manager.rightStickScroll.value)
+        manager.setRightStickScroll(0.7f)
+        assertEquals(0.7f, manager.rightStickScroll.value)
+        manager.setRightStickScroll(0f)
+        assertEquals(0f, manager.rightStickScroll.value)
+    }
+
     // ── Player-slot assignment (#1359) ───────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

The right analog stick did nothing in the UI — scrollable screens (Settings) and the controller-buttons dialog could only be scrolled by moving D-pad focus. Adds scroll-wheel-style continuous scrolling driven by the right stick, in gamepad mode, independent of focus.

## Mechanism (cross-platform)

- **`GamepadPortManager.rightStickScroll`** — a shared `StateFlow<Float>` (-1 up .. +1 down, 0 at rest after deadzone) published by the platform input layers.
- **`RightStickScroll(ScrollableState)`** — a Compose effect that, in gamepad mode, scrolls by a frame-rate-independent delta while the stick is deflected. `ScrollableState` is the common supertype of `ScrollState` (verticalScroll) and `LazyListState` (LazyColumn), so one effect drives either. Wired into `SpScrollableContent` (most screens), the Settings content `LazyColumn`, and the controller-buttons dialog list.
- **Android** — `MainActivity.onGenericMotionEvent` publishes the deadzoned `AXIS_RZ` to the signal, replacing an earlier synthesized `ACTION_SCROLL` approach that routed by pointer position and so missed the focused pane on multi-pane screens like Settings.
- **Desktop** — `DesktopGamepadPoller` publishes the largest right-stick Y deflection across pads each frame (before the port check, so an unassigned pad still scrolls the UI).

Guarded by `LocalInputMode == GAMEPAD` so touch/mouse is unaffected. The effect uses `collectLatest` so it requests animation frames **only while the stick is deflected** — at rest it suspends on the flow (no perpetual rendering; Compose can idle).

## Tests

- `GamepadPortManagerTest` (+1, the signal).
- Full `:shared:desktopTest` + `:desktop:desktopTest` green; Android + desktop compile.
- Scroll feel + direction verified on the AYN Thor.

Closes #1362
