### PR TITLE
fix(player): Settings gamepad first-entry focus + pill clearance (#1382, #1393)

### DIFF
--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -377,10 +377,17 @@ class MainActivity : ComponentActivity() {
                 return true
             }
             KeyEvent.KEYCODE_BUTTON_L1 -> {
+                // Switching tabs via the bumpers is a gamepad action: force Compose
+                // into keyboard input mode so the destination tab's focusRestoreItem
+                // default/restore fires and the D-pad is live on arrival (#1382).
+                // The hardware bumper (source=0) doesn't flip the mode on its own,
+                // same as the d-pad case below.
+                ComposeFocusBridge.requestKeyboardMode?.invoke()
                 navigationViewModel.onIntent(NavigationIntent.PreviousSection)
                 return true
             }
             KeyEvent.KEYCODE_BUTTON_R1 -> {
+                ComposeFocusBridge.requestKeyboardMode?.invoke()
                 navigationViewModel.onIntent(NavigationIntent.NextSection)
                 return true
             }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
@@ -311,8 +311,15 @@ class SettingsConsoleNavigationTest {
         harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advanceQuick(harness)
 
-        // Focus + drill into SNES (by row tag, scrolled into view if needed).
-        onNodeWithTag("console_settings_row_snes").performScrollTo().performClick()
+        // Give the SNES row focus (saves it to the content pane's focus memory),
+        // then drill into its settings via the nav intent. We focus+navigate rather
+        // than click because in gamepad mode the section-pill overlay can intercept
+        // a pointer click on a scrolled-up row.
+        onNodeWithTag("console_settings_row_snes").performScrollTo().requestFocus()
+        advanceQuick(harness)
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ConsoleSettings("snes")),
+        )
         advance(harness)
         assertEquals(
             SpScreen.ConsoleSettings("snes"),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
@@ -25,6 +25,8 @@ import com.spela.player.presentation.ui.components.SpScreen
 import com.spela.player.presentation.ui.components.SpTextField
 import com.spela.player.presentation.ui.components.keymapping.PresetPickerDialog
 import com.spela.player.presentation.ui.feature.library.darken
+import com.spela.player.presentation.ui.gamepad.InputMode
+import com.spela.player.presentation.ui.gamepad.LocalInputMode
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -81,6 +83,11 @@ fun SettingsScreen(
     )
 
     val titleBarInset = LocalTitleBarInset.current
+    // In gamepad mode the section-indicator pill overlays the top-center of the
+    // screen; reserve its clearance so subscreen content isn't hidden behind it
+    // (#1382), matching SpScreenTopSpacer used by other screens.
+    val topInset = titleBarInset +
+        if (LocalInputMode.current == InputMode.GAMEPAD) SpSpacing.SectionIndicatorClearance else 0.dp
     val gradientColors = listOf(
         SpColor.PrimaryDark.darken(0.74f),
         SpColor.SecondaryDark.darken(0.82f),
@@ -100,7 +107,7 @@ fun SettingsScreen(
                         username = state.username,
                         serverUrl = state.serverUrl,
                         modifier = Modifier.width(280.dp).fillMaxHeight(),
-                        topPadding = titleBarInset,
+                        topPadding = topInset,
                     )
                     SettingsCategoryContent(
                         category = selectedCategory,
@@ -117,7 +124,7 @@ fun SettingsScreen(
                         onNavigateToLicenses = onNavigateToLicenses,
                         onLogout = onLogout,
                         modifier = Modifier.weight(1f).fillMaxHeight(),
-                        topPadding = titleBarInset,
+                        topPadding = topInset,
                     )
                 }
             } else {
@@ -139,7 +146,7 @@ fun SettingsScreen(
                         onNavigateToLicenses = onNavigateToLicenses,
                         onLogout = onLogout,
                         modifier = Modifier.fillMaxSize(),
-                        topPadding = titleBarInset,
+                        topPadding = topInset,
                     )
                 } else {
                     PlatformBackHandler { onBack() }
@@ -152,7 +159,7 @@ fun SettingsScreen(
                         username = state.username,
                         serverUrl = state.serverUrl,
                         modifier = Modifier.fillMaxSize(),
-                        topPadding = titleBarInset,
+                        topPadding = topInset,
                     )
                 }
             }


### PR DESCRIPTION
## Summary

Two Settings-screen gamepad fixes, found and hardware-verified on the AYN Thor while finishing #1382.

### #1382 — D-pad dead until touch on Settings entry
Switching tabs with the **L1/R1 bumpers** is a gamepad action, but those handlers (unlike the d-pad handler) never flipped Compose into keyboard input mode. The Thor's bumpers report `source=0`, so the mode doesn't auto-flip either — so on landing on a tab the `focusRestoreItem` `snapshotFlow` listener never woke up and the default focus never fired, leaving the D-pad dead until a screen touch provided a Touch→Keyboard transition.

The L1/R1 handlers now call `ComposeFocusBridge.requestKeyboardMode()` (same as the d-pad handler), so the destination tab's default/restore focus fires on arrival. Diagnosed with `[FocusDbg]` logging — synthetic ADB events flip the mode and couldn't reproduce it, so this needed on-device logs.

### #1393 — content rendered under the section pill
In gamepad mode the section-indicator pill (top-center, 56dp) overlays the top of the Settings panes — the panes only applied `LocalTitleBarInset` (0dp on Android), not the pill's `SectionIndicatorClearance`. `SettingsScreen` now adds that clearance to the panes' top inset in gamepad mode, matching `SpScreenTopSpacer` used elsewhere.

## Tests

- Full `:shared:desktopTest` + `:desktop:desktopTest` green (the back-restore test exercises gamepad-mode Settings with the clearance).
- The L1/R1 mode flip is Android-input behavior (`source=0` can't be reproduced by ADB synthetic events) and is **hardware-verified on the Thor**; the pill clearance is verified visually on the Thor.

Closes #1382, closes #1393
