### PR TITLE
feat(player): approximate positional gamepad schematic (#1366)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/GamepadSchematicTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/GamepadSchematicTest.kt
@@ -1,0 +1,35 @@
+package com.spela.player.desktop.components
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.GamepadPosition
+import com.spela.player.presentation.ui.components.gamepad.GamepadSchematic
+import kotlin.test.Test
+
+/** Coverage for the #1366 positional schematic: every canonical position renders
+ *  as a pip, and only the highlighted ones report Active. */
+@OptIn(ExperimentalTestApi::class)
+class GamepadSchematicTest {
+
+    @Test
+    fun rendersEveryCanonicalPositionAndHighlightsOnlyActive() = runComposeUiTest {
+        setContent {
+            GamepadSchematic(highlighted = setOf(GamepadPosition.SOUTH, GamepadPosition.R1))
+        }
+
+        // All 16 canonical positions are drawn.
+        GamepadPosition.entries.forEach { pos ->
+            onNodeWithTag("schematic_${pos.name}").assertExists()
+        }
+
+        // Highlighted → Active; everything else → Inactive.
+        onNodeWithTag("schematic_SOUTH")
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Active"))
+        onNodeWithTag("schematic_R1")
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Active"))
+        onNodeWithTag("schematic_NORTH")
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Inactive"))
+        onNodeWithTag("schematic_DPAD_LEFT")
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "Inactive"))
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadInputTester.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadInputTester.kt
@@ -81,6 +81,10 @@ fun GamepadInputTester(
             color = SpColor.OnBackgroundTertiary,
         )
         Spacer(Modifier.height(SpSpacing.Medium))
+        // At-a-glance positional overview (#1366): the pressed position lights up on
+        // an approximate gamepad layout. The labelled chips below stay authoritative.
+        GamepadSchematic(highlighted = pressedPositions)
+        Spacer(Modifier.height(SpSpacing.Medium))
         FlowRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadSchematic.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/gamepad/GamepadSchematic.kt
@@ -1,0 +1,173 @@
+package com.spela.player.presentation.ui.components.gamepad
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.GamepadPosition
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Brand-neutral, approximate schematic of a generic gamepad (#1366) — drawn from
+ * primitives (circles + labels), with each canonical [GamepadPosition] placed at
+ * its rough physical location: shoulders/triggers across the top, the D-pad on the
+ * left, the face-button diamond on the right, Select/Start in the centre, and the
+ * stick clicks below. It is an at-a-glance orientation aid, NOT a per-console
+ * replica; the labelled mapping stays authoritative.
+ *
+ * Positions in [highlighted] render filled (e.g. currently pressed, or the button
+ * being bound). A single reusable layout — driven by the canonical position set,
+ * not per-console art.
+ */
+@Composable
+fun GamepadSchematic(
+    highlighted: Set<GamepadPosition>,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(SpSpacing.RadiusLarge))
+            .background(SpColor.SurfaceVariant)
+            .padding(SpSpacing.Default),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.Default),
+    ) {
+        // Shoulders / triggers: L2 L1 … R1 R2
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Row(horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small)) {
+                Pip(GamepadPosition.L2, highlighted)
+                Pip(GamepadPosition.L1, highlighted)
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small)) {
+                Pip(GamepadPosition.R1, highlighted)
+                Pip(GamepadPosition.R2, highlighted)
+            }
+        }
+
+        // Main body: D-pad cross (left) · Select/Start (centre) · face diamond (right)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Cross(
+                up = GamepadPosition.DPAD_UP,
+                down = GamepadPosition.DPAD_DOWN,
+                left = GamepadPosition.DPAD_LEFT,
+                right = GamepadPosition.DPAD_RIGHT,
+                highlighted = highlighted,
+            )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            ) {
+                Pip(GamepadPosition.SELECT, highlighted)
+                Pip(GamepadPosition.START, highlighted)
+            }
+            Cross(
+                up = GamepadPosition.NORTH,
+                down = GamepadPosition.SOUTH,
+                left = GamepadPosition.WEST,
+                right = GamepadPosition.EAST,
+                highlighted = highlighted,
+            )
+        }
+
+        // Stick clicks
+        Row(horizontalArrangement = Arrangement.spacedBy(SpSpacing.Large)) {
+            Pip(GamepadPosition.L3, highlighted)
+            Pip(GamepadPosition.R3, highlighted)
+        }
+    }
+}
+
+/** A 3×3 cross with the four directional positions on the arms (centre empty). */
+@Composable
+private fun Cross(
+    up: GamepadPosition,
+    down: GamepadPosition,
+    left: GamepadPosition,
+    right: GamepadPosition,
+    highlighted: Set<GamepadPosition>,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Pip(up, highlighted)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Pip(left, highlighted)
+            Spacer(Modifier.size(PIP_SIZE.dp))
+            Pip(right, highlighted)
+        }
+        Pip(down, highlighted)
+    }
+}
+
+/** A single labelled button. Filled when [position] is in [highlighted]. */
+@Composable
+private fun Pip(position: GamepadPosition, highlighted: Set<GamepadPosition>) {
+    val active = position in highlighted
+    Box(
+        modifier = Modifier
+            .size(PIP_SIZE.dp)
+            .clip(CircleShape)
+            .background(if (active) SpColor.Primary else SpColor.SurfaceElevated)
+            .border(1.dp, if (active) SpColor.Primary else SpColor.OnBackgroundTertiary, CircleShape)
+            .padding(SpSpacing.XXSmall)
+            .testTag("schematic_${position.name}")
+            .semantics {
+                contentDescription = position.displayName
+                stateDescription = if (active) "Active" else "Inactive"
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = schematicLabel(position),
+            style = SpTypography.LabelSmall,
+            color = if (active) SpColor.OnPrimary else SpColor.OnBackgroundTertiary,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+private const val PIP_SIZE = 34
+
+/** Short glyph/label for the schematic pip — positional, brand-neutral. */
+private fun schematicLabel(position: GamepadPosition): String = when (position) {
+    GamepadPosition.DPAD_UP -> "↑"
+    GamepadPosition.DPAD_DOWN -> "↓"
+    GamepadPosition.DPAD_LEFT -> "←"
+    GamepadPosition.DPAD_RIGHT -> "→"
+    GamepadPosition.NORTH -> "▲"
+    GamepadPosition.SOUTH -> "▼"
+    GamepadPosition.WEST -> "◀"
+    GamepadPosition.EAST -> "▶"
+    GamepadPosition.L1 -> "L1"
+    GamepadPosition.R1 -> "R1"
+    GamepadPosition.L2 -> "L2"
+    GamepadPosition.R2 -> "R2"
+    GamepadPosition.L3 -> "L3"
+    GamepadPosition.R3 -> "R3"
+    GamepadPosition.START -> "ST"
+    GamepadPosition.SELECT -> "SE"
+}


### PR DESCRIPTION
## Summary

Follow-up to #1335 (epic #1333): #1335 replaced the inaccurate per-console controller diagram with a labelled list; this adds the visual the user wanted back — an **approximation, not a replica**.

- **`GamepadSchematic`** — a brand-neutral generic-pad schematic drawn from primitives (circles + labels), each canonical `GamepadPosition` at its rough physical spot: shoulders/triggers across the top, D-pad cross left, face diamond right, Select/Start centre, stick clicks below. Positions in `highlighted` render filled. **One reusable layout** driven by the canonical position set — no per-console SVG art (the thing that drifted before #1335).
- Wired into the **input tester** (controller detail) above the labelled chips, so the pressed position lights up on the pad live. The chips stay authoritative; the schematic is the at-a-glance orientation aid (the "hybrid" from the #1335 brainstorm).

## Tests
- `GamepadSchematicTest` — all 16 canonical positions render; only highlighted ones report "Active".
- Existing input-tester test unaffected. Full `:shared:desktopTest` + `:desktop:desktopTest` green; Android compiles. ui-agent review: **APPROVE**.

The schematic is reusable; the per-console mapping dialog is a natural second home (follow-up if wanted).

Closes #1366