### PR TITLE
feat(web): remote-game page to import a connected-server game (#1385)

### DIFF
--- a/server/internal/api/federation_catalog.go
+++ b/server/internal/api/federation_catalog.go
@@ -190,6 +190,7 @@ type AvailableGamesInput struct {
 	MaxHops    int    `query:"maxHops"`    // viewer reach; <=0 = full reachable mesh
 	RemoteOnly bool   `query:"remoteOnly"` // only games not available locally
 	Q          string `query:"q"`          // case-insensitive title filter; empty = all
+	Key        string `query:"key"`        // exact cross-key filter; empty = all
 }
 type AvailableGamesOutput struct {
 	Body struct {
@@ -228,6 +229,18 @@ func (h *FederationHandler) HumaAvailableGames(_ context.Context, in *AvailableG
 		filtered := make([]federation.CatalogAvailability, 0, len(games))
 		for _, g := range games {
 			if strings.Contains(strings.ToLower(g.Title), q) {
+				filtered = append(filtered, g)
+			}
+		}
+		games = filtered
+	}
+	// Exact key filter: lets the remote-game page fetch one entry by its
+	// cross-key (e.g. on a deep link / refresh) without resolving covers for
+	// the whole catalog — only the single match below reaches the resolver.
+	if key := strings.TrimSpace(in.Key); key != "" {
+		filtered := make([]federation.CatalogAvailability, 0, 1)
+		for _, g := range games {
+			if g.Key == key {
 				filtered = append(filtered, g)
 			}
 		}

--- a/server/internal/api/federation_catalog_test.go
+++ b/server/internal/api/federation_catalog_test.go
@@ -259,3 +259,29 @@ func TestAvailableGames_FiltersByQuery(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, none.Body.Games, 2)
 }
+
+func TestAvailableGames_FiltersByKey(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	h := catalogHandler(database, selfID, nil)
+	const cover = "https://images.igdb.com/igdb/image/upload/t_cover_big/co1.jpg"
+	h.CoverResolver = fakeCoverResolver{byKey: map[string]string{"igdb:1": cover}}
+
+	require.NoError(t, h.CatalogSnapshots.ReplacePeerSnapshot("B", []federation.CatalogEntry{
+		{OriginFingerprint: "B", Hops: 1, Key: "igdb:1", Title: "Super Mario Bros", Console: "NES"},
+		{OriginFingerprint: "B", Hops: 1, Key: "igdb:2", Title: "Sonic the Hedgehog", Console: "MD"},
+	}, time.Unix(1, 0)))
+
+	// Exact key match returns just that entry, with its cover resolved — this
+	// is how the remote-game page fetches a single entry on a deep link.
+	res, err := h.HumaAvailableGames(context.Background(), &AvailableGamesInput{Key: "igdb:1"})
+	require.NoError(t, err)
+	require.Len(t, res.Body.Games, 1)
+	assert.Equal(t, "Super Mario Bros", res.Body.Games[0].Title)
+	assert.Equal(t, cover, res.Body.Games[0].Cover)
+
+	// A key offered by no connected server returns nothing.
+	none, err := h.HumaAvailableGames(context.Background(), &AvailableGamesInput{Key: "igdb:999"})
+	require.NoError(t, err)
+	assert.Empty(t, none.Body.Games)
+}

--- a/web/e2e/federation-import.spec.ts
+++ b/web/e2e/federation-import.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect, resetServer } from "./fixtures";
+
+const SERVER_URL = "http://localhost:8080";
+
+// Drives the connected-server import flow against the real backend: seed a
+// catalog entry (no second server needed), navigate from ⌘K to the remote-game
+// page, and start an import. With no peer actually serving the ROM the job
+// fails — but that still exercises the full enqueue → worker → status pipeline
+// and the queue UI end to end. The happy path (a completed import) is covered
+// by the server's Go unit + two-server integration tests.
+test.describe("Federation — import a connected-server game", () => {
+  test.beforeEach(async () => {
+    await resetServer();
+  });
+
+  test("⌘K result opens the remote-game page and starts an import", async ({
+    page,
+  }) => {
+    const seed = await fetch(`${SERVER_URL}/api/test/federation/seed-catalog`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        originFingerprint: "e2e-remote-server-fingerprint",
+        key: "igdb:1022",
+        title: "Chrono Trigger",
+        console: "SNES",
+      }),
+    });
+    expect(seed.ok, "seed-catalog endpoint failed").toBe(true);
+
+    await page.goto("/");
+
+    // Open ⌘K and surface the connected-server result, then click into it.
+    await page.getByRole("button", { name: "Open search" }).click();
+    await expect(page.getByTestId("search-palette")).toBeVisible();
+    await page.getByLabel("Search input").fill("Chrono");
+    const row = page.getByTestId("federated-result-igdb:1022");
+    await expect(row).toBeVisible();
+    await row.click();
+
+    // The remote-game page renders the sparse connected-server detail.
+    const detail = page.getByTestId("remote-game-detail");
+    await expect(detail).toBeVisible();
+    await expect(detail).toContainText("Chrono Trigger");
+    await expect(detail).toContainText("SNES");
+    await expect(detail).toContainText("Available on 1 connected server");
+
+    // The default E2E user is an admin, so the import action is available.
+    const importButton = page.getByTestId("import-game-button");
+    await expect(importButton).toBeVisible();
+    await importButton.click();
+
+    // The job appears in the queue and reaches a terminal state.
+    const jobRow = page.getByTestId(/^import-job-\d+$/).first();
+    await expect(jobRow).toBeVisible();
+    await expect(jobRow).toContainText("Chrono Trigger");
+    await expect(page.getByTestId("import-job-status").first()).toContainText(
+      "Failed",
+      { timeout: 20000 },
+    );
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,7 @@ const ConsoleDetailPage = lazy(() => import("@/pages/console-detail-page"));
 const ConsoleGamesPage = lazy(() => import("@/pages/console-games-page"));
 const GamesPage = lazy(() => import("@/pages/games-page"));
 const GameDetailPage = lazy(() => import("@/pages/game-detail-page"));
+const RemoteGameDetailPage = lazy(() => import("@/pages/remote-game-detail-page"));
 const GameAchievementsPage = lazy(() => import("@/pages/game-achievements-page"));
 const FavoritesPage = lazy(() => import("@/pages/favorites-page"));
 const PlayLaterPage = lazy(() => import("@/pages/play-later-page"));
@@ -176,6 +177,10 @@ export function App() {
                       element={<ConsoleGamesPage />}
                     />
                     <Route path="games/:id" element={<GameDetailPage />} />
+                    <Route
+                      path="remote-games/:key"
+                      element={<RemoteGameDetailPage />}
+                    />
                     <Route
                       path="games/:id/achievements"
                       element={<GameAchievementsPage />}

--- a/web/src/features/admin/components/edit-user-modal.tsx
+++ b/web/src/features/admin/components/edit-user-modal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button, Modal, Input, Select } from "@/components/ui";
+import { Button, Modal, Input, Select, Switch } from "@/components/ui";
 import { useUpdateUser } from "@/hooks/use-admin";
 import { useToast } from "@/components/ui";
 import type { User } from "@/types/api";
@@ -45,6 +45,9 @@ function EditUserForm({
   const [editPassword, setEditPassword] = useState("");
   const [editRole, setEditRole] = useState<string>(user.role);
   const [editDisabled, setEditDisabled] = useState(user.disabled);
+  const [editCanImportGames, setEditCanImportGames] = useState(
+    user.canImportGames,
+  );
 
   function handleSaveUser() {
     const data: {
@@ -52,11 +55,14 @@ function EditUserForm({
       email?: string;
       password?: string;
       disabled?: boolean;
+      canImportGames?: boolean;
     } = {};
     if (editEmail !== user.email) data.email = editEmail;
     if (editPassword) data.password = editPassword;
     if (editRole !== user.role) data.role = editRole;
     if (editDisabled !== user.disabled) data.disabled = editDisabled;
+    if (editCanImportGames !== user.canImportGames)
+      data.canImportGames = editCanImportGames;
 
     updateUser.mutate(
       { id: user.id, data },
@@ -96,15 +102,28 @@ function EditUserForm({
         disabled={user.role === "owner" || user.id === currentUser?.id}
       />
       {user.role !== "owner" && (
-        <label className="flex items-center gap-3 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={editDisabled}
-            onChange={(e) => setEditDisabled(e.target.checked)}
-            className="h-4 w-4 rounded border-surface-600 bg-surface-800 text-brand-500 focus:ring-brand-500"
-          />
+        <div className="flex items-center justify-between gap-3">
           <span className="text-sm text-surface-300">Disable account</span>
-        </label>
+          <Switch
+            checked={editDisabled}
+            onChange={setEditDisabled}
+            data-testid="disable-account-toggle"
+          />
+        </div>
+      )}
+      {/* Admins/owners can always import; this grants the capability to a
+          plain user, so it only applies while the role is "user". */}
+      {editRole === "user" && (
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-sm text-surface-300">
+            Can import games from connected servers
+          </span>
+          <Switch
+            checked={editCanImportGames}
+            onChange={setEditCanImportGames}
+            data-testid="can-import-games-toggle"
+          />
+        </div>
       )}
       <div className="flex justify-end gap-3">
         <Button variant="secondary" onClick={onClose}>

--- a/web/src/features/federation/components/import-status.test.tsx
+++ b/web/src/features/federation/components/import-status.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import { ImportJobRow, ImportsQueue } from "./import-status";
+import type { ImportJob } from "@/generated/schemas";
+
+function makeJob(overrides: Partial<ImportJob> = {}): ImportJob {
+  return {
+    id: 1,
+    status: "pending",
+    key: "igdb:42",
+    title: "Chrono Trigger",
+    console: "SNES",
+    bytesDownloaded: 0,
+    totalBytes: 0,
+    errorMessage: "",
+    gameId: null,
+    requestedByUserId: 7,
+    createdAt: "2026-06-16T00:00:00Z",
+    updatedAt: "2026-06-16T00:00:00Z",
+    startedAt: null,
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+function renderRow(job: ImportJob) {
+  return render(
+    <MemoryRouter>
+      <ImportJobRow job={job} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ImportJobRow", () => {
+  it("shows a Queued status for a pending job", () => {
+    renderRow(makeJob({ status: "pending" }));
+    expect(screen.getByTestId("import-job-status")).toHaveTextContent("Queued");
+  });
+
+  it("shows a byte progress bar while downloading with a known size", () => {
+    renderRow(
+      makeJob({ status: "downloading", bytesDownloaded: 512, totalBytes: 1024 }),
+    );
+    expect(screen.getByTestId("import-job-status")).toHaveTextContent(
+      "Downloading",
+    );
+    // ProgressBar renders a progressbar role with the byte values.
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "512");
+    expect(bar).toHaveAttribute("aria-valuemax", "1024");
+  });
+
+  it("surfaces the error message for a failed job", () => {
+    renderRow(
+      makeJob({ status: "failed", errorMessage: "no connected server" }),
+    );
+    expect(screen.getByTestId("import-job-status")).toHaveTextContent("Failed");
+    expect(screen.getByTestId("import-job-error")).toHaveTextContent(
+      "no connected server",
+    );
+  });
+
+  it("links into the library once imported", () => {
+    renderRow(makeJob({ status: "completed", gameId: 99 }));
+    expect(screen.getByTestId("import-job-status")).toHaveTextContent(
+      "Imported",
+    );
+    const link = screen.getByTestId("import-job-open-game");
+    expect(link).toHaveAttribute("href", "/games/99");
+  });
+});
+
+describe("ImportsQueue", () => {
+  it("renders an empty state with no jobs", () => {
+    render(
+      <MemoryRouter>
+        <ImportsQueue jobs={[]} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("No imports yet")).toBeInTheDocument();
+  });
+
+  it("renders a row per job", () => {
+    render(
+      <MemoryRouter>
+        <ImportsQueue
+          jobs={[
+            makeJob({ id: 1, title: "Game One" }),
+            makeJob({ id: 2, title: "Game Two" }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("import-job-1")).toHaveTextContent("Game One");
+    expect(screen.getByTestId("import-job-2")).toHaveTextContent("Game Two");
+  });
+});

--- a/web/src/features/federation/components/import-status.tsx
+++ b/web/src/features/federation/components/import-status.tsx
@@ -1,0 +1,114 @@
+import { Link } from "react-router-dom";
+import { Inbox } from "lucide-react";
+import { Badge, ProgressBar, EmptyState } from "@/components/ui";
+import { Card } from "@/components/ui/card";
+import { ConsoleBadge } from "@/components/console-badge";
+import { formatFileSize } from "@/lib/format";
+import type { ImportJob } from "@/generated/schemas";
+
+// Human label for each job status. The server drives the state machine:
+// pending -> downloading -> ingesting -> scraping -> completed | failed.
+function importStatusLabel(status: string): string {
+  switch (status) {
+    case "pending":
+      return "Queued";
+    case "downloading":
+      return "Downloading";
+    case "ingesting":
+      return "Adding to library";
+    case "scraping":
+      return "Fetching metadata";
+    case "completed":
+      return "Imported";
+    case "failed":
+      return "Failed";
+    default:
+      return status;
+  }
+}
+
+function statusVariant(
+  status: string,
+): "default" | "brand" | "success" | "danger" {
+  if (status === "completed") return "success";
+  if (status === "failed") return "danger";
+  if (status === "pending") return "default";
+  return "brand";
+}
+
+// One import job: title + console, a status badge, and the state-appropriate
+// detail — a byte progress bar while downloading, the error when failed, or a
+// link into the local library once imported.
+export function ImportJobRow({ job }: { job: ImportJob }) {
+  return (
+    <Card data-testid={`import-job-${job.id}`} className="p-3">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 flex-col gap-1">
+            <p className="truncate text-sm font-medium text-surface-100">
+              {job.title || job.key}
+            </p>
+            <ConsoleBadge code={job.console} className="self-start" />
+          </div>
+          <Badge
+            variant={statusVariant(job.status)}
+            data-testid="import-job-status"
+          >
+            {importStatusLabel(job.status)}
+          </Badge>
+        </div>
+
+        {job.status === "downloading" && job.totalBytes > 0 && (
+          <ProgressBar
+            value={job.bytesDownloaded}
+            max={job.totalBytes}
+            size="sm"
+            showPercentage
+            label={`${formatFileSize(job.bytesDownloaded)} / ${formatFileSize(job.totalBytes)}`}
+          />
+        )}
+        {job.status === "downloading" && job.totalBytes <= 0 && (
+          <p className="text-xs text-surface-400">
+            {formatFileSize(job.bytesDownloaded)} downloaded
+          </p>
+        )}
+
+        {job.status === "failed" && job.errorMessage && (
+          <p className="text-xs text-danger-500" data-testid="import-job-error">
+            {job.errorMessage}
+          </p>
+        )}
+
+        {job.status === "completed" && job.gameId != null && (
+          <Link
+            to={`/games/${job.gameId}`}
+            data-testid="import-job-open-game"
+            className="text-xs font-medium text-brand-400 hover:text-brand-300"
+          >
+            View in library →
+          </Link>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+// A live list of import jobs (newest first).
+export function ImportsQueue({ jobs }: { jobs: ImportJob[] }) {
+  if (jobs.length === 0) {
+    return (
+      <EmptyState
+        icon={Inbox}
+        title="No imports yet"
+        description="Games you import from connected servers will appear here."
+      />
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2" data-testid="imports-queue">
+      {jobs.map((job) => (
+        <ImportJobRow key={job.id} job={job} />
+      ))}
+    </div>
+  );
+}

--- a/web/src/features/search/components/search-results.tsx
+++ b/web/src/features/search/components/search-results.tsx
@@ -28,8 +28,8 @@ interface SearchResultsDisplayProps {
   // Optional: federated results can render before the local search resolves.
   results?: SearchResults;
   onNavigate: (path: string) => void;
-  // Games found on connected servers (not in the local library). Read-only —
-  // listed for discovery; not navigable or downloadable yet.
+  // Games found on connected servers (not in the local library). Navigable to
+  // the remote-game page, where an import-capable user can pull them in.
   federatedGames?: CatalogAvailability[];
 }
 
@@ -43,6 +43,9 @@ interface ResultSection {
 interface ResultItem {
   id: string;
   path: string;
+  // Router navigation state — federated rows carry their catalog entry so the
+  // remote-game page can render instantly without a refetch.
+  state?: CatalogAvailability;
   render: (highlighted: boolean) => React.ReactNode;
 }
 
@@ -138,8 +141,17 @@ export function SearchResultsDisplay({
   federatedGames,
 }: SearchResultsDisplayProps) {
   const sections = results ? buildSections(results) : [];
-  const fedGames = federatedGames ?? [];
-  const allItems = sections.flatMap((s) => s.items);
+  const allFedGames = Array.isArray(federatedGames) ? federatedGames : [];
+  const fedGames = allFedGames.slice(0, FEDERATED_LIMIT);
+  const allItems: ResultItem[] = [
+    ...sections.flatMap((s) => s.items),
+    ...fedGames.map((game) => ({
+      id: `federated-${game.key}`,
+      path: `/remote-games/${encodeURIComponent(game.key)}`,
+      state: game,
+      render: (hl: boolean) => <FederatedGameRow game={game} highlighted={hl} />,
+    })),
+  ];
   const [highlightIndex, setHighlightIndex] = useState(-1);
   const scrollRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
@@ -168,7 +180,11 @@ export function SearchResultsDisplay({
         const item = allItems[highlightIndex];
         if (item) {
           onNavigate(item.path);
-          navigate(item.path);
+          if (item.state) {
+            navigate(item.path, { state: item.state });
+          } else {
+            navigate(item.path);
+          }
         }
       }
     },
@@ -219,7 +235,11 @@ export function SearchResultsDisplay({
                 className="w-full text-left px-4 py-1.5 cursor-pointer"
                 onClick={() => {
                   onNavigate(item.path);
-                  navigate(item.path);
+                  if (item.state) {
+                    navigate(item.path, { state: item.state });
+                  } else {
+                    navigate(item.path);
+                  }
                 }}
                 onMouseEnter={() => setHighlightIndex(currentIndex)}
               >
@@ -236,22 +256,34 @@ export function SearchResultsDisplay({
             <span className="text-xs font-semibold uppercase tracking-wider text-surface-500">
               On connected servers
             </span>
-            {fedGames.length > FEDERATED_LIMIT && (
+            {allFedGames.length > FEDERATED_LIMIT && (
               <span className="text-xs text-surface-500">
-                {fedGames.length} total
+                {allFedGames.length} total
               </span>
             )}
           </div>
-          {fedGames.slice(0, FEDERATED_LIMIT).map((game) => (
-            // Read-only: discovery only — not navigable or downloadable yet.
-            <div
-              key={game.key}
-              data-testid={`federated-result-${game.key}`}
-              className="px-4 py-1.5"
-            >
-              <FederatedGameRow game={game} />
-            </div>
-          ))}
+          {fedGames.map((game) => {
+            const currentIndex = globalIndex++;
+            return (
+              <button
+                key={game.key}
+                data-result-index={currentIndex}
+                data-testid={`federated-result-${game.key}`}
+                className="w-full text-left px-4 py-1.5 cursor-pointer"
+                onClick={() => {
+                  const path = `/remote-games/${encodeURIComponent(game.key)}`;
+                  onNavigate(path);
+                  navigate(path, { state: game });
+                }}
+                onMouseEnter={() => setHighlightIndex(currentIndex)}
+              >
+                <FederatedGameRow
+                  game={game}
+                  highlighted={highlightIndex === currentIndex}
+                />
+              </button>
+            );
+          })}
         </div>
       )}
     </div>
@@ -374,7 +406,13 @@ function GameRow({
 // Connected-server game: discovery row. Box art is the origin server's public
 // IGDB cover URL when the federated catalog carries one, else a placeholder —
 // covers aren't guaranteed for every connected-server game.
-function FederatedGameRow({ game }: { game: CatalogAvailability }) {
+function FederatedGameRow({
+  game,
+  highlighted,
+}: {
+  game: CatalogAvailability;
+  highlighted: boolean;
+}) {
   const servers = game.originCount;
   const icon = game.cover ? (
     <img
@@ -395,7 +433,7 @@ function FederatedGameRow({ game }: { game: CatalogAvailability }) {
           {game.console}
         </span>
       }
-      highlighted={false}
+      highlighted={highlighted}
     />
   );
 }

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -14242,6 +14242,7 @@ export interface operations {
                 maxHops?: number;
                 remoteOnly?: boolean;
                 q?: string;
+                key?: string;
             };
             header?: never;
             path?: never;

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -19196,6 +19196,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "explode": false,
+            "in": "query",
+            "name": "key",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/web/src/hooks/use-federation-import.ts
+++ b/web/src/hooks/use-federation-import.ts
@@ -1,0 +1,65 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { typedApi, unwrap } from "@/lib/api-client";
+import type { CatalogAvailability, ImportJob } from "@/generated/schemas";
+
+// A job is still doing work until it reaches a terminal status.
+export function isImportActive(job: ImportJob): boolean {
+  return job.status !== "completed" && job.status !== "failed";
+}
+
+// Fetch a single connected-server catalog entry by its cross-key. The remote-game
+// page uses this on a deep link / refresh, when no row was handed over via
+// navigation state. Resolves to undefined when no connected server offers the key.
+export function useRemoteGame(key: string) {
+  return useQuery({
+    queryKey: ["federation", "catalog", "entry", key],
+    queryFn: async (): Promise<CatalogAvailability | undefined> => {
+      const data = await unwrap(
+        typedApi.GET("/api/federation/catalog/available", {
+          params: { query: { key, remoteOnly: true } },
+        }),
+      );
+      return data?.games[0];
+    },
+    enabled: key.length > 0,
+    staleTime: 30 * 1000,
+  });
+}
+
+// Import job queue + per-job progress. Gated to import-capable users (the server
+// returns 403 otherwise), so only enable it when the caller may import. Polls
+// quickly while any job is in flight and slowly when the queue is idle.
+export function useImports(enabled: boolean) {
+  return useQuery({
+    queryKey: ["federation", "imports"],
+    queryFn: async (): Promise<ImportJob[]> => {
+      const data = await unwrap(typedApi.GET("/api/federation/imports"));
+      return data?.imports ?? [];
+    },
+    enabled,
+    refetchInterval: (query) => {
+      const jobs = query.state.data;
+      return jobs?.some(isImportActive) ? 1500 : 10000;
+    },
+  });
+}
+
+// Start importing a connected-server game into the local library.
+export function useStartImport() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (game: { key: string; title: string; console: string }) =>
+      unwrap(
+        typedApi.POST("/api/federation/import", {
+          body: {
+            key: game.key,
+            title: game.title,
+            console: game.console,
+          },
+        }),
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["federation", "imports"] });
+    },
+  });
+}

--- a/web/src/pages/remote-game-detail-page.tsx
+++ b/web/src/pages/remote-game-detail-page.tsx
@@ -1,0 +1,188 @@
+import { useEffect } from "react";
+import { useParams, useLocation, useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { ServerOff } from "lucide-react";
+import { PageLayout, SectionList, TitledSection } from "@/components/layout";
+import { Button, EmptyState, Skeleton, useToast } from "@/components/ui";
+import { ConsoleBadge } from "@/components/console-badge";
+import { useAuth } from "@/hooks/use-auth";
+import {
+  useRemoteGame,
+  useImports,
+  useStartImport,
+  isImportActive,
+} from "@/hooks/use-federation-import";
+import { ImportsQueue } from "@/features/federation/components/import-status";
+import type { CatalogAvailability } from "@/generated/schemas";
+
+// Detail page for a game that lives only on a connected federation server.
+// Reached from the ⌘K "On connected servers" results. The data is sparse — we
+// only know the cross-key, title, console, a cover, and how many connected
+// servers offer it — so the page's job is to let an import-capable user pull it
+// into the local library and watch the job progress.
+export function RemoteGameDetailPage() {
+  const { key = "" } = useParams<{ key: string }>();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  const canImport =
+    !!user &&
+    (user.role === "admin" || user.role === "owner" || user.canImportGames);
+
+  // Coming from search we already have the row; on a deep link / refresh we
+  // fetch it by key. Prefer freshly fetched data, fall back to nav state.
+  const navState = (location.state as CatalogAvailability | null) ?? null;
+  const remoteQuery = useRemoteGame(key);
+  const game = remoteQuery.data ?? navState ?? undefined;
+  const isLoading = remoteQuery.isLoading && !navState;
+
+  const importsQuery = useImports(canImport);
+  const jobs = importsQuery.data ?? [];
+  const currentJob = jobs.find((j) => j.key === key); // newest first
+
+  const startImport = useStartImport();
+
+  // Once this game's import completes, refresh the local library so the new
+  // game shows up there immediately.
+  useEffect(() => {
+    if (currentJob?.status === "completed") {
+      queryClient.invalidateQueries({ queryKey: ["games"] });
+    }
+  }, [currentJob?.status, queryClient]);
+
+  function handleImport() {
+    if (!game) return;
+    startImport.mutate(
+      { key: game.key, title: game.title, console: game.console },
+      {
+        onSuccess: () => toast("success", "Import started"),
+        onError: (e) =>
+          toast("error", e instanceof Error ? e.message : "Import failed"),
+      },
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <PageLayout backButtonVariant="standard">
+        <div className="flex flex-col gap-6 sm:flex-row">
+          <Skeleton className="h-60 w-44 flex-shrink-0 rounded-lg" />
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-9 w-64" />
+            <Skeleton className="h-5 w-44" />
+            <Skeleton className="h-10 w-36" />
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (!game) {
+    return (
+      <PageLayout backButtonVariant="standard">
+        <EmptyState
+          icon={ServerOff}
+          title="Game not available"
+          description="No connected server is currently offering this game."
+        />
+      </PageLayout>
+    );
+  }
+
+  const servers = game.originCount;
+  const importing = currentJob != null && isImportActive(currentJob);
+
+  return (
+    <PageLayout backButtonVariant="standard" backLabel="Back">
+      <SectionList>
+        <div
+          className="flex flex-col gap-6 sm:flex-row"
+          data-testid="remote-game-detail"
+        >
+          {game.cover ? (
+            <img
+              src={game.cover}
+              alt=""
+              className="h-60 w-44 flex-shrink-0 rounded-lg object-cover shadow-lg"
+            />
+          ) : (
+            <div className="h-60 w-44 flex-shrink-0 rounded-lg bg-surface-800" />
+          )}
+
+          <div className="flex min-w-0 flex-col gap-3">
+            <div>
+              <h1 className="text-3xl font-bold text-surface-100">
+                {game.title}
+              </h1>
+              <div className="mt-2 flex items-center gap-2">
+                <ConsoleBadge code={game.console} />
+                <span className="text-sm text-surface-400">
+                  Available on {servers} connected{" "}
+                  {servers === 1 ? "server" : "servers"}
+                </span>
+              </div>
+            </div>
+
+            {/* Call to action — reflects the latest import for this game.
+                Detailed per-job progress lives in the queue below. */}
+            {currentJob?.status === "completed" && currentJob.gameId != null ? (
+              <Button
+                onClick={() => navigate(`/games/${currentJob.gameId}`)}
+                data-testid="open-imported-game"
+                className="self-start"
+              >
+                View in library
+              </Button>
+            ) : importing ? (
+              <Button
+                disabled
+                loading
+                data-testid="import-in-progress"
+                className="self-start"
+              >
+                Importing…
+              </Button>
+            ) : canImport ? (
+              <div className="flex flex-col gap-2">
+                {currentJob?.status === "failed" && currentJob.errorMessage && (
+                  <p
+                    className="text-sm text-danger-500"
+                    data-testid="remote-game-import-error"
+                  >
+                    Last import failed: {currentJob.errorMessage}
+                  </p>
+                )}
+                <Button
+                  onClick={handleImport}
+                  loading={startImport.isPending}
+                  data-testid="import-game-button"
+                  className="self-start"
+                >
+                  {currentJob?.status === "failed"
+                    ? "Retry import"
+                    : "Import to library"}
+                </Button>
+              </div>
+            ) : (
+              <p className="text-sm text-surface-400" data-testid="import-denied">
+                You don't have permission to import games. Ask an admin for
+                access.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {canImport && (
+          <TitledSection title="Import queue">
+            <ImportsQueue jobs={jobs} />
+          </TitledSection>
+        )}
+      </SectionList>
+    </PageLayout>
+  );
+}
+
+export default RemoteGameDetailPage;


### PR DESCRIPTION
## What

Surfaces the federation import feature in the web UI (PR 2 of 2 — backend landed in #1386). When you find a game that lives only on a *connected server* via ⌘K, you can now open it and import it into your local library, with live job progress and a queue.

## How

- **`/remote-games/:key` page** — modeled on the game detail screen but sparse (connected-server games only carry a cross-key, title, console, cover, origin count). Shows the cover/title/console + "Available on N connected servers", and a capability-gated call to action: **Import** / **Importing…** / **View in library** / **Retry** / a permission note for users without access.
- **Live import queue** on the page (`ImportJobRow` + `ImportsQueue`): status badge, byte-level download progress, error surfacing, and a link into the local library on completion. Polls quickly while a job is in flight, slowly when idle.
- **⌘K results made navigable** — the "On connected servers" rows now navigate (mouse + keyboard) to the remote-game page, carrying the catalog entry as router state so the page renders instantly; a deep link refetches it by key.
- **Admin grant** — admins grant a plain user the import capability via a toggle in the edit-user modal (both modal toggles migrated to the `Switch` component for consistency).
- **Backend** — a small `key` exact-match filter on `GET /api/federation/catalog/available` so the page can fetch one entry by key on a deep link without resolving the whole catalog's covers.
- **Hooks** — `useRemoteGame`, `useImports` (capability-gated, adaptive polling), `useStartImport`.

## Design review

Went through the project's design-system checklist (AGENT_TEAM.md / DESIGN_IMPLEMENTATION.md): uses `PageLayout` / `SectionList` / `TitledSection` / `Card` / `Badge` / `ConsoleBadge` / `ProgressBar` / `EmptyState` / `Switch` / `Skeleton` rather than re-implementing them; loading state is a skeleton (not a spinner); console codes go through `ConsoleBadge`.

## Testing

- **Unit:** `import-status.test.tsx` covers the queue/row states (queued, downloading progress, failed error, completed → library link, empty state). Full web suite green (1644 tests).
- **Go:** `TestAvailableGames_FiltersByKey` for the new filter; full `internal/api` package green.
- **E2E:** `federation-import.spec.ts` drives ⌘K → remote-game page → import against the real backend (the job fails without a peer serving the ROM, which still exercises the enqueue → worker → queue-UI pipeline; the happy path is covered by the server's Go unit + two-server integration tests).

Closes #1385. Part of #1343.