### PR TITLE
fix(player): reuse one WebSocket client across reconnects to stop FD leak (#1399)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
@@ -67,27 +67,38 @@ class PresenceService(
         if (wsJob?.isActive == true) return
 
         wsJob = scope.launch(dispatchers.io) {
-            while (isActive) {
-                val wsUrl = apiClient.getWebSocketUrl() ?: run {
-                    delay(RECONNECT_DELAY_MS)
-                    return@launch
-                }
-                try {
-                    val wsClient = HttpClient(engineFactory) {
-                        install(WebSockets)
+            // A single Ktor client is reused across every reconnect attempt.
+            // Creating a new HttpClient per attempt leaked the engine's
+            // SelectorManager (and its kqueue/wakeup-pipe/socket FDs) on each
+            // reconnect: webSocket() throws on a failed upgrade — the normal
+            // reconnect case — which skipped the per-loop close(), eventually
+            // exhausting the process file-descriptor limit (#1399). Ktor
+            // clients are built to be reused, so we create one here and close
+            // it once in finally when disconnect() cancels this coroutine.
+            val wsClient = HttpClient(engineFactory) {
+                install(WebSockets)
+            }
+            try {
+                while (isActive) {
+                    val wsUrl = apiClient.getWebSocketUrl() ?: run {
+                        delay(RECONNECT_DELAY_MS)
+                        return@launch
                     }
-                    wsClient.webSocket(wsUrl) {
-                        for (frame in incoming) {
-                            if (frame is Frame.Text) {
-                                handleFrame(frame.readText())
+                    try {
+                        wsClient.webSocket(wsUrl) {
+                            for (frame in incoming) {
+                                if (frame is Frame.Text) {
+                                    handleFrame(frame.readText())
+                                }
                             }
                         }
+                    } catch (_: Exception) {
+                        // Connection failed or closed, retry
                     }
-                    wsClient.close()
-                } catch (_: Exception) {
-                    // Connection failed or closed, retry
+                    delay(RECONNECT_DELAY_MS)
                 }
-                delay(RECONNECT_DELAY_MS)
+            } finally {
+                wsClient.close()
             }
         }
     }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/PresenceServiceConnectionTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/PresenceServiceConnectionTest.kt
@@ -1,0 +1,124 @@
+package com.spela.player.data.remote
+
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.interceptor.TokenManager
+import com.spela.player.util.DispatcherProvider
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.job
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Locks the reconnect-loop file-descriptor leak fix (#1399).
+ *
+ * [PresenceService.connect] reuses a single Ktor [io.ktor.client.HttpClient]
+ * across every reconnect attempt. The previous code created a fresh client
+ * each iteration and only closed it *after* a successful session — but
+ * `webSocket()` throws on a failed upgrade (the normal offline-reconnect
+ * case), skipping the close. Every leaked client kept a live SelectorManager
+ * holding kqueue/wakeup-pipe/socket FDs, so a server that stayed unreachable
+ * drained the process FD limit one reconnect at a time.
+ *
+ * Run against a real dispatcher (not virtual time): the WebSocket attempt is
+ * routed through MockEngine, whose request execution completes on its own
+ * dispatcher, so virtual-time advancement can't drive the reconnect loop.
+ * The reconnect delay is a real 5s, so the wait below spans more than one
+ * reconnect cycle — long enough that the old per-attempt-client code would
+ * have built a second engine. With the fix, exactly one engine is ever built
+ * no matter how long the loop churns, and it is closed when disconnect()
+ * cancels the loop.
+ */
+class PresenceServiceConnectionTest {
+
+    private class TestDispatchers(d: CoroutineDispatcher) : DispatcherProvider {
+        override val main = d
+        override val io = d
+        override val default = d
+    }
+
+    /** Plain engine for the API client; its own client must not skew the count. */
+    private object ApiEngineFactory : HttpClientEngineFactory<MockEngineConfig> {
+        override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine =
+            MockEngine(
+                MockEngineConfig().apply {
+                    addHandler { throw RuntimeException("no API calls expected") }
+                    block()
+                },
+            )
+    }
+
+    /**
+     * Counts engine constructions and remembers the engine it built so the
+     * test can assert close-on-disconnect. Every request fails, so the
+     * WebSocket upgrade always throws and `connect()` keeps reconnecting.
+     */
+    private class CountingEngineFactory : HttpClientEngineFactory<MockEngineConfig> {
+        val createCount = AtomicInteger(0)
+
+        @Volatile
+        var lastEngine: MockEngine? = null
+
+        override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine {
+            createCount.incrementAndGet()
+            return MockEngine(
+                MockEngineConfig().apply {
+                    addHandler { throw RuntimeException("simulated connection failure") }
+                    block()
+                },
+            ).also { lastEngine = it }
+        }
+    }
+
+    @Test
+    fun reusesOneClientAcrossReconnects_andClosesItOnDisconnect() = runBlocking {
+        val serviceScope = CoroutineScope(Dispatchers.IO + Job())
+        val factory = CountingEngineFactory()
+        val tokenManager = TokenManager().also { it.setTokens("test-access", "test-refresh") }
+        val apiClient = SpelaApiClient(ApiEngineFactory, tokenManager).also { it.setBaseUrl("http://localhost:8080") }
+        val service = PresenceService(apiClient, factory, TestDispatchers(Dispatchers.IO), serviceScope)
+
+        try {
+            service.connect()
+            // Span more than one 5s reconnect cycle. The buggy code would have
+            // built a second (leaked) client by now.
+            delay(7_000)
+
+            assertEquals(
+                1,
+                factory.createCount.get(),
+                "connect() must reuse a single HttpClient across reconnects, not build one per attempt",
+            )
+
+            service.disconnect()
+
+            // Poll for the cancellation + finally { close() } to propagate
+            // rather than sleeping a fixed amount, so a loaded CI box can't
+            // flake the assertion.
+            val engineJob = factory.lastEngine?.coroutineContext?.job
+            var waited = 0
+            while (engineJob?.isActive == true && waited < 3_000) {
+                delay(50)
+                waited += 50
+            }
+            assertFalse(
+                engineJob?.isActive ?: true,
+                "disconnect() must close the reused client's engine",
+            )
+        } finally {
+            service.disconnect()
+            serviceScope.cancel()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`PresenceService.connect()` created a fresh Ktor `HttpClient` **inside** its reconnect `while` loop and only closed it (`wsClient.close()`) *after* a successful `webSocket()` session. But `webSocket()` throws on a failed upgrade — the normal offline / server-unreachable / reconnect case — so the close was skipped on every reconnect attempt.

Each leaked client kept a live `SelectorManager` holding kqueue / wakeup-pipe / socket file descriptors. A server that stayed unreachable therefore drained the process FD limit one reconnect (every `RECONNECT_DELAY_MS` = 5s) at a time, eventually exhausting it (~92k on macOS), which is what brought down a long-running desktop session.

## Fix

Hoist a **single** `HttpClient` above the `while` loop and reuse it across every reconnect attempt (Ktor clients are designed to be reused), closing it exactly once in a `finally` when `disconnect()` cancels the coroutine.

- The null-URL early-return (`getWebSocketUrl()` → `null`) still runs the `finally` (non-local `return@launch` unwinds through the `try`), so the client is closed in that path too.
- Per-attempt retry/backoff behavior is otherwise unchanged.

## Test Plan

- [x] New `PresenceServiceConnectionTest` drives the reconnect loop against a counting engine factory (over a real dispatcher, since the WS attempt routes through `MockEngine` whose execution can't be driven by virtual time) and asserts:
  - exactly **one** engine is constructed across multiple 5s reconnect cycles, and
  - the engine is **closed** when `disconnect()` cancels the loop.
- [x] Verified **red** on the old code (`expected:<1> but was:<2>`), **green** on the fix.
- [x] Full `:shared:desktopTest` green.
- [x] `code-reviewer`: APPROVE.

No hardware run needed — this is a shared-logic resource-lifecycle bug; the desktop regression test is the correct coverage per the player testing strategy.

Closes #1399
