### PR TITLE
feat(player): in-game controller-buttons editor via overlay menu (#1340)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/OverlayActionButtonsOptOutTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/OverlayActionButtonsOptOutTest.kt
@@ -77,4 +77,45 @@ class OverlayActionButtonsOptOutTest {
         onNodeWithText("Save").assertDoesNotExist()
         onNodeWithText("Screenshot").assertIsDisplayed()
     }
+
+    @Test
+    fun showsRemapActionWhenEnabledAndInvokesCallback() = runComposeUiTest {
+        var configured = false
+        setContent {
+            Row {
+                OverlayActionButtons(
+                    isFastForward = false,
+                    supportsSaveStates = true,
+                    saveStatesOptedOut = false,
+                    onSave = {}, onLoad = {}, onScreenshot = {},
+                    onToggleFastForward = {}, onChallenge = {}, onControls = {},
+                    showButtonRemap = true,
+                    onConfigureButtons = { configured = true },
+                )
+            }
+        }
+
+        onNodeWithText("Remap").assertIsDisplayed()
+        onNodeWithText("Remap").performClick()
+        assert(configured) { "onConfigureButtons should fire when the Buttons action is tapped" }
+    }
+
+    @Test
+    fun hidesRemapActionWhenDisabled() = runComposeUiTest {
+        setContent {
+            Row {
+                OverlayActionButtons(
+                    isFastForward = false,
+                    supportsSaveStates = true,
+                    saveStatesOptedOut = false,
+                    onSave = {}, onLoad = {}, onScreenshot = {},
+                    onToggleFastForward = {}, onChallenge = {}, onControls = {},
+                    showButtonRemap = false,
+                )
+            }
+        }
+
+        onNodeWithText("Remap").assertDoesNotExist()
+        onNodeWithText("Controls").assertIsDisplayed()
+    }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -516,6 +516,7 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
                             viewModel = emulationViewModel,
                             keyMappingViewModel = keyMappingViewModel,
                             gamepadConfigViewModel = gamepadConfigViewModel,
+                            gamepadMappingViewModel = gamepadMappingViewModel,
                             onExit = {
                                 // Mirror the requestExit-driven
                                 // LaunchedEffect's cleanup. Several

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Replay
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.SportsEsports
 import androidx.compose.material.icons.filled.Stop
@@ -67,6 +68,8 @@ internal fun InGameOverlayPanel(
     viewModel: EmulationViewModel,
     continueFocusRequester: FocusRequester,
     useGamepadConfig: Boolean = false,
+    showButtonRemap: Boolean = false,
+    onConfigureButtons: () -> Unit = {},
 ) {
     Box(
         modifier = Modifier
@@ -290,6 +293,8 @@ internal fun InGameOverlayPanel(
                                 if (useGamepadConfig) EmulationIntent.ShowGamepadConfig else EmulationIntent.ShowKeyMapping
                             )
                         },
+                            showButtonRemap = showButtonRemap,
+                            onConfigureButtons = onConfigureButtons,
                         )
                     }
 
@@ -418,6 +423,8 @@ fun RowScope.OverlayActionButtons(
     onChallenge: () -> Unit,
     onCheats: () -> Unit = {},
     onControls: () -> Unit,
+    showButtonRemap: Boolean = false,
+    onConfigureButtons: () -> Unit = {},
 ) {
     // Save / Load / Challenge are all gated on the user's per-console
     // opt-out. The toggle is read-only at the overlay level on purpose
@@ -486,6 +493,12 @@ fun RowScope.OverlayActionButtons(
         OverlayAction(label = "Cheats", icon = Icons.Filled.Code, onClick = onCheats)
     }
     OverlayAction(label = "Controls", icon = Icons.Filled.SportsEsports, onClick = onControls)
+    // Positional button remap for the current console — same editor as Settings
+    // (#1340). "Remap" (vs the adjacent "Controls" = controller list) to keep the
+    // two gamepad actions distinct.
+    if (showButtonRemap) {
+        OverlayAction(label = "Remap", icon = Icons.Filled.Tune, onClick = onConfigureButtons)
+    }
 }
 
 @Composable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -15,7 +15,9 @@ import com.spela.player.presentation.ui.theme.SpSpacing
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import kotlinx.coroutines.delay
 import androidx.compose.ui.focus.FocusRequester
 import com.spela.player.domain.model.DefaultKeyMappings
@@ -44,6 +46,9 @@ import com.spela.player.presentation.viewmodel.EmulationViewModel
 import com.spela.player.presentation.viewmodel.GamepadConfigIntent
 import com.spela.player.util.currentPlatform
 import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
+import com.spela.player.presentation.viewmodel.GamepadMappingIntent
+import com.spela.player.presentation.viewmodel.GamepadMappingViewModel
+import com.spela.player.presentation.ui.components.gamepad.GamepadMappingDialog
 import com.spela.player.presentation.viewmodel.KeyMappingViewModel
 
 @Composable
@@ -51,11 +56,16 @@ fun InGameOverlay(
     viewModel: EmulationViewModel,
     keyMappingViewModel: KeyMappingViewModel,
     gamepadConfigViewModel: GamepadConfigViewModel? = null,
+    gamepadMappingViewModel: GamepadMappingViewModel? = null,
     onExit: () -> Unit,
 ) {
     val state by viewModel.state.collectAsState()
     val continueFocusRequester = remember { FocusRequester() }
     val hasGamepadConfig = gamepadConfigViewModel != null
+    // Positional button-mapping editor (#1340): the same per-console hold-to-bind
+    // dialog used in Settings, opened from the overlay menu. Dismissing it returns
+    // to the overlay menu (it's a modal dialog rendered over the panel).
+    var showButtonMapping by remember { mutableStateOf(false) }
 
     // #1087: top-anchored achievement banner on the primary in-game
     // surface. Reads `state.achievementEvent`, which the VM pumps from
@@ -92,6 +102,8 @@ fun InGameOverlay(
             viewModel = viewModel,
             continueFocusRequester = continueFocusRequester,
             useGamepadConfig = hasGamepadConfig,
+            showButtonRemap = hasGamepadConfig && gamepadMappingViewModel != null,
+            onConfigureButtons = { showButtonMapping = true },
         )
     }
 
@@ -553,6 +565,36 @@ fun InGameOverlay(
                 },
             )
         }
+    }
+
+    // Positional controller-buttons editor (#1340): the same per-console
+    // hold-to-bind dialog as Settings, opened from the overlay menu. Rendered over
+    // the panel, so Done/back returns to the overlay menu.
+    if (showButtonMapping && gamepadMappingViewModel != null) {
+        val gamepadMappingState by gamepadMappingViewModel.state.collectAsState()
+        val consoleId = state.consoleId
+        LaunchedEffect(consoleId) {
+            gamepadMappingViewModel.onIntent(GamepadMappingIntent.Load(consoleId))
+        }
+        GamepadMappingDialog(
+            state = gamepadMappingState,
+            onStartBinding = { output ->
+                gamepadMappingViewModel.onIntent(GamepadMappingIntent.StartBinding(output))
+            },
+            onBindKey = { position, pressed ->
+                gamepadMappingViewModel.onIntent(GamepadMappingIntent.ReportBindInput(position, pressed))
+            },
+            onCancelBinding = {
+                gamepadMappingViewModel.onIntent(GamepadMappingIntent.CancelBinding)
+            },
+            onResetToDefaults = {
+                gamepadMappingViewModel.onIntent(GamepadMappingIntent.ResetAll)
+            },
+            onDismiss = {
+                gamepadMappingViewModel.onIntent(GamepadMappingIntent.CancelBinding)
+                showButtonMapping = false
+            },
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Surface the per-console positional controller-buttons editor (the hold-to-bind `GamepadMappingDialog` from #1377) inside the **in-game overlay**, so you can remap a console's buttons mid-session without leaving the game for Settings.

- New **"Remap"** action in the overlay menu (next to "Controls"), shown only when a gamepad is connected. "Controls" stays the controller list (assign players); "Remap" opens the positional button editor.
- Opens the **same** `GamepadMappingDialog` as Settings, for the current console (`state.consoleId`). It's modal over the overlay panel, so **Done/Cancel/B returns to the overlay menu** — not the Settings screen.
- `gamepadMappingViewModel` threaded `SpelaApp → InGameOverlay`; `OverlayActionButtons` gained `showButtonRemap` / `onConfigureButtons`.

## Tests
- `OverlayActionButtonsOptOutTest` (+2 — Remap action shown + fires its callback when remap is enabled, hidden when not).
- Full `:shared:desktopTest` + `:desktop:desktopTest` green; Android compiles. ui-agent review: APPROVE (renamed "Buttons" → "Remap" per its nit, to disambiguate from "Controls").

Reuses the already-approved dialog (#1377) — no new editor.

Closes #1340