### PR TITLE
refactor(web): retitle federation admin 'friend server' → 'connected server' (#1389)

### DIFF
--- a/web/src/features/admin/components/federation-exchange-table.tsx
+++ b/web/src/features/admin/components/federation-exchange-table.tsx
@@ -8,7 +8,7 @@ interface FederationExchangeTableProps {
   isLoading: boolean;
 }
 
-const HEADERS = ["Time", "Friend", "Direction", "Operation", "Status", "Items"];
+const HEADERS = ["Time", "Server", "Direction", "Operation", "Status", "Items"];
 
 function statusVariant(status: string): "success" | "danger" | "warning" | "default" {
   switch (status) {
@@ -62,7 +62,7 @@ export function FederationExchangeTable({
                   <EmptyState
                     icon={Activity}
                     title="No federation activity yet"
-                    description="Exchanges with friend servers (stats pulls, catalog refreshes, downloads) will appear here."
+                    description="Exchanges with connected servers (stats pulls, catalog refreshes, downloads) will appear here."
                   />
                 </td>
               </tr>

--- a/web/src/features/admin/components/federation-peers-table.tsx
+++ b/web/src/features/admin/components/federation-peers-table.tsx
@@ -13,7 +13,7 @@ interface FederationPeersTableProps {
   onRevoke: (peer: FederationPeer) => void;
 }
 
-const HEADERS = ["Friend", "Status", "Last contact", "Last error", ""];
+const HEADERS = ["Server", "Status", "Last contact", "Last error", ""];
 
 export function FederationPeersTable({
   peers,
@@ -49,8 +49,8 @@ export function FederationPeersTable({
                 <td colSpan={HEADERS.length}>
                   <EmptyState
                     icon={Network}
-                    title="No friend servers"
-                    description="Pair with a friend server to start sharing across the mesh."
+                    title="No connected servers"
+                    description="Add a connected server to start sharing across the mesh."
                   />
                 </td>
               </tr>
@@ -63,7 +63,7 @@ export function FederationPeersTable({
                 >
                   <td className="px-5 py-3">
                     <div className="text-sm font-medium text-surface-200">
-                      {peer.name || "Unnamed friend"}
+                      {peer.name || "Unnamed server"}
                     </div>
                     <div className="font-mono text-xs text-surface-500">
                       {peer.fingerprint.slice(0, 16)}…

--- a/web/src/features/admin/components/federation-relay-toggle.tsx
+++ b/web/src/features/admin/components/federation-relay-toggle.tsx
@@ -3,9 +3,9 @@ import { useServerSettings, useUpdateSettings } from "@/hooks/use-admin";
 
 const RELAY_KEY = "federation_relay_enabled";
 
-// Server-wide opt-in for relaying ROM downloads between a friend and one of
-// their friends. Default off — enabling it makes this server pass ROM bytes
-// through on behalf of others, so it must be a deliberate admin choice.
+// Server-wide opt-in for relaying ROM downloads between a connected server and
+// one of ITS connected servers. Default off — enabling it makes this server pass
+// ROM bytes through on behalf of others, so it must be a deliberate admin choice.
 export function FederationRelayToggle() {
   const { toast } = useToast();
   const { data: settings } = useServerSettings();
@@ -32,13 +32,14 @@ export function FederationRelayToggle() {
       <div className="flex items-start justify-between gap-6 p-5">
         <div className="space-y-1">
           <div className="text-sm font-medium text-surface-200">
-            Relay ROM downloads for friends of friends
+            Relay ROM downloads between connected servers
           </div>
           <p className="max-w-2xl text-sm text-surface-400">
-            When enabled, your server forwards ROM transfers between a friend
-            and one of <em>their</em> friends (hop-bounded) — the bytes pass
-            through your server as a bridge. Leave this off unless you intend to
-            act as a relay in the mesh. Per-friend download policy still applies.
+            When enabled, your server forwards ROM transfers between a connected
+            server and one of <em>its</em> connected servers (hop-bounded) — the
+            bytes pass through your server as a bridge. Leave this off unless you
+            intend to act as a relay in the mesh. Per-server download policy still
+            applies.
           </p>
         </div>
         <Switch

--- a/web/src/features/admin/components/pair-friend-dialog.tsx
+++ b/web/src/features/admin/components/pair-friend-dialog.tsx
@@ -21,9 +21,9 @@ interface PairFriendDialogProps {
 
 type Tab = "accept" | "invite";
 
-// Modal for forming a federation link with a friend server. Two directions:
-// accept an invite a friend gave you, or generate one to hand to them. Pairing
-// is mutual and invite-gated; either side can initiate.
+// Modal for forming a federation link with a connected server. Two directions:
+// accept an invite the other admin gave you, or generate one to hand to them.
+// Pairing is mutual and invite-gated; either side can initiate.
 export function PairFriendDialog({ open, onClose }: PairFriendDialogProps) {
   const { toast } = useToast();
   const [tab, setTab] = useState<Tab>("accept");
@@ -55,7 +55,7 @@ export function PairFriendDialog({ open, onClose }: PairFriendDialogProps) {
       { invite: invite.trim(), name: name.trim() },
       {
         onSuccess: () => {
-          toast("success", "Friend server paired");
+          toast("success", "Connected server added");
           close();
         },
         onError: (e) =>
@@ -91,34 +91,34 @@ export function PairFriendDialog({ open, onClose }: PairFriendDialogProps) {
   };
 
   return (
-    <Modal open={open} onClose={close} title="Pair a friend server" size="lg">
+    <Modal open={open} onClose={close} title="Add a connected server" size="lg">
       <div className="space-y-5">
         <StateTabNav>
           <StateTabItem active={tab === "accept"} onClick={() => setTab("accept")}>
             Accept an invite
           </StateTabItem>
           <StateTabItem active={tab === "invite"} onClick={() => setTab("invite")}>
-            Invite a friend
+            Generate an invite
           </StateTabItem>
         </StateTabNav>
 
         {tab === "accept" ? (
           <div className="space-y-4" data-testid="accept-invite-panel">
             <p className="text-sm text-surface-400">
-              Paste the invite a friend sent you. We'll verify it, connect to
-              their server, and add them as a peer.
+              Paste the invite another server's admin sent you. We'll verify it,
+              connect to their server, and add it as a connected server.
             </p>
             <Textarea
-              label="Friend's invite"
+              label="Invite"
               rows={4}
               value={invite}
               onChange={(e) => setInvite(e.target.value)}
-              placeholder="Paste the invite string your friend sent you"
+              placeholder="Paste the invite string the other admin sent you"
               className="font-mono text-xs"
               data-testid="accept-invite-input"
             />
             <Input
-              label="Name for this friend"
+              label="Name for this server"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. Alice's Server"
@@ -139,7 +139,7 @@ export function PairFriendDialog({ open, onClose }: PairFriendDialogProps) {
         ) : (
           <div className="space-y-4" data-testid="invite-friend-panel">
             <p className="text-sm text-surface-400">
-              Generate a one-time invite and send it to your friend's admin
+              Generate a one-time invite and send it to the other server's admin
               out-of-band. They paste it under “Accept an invite” to connect.
             </p>
             {generated ? (

--- a/web/src/features/admin/components/policy-editor-dialog.tsx
+++ b/web/src/features/admin/components/policy-editor-dialog.tsx
@@ -35,7 +35,7 @@ interface PolicyEditorDialogProps {
   onClose: () => void;
 }
 
-// Per-friend share/consume editor. Mounted only while a peer is selected, so
+// Per-server share/consume editor. Mounted only while a peer is selected, so
 // the initial toggle state reads straight from that peer's stored policy.
 export function PolicyEditorDialog({ peer, onClose }: PolicyEditorDialogProps) {
   const { toast } = useToast();
@@ -70,13 +70,13 @@ export function PolicyEditorDialog({ peer, onClose }: PolicyEditorDialogProps) {
     <Modal
       open
       onClose={onClose}
-      title={`Sharing with ${peer.name || "this friend"}`}
+      title={`Sharing with ${peer.name || "this server"}`}
       size="lg"
     >
       <div className="space-y-5">
         <p className="text-sm text-surface-400">
           Choose which data you{" "}
-          <span className="text-surface-200">share</span> with this friend and
+          <span className="text-surface-200">share</span> with this server and
           which you <span className="text-surface-200">accept</span> from them.
           Both sides must opt in for data to flow.
         </p>

--- a/web/src/pages/admin/__tests__/federation-page.test.tsx
+++ b/web/src/pages/admin/__tests__/federation-page.test.tsx
@@ -127,7 +127,7 @@ describe("AdminFederationPage", () => {
   it("shows empty states when there are no peers or activity", () => {
     renderPage();
 
-    expect(screen.getByText("No friend servers")).toBeInTheDocument();
+    expect(screen.getByText("No connected servers")).toBeInTheDocument();
     expect(screen.getByText("No federation activity yet")).toBeInTheDocument();
   });
 
@@ -144,7 +144,7 @@ describe("AdminFederationPage", () => {
     renderPage();
 
     const errorBlock = screen.getByTestId("federation-error");
-    expect(errorBlock).toHaveTextContent("Failed to load friend servers");
+    expect(errorBlock).toHaveTextContent("Failed to load connected servers");
     expect(errorBlock).toHaveTextContent("network down");
     expect(screen.queryByTestId("federation-peer-row")).not.toBeInTheDocument();
 
@@ -188,7 +188,7 @@ describe("AdminFederationPage", () => {
     await user.click(screen.getByTestId("pair-friend-button"));
     expect(screen.getByTestId("accept-invite-panel")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("tab", { name: "Invite a friend" }));
+    await user.click(screen.getByRole("tab", { name: "Generate an invite" }));
     await user.click(screen.getByTestId("generate-invite-button"));
 
     expect(mockIssueMutate).toHaveBeenCalled();

--- a/web/src/pages/admin/federation-page.tsx
+++ b/web/src/pages/admin/federation-page.tsx
@@ -48,7 +48,7 @@ export function AdminFederationPage() {
     if (!revokeTarget) return;
     revokePeer.mutate(revokeTarget.fingerprint, {
       onSuccess: () => {
-        toast("success", "Friend server revoked");
+        toast("success", "Connected server revoked");
         setRevokeTarget(null);
       },
       onError: (e) => {
@@ -61,11 +61,11 @@ export function AdminFederationPage() {
   return (
     <PageLayout
       title="Federation"
-      subtitle="Your friend servers and the data flowing between them. Pulls, catalog refreshes, and downloads are recorded below."
+      subtitle="Your connected servers and the data flowing between them. Pulls, catalog refreshes, and downloads are recorded below."
     >
       <SectionList>
         <TitledSection
-          title="Friend servers"
+          title="Connected servers"
           renderRight={
             <Button
               variant="primary"
@@ -74,13 +74,13 @@ export function AdminFederationPage() {
               data-testid="pair-friend-button"
             >
               <Plus className="h-4 w-4" />
-              Pair friend server
+              Add connected server
             </Button>
           }
         >
           {peersError ? (
             <FederationErrorBlock
-              title="Failed to load friend servers"
+              title="Failed to load connected servers"
               error={peersErrorObj}
               onRetry={() => refetchPeers()}
             />
@@ -128,8 +128,8 @@ export function AdminFederationPage() {
       <ConfirmDeleteModal
         open={revokeTarget !== null}
         onClose={() => setRevokeTarget(null)}
-        title="Revoke friend server"
-        message={`Revoke "${revokeTarget?.name || "this friend"}"? They will be removed as a peer and their shared data will stop appearing across the mesh. You can re-pair later with a new invite.`}
+        title="Revoke connected server"
+        message={`Revoke "${revokeTarget?.name || "this server"}"? It will be removed as a peer and its shared data will stop appearing across the mesh. You can reconnect later with a new invite.`}
         onConfirm={handleRevoke}
         isPending={revokePeer.isPending}
         actionLabel="Revoke"


### PR DESCRIPTION
## What

The federation admin UI (`/admin/federation`) used user-to-user **"friend"** language for what is actually a **server-to-server** relation. Per the locked terminology decision, server↔server relations are **"connected servers."** ("Friends" stays reserved for the user-to-user relation — netplay / shared-sessions copy is intentionally untouched.)

## Changes (copy only — no behavior change)

- Page: "Friend servers" → "Connected servers"; "Pair friend server" → "Add connected server"; subtitle; revoke toast/modal copy.
- Peers table: "Friend" header → "Server"; empty state; "Unnamed friend" → "Unnamed server".
- Exchange table: "Friend" header → "Server"; empty state.
- Pair dialog: title → "Add a connected server"; "Invite a friend" tab → "Generate an invite"; field labels and helper copy; success toast → "Connected server added".
- Policy editor: "Sharing with {server}"; helper copy.
- Relay toggle: "Relay ROM downloads between connected servers"; helper copy; "Per-server download policy".

## Deliberately left alone

- **Code identifiers and `data-testid`s** are kept stable (e.g. `pair-friend-button`, `pair-friend-dialog.tsx`, `PairFriendDialog`) so tests/automation don't churn — the issue explicitly prefers stable testids.
- **Generated OpenAPI summaries** ("Accept a friend's invite", etc.) are backend API-doc strings, not end-user UI — out of scope for this web-copy PR.
- **User-to-user "friend" copy** in `netplay`/`shared-sessions` — correct as-is.

## Testing

Updated the affected `federation-page.test.tsx` assertions. Full web unit suite (1644) green; build green. (Copy-only diff — no new UI surface, so no design-system review needed.)

Closes #1389. Part of #1343.