### PR TITLE
feat(federation): cross-mesh presence — who's playing now (#1349)

### DIFF
--- a/server/internal/api/federation_presence.go
+++ b/server/internal/api/federation_presence.go
@@ -1,0 +1,202 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+)
+
+// maxPresenceResponseBytes caps an inbound friend presence payload (defense
+// against a hostile/misconfigured peer returning an unbounded body).
+const maxPresenceResponseBytes = 1 << 20 // 1 MiB
+
+// maxPresenceEntriesPerPeer caps how many presence rows we accept from one
+// connected server per read, bounding a single peer's influence on the view.
+const maxPresenceEntriesPerPeer = 2000
+
+// presenceClient fetches a connected server's live presence over a signed
+// request. Unlike stats, presence is pulled live at read time (no snapshot
+// cache) because it is ephemeral.
+type presenceClient interface {
+	FetchPresence(baseURL, requestID string, id federation.Identity, peerFingerprint string) ([]federation.PresenceEntry, error)
+}
+
+type httpPresenceClient struct{}
+
+func (httpPresenceClient) FetchPresence(baseURL, requestID string, id federation.Identity, peerFingerprint string) ([]federation.PresenceEntry, error) {
+	const path = "/api/federation/presence"
+	req, err := http.NewRequest(http.MethodGet, baseURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range signedFederationHeaders(id, http.MethodGet, path, requestID, nil, peerFingerprint) {
+		req.Header.Set(k, v)
+	}
+	resp, err := fedHTTPClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("remote returned %d", resp.StatusCode)
+	}
+	var body struct {
+		Entries []federation.PresenceEntry `json:"entries"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxPresenceResponseBytes)).Decode(&body); err != nil {
+		return nil, err
+	}
+	return body.Entries, nil
+}
+
+// buildLocalPresence snapshots the hub's active sessions and turns them into
+// source-stamped hop-0 presence. Returns an empty slice when no hub is wired
+// (e.g. in handlers constructed without one).
+func (h *FederationHandler) buildLocalPresence() ([]federation.PresenceEntry, error) {
+	if h.Hub == nil {
+		return []federation.PresenceEntry{}, nil
+	}
+	raw := h.Hub.PlayingNow()
+	sessions := make([]federation.PlayingSession, len(raw))
+	for i, s := range raw {
+		sessions[i] = federation.PlayingSession{UserID: s.UserID, GameID: s.GameID}
+	}
+	return federation.BuildLocalPresence(h.DB, h.Identity.Fingerprint(), sessions)
+}
+
+// sanitizePresenceBatch cleans a connected server's presence before we ingest
+// it: drop entries claiming OUR origin (a loop), missing an origin, or claiming
+// any hop other than 0. A direct server exports only its own (hop-0) presence —
+// it does not relay transitive presence — so anything else is malformed or
+// hostile. Caps the count per peer.
+func sanitizePresenceBatch(entries []federation.PresenceEntry, selfFingerprint string) []federation.PresenceEntry {
+	out := make([]federation.PresenceEntry, 0, len(entries))
+	for _, e := range entries {
+		if e.OriginFingerprint == "" || e.OriginFingerprint == selfFingerprint {
+			continue
+		}
+		if e.Hops != 0 {
+			continue
+		}
+		out = append(out, e)
+		if len(out) >= maxPresenceEntriesPerPeer {
+			break
+		}
+	}
+	return out
+}
+
+// ginExportPresence serves this server's own live presence (hop 0) to a verified
+// connected server. Behind VerifyFederationRequest + SharePolicy(presence).
+// Presence is never re-served transitively — only local sessions are exposed.
+func (h *FederationHandler) ginExportPresence(c *gin.Context) {
+	reqID := c.GetHeader(headerFedRequestID)
+	if reqID == "" {
+		reqID = federation.NewRequestID()
+	}
+	peer, ok := federationPeerFromGin(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "no verified peer"})
+		return
+	}
+	if !federation.CanShare(*peer, federation.DataClassPresence) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "presence not shared with this peer"})
+		return
+	}
+
+	local, err := h.buildLocalPresence()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build presence"})
+		return
+	}
+
+	federation.RecordExchange(h.DB, federation.ExchangeRecord{
+		RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+		Direction: db.ExchangeInbound, Operation: "presence_export",
+		DataClass: string(federation.DataClassPresence), Status: db.ExchangeOK, ItemCount: len(local),
+	})
+	c.JSON(http.StatusOK, gin.H{"entries": local})
+}
+
+// --- Aggregated read (user-facing) -----------------------------------------
+
+type AggregatedPresenceInput struct{}
+type AggregatedPresenceOutput struct {
+	Body struct {
+		Presence []federation.PresenceEntry `json:"presence"`
+	}
+}
+
+// HumaAggregatedPresence returns who is playing what right now across the mesh:
+// this server's own sessions (hop 0) plus a LIVE pull from each
+// presence-consumable active connected server (hop 1). There is no snapshot
+// cache — presence is too short-lived to cache — so the pulls happen on every
+// read. Entries are deduped by (origin, user) and the admin-only origin
+// fingerprint is stripped from the user-facing response (a friendly ServerName
+// is provided instead).
+func (h *FederationHandler) HumaAggregatedPresence(_ context.Context, _ *AggregatedPresenceInput) (*AggregatedPresenceOutput, error) {
+	all, err := h.buildLocalPresence()
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to build local presence")
+	}
+
+	peers, err := h.Peers.List()
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to list peers")
+	}
+	client := h.PresenceClient
+	if client == nil {
+		client = httpPresenceClient{}
+	}
+	self := h.Identity.Fingerprint()
+	// Pulls are sequential; with the small connected-server counts this targets,
+	// that's fine. Parallelizing across peers is a later optimization.
+	for _, peer := range peers {
+		if peer.Status != db.PeerStatusActive || !federation.CanConsume(peer, federation.DataClassPresence) {
+			continue
+		}
+		reqID := federation.NewRequestID()
+		started := time.Now()
+		raw, ferr := client.FetchPresence(peer.BaseURL, reqID, h.Identity, peer.Fingerprint)
+		if ferr != nil {
+			federation.RecordExchange(h.DB, federation.ExchangeRecord{
+				RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+				Direction: db.ExchangeOutbound, Operation: "presence_pull",
+				DataClass: string(federation.DataClassPresence), Status: db.ExchangeError,
+				StartedAt: started, Error: ferr.Error(),
+			})
+			continue
+		}
+		cleaned := sanitizePresenceBatch(raw, self)
+		for i := range cleaned {
+			cleaned[i].Hops++ // distance from us = distance from the server + 1
+			cleaned[i].ServerName = peer.Name
+		}
+		all = append(all, cleaned...)
+		federation.RecordExchange(h.DB, federation.ExchangeRecord{
+			RequestID: reqID, PeerFingerprint: peer.Fingerprint, PeerName: peer.Name,
+			Direction: db.ExchangeOutbound, Operation: "presence_pull",
+			DataClass: string(federation.DataClassPresence), Status: db.ExchangeOK,
+			StartedAt: started, ItemCount: len(cleaned),
+		})
+	}
+
+	deduped := federation.DedupePresenceEntries(all)
+	// Strip the origin fingerprint: it identifies peers, and the peer roster is
+	// admin-only elsewhere. The friendly ServerName remains for display.
+	for i := range deduped {
+		deduped[i].OriginFingerprint = ""
+	}
+
+	out := &AggregatedPresenceOutput{}
+	out.Body.Presence = deduped
+	return out, nil
+}

--- a/server/internal/api/federation_presence_test.go
+++ b/server/internal/api/federation_presence_test.go
@@ -1,0 +1,292 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/federation"
+	ws "github.com/spela/server/internal/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// fakePresenceClient returns canned presence entries keyed by base URL.
+type fakePresenceClient struct {
+	byBase map[string][]federation.PresenceEntry
+	err    error
+}
+
+func (f *fakePresenceClient) FetchPresence(baseURL, _ string, _ federation.Identity, _ string) ([]federation.PresenceEntry, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.byBase[baseURL], nil
+}
+
+// presencePolicyPeer upserts an active peer with a presence share/consume policy.
+func presencePolicyPeer(t *testing.T, database *gorm.DB, id federation.Identity, name, baseURL string, share, consume bool) {
+	t.Helper()
+	sp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassPresence: share})
+	cp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassPresence: consume})
+	require.NoError(t, federation.PeerStore{DB: database}.Upsert(&db.FederationPeer{
+		Fingerprint: id.Fingerprint(), PublicKey: b64(id.PublicKey), Name: name, BaseURL: baseURL,
+		Status: db.PeerStatusActive, SharePolicy: sp, ConsumePolicy: cp,
+	}))
+}
+
+func presenceHandler(database *gorm.DB, selfID federation.Identity, hub *ws.Hub, client presenceClient) *FederationHandler {
+	return &FederationHandler{
+		DB: database, Identity: selfID,
+		Peers:          federation.PeerStore{DB: database},
+		BaseURL:        "https://self",
+		Hub:            hub,
+		PresenceClient: client,
+	}
+}
+
+// seedPresenceSession creates a public user + an IGDB-identified game and marks
+// the user as currently playing it in the hub. Returns the game's cross-key.
+func seedPresenceSession(t *testing.T, database *gorm.DB, hub *ws.Hub, username, scraperID string) string {
+	t.Helper()
+	u := db.User{Username: username, Email: username + "@x.test", PasswordHash: "h", ProfileVisibility: "public"}
+	require.NoError(t, database.Create(&u).Error)
+	g := db.Game{Title: "Game " + scraperID, ScraperID: scraperID, FilePath: "/g-" + scraperID, ConsoleID: 1}
+	require.NoError(t, database.Create(&g).Error)
+	hub.SetUserGame(u.ID, g.ID)
+	return scraperID
+}
+
+// --- Sanitize -------------------------------------------------------------
+
+func TestSanitizePresenceBatch_DropsLoopsSelfAndNonZeroHops(t *testing.T) {
+	in := []federation.PresenceEntry{
+		{OriginFingerprint: "self", Hops: 0, Username: "loop"},    // our own origin looping back
+		{OriginFingerprint: "", Hops: 0, Username: "noorigin"},    // missing origin
+		{OriginFingerprint: "X", Hops: 1, Username: "transitive"}, // friend relaying (not allowed)
+		{OriginFingerprint: "Y", Hops: 0, Username: "good"},       // accepted
+	}
+	out := sanitizePresenceBatch(in, "self")
+	require.Len(t, out, 1)
+	assert.Equal(t, "good", out[0].Username)
+}
+
+// --- Export ---------------------------------------------------------------
+
+func callExportPresence(h *FederationHandler, peer *db.FederationPeer) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/x", func(c *gin.Context) {
+		c.Set(fedPeerContextKey, peer)
+		h.ginExportPresence(c)
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/x", nil))
+	return w
+}
+
+func TestExportPresence_ForbiddenWhenNotShared(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	hub := ws.NewHub(nil)
+	seedPresenceSession(t, database, hub, "alice", "igdb:1")
+	h := presenceHandler(database, selfID, hub, nil)
+
+	peer := &db.FederationPeer{Fingerprint: "fp-friend", Name: "Friend", SharePolicy: "", Status: db.PeerStatusActive}
+	w := callExportPresence(h, peer)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestExportPresence_ServesLocalPresence(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	hub := ws.NewHub(nil)
+	seedPresenceSession(t, database, hub, "alice", "igdb:1")
+	h := presenceHandler(database, selfID, hub, nil)
+
+	sp, _ := federation.MarshalPolicy(map[federation.DataClass]bool{federation.DataClassPresence: true})
+	peer := &db.FederationPeer{Fingerprint: "fp-friend", Name: "Friend", SharePolicy: sp, Status: db.PeerStatusActive}
+
+	w := callExportPresence(h, peer)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body struct {
+		Entries []federation.PresenceEntry `json:"entries"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Len(t, body.Entries, 1)
+	assert.Equal(t, selfID.Fingerprint(), body.Entries[0].OriginFingerprint)
+	assert.Equal(t, 0, body.Entries[0].Hops)
+	assert.Equal(t, "alice", body.Entries[0].Username)
+	assert.Equal(t, "igdb:1", body.Entries[0].GameKey)
+}
+
+// --- Aggregated read ------------------------------------------------------
+
+func TestAggregatedPresence_MergesLocalAndLiveFriend(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+	presencePolicyPeer(t, database, friendID, "Friend B", "https://friend", true, true)
+
+	hub := ws.NewHub(nil)
+	seedPresenceSession(t, database, hub, "localalice", "igdb:1")
+
+	fake := &fakePresenceClient{byBase: map[string][]federation.PresenceEntry{
+		"https://friend": {{
+			OriginFingerprint: friendID.Fingerprint(), Hops: 0,
+			Username: "remotebob", GameKey: "igdb:99", GameTitle: "Remote Game",
+		}},
+	}}
+	h := presenceHandler(database, selfID, hub, fake)
+
+	out, err := h.HumaAggregatedPresence(context.Background(), &AggregatedPresenceInput{})
+	require.NoError(t, err)
+	require.Len(t, out.Body.Presence, 2)
+
+	byUser := map[string]federation.PresenceEntry{}
+	for _, e := range out.Body.Presence {
+		byUser[e.Username] = e
+		assert.Empty(t, e.OriginFingerprint, "origin fingerprint stripped from the user-facing response")
+	}
+
+	local, ok := byUser["localalice"]
+	require.True(t, ok)
+	assert.Equal(t, 0, local.Hops)
+	assert.Empty(t, local.ServerName, "local presence has no server label")
+
+	remote, ok := byUser["remotebob"]
+	require.True(t, ok)
+	assert.Equal(t, 1, remote.Hops, "friend's hop-0 datum surfaces at hop 1")
+	assert.Equal(t, "Friend B", remote.ServerName)
+	assert.Equal(t, "igdb:99", remote.GameKey)
+}
+
+func TestAggregatedPresence_SkipsNonConsumablePeer(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+	presencePolicyPeer(t, database, friendID, "Friend B", "https://friend", true, false) // consume=false
+
+	hub := ws.NewHub(nil)
+	seedPresenceSession(t, database, hub, "localalice", "igdb:1")
+
+	fake := &fakePresenceClient{byBase: map[string][]federation.PresenceEntry{
+		"https://friend": {{OriginFingerprint: friendID.Fingerprint(), Hops: 0, Username: "remotebob", GameKey: "igdb:99"}},
+	}}
+	h := presenceHandler(database, selfID, hub, fake)
+
+	out, err := h.HumaAggregatedPresence(context.Background(), &AggregatedPresenceInput{})
+	require.NoError(t, err)
+	require.Len(t, out.Body.Presence, 1, "non-consumable peer's presence is not pulled")
+	assert.Equal(t, "localalice", out.Body.Presence[0].Username)
+}
+
+func TestAggregatedPresence_RecordsErrorOnPullFailure(t *testing.T) {
+	database := openAPIFedTestDB(t)
+	selfID, _ := federation.GenerateIdentity()
+	friendID, _ := federation.GenerateIdentity()
+	presencePolicyPeer(t, database, friendID, "Friend B", "https://friend", true, true)
+
+	h := presenceHandler(database, selfID, ws.NewHub(nil), &fakePresenceClient{err: errors.New("connection refused")})
+
+	out, err := h.HumaAggregatedPresence(context.Background(), &AggregatedPresenceInput{})
+	require.NoError(t, err)
+	assert.Empty(t, out.Body.Presence, "a failed pull contributes nothing but does not fail the read")
+
+	var errs int64
+	database.Model(&db.FederationExchange{}).Where("operation = ? AND status = ?", "presence_pull", db.ExchangeError).Count(&errs)
+	assert.Equal(t, int64(1), errs)
+}
+
+// --- Two-server (real signed HTTP) ----------------------------------------
+
+// TestTwoServers_PresenceOverHTTP wires two real federation servers over
+// httptest and exercises the live cross-mesh presence path end-to-end: server B
+// has a user playing a game; server A pulls B's presence live (signed GET,
+// verified by B's middleware, SharePolicy(presence)-gated) and surfaces it.
+func TestTwoServers_PresenceOverHTTP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// --- Server B (origin): a user playing a game, presence export routes.
+	dbB := openAPIFedTestDB(t)
+	idB, _ := federation.GenerateIdentity()
+	hubB := ws.NewHub(nil)
+	hB := &FederationHandler{
+		DB: dbB, Identity: idB, Peers: federation.PeerStore{DB: dbB},
+		Snapshots: federation.SnapshotStore{DB: dbB}, CatalogSnapshots: federation.CatalogSnapshotStore{DB: dbB},
+		Hub: hubB,
+	}
+	rB := gin.New()
+	RegisterFederationGinRoutes(rB, hB, NewRateLimiter(1000, time.Minute))
+	srvB := httptest.NewServer(rB)
+	defer srvB.Close()
+	hB.BaseURL = srvB.URL
+	seedPresenceSession(t, dbB, hubB, "remotebob", "igdb:1022")
+
+	// --- Server A (consumer). PresenceClient nil => real signed HTTP to B.
+	dbA := openAPIFedTestDB(t)
+	idA, _ := federation.GenerateIdentity()
+	hA := &FederationHandler{
+		DB: dbA, Identity: idA, Peers: federation.PeerStore{DB: dbA},
+		Snapshots: federation.SnapshotStore{DB: dbA}, CatalogSnapshots: federation.CatalogSnapshotStore{DB: dbA},
+	}
+
+	// Mutual policy: A consumes presence from B; B shares presence with A.
+	presencePolicyPeer(t, dbA, idB, "Server B", srvB.URL, false, true)
+	presencePolicyPeer(t, dbB, idA, "Server A", "", true, false)
+
+	out, err := hA.HumaAggregatedPresence(context.Background(), &AggregatedPresenceInput{})
+	require.NoError(t, err)
+	require.Len(t, out.Body.Presence, 1)
+	g := out.Body.Presence[0]
+	assert.Equal(t, "remotebob", g.Username)
+	assert.Equal(t, "igdb:1022", g.GameKey)
+	assert.Equal(t, 1, g.Hops)
+	assert.Equal(t, "Server B", g.ServerName)
+	assert.Empty(t, g.OriginFingerprint, "origin fingerprint stripped from the user-facing response")
+}
+
+// TestTwoServers_PresenceBlockedWithoutSharePolicy verifies the per-peer gate:
+// if B does not share presence with A, A's live pull is rejected and surfaces
+// nothing.
+func TestTwoServers_PresenceBlockedWithoutSharePolicy(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dbB := openAPIFedTestDB(t)
+	idB, _ := federation.GenerateIdentity()
+	hubB := ws.NewHub(nil)
+	hB := &FederationHandler{
+		DB: dbB, Identity: idB, Peers: federation.PeerStore{DB: dbB},
+		Snapshots: federation.SnapshotStore{DB: dbB}, CatalogSnapshots: federation.CatalogSnapshotStore{DB: dbB},
+		Hub: hubB,
+	}
+	rB := gin.New()
+	RegisterFederationGinRoutes(rB, hB, NewRateLimiter(1000, time.Minute))
+	srvB := httptest.NewServer(rB)
+	defer srvB.Close()
+	hB.BaseURL = srvB.URL
+	seedPresenceSession(t, dbB, hubB, "remotebob", "igdb:1022")
+
+	dbA := openAPIFedTestDB(t)
+	idA, _ := federation.GenerateIdentity()
+	hA := &FederationHandler{
+		DB: dbA, Identity: idA, Peers: federation.PeerStore{DB: dbA},
+		Snapshots: federation.SnapshotStore{DB: dbA}, CatalogSnapshots: federation.CatalogSnapshotStore{DB: dbA},
+	}
+
+	// A wants to consume; but B does NOT share presence with A (share=false).
+	presencePolicyPeer(t, dbA, idB, "Server B", srvB.URL, false, true)
+	presencePolicyPeer(t, dbB, idA, "Server A", "", false, false)
+
+	out, err := hA.HumaAggregatedPresence(context.Background(), &AggregatedPresenceInput{})
+	require.NoError(t, err)
+	assert.Empty(t, out.Body.Presence, "A surfaces nothing without B's share consent")
+}

--- a/server/internal/api/huma_federation.go
+++ b/server/internal/api/huma_federation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/federation"
+	ws "github.com/spela/server/internal/websocket"
 	"gorm.io/gorm"
 )
 
@@ -52,6 +53,12 @@ type FederationHandler struct {
 	// DownloadClient fetches a ROM from a friend. Defaults to httpDownloadClient
 	// when nil; overridden in tests.
 	DownloadClient downloadClient
+	// Hub is the websocket hub whose active sessions power cross-mesh presence
+	// (#1349). Nil = no local presence (the export/aggregate serve empty).
+	Hub *ws.Hub
+	// PresenceClient fetches a connected server's live presence. Defaults to
+	// httpPresenceClient when nil; overridden in tests.
+	PresenceClient presenceClient
 	// refreshMu / catalogRefreshMu serialize the respective refreshes so the
 	// periodic ticker and an admin trigger can't race the snapshot stores.
 	refreshMu        sync.Mutex

--- a/server/internal/api/huma_federation_admin.go
+++ b/server/internal/api/huma_federation_admin.go
@@ -425,6 +425,17 @@ func RegisterFederationRoutes(api huma.API, h *FederationHandler, jwtSecret stri
 		Security:    sec,
 	}, h.HumaAggregatedStats)
 
+	// User-facing: who's playing what right now across the mesh (live, hop-bounded).
+	huma.Register(api, huma.Operation{
+		OperationID: "federationAggregatedPresence",
+		Method:      http.MethodGet,
+		Path:        "/api/federation/presence/aggregated",
+		Summary:     "Who's playing now across the connected-server mesh (live)",
+		Tags:        []string{"federation", "presence"},
+		Middlewares: huma.Middlewares{requireAuth, rateLimit},
+		Security:    sec,
+	}, h.HumaAggregatedPresence)
+
 	// Admin: force a refresh of cached friend rollups (also runs periodically).
 	huma.Register(api, huma.Operation{
 		OperationID: "federationRefreshStats",
@@ -499,6 +510,7 @@ func RegisterFederationGinRoutes(r *gin.Engine, h *FederationHandler, downloadLi
 	requireFedPeer := VerifyFederationRequest(h.DB, h.Identity.Fingerprint())
 	r.GET("/api/federation/ping", requireFedPeer, h.ginPing)
 	r.GET("/api/federation/stats", requireFedPeer, h.ginExportStats)
+	r.GET("/api/federation/presence", requireFedPeer, h.ginExportPresence)
 	r.GET("/api/federation/catalog", requireFedPeer, h.ginExportCatalog)
 	// Binary ROM transfer routes are bandwidth-sensitive — rate-limit them like
 	// the other download endpoints (#1348 Phase 3b-1).

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -195,6 +195,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		GameDirs:         cfg.GameDirs,
 		JWTSecret:        cfg.JWTSecret,
 		BaseURL:          cfg.PublicBaseURL,
+		Hub:              cfg.Hub,
 		// Covers for connected-server games are resolved locally from the
 		// cross-key via this server's IGDB client (read lazily so a runtime
 		// re-config of the scraper's client is picked up).

--- a/server/internal/federation/presence.go
+++ b/server/internal/federation/presence.go
@@ -1,0 +1,133 @@
+package federation
+
+import (
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// PresenceEntry is one source-stamped "user is playing this game right now" datum
+// from a single origin server. Hops is the graph distance from the holder to the
+// origin (0 = originated here, 1 = a direct connected server).
+//
+// Unlike StatEntry, presence is EPHEMERAL: it is never cached in a snapshot table
+// and never re-served transitively. Each consumer pulls it live from its direct
+// connected servers (one hop) at read time, so a stale 15-minute cache can't
+// claim someone is playing a game they quit ten minutes ago.
+type PresenceEntry struct {
+	OriginFingerprint string `json:"originFingerprint"`
+	Hops              int    `json:"hops"`
+	Username          string `json:"username"`
+	// GameKey is the cross-server game identity (IGDB scraper id, else CRC32), so
+	// a client can link a presence to a remote game it can browse/import. Sessions
+	// on games with no cross-identifier are not federated (see BuildLocalPresence).
+	GameKey   string `json:"gameKey"`
+	GameTitle string `json:"gameTitle"`
+	// ServerName is a friendly label for the origin server, filled in by the
+	// consumer from its peer roster. Empty means this (local) server. It exists so
+	// the user-facing view can show "playing on <server>" without exposing the
+	// admin-only peer fingerprints.
+	ServerName string `json:"serverName"`
+}
+
+// PlayingSession is one active local game session (userID + gameID), the input
+// to BuildLocalPresence. It mirrors the websocket hub's snapshot so the
+// federation domain stays free of a websocket dependency — the api layer maps
+// the hub's sessions onto this type.
+type PlayingSession struct {
+	UserID uint
+	GameID uint
+}
+
+// presenceDedupeKey identifies a presence by origin + user, so the same session
+// reaching us via multiple paths is shown exactly once.
+type presenceDedupeKey struct {
+	origin   string
+	username string
+}
+
+// DedupePresenceEntries removes duplicate (origin, username) entries, keeping the
+// FIRST occurrence (diamond-safe, idempotent). Same rationale as
+// DedupeStatEntries: first-seen prevents a near (possibly misbehaving) relay's
+// copy from overriding the origin's honest copy arriving via a longer path.
+func DedupePresenceEntries(entries []PresenceEntry) []PresenceEntry {
+	seen := make(map[presenceDedupeKey]bool, len(entries))
+	out := make([]PresenceEntry, 0, len(entries))
+	for _, e := range entries {
+		k := presenceDedupeKey{e.OriginFingerprint, e.Username}
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, e)
+	}
+	return out
+}
+
+// BuildLocalPresence turns the hub's active sessions into source-stamped
+// PresenceEntry values (origin = selfFingerprint, hop 0). It applies the same
+// origin-side privacy gate as the stats rollup (publicActiveUserFilter), so
+// private, disabled, and pending-approval users never appear in the mesh, and it
+// drops sessions on games with no cross-server identifier (a title fallback
+// would falsely merge distinct games).
+func BuildLocalPresence(database *gorm.DB, selfFingerprint string, sessions []PlayingSession) ([]PresenceEntry, error) {
+	if len(sessions) == 0 {
+		return []PresenceEntry{}, nil
+	}
+
+	userIDs := make([]uint, 0, len(sessions))
+	gameIDs := make([]uint, 0, len(sessions))
+	seenU := make(map[uint]bool, len(sessions))
+	seenG := make(map[uint]bool, len(sessions))
+	for _, s := range sessions {
+		if !seenU[s.UserID] {
+			seenU[s.UserID] = true
+			userIDs = append(userIDs, s.UserID)
+		}
+		if !seenG[s.GameID] {
+			seenG[s.GameID] = true
+			gameIDs = append(gameIDs, s.GameID)
+		}
+	}
+
+	// Public + active users only: this is the origin-side privacy gate.
+	var users []db.User
+	if err := database.Where("id IN ?", userIDs).
+		Where(publicActiveUserFilter, "public", false, false).
+		Find(&users).Error; err != nil {
+		return nil, err
+	}
+	userByID := make(map[uint]db.User, len(users))
+	for _, u := range users {
+		userByID[u.ID] = u
+	}
+
+	var games []db.Game
+	if err := database.Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		return nil, err
+	}
+	gameByID := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameByID[g.ID] = g
+	}
+
+	entries := make([]PresenceEntry, 0, len(sessions))
+	for _, s := range sessions {
+		u, ok := userByID[s.UserID]
+		if !ok {
+			continue // private / disabled / pending — not federated
+		}
+		g, ok := gameByID[s.GameID]
+		if !ok {
+			continue
+		}
+		key, hasKey := gameStatKey(g)
+		if !hasKey {
+			continue // can't cross-identify this game — don't federate it
+		}
+		entries = append(entries, PresenceEntry{
+			OriginFingerprint: selfFingerprint, Hops: 0,
+			Username: u.Username, GameKey: key, GameTitle: g.Title,
+		})
+	}
+	return entries, nil
+}

--- a/server/internal/federation/presence_test.go
+++ b/server/internal/federation/presence_test.go
@@ -1,0 +1,76 @@
+package federation
+
+import (
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func openPresenceTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&db.User{}, &db.Game{}))
+	return database
+}
+
+func TestDedupePresenceEntries_KeepsFirstPerOriginUser(t *testing.T) {
+	in := []PresenceEntry{
+		{OriginFingerprint: "A", Username: "bob", GameKey: "igdb:1", GameTitle: "Real"},
+		{OriginFingerprint: "A", Username: "bob", GameKey: "igdb:2", GameTitle: "Dup via other path"},
+		{OriginFingerprint: "B", Username: "bob", GameKey: "igdb:3", GameTitle: "Different origin"},
+	}
+	out := DedupePresenceEntries(in)
+	require.Len(t, out, 2)
+	assert.Equal(t, "igdb:1", out[0].GameKey, "first occurrence wins for (A, bob)")
+	assert.Equal(t, "B", out[1].OriginFingerprint, "same username on a different origin is distinct")
+
+	// Idempotent.
+	assert.Equal(t, out, DedupePresenceEntries(out))
+}
+
+func TestBuildLocalPresence_GatesPrivateAndUnidentifiableGames(t *testing.T) {
+	database := openPresenceTestDB(t)
+
+	pub := db.User{Username: "publicguy", Email: "a@x.test", PasswordHash: "h", ProfileVisibility: "public"}
+	priv := db.User{Username: "privateguy", Email: "b@x.test", PasswordHash: "h", ProfileVisibility: "private"}
+	disabled := db.User{Username: "banned", Email: "c@x.test", PasswordHash: "h", ProfileVisibility: "public", Disabled: true}
+	require.NoError(t, database.Create(&pub).Error)
+	require.NoError(t, database.Create(&priv).Error)
+	require.NoError(t, database.Create(&disabled).Error)
+
+	identified := db.Game{Title: "Zelda", ScraperID: "igdb:1022", FilePath: "/z", ConsoleID: 1}
+	homebrew := db.Game{Title: "Homebrew", FilePath: "/h", ConsoleID: 1} // no scraper id / CRC
+	require.NoError(t, database.Create(&identified).Error)
+	require.NoError(t, database.Create(&homebrew).Error)
+
+	sessions := []PlayingSession{
+		{UserID: pub.ID, GameID: identified.ID},      // included
+		{UserID: priv.ID, GameID: identified.ID},     // dropped: private
+		{UserID: disabled.ID, GameID: identified.ID}, // dropped: disabled
+		{UserID: pub.ID, GameID: homebrew.ID},        // dropped: no cross-key
+	}
+
+	entries, err := BuildLocalPresence(database, "selfFP", sessions)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "selfFP", entries[0].OriginFingerprint)
+	assert.Equal(t, 0, entries[0].Hops)
+	assert.Equal(t, "publicguy", entries[0].Username)
+	assert.Equal(t, "igdb:1022", entries[0].GameKey)
+	assert.Equal(t, "Zelda", entries[0].GameTitle)
+}
+
+func TestBuildLocalPresence_EmptyForNoSessions(t *testing.T) {
+	database := openPresenceTestDB(t)
+	entries, err := BuildLocalPresence(database, "selfFP", nil)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -87,7 +87,7 @@ func NewHub(allowedOrigins []string) *Hub {
 	h.upgrader = websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
-		CheckOrigin: checkOrigin(allowedOrigins),
+		CheckOrigin:     checkOrigin(allowedOrigins),
 	}
 	return h
 }
@@ -276,6 +276,33 @@ func (h *Hub) GetUserGame(userID uint) uint {
 		return 0
 	}
 	return entry.GameID
+}
+
+// PlayingSession is one user's currently-active game session.
+type PlayingSession struct {
+	UserID uint
+	GameID uint
+}
+
+// PlayingNow returns a snapshot of the users currently playing a game, skipping
+// entries with no game and those whose heartbeat has gone stale (the same
+// timeout the cleanup goroutine uses, applied live so a caller never sees a
+// session the cleanup tick hasn't swept yet). Powers cross-mesh presence (#1349).
+func (h *Hub) PlayingNow() []PlayingSession {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	now := h.nowFunc()
+	out := make([]PlayingSession, 0, len(h.userGames))
+	for userID, entry := range h.userGames {
+		if entry.GameID == 0 {
+			continue
+		}
+		if now.Sub(entry.LastHeartbeat) > heartbeatTimeout {
+			continue
+		}
+		out = append(out, PlayingSession{UserID: userID, GameID: entry.GameID})
+	}
+	return out
 }
 
 // Close stops the hub event loop and cleanup goroutine.


### PR DESCRIPTION
First slice of **Phase 4** (#1349): surface "friends playing now" across the connected-server mesh — which users on connected servers are actively playing a game right now — sourced live from the existing websocket heartbeat presence, consent-gated and privacy-gated.

## Design note — live pull, not a snapshot cache

The issue originally sketched a `FederationPresenceSnapshot` table + periodic refresh, mirroring the stats/catalog federation. I deliberately diverged: **presence is ephemeral.** A 15-minute snapshot cache would happily claim someone is playing a game they quit ten minutes ago. So instead the aggregate endpoint does a **live pull from each direct (hop-1) connected server at read time** — no snapshot table, no transitive re-serving. This is both simpler (no store, no refresh ticker, no revoke-drops-snapshot bookkeeping) and correct for short-lived state. Transitive (friends-of-friends) presence and any caching are explicit follow-ups if ever wanted.

A connected server's export returns **only its own hop-0 presence** (it does not relay transitive presence), so the consumer rejects any entry with `Hops != 0` and bumps accepted entries to hop 1.

## What's here

- **websocket** (`hub.go`): `Hub.PlayingNow()` snapshots active sessions under the existing lock, skipping no-game and stale-heartbeat entries.
- **federation** (`presence.go`): `PresenceEntry` + `DedupePresenceEntries` (first-seen, diamond-safe, idempotent — same rationale as `DedupeStatEntries`); `BuildLocalPresence` stamps hop-0 presence applying the **same `publicActiveUserFilter` as the stats rollup** (private/disabled/pending-approval users never federate) and dropping games with no cross-server key.
- **api** (`federation_presence.go`):
  - `GET /api/federation/presence` — signed, `SharePolicy(presence)`-gated, exports local hop-0 presence only.
  - `GET /api/federation/presence/aggregated` — auth + rate-limit, merges local + a live pull from each `ConsumePolicy(presence)` active peer (sanitize → +1 hop → dedupe), strips the admin-only origin fingerprint, and labels each entry with the friendly server name.
- Wires the **first enforcement of `DataClass "presence"`** (it was in `AllDataClasses` but unused).

## Acceptance (from #1400)

- [x] Private / non-consented users never appear in exported or aggregated presence (`publicActiveUserFilter` + `SharePolicy`/`ConsumePolicy` gates).
- [x] Aggregate is hop-bounded (1 hop) and deduped; a revoked peer is simply no longer pulled (no snapshot to drop — cleaner than the cached design).
- [x] Go tests incl. in-process two-server round-trips over real signed HTTP (served + blocked-without-share), mirroring `federation_twoserver_test.go`.

## Tests

`go test ./internal/federation/ ./internal/api/ ./internal/websocket/` — all green. Covers dedupe/build units, sanitize, export forbidden/served, aggregate merge + skip-non-consumable + pull-failure-records-error, and the two two-server HTTP round-trips. An adversarial code-review pass caught a missing `StartedAt` on the presence-pull ledger rows (latency would have always logged as 0) — fixed.

Surfacing UI ("friends playing now" in web + player) is a follow-up.

Closes #1400. Part of #1349, closes nothing else.