### PR TITLE
fix(player): Settings gamepad focus restore + filter empty consoles (#1382, #1383)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
@@ -6,6 +6,7 @@ import com.spela.player.domain.model.ControllerStyle
 import com.spela.player.domain.model.GamepadPosition
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.viewmodel.GamepadConfigIntent
 import com.spela.player.presentation.viewmodel.SettingsIntent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -294,6 +295,35 @@ class SettingsConsoleNavigationTest {
         // The console rows are only rendered in the Per-Console category content;
         // before the rememberSaveable fix this reset to General and the rows were gone.
         onNodeWithText("Nintendo Entertainment System").assertIsDisplayed()
+    }
+
+    /**
+     * Back from a console's settings restores focus to that console row (#1382),
+     * so D-pad navigation continues from there. Uses SNES (not the default first
+     * console) to prove restoration, not just default focus.
+     */
+    @Test
+    fun backFromConsoleSettingsRestoresFocusToThatConsole() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        navigateToSettings(harness)
+        navigateToControlsCategory(harness)
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        advanceQuick(harness)
+
+        // Focus + drill into SNES (by row tag, scrolled into view if needed).
+        onNodeWithTag("console_settings_row_snes").performScrollTo().performClick()
+        advance(harness)
+        assertEquals(
+            SpScreen.ConsoleSettings("snes"),
+            harness.navigationViewModel.state.value.currentScreen,
+        )
+
+        // Back → focus restored to the SNES row.
+        harness.navigationViewModel.onIntent(NavigationIntent.GoBack)
+        advance(harness)
+
+        onNodeWithTag("console_settings_row_snes").assertIsFocused()
     }
 
     @Test

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/LibraryConsolesTab.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/LibraryConsolesTab.kt
@@ -73,6 +73,9 @@ internal fun LibraryConsolesTab(
         SpColor.AccentDark.darken(0.80f),
     )
 
+    // Only show consoles the server has games for (#1383) — empty consoles aren't
+    // browsable. (Loading uses the raw list so the skeleton still shows on first load.)
+    val visibleConsoles = state.consoles.filter { it.gameCount > 0 }
     SpScreen(gradientColors = gradientColors) {
         if (state.isLoading && state.consoles.isEmpty()) {
             SpScrollableContent {
@@ -93,7 +96,7 @@ internal fun LibraryConsolesTab(
                 onRefresh = { viewModel.onIntent(GameListIntent.LoadConsoles) },
                 modifier = Modifier.fillMaxSize(),
             ) {
-                if (state.consoles.isEmpty()) {
+                if (visibleConsoles.isEmpty()) {
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center,
@@ -111,7 +114,7 @@ internal fun LibraryConsolesTab(
                             Spacer(Modifier.height(SpSpacing.Medium))
                             BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
                                 ConsolesGrid(
-                                    consoles = state.consoles,
+                                    consoles = visibleConsoles,
                                     onConsoleSelected = onConsoleSelected,
                                     consolesWithMissingBios = state.consolesWithMissingBios,
                                     columnsPerRow = consoleColumnsForWidth(maxWidth),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
@@ -53,8 +53,12 @@ import com.spela.player.presentation.viewmodel.SettingsState
 import com.spela.player.presentation.intent.KeyMappingIntent
 import com.spela.player.presentation.viewmodel.KeyMappingViewModel
 import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
+import androidx.compose.runtime.CompositionLocalProvider
 import com.spela.player.presentation.ui.components.gamepad.ControllerControls
+import com.spela.player.presentation.ui.gamepad.LocalFocusMemory
 import com.spela.player.presentation.ui.gamepad.RightStickScroll
+import com.spela.player.presentation.ui.gamepad.focusRestoreItem
+import com.spela.player.presentation.ui.gamepad.rememberFocusMemoryState
 import com.spela.player.util.currentPlatform
 import com.spela.player.presentation.state.KeyMappingState
 import com.spela.player.data.remote.SyncState
@@ -85,6 +89,10 @@ fun SettingsCategoryContent(
     val listState = rememberLazyListState()
     // Right analog stick scrolls the settings content in gamepad mode (#1362).
     RightStickScroll(listState)
+    // Screen-scoped focus memory for the content pane (#1382), so e.g. drilling
+    // into a console's settings and pressing B restores focus to that console row.
+    val contentFocusMemory = rememberFocusMemoryState()
+    CompositionLocalProvider(LocalFocusMemory provides contentFocusMemory) {
     LazyColumn(
         state = listState,
         modifier = modifier.fillMaxSize().testTag("settings_category_content_list"),
@@ -125,6 +133,7 @@ fun SettingsCategoryContent(
         // Bottom spacing
         item { Spacer(Modifier.height(SpSpacing.XXXLarge)) }
     }
+    } // CompositionLocalProvider(LocalFocusMemory)
 }
 
 // --- Category content functions (LazyListScope extensions) ---
@@ -328,13 +337,25 @@ private fun androidx.compose.foundation.lazy.LazyListScope.consolesContent(
     state: SettingsState,
     onNavigateToConsoleSettings: (String) -> Unit,
 ) {
-    if (state.consoles.isNotEmpty()) {
+    // Only list consoles the server actually has games for (#1383) — there's
+    // nothing to configure for an empty console, and the empty-state below already
+    // promises "with games".
+    val consoles = state.consoles.filter { it.gameCount > 0 }.sortedForConsoleList()
+    if (consoles.isNotEmpty()) {
+        val firstConsoleId = consoles.first().id
         items(
-            items = state.consoles.sortedForConsoleList(),
+            items = consoles,
             key = { "console_${it.id}" },
         ) { console ->
             SpCard(
-                modifier = Modifier.testTag("console_settings_row_${console.id}"),
+                // Restore focus to this row on back from its ConsoleSettings, and
+                // default-focus the first console on first entry (#1382).
+                modifier = Modifier
+                    .testTag("console_settings_row_${console.id}")
+                    .focusRestoreItem(
+                        key = "console_settings_${console.id}",
+                        isDefault = console.id == firstConsoleId,
+                    ),
                 onClick = { onNavigateToConsoleSettings(console.id) },
                 onGradient = true,
             ) {


### PR DESCRIPTION
## Summary

Two Settings-screen gamepad fixes found while testing #1362 on the AYN Thor.

### #1382 — focus restore in the Per-Console list
The Settings **content** pane never joined the focus-memory system (no `LocalFocusMemory` scope, no `focusRestoreItem`), so drilling into a console's settings and pressing **B** returned to the Per-Console list with nothing focused — D-pad dead until touch. Now `SettingsCategoryContent` provides a screen-scoped focus memory, and each console row is a `focusRestoreItem(key = console.id)`:

- Focus a console → open its settings → **B restores focus to that console row** (the exact reported behavior).
- The first console is the default focus on first entry to the category.

### #1383 — only list consoles with games
The Per-Console settings list **and** the main Consoles tab both rendered the full `getConsoles()` catalog, including consoles with zero games (the backend already reports per-console `gameCount`; neither surface filtered). Both now filter to `gameCount > 0` — the Per-Console empty state already promised "No consoles with games found".

## Tests

- `SettingsConsoleNavigationTest`: new back-restore test (focus SNES → open → B → assert SNES row focused); existing console-row tests stay green under the `gameCount` filter (harness consoles have games).
- Full `:shared:desktopTest` + `:desktop:desktopTest` green.
- Verified on the AYN Thor.

## Scope note

The broader "Settings is dead until touch on **first tab entry**" symptom is the harder #1194-area input-mode timing (the category list's default focus not firing on the Thor). That's tracked separately and stays open on **#1382**; this PR delivers the deterministic back-restore + per-category default focus.

Closes #1383
